### PR TITLE
Refactoring, fix dependencies and issues with running agent in daemon…

### DIFF
--- a/deploy-agent/setup.py
+++ b/deploy-agent/setup.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,11 +25,11 @@ console_scripts = ['deploy-agent = deployd.agent:main',
                    'deploy-stager = deployd.staging.stager:main']
 
 install_requires = [
-    "requests>=2.5.1",
+    "requests==2.9.1",
     "gevent==1.0.2",
     "lockfile==0.12.2",
-    "boto>=2.13.3",
-    "python-daemon>=2.1"
+    "boto>=2.39.0",
+    "python-daemon==2.0.6"
 ]
 
 # Pinterest specific settings


### PR DESCRIPTION
This change includes:
1. Use # for block comments, which really is the only way for Python comments. Use triple quote is not really recommended by https://www.python.org/dev/peps/pep-0008/#block-comments
2. Fix some other Python code style issue - we will add pep lint checker next
3. Fix the dependencies version, especially use python-daemon 2.0.6, which does not require root permission to run deployagent: https://github.com/ThiefMaster/maildump/issues/17, not sure this is the best approach, will revisit
4. This is most important, preserve the log handler in daemon mode - otherwise, the log handler will be closed, and no log written
