### PR TITLE
Transform opcode from int to string when loading from env status file

### DIFF
--- a/deploy-agent/.bumpversion.cfg
+++ b/deploy-agent/.bumpversion.cfg
@@ -2,5 +2,5 @@
 files = setup.py
 commit = True
 tag = True
-current_version = 1.1.10
+current_version = 1.2.0
 

--- a/deploy-agent/deployd/common/types.py
+++ b/deploy-agent/deployd/common/types.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from deployd.types.ping_report import PingReport
+from deployd.types.opcode import OpCode
 
 
 class AgentStatus(object):
@@ -178,7 +179,11 @@ class DeployStatus(object):
                                         build_branch=build_info.get('build_branch'))
 
         self.runtime_config = json_value.get('runtime_config')
-        self.op_code = json_value.get('op_code', OpCode.NOOP)
+        op_code = json_value.get('op_code', OpCode.NOOP)
+        if isinstance(op_code, int):
+            self.op_code = OpCode._VALUES_TO_NAMES[op_code]
+        else:
+            self.op_code = op_code
 
     def to_json(self):
         json = {}

--- a/deploy-agent/setup.py
+++ b/deploy-agent/setup.py
@@ -15,7 +15,7 @@
 from setuptools import setup
 import os
 
-__version__ = '1.1.10'
+__version__ = '1.2.0'
 
 markdown_contents = open(os.path.join(os.path.dirname(__file__),
                                       'README.md')).read()


### PR DESCRIPTION
When we loading env status file, we should also transform the opcode from int to string.
(Before, only when do a deploy, the opcode can be transformed)

@jinruh @sbaogang 
