### PR TITLE
fix several bugs in transformer

### DIFF
--- a/deploy-agent/README.md
+++ b/deploy-agent/README.md
@@ -1,1 +1,5 @@
 Deploy-agent runs on every host and execute deploy scripts. See documentation for more details.
+
+To run unit tests
+
+> tox

--- a/deploy-agent/deployd/staging/stager.py
+++ b/deploy-agent/deployd/staging/stager.py
@@ -105,10 +105,6 @@ class Stager(object):
         return symlink_target.rsplit("/", 1)[-1]
 
     def transform_script(self):
-        # if the dict is empty, no need to transform script
-        if self._transformer.dict_size() == 0:
-            return
-
         script_dir = os.path.join(self._target, self._script_dirname)
         if not os.path.exists(script_dir):
             return

--- a/deploy-agent/deployd/staging/transformer.py
+++ b/deploy-agent/deployd/staging/transformer.py
@@ -53,11 +53,17 @@ class Transformer(object):
             with open(from_path, 'r') as f:
                 res = f.read()
 
-            matcher = "\{\$TELETRAAN_(?P<KEY>[a-zA-Z0-9\-_]+):(?P<VALUE>.*)\}"
+            matcher = "(\{\$|\$\{)TELETRAAN_(?P<KEY>[a-zA-Z0-9\-_]+)(?P<COLON>:)?(?P<VALUE>.*?)\}"
             match_string = re.finditer(matcher, res)
             for match in match_string:
-                value = self._dictionary.get(match.group("KEY"), match.group("VALUE"))
-                res = res.replace(match.group(), value)
+                key = match.group("KEY")
+                colon = match.group("COLON")
+                value = match.group("VALUE")
+                if colon is None:
+                    value = None
+                value = self._dictionary.get(key, value)
+                if value is not None:
+                    res = res.replace(match.group(), value)
 
             s = TeletraanTemplate(res)
             res = s.safe_substitute(self._dictionary)

--- a/deploy-agent/requirements.txt
+++ b/deploy-agent/requirements.txt
@@ -4,6 +4,6 @@
 tox==1.6.1
 coverage
 pytest==2.3.5
-mock
+mock==1.0.1
 flake8
 nose-socket-whitelist

--- a/deploy-agent/tests/unit/deploy/common/test_config.py
+++ b/deploy-agent/tests/unit/deploy/common/test_config.py
@@ -38,7 +38,7 @@ class TestConfigFunctions(tests.TestCase):
             f.writelines(lines)
 
         config_reader = mock.Mock()
-        config_reader.get = mock.Mock(return_value="")
+        config_reader.get = mock.Mock(return_value="/tmp")
         cls.config = Config(config_reader=config_reader)
 
     def test_get_target(self):

--- a/deploy-agent/tests/unit/deploy/staging/test_transformer.py
+++ b/deploy-agent/tests/unit/deploy/staging/test_transformer.py
@@ -21,50 +21,103 @@ import tempfile
 from deployd.staging.transformer import Transformer
 
 
