### PR TITLE
Fix crash on downloading multipart S3 uploads.

### DIFF
--- a/deploy-agent/deployd/download/s3_download_helper.py
+++ b/deploy-agent/deployd/download/s3_download_helper.py
@@ -55,13 +55,16 @@ class S3DownloadHelper(DownloadHelper):
 
             filekey.get_contents_to_filename(local_full_fn)
             etag = filekey.etag
-            if etag.startswith('"') and etag.endswith('"'):
-                etag = etag[1:-1]
-
-            md5 = self.md5_file(local_full_fn)
-            if md5 != etag:
-                log.error("MD5 verification failed. tarball is corrupt.")
-                return Status.FAILED
+            if "-" not in etag:
+                if etag.startswith('"') and etag.endswith('"'):
+                    etag = etag[1:-1]
+            
+                md5 = self.md5_file(local_full_fn)
+                if md5 != etag:
+                    log.error("MD5 verification failed. tarball is corrupt.")
+                    return Status.FAILED
+            else:
+                log.info("MD5 verification currently not supported on multipart uploads.")
 
             log.info("Successfully downloaded to {}".format(local_full_fn))
             return Status.SUCCEEDED


### PR DESCRIPTION
As S3 stores multipart upload md5’s in a special format within the
etag, standard md5sum’ing doesn’t work and causes the download to fail.
See:
http://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders
.html and