### PR TITLE
Add percentage based auto-scaling

### DIFF
--- a/deploy-board/deploy_board/templates/groups/asg_policy.tmpl
+++ b/deploy-board/deploy_board/templates/groups/asg_policy.tmpl
@@ -8,21 +8,35 @@
                     <label for="scaleUpSize" class="deployToolTip control-label col-xs-2"
                         data-toggle="tooltip"
                         title="minimum number of hosts in one autoscaling group">
-                        Scaleup by:
+                        Scale up:
                     </label>
 
-                    <div class="col-xs-3">
+                    <div class="col-xs-1">
                     <div class="input-group">
                     {% if policy.enabled %}
-                        <input class="form-control" name="scaleupSize" required="true"
+                        <input class="form-control col-xs-1" name="scaleupSize" required="true"
                                type="text" value="{{ policy.scaleUpSize }}"/>
                     {% else %}
-                        <input class="form-control" name="scaleupSize" required="true"
+                        <input class="form-control col-xs-1" name="scaleupSize" required="true"
                                type="text" value=""/>
                     {% endif %}
-                    <span class="input-group-addon">instances</span>
+
                     </div>
                     </div>
+
+                <div class="col-xs-2">
+                <select class="form-control" name="scaleupType" required="true" id="scaleupSelectId">
+
+                   {% if policy.scaleUpType == "ChangeInCapacity" %}
+                   <option value="ChangeInCapacity" selected>Instances</option>
+                   <option value="PercentChangeInCapacity">Percent of the group</option>
+                   {% else %}
+                   <option value="ChangeInCapacity">Instances</option>
+                   <option value="PercentChangeInCapacity" selected>Percent of the group</option>
+                   {% endif %}
+
+               </select>
+            </div>
                     <label for="maxSize" class="deployToolTip control-label col-xs-2"
                         data-toggle="tooltip"
                         title="maximum number of hosts in one autoscaling group">
@@ -41,7 +55,7 @@
                     <span class="input-group-addon">minutes</span>
                     </div>
                     </div>
-                     <label for="maxSize" class="deployToolTip control-label col-xs-3"
+                     <label for="maxSize" class="deployToolTip control-label col-xs-2"
                         style="font-weight: normal !important">
                         before allowing another activity
                     </label>
@@ -51,10 +65,9 @@
                     <label for="minSize" class="deployToolTip control-label col-xs-2"
                         data-toggle="tooltip"
                         title="minimum number of hosts in one autoscaling group">
-                        Scaledown by:
+                        Scale down:
                     </label>
-
-                    <div class="col-xs-3">
+                    <div class="col-xs-1">
                     <div class="input-group">
                     {% if policy.enabled %}
                         <input class="form-control" name="scaledownSize" required="true"
@@ -63,9 +76,22 @@
                         <input class="form-control" name="scaledownSize" required="true"
                                type="text" value=""/>
                     {% endif %}
-                    <span class="input-group-addon">instances</span>
+
                     </div>
                     </div>
+<div class="col-xs-2">
+                <select class="form-control" name="scaledownType" required="true" id="scaledownSelectId">
+
+                   {% if policy.scaleDownType == "ChangeInCapacity" %}
+                   <option value="ChangeInCapacity" selected>Instances</option>
+                   <option value="PercentChangeInCapacity">Percent of the group</option>
+                   {% else %}
+                   <option value="ChangeInCapacity">Instances</option>
+                   <option value="PercentChangeInCapacity" selected>Percent of the group</option>
+                   {% endif %}
+
+               </select>
+               </div>
                     <label for="maxSize"  class="deployToolTip control-label col-xs-2"
                         data-toggle="tooltip">
                          and then wait for:
@@ -85,7 +111,7 @@
 
                     </div>
 
-                     <label for="maxSize" style="font-weight: normal !important" class="control-label col-xs-3">
+                     <label for="maxSize" style="font-weight: normal !important" class="control-label col-xs-2">
                         before allowing another activity
                     </label>
                 </div>

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -35,6 +35,7 @@ log = logging.getLogger(__name__)
 
 DEFAULT_PAGE_SIZE = 50
 
+ScalingType = ["ChangeInCapacity", "ExactCapacity", "PercentChangeInCapacity"]
 
 def group_landing(request):
     index = int(request.GET.get('page_index', '1'))
@@ -253,6 +254,8 @@ class ScalingPolicy(object):
             self.scaleDownSize = policies.get("scaledownPolicies")[0].get("scaleSize")
             self.scaleUpCoolDownTime = policies.get("scaleupPolicies")[0].get("coolDown")
             self.scaleDownCoolDownTime = policies.get("scaledownPolicies")[0].get("coolDown")
+            self.scaleUpType = policies.get("scaleupPolicies")[0].get("scalingType")
+            self.scaleDownType = policies.get("scaleupPolicies")[0].get("scalingType")
 
 
 def get_policy(request, group_name):
@@ -273,8 +276,10 @@ def update_policy(request, group_name):
         scaling_policies["scaleupPolicies"] = []
         scaling_policies["scaledownPolicies"] = []
         scaling_policies["scaleupPolicies"].append({"scaleSize": make_int(params["scaleupSize"]),
+                                                    "scalingType": params["scaleupType"],
                                                     "coolDown": make_int(params["scaleupCooldownTime"])})
         scaling_policies["scaledownPolicies"].append({"scaleSize": make_int(params["scaledownSize"]),
+                                                      "scalingType": params["scaledownType"],
                                                       "coolDown": make_int(params["scaleDownCooldownTime"])})
 
         groups_helper.put_scaling_policies(request, group_name, scaling_policies)

--- a/deploy-board/deploy_board/webapp/helpers/groups_helper.py
+++ b/deploy-board/deploy_board/webapp/helpers/groups_helper.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/deploy-service/common/src/main/java/com/pinterest/arcee/autoscaling/AwsAutoScaleGroupManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/arcee/autoscaling/AwsAutoScaleGroupManager.java
@@ -388,7 +388,7 @@ public class AwsAutoScaleGroupManager implements AutoScaleGroupManager {
     @Override
     public void addScalingPolicyToGroup(String groupName, ScalingPolicyBean policyBean) throws Exception {
         PutScalingPolicyRequest request = new PutScalingPolicyRequest();
-        request.setAdjustmentType("ChangeInCapacity");
+        request.setAdjustmentType(policyBean.getScalingType());
         request.setPolicyName(policyBean.getPolicyName());
         request.setAutoScalingGroupName(groupName);
         request.setScalingAdjustment(policyBean.getScaleSize());
@@ -407,6 +407,7 @@ public class AwsAutoScaleGroupManager implements AutoScaleGroupManager {
             for (ScalingPolicy policy : policySet) {
                 ScalingPolicyBean bean = new ScalingPolicyBean();
                 bean.setCoolDownTime(policy.getCooldown() / 60);
+                bean.setScalingType(policy.getAdjustmentType());
                 bean.setPolicyName(policy.getPolicyName());
                 bean.setScaleSize(policy.getScalingAdjustment());
                 bean.setARN(policy.getPolicyARN());

--- a/deploy-service/common/src/main/java/com/pinterest/arcee/bean/ScalingPolicyBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/arcee/bean/ScalingPolicyBean.java
@@ -26,6 +26,12 @@ public class ScalingPolicyBean {
     private String policyName;
 
     @NotNull
+    @JsonProperty("scalingType")
+    private String scalingType;
+    /*
+     *
+     */
+    @NotNull
     @JsonProperty("scaleSize")
     private int scaleSize;
 
@@ -43,6 +49,10 @@ public class ScalingPolicyBean {
     public void setPolicyName(String policyName) {
         this.policyName = policyName;
     }
+
+    public String getScalingType() { return scalingType; }
+
+    public void setScalingType(String scalingType) { this.scalingType = scalingType; }
 
     public int getScaleSize() {
         return scaleSize;

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/ReservedInstanceScheduler.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/ReservedInstanceScheduler.java
@@ -11,7 +11,6 @@ import com.pinterest.arcee.metrics.MetricSource;
 import com.pinterest.deployservice.ServiceContext;
 
 import java.util.*;
-import java.util.concurrent.ExecutionException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
As discussed in the task:
Percentage based auto-scaling. Right now I (afaik) can only scale up and down using a set number of instances. That turns out to be problematic when the min number of instances is very low (we have some clusters where we do no work at all for periods of time), since the impact of the scale up/down actions ends varying quite a lot depending on how far the cluster has already scaled. Having the ability to do percentage based scaling would help with this.

@sbaogang @yujunglo 