### PR TITLE
add scan on NULL group for handle stale hosts with no group

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/Constants.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/Constants.java
@@ -38,6 +38,11 @@ public class Constants {
     public static final int DEFAULT_DEPLOY_NUM = 5000;
     public static final int DEFAULT_DEPLOY_DAY = 365;
 
+    // TODO this is a hack to use NULL represent host with not group info
+    // Ideally we use database value NULL, but it will break a lot of existing
+    // functions, need to revisit
+    public static final String NULL_HOST_GROUP = "NULL";
+
     public static final String CONFIG_TYPE_GROUP = "ASG Config Change";
     public static final String CONFIG_TYPE_ENV = "Deploy Env Config Change";
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
@@ -29,6 +29,7 @@ import com.pinterest.deployservice.bean.OpCode;
 import com.pinterest.deployservice.bean.PingReportBean;
 import com.pinterest.deployservice.bean.PingRequestBean;
 import com.pinterest.deployservice.bean.PingResponseBean;
+import com.pinterest.deployservice.common.Constants;
 import com.pinterest.deployservice.common.DeployInternalException;
 import com.pinterest.deployservice.common.StateMachines;
 import com.pinterest.deployservice.dao.AgentDAO;
@@ -73,7 +74,7 @@ public class PingHandler {
         NOOP.setOpCode(OpCode.NOOP);
 
         // TODO better to treat empty group as REAL NULL
-        EMPTY_GROUPS = new HashSet<>(Arrays.asList("NULL"));
+        EMPTY_GROUPS = new HashSet<>(Arrays.asList(Constants.NULL_HOST_GROUP));
     }
 
     private AgentDAO agentDAO;

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/SimpleAgentJanitor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/SimpleAgentJanitor.java
@@ -20,6 +20,7 @@ import com.pinterest.deployservice.bean.AgentBean;
 import com.pinterest.deployservice.bean.AgentState;
 import com.pinterest.deployservice.bean.HostBean;
 import com.pinterest.deployservice.bean.HostState;
+import com.pinterest.deployservice.common.Constants;
 import com.pinterest.deployservice.dao.AgentDAO;
 import com.pinterest.deployservice.dao.GroupDAO;
 import com.pinterest.deployservice.dao.HostDAO;
@@ -163,6 +164,8 @@ public class SimpleAgentJanitor implements Runnable {
     void processBatch() throws Exception {
         // First, check those groups associates with certain envs
         List<String> groups = groupDAO.getAllEnvGroups();
+        // Manually inject the NULL group
+        groups.add(Constants.NULL_HOST_GROUP);
         Collections.shuffle(groups);
         for (String group : groups) {
             try {


### PR DESCRIPTION
By handling also the NULL group explicitly, it will find the stale host, and use the host_id, which is the same as host_name, check AWS if it exists, if not, delete all the records indexed by host_id/host_name.