-class TestHelper(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.base_dir = tempfile.mkdtemp()
-        cls.template_dir = os.path.join(cls.base_dir, 'teletraan_template')
-        cls.script_dir = os.path.join(cls.base_dir, 'teletraan')
-        os.mkdir(cls.template_dir)
-        os.mkdir(cls.script_dir)
+class TransformTest(unittest.TestCase):
+    def setUp(self):
+        self.base_dir = tempfile.mkdtemp()
+        self.template_dir = os.path.join(self.base_dir, 'teletraan_template')
+        self.script_dir = os.path.join(self.base_dir, 'teletraan')
+        os.mkdir(self.template_dir)
+        os.mkdir(self.script_dir)
 
-        fn1 = os.path.join(cls.template_dir, 'test1.tmpl')
-        fn2 = os.path.join(cls.template_dir, 'test2.tmpl')
+        fn1 = os.path.join(self.template_dir, 'test1.tmpl')
+        fn2 = os.path.join(self.template_dir, 'test2.tmpl')
         with open(fn1, 'w') as f:
-            f.write('$TELETRAAN_who is $TELETRAAN_mike.')
+            f.write('foo1=foo-${TELETRAAN_foo}-${TELETRAAN_foo}\n')
+            f.write('foo2=foo-{$TELETRAAN_foo}-{$TELETRAAN_foo}\n')
+            f.write('foo3=foo-$TELETRAAN_foo $TELETRAAN_foo\n')
+            f.write('foo4=foo-${TELETRAAN_foo:foo}-${TELETRAAN_foo:foo}\n')
+            f.write('foo5=foo-{$TELETRAAN_foo:foo}-{$TELETRAAN_foo:foo}\n')
+            f.write('foo6=foo-${TELETRAAN_bar:foo}-${TELETRAAN_bar:foo}\n')
+            f.write('foo7=foo-{$TELETRAAN_bar:foo}-{$TELETRAAN_bar:foo}\n')
+            f.write('foo8=foo-${TELETRAAN_bar}-${TELETRAAN_bar:}\n')
+            f.write('foo9=foo-{$TELETRAAN_bar}-{$TELETRAAN_bar:}\n')
+            f.write('foo10=foo-$TELETRAAN_bar $TELETRAAN_bar\n')
 
         with open(fn2, 'w') as f:
             f.write('$TEST="$TELETRAAN_Wh-O"')
 
-        lines = ['who = \"test1\"\n',
+        lines = ['foo = \"bar\"\n',
                  'Wh-O =   \'test2\'\n',
                  'TEST = test3\n']
-        with open(os.path.join(cls.base_dir, '123_SCRIPT_CONFIG'), 'w') as f:
+        with open(os.path.join(self.base_dir, '123_SCRIPT_CONFIG'), 'w') as f:
             f.writelines(lines)
 
-    @classmethod
-    def tearDownClass(cls):
-        shutil.rmtree(cls.base_dir)
+    def tearDown(self):
+        shutil.rmtree(self.base_dir)
 
     def test_load_configs(self):
         transformer = Transformer(agent_dir=self.base_dir, env_name="123")
-        self.assertEqual(transformer._dictionary.get('who'), 'test1')
+        self.assertEqual(transformer._dictionary.get('foo'), 'bar')
         self.assertEqual(transformer._dictionary.get('Wh-O'), 'test2')
         self.assertEqual(transformer._dictionary.get('TEST'), 'test3')
 
-    def test_translate(self):
+    def test_translate1(self):
         transformer = Transformer(agent_dir=self.base_dir, env_name="123")
         transformer.transform_scripts(self.template_dir, self.template_dir, self.script_dir)
 
         fn1 = os.path.join(self.script_dir, 'test1')
         fn2 = os.path.join(self.script_dir, 'test2')
 
+        # match console value
+        value1 = "foo-bar-bar"
+        # no console value, use default
+        value2 = "foo-foo-foo"
+        values = {
+            "foo1": value1,
+            "foo2": value1,
+            "foo3": "foo-bar bar",
+            "foo4": value1,
+            "foo5": value1,
+            "foo6": value2,
+            "foo7": value2,
+            "foo8": "foo-${TELETRAAN_bar}-",
+            "foo9": "foo-{$TELETRAAN_bar}-",
+            "foo10": "foo-$TELETRAAN_bar $TELETRAAN_bar"
+        }
+
         with open(fn1, 'r') as f:
-            s = f.read()
-            self.assertEqual(s, 'test1 is $TELETRAAN_mike.')
+            for line in f:
+                key, value = line.split("=")
+                newline = "%s=%s\n" % (key, values[key])
+                self.assertEqual(line, newline)
 
         with open(fn2, 'r') as f:
             s = f.read()
             self.assertEqual(s, '$TEST="test2"')
+
+    def test_translate2(self):
+        transformer = Transformer(agent_dir=self.base_dir, env_name="xyz")
+        transformer.transform_scripts(self.template_dir, self.template_dir, self.script_dir)
+
+        fn1 = os.path.join(self.script_dir, 'test1')
+        fn2 = os.path.join(self.script_dir, 'test2')
+
+        value1 = "foo-foo-foo"
+        values = {
+            "foo1": "foo-${TELETRAAN_foo}-${TELETRAAN_foo}",
+            "foo2": "foo-{$TELETRAAN_foo}-{$TELETRAAN_foo}",
+            "foo3": "foo-$TELETRAAN_foo $TELETRAAN_foo",
+            "foo4": value1,
+            "foo5": value1,
+            "foo6": value1,
+            "foo7": value1,
+            "foo8": "foo-${TELETRAAN_bar}-",
+            "foo9": "foo-{$TELETRAAN_bar}-",
+            "foo10": "foo-$TELETRAAN_bar $TELETRAAN_bar"
+        }
+
+        with open(fn1, 'r') as f:
+            for line in f:
+                key, value = line.split("=")
+                newline = "%s=%s\n" % (key, values[key])
+                self.assertEqual(line, newline)

--- a/deploy-agent/tox.ini
+++ b/deploy-agent/tox.ini
@@ -1,7 +1,10 @@
 [tox]
-envlist = py27
+envlist=py27
 
 [flake8]
-exclude = .tox
-# Change this to 79 one day...
-max-line-length = 100
+exclude=.tox
+max-line-length=100
+
+[testenv:py27]
+deps=-rrequirements.txt
+commands=py.test {posargs}


### PR DESCRIPTION
1. Fix tox.ini and update README for how to run unit test using tox
2. Fix the case we do not transform ${FOO-bar:80} if the teletraan UI does not provide any variables; we still need to translate ${FOO-bar:80}  to 80, even though there is no script variables defined on the UI.
3. Fix the case we do not support ${FOO-bar:80}-XYZ-${FOO-bar:80}
4. Added more support so we will translate both ${FOO-bar:80} and {$FOO-bar:80}. I think more people will be farmiliar with ${FOO-bar:80}, which is the same syntax as shell
5. Added more test cases, and fix one test failure
