### PR TITLE
Prevent overwriting terminating host state

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostDAOImpl.java
@@ -35,7 +35,8 @@ public class DBHostDAOImpl implements HostDAO {
             "LEFT JOIN agent_errors ON agents.host_name=agent_errors.host_name WHERE hosts.host_id=?";
     private static final String UPDATE_HOST_BY_ID = "UPDATE hosts SET %s WHERE host_id=?";
     private static final String INSERT_HOST_TEMPLATE = "INSERT INTO hosts SET %s ON DUPLICATE KEY UPDATE %s";
-    private static final String INSERT_UPDATE_TEMPLATE = "INSERT INTO hosts %s VALUES %s ON DUPLICATE KEY UPDATE ip=?, last_update=?, state=?, " +
+    private static final String INSERT_UPDATE_TEMPLATE = "INSERT INTO hosts %s VALUES %s ON DUPLICATE KEY UPDATE ip=?, last_update=?, " +
+            "state=IF(state!='%s' AND state!='%s', VALUES(state), state), " +
             "host_name=CASE WHEN host_name IS NULL THEN ? WHEN host_name=host_id THEN ? ELSE host_name END, " +
             "ip=CASE WHEN ip IS NULL THEN ? ELSE ip END";
     private static final String DELETE_HOST_BY_ID = "DELETE FROM hosts WHERE host_id=?";
@@ -97,6 +98,7 @@ public class DBHostDAOImpl implements HostDAO {
     public void insertOrUpdate(String hostName, String ip, String hostId, String state, Set<String> groupNames) throws Exception {
         long now = System.currentTimeMillis();
         //TODO need to refactoring this to be more generic to all columns, e.g. use genStringGroupClause() like the other DAOs
+        // If state is PENDING_TERMINATE or TERMINATING, do not overwrite its state
         StringBuilder names = new StringBuilder("(host_id,group_name,create_date,last_update,state");
         if (hostName != null) {
             names.append(",host_name");
@@ -132,7 +134,8 @@ public class DBHostDAOImpl implements HostDAO {
             sb.append("'),");
         }
         sb.setLength(sb.length() - 1);
-        new QueryRunner(dataSource).update(String.format(INSERT_UPDATE_TEMPLATE, names, sb.toString()), ip, now, state, hostName, hostName, ip);
+        new QueryRunner(dataSource).update(String.format(INSERT_UPDATE_TEMPLATE, names, sb.toString(),
+                HostState.PENDING_TERMINATE.toString(), HostState.TERMINATING.toString()), ip, now, hostName, hostName, ip);
     }
 
     @Override

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
@@ -124,11 +124,11 @@ public class PingHandler {
         return cache.get(key);
     }
 
-    // Keep host and group memebership in sync
+    // Keep host and group membership in sync
     void updateHosts(PingRequestBean pingRequest) throws Exception {
         hostDAO.insertOrUpdate(pingRequest.getHostName(), pingRequest.getHostIp(),
-            pingRequest.getHostId(), HostState.ACTIVE.toString(), pingRequest.getGroups());
-
+                pingRequest.getHostId(), HostState.ACTIVE.toString(), pingRequest.getGroups());
+        
         List<String> recordedGroups = hostDAO.getGroupNamesByHost(pingRequest.getHostName());
         Set<String> groups = pingRequest.getGroups();
         for (String recordedGroup : recordedGroups) {

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/db/DBDAOTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/db/DBDAOTest.java
@@ -574,7 +574,10 @@ public class DBDAOTest {
         // Added 2 hosts to group1 and group2
         Set<String> groups = new HashSet<>(Arrays.asList("group1", "group2"));
         hostDAO.insertOrUpdate("host-1", "1.1.1.1", "id-123434", HostState.ACTIVE.toString(), groups);
+        hostDAO.insertOrUpdate("host-2", "1.1.1.2", "id-123435", HostState.TERMINATING.toString(), groups);
         hostDAO.insertOrUpdate("host-2", "1.1.1.2", "id-123435", HostState.ACTIVE.toString(), groups);
+        List<HostBean> hostBeans = hostDAO.getHostsByHostId("id-123435");
+        assertEquals(hostBeans.get(0).getState(), HostState.TERMINATING);
 
         // Total capacity for env-1 should be 3, host1, host-1(group1), host-2(group2)
         assertEquals(environDAO.getOverrideHosts("env-1", "s-1", "prod").size(), 0);


### PR DESCRIPTION
@sbaogang @jinruh 
Prevent overwriting the terminating host state to ACTIVE when agent pings back.