### PR TITLE
Remove the PENDING_TERMINATE host state when health check completed.

### DIFF
--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/HealthChecker.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/HealthChecker.java
@@ -432,30 +432,6 @@ public class HealthChecker implements Runnable {
             }
         }
 
-        // Terminate the host
-        String hostId = healthCheckBean.getHost_id();
-        LOG.info("Start to terminates host id {}, for group {}", hostId, groupName);
-        List<String> runningIds = hostInfoDAO.getRunningInstances(Arrays.asList(hostId));
-        if (runningIds.isEmpty()) {
-            LOG.info("The host {} has been terminated", hostId);
-            healthCheckBean.setHost_terminated(true);
-        } else {
-            HostBean hostBean = new HostBean();
-            if (healthCheckBean.getStatus() == HealthCheckStatus.FAILED || healthCheckBean.getStatus() == HealthCheckStatus.TIMEOUT) {
-                LOG.info(String.format("Health check %s. Retain the host %s for debugging", healthCheckBean.getStatus().toString(), hostId));
-                hostBean.setState(HostState.PENDING_TERMINATE);
-                hostBean.setLast_update(System.currentTimeMillis());
-                healthCheckBean.setHost_terminated(false);
-            } else {
-                LOG.info(String.format("Health check %s. Termimate the host %s", healthCheckBean.getStatus().toString(), hostId));
-                hostInfoDAO.terminateHost(hostId);
-                hostBean.setState(HostState.TERMINATING);
-                hostBean.setLast_update(System.currentTimeMillis());
-                healthCheckBean.setHost_terminated(true);
-            }
-            hostDAO.updateHostById(hostId, hostBean);
-        }
-
         transistionState(healthCheckBean, HealthCheckState.COMPLETED, null, "");
         LOG.info("Health Check Succeeded: id {}, group {}, state {}, status {}",
             healthCheckBean.getId(), groupName, healthCheckBean.getState(), healthCheckBean.getStatus());

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/HostTerminator.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/HostTerminator.java
@@ -29,7 +29,7 @@ import java.util.*;
 
 public class HostTerminator implements Runnable {
     private static final Logger LOG = LoggerFactory.getLogger(HostTerminator.class);
-    private static final long timeToRetain = 2 * 60 * 60 * 1000; // 2 hour
+    private static final long timeToRetain = 60 * 60 * 1000; // 1 hour
     private final HostDAO hostDAO;
     private final HostInfoDAO hostInfoDAO;
     private final UtilDAO utilDAO;
@@ -43,7 +43,7 @@ public class HostTerminator implements Runnable {
     void terminateHost(HostBean host) throws Exception {
         if ((System.currentTimeMillis() - host.getLast_update()) > timeToRetain) {
             String hostId = host.getHost_id();
-            LOG.info(String.format("This host %s has been retained for more than 2 hours since it's last updated. Terminate it", hostId));
+            LOG.info(String.format("This host %s has been retained for more than 1 hours since it's last updated. Terminate it", hostId));
             hostInfoDAO.terminateHost(hostId);
 
             HostBean hostBean = new HostBean();


### PR DESCRIPTION
Since we have HealthCheckHostTerminator to keep track of health check instances now, we don't need to set the PENDING_TERMINATE host state (which is used to clean up instances before). And also adjust the time to retain instances before it is terminated.
