### PR TITLE
Use cloudwatch alarm to enable/disable scale up/down activities

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/arcee/autoscaling/AlarmManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/arcee/autoscaling/AlarmManager.java
@@ -30,6 +30,10 @@ public interface AlarmManager {
 
     void putMetricsToAlarm(String groupName, String metricName, Collection<MetricDatumBean> metricDataPoints) throws Exception;
 
+    void disableAlarm(List<String> actionId, String groupName) throws Exception;
+
+    void enableAlarm(List<String> actionId, String groupName) throws Exception;
+
     List<String> listAwsMetrics(String groupName) throws Exception;
 
     List<MetricDatumBean> getMetricsStatistics(String groupName, String metricName, String startFrom) throws Exception;

--- a/deploy-service/common/src/main/java/com/pinterest/arcee/autoscaling/AwsAlarmManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/arcee/autoscaling/AwsAlarmManager.java
@@ -58,16 +58,39 @@ public class AwsAlarmManager implements AlarmManager {
 
         request.setMetricName(asgAlarmBean.getMetric_name());
         request.setThreshold(asgAlarmBean.getThreshold());
-        request.setAlarmName(getAlarmName(asgAlarmBean));
+        request.setAlarmName(getAlarmName(asgAlarmBean.getGroup_name(), asgAlarmBean.getAlarm_id()));
 
         acwClient.putMetricAlarm(request);
+    }
+
+
+    @Override
+    public void enableAlarm(List<String> alarmIds, String groupName) throws Exception {
+        List<String> alarmNames = new ArrayList<>();
+        for (String alarmId : alarmIds) {
+            alarmNames.add(getAlarmName(groupName, alarmId));
+        }
+        EnableAlarmActionsRequest request = new EnableAlarmActionsRequest();
+        request.setAlarmNames(alarmNames);
+        acwClient.enableAlarmActions(request);
+    }
+
+    @Override
+    public void disableAlarm(List<String> alarmIds, String groupName) throws Exception {
+        List<String> alarmNames = new ArrayList<>();
+        for (String alarmId : alarmIds) {
+            alarmNames.add(getAlarmName(groupName, alarmId));
+        }
+        DisableAlarmActionsRequest request = new DisableAlarmActionsRequest();
+        request.setAlarmNames(alarmNames);
+        acwClient.disableAlarmActions(request);
     }
 
     @Override
     public void deleteAlarmFromPolicy(AsgAlarmBean asgAlarmBean) throws Exception {
         DeleteAlarmsRequest request = new DeleteAlarmsRequest();
         List<String> alarmNames = new LinkedList<>();
-        alarmNames.add(getAlarmName(asgAlarmBean));
+        alarmNames.add(getAlarmName(asgAlarmBean.getGroup_name(), asgAlarmBean.getAlarm_id()));
         request.setAlarmNames(alarmNames);
         acwClient.deleteAlarms(request);
     }
@@ -135,8 +158,9 @@ public class AwsAlarmManager implements AlarmManager {
         return metricDataPoints;
     }
 
-    private String getAlarmName(AsgAlarmBean asgAlarmBean) {
-        return String.format("%s-alarm-%s", asgAlarmBean.getGroup_name(), asgAlarmBean.getAlarm_id());
+
+    private String getAlarmName(String groupName, String alarmId) {
+        return String.format("%s-alarm-%s", groupName, alarmId);
     }
 
     private Dimension getDimention(String groupName) {

--- a/deploy-service/common/src/main/java/com/pinterest/arcee/aws/EC2HostInfoDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/arcee/aws/EC2HostInfoDAOImpl.java
@@ -30,8 +30,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 
 public class EC2HostInfoDAOImpl implements HostInfoDAO {

--- a/deploy-service/common/src/main/java/com/pinterest/arcee/handler/GroupHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/arcee/handler/GroupHandler.java
@@ -697,8 +697,8 @@ public class GroupHandler {
         spotAlarmBean.setGroup_name(spotGroupName);
         spotAlarmBean.setMetric_source(asgAlarmBean.getMetric_source());
         spotAlarmBean.setMetric_name(asgAlarmBean.getMetric_name());
-        if (asgAlarmBean.getComparator().equals("LessThanOrEqualToThreshold")) {
-            spotAlarmBean.setThreshold(asgAlarmBean.getThreshold() * (1 - sensitivity_ratio));
+        if (asgAlarmBean.getComparator().equals("LessThanOrEqualToThreshold")) { // makes spot auto scaling more sensitive
+            spotAlarmBean.setThreshold(asgAlarmBean.getThreshold() * (1 + sensitivity_ratio));
         } else {
             spotAlarmBean.setThreshold(asgAlarmBean.getThreshold() * (1 - sensitivity_ratio));
         }


### PR DESCRIPTION
The spot auto scaling group would work as follows:
1. When there are enough reserved instance: disable scale up, enable scale down -> peak hours, scale up on demand group;  off-peak hours, scale down spot first, then on demand instance.
2. When the reserve instance inventory is low: disable scale down, enable scale up -> off-peak hours, scale down on demand first, then spot instance; peak hours: scale up spot instance first, then on demand instances.

@yujunglo 