### PR TITLE
Remove use of javafx.util.Pair class

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/group/CMDBHostGroupManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/group/CMDBHostGroupManager.java
@@ -22,7 +22,6 @@ import com.google.gson.JsonParser;
 import com.pinterest.deployservice.bean.HostBean;
 import com.pinterest.deployservice.common.CommonUtils;
 import com.pinterest.deployservice.common.HTTPClient;
-import javafx.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -151,5 +150,23 @@ public class CMDBHostGroupManager implements HostGroupManager {
                 URLEncoder.encode(entry.getValue(), "UTF-8")));
         }
         return sb.toString();
+    }
+
+    private static class Pair<K, V> {
+        private final K key;
+        private final V val;
+
+        private Pair(K key, V val) {
+            this.key = key;
+            this.val = val;
+        }
+
+        private K getKey() {
+            return key;
+        }
+
+        private V getValue() {
+            return val;
+        }
     }
 }


### PR DESCRIPTION
Remove use of the javafx Pair class and replace it with a locally defined Pair class.

Depending on how the JDK is installed, sometimes JavaFX (javafx-mx.jar) isn't available. I only discovered this since it's an option in Gentoo Linux so I don't imagine this affects many people at all. But, it seemed weird to make use of JavaFX in a web service just for a single utility class, so I've removed it with this PR.

Feel free to close this PR if this isn't desired. Thanks!