### PR TITLE
Allowing set a percentage number for maximum number of hosts deployed

### DIFF
--- a/deploy-board/deploy_board/templates/configs/env_config.tmpl
+++ b/deploy-board/deploy_board/templates/configs/env_config.tmpl
@@ -8,14 +8,28 @@
                     <label for="maxParallelHosts" class="deployToolTip control-label col-xs-2"
                         data-toggle="tooltip"
                         title="Maximum number (or percentage) of hosts allowed to deploy at the same time">
-                        Maximum Deploys In Parallel
+                        Maximum Parallel Number
                     </label>
 
-                    <div class="col-xs-4">
+                    <div class="col-xs-2">                      
                         <div class="input-group">
-                            <input class="form-control" name="maxParallelHosts" required="true"
-                               type="text" value="{{ env.finalParallel }}"/>
-                            <span class="input-group-addon">eg. 5 or 20%</span>
+                            <span class="input-group-addon">
+                                <input type="radio" name="maxParallel" value="Number"
+                                    {% ifequal env.showNumber True%}checked{% endifequal %} >
+                            </span>
+                                <input type="text" id="maxParallelValue" name="maxParallelValue" class="form-control" 
+                                    value="{% ifequal env.showNumber True%}{{env.maxParallel}}{% endifequal %}">
+                        </div>
+                    </div>
+                    <div class="col-xs-2">
+                        <div class="input-group">
+                            <span class="input-group-addon">
+                                <input type="radio" name="maxParallel" value="Percentage"
+                                    {% ifequal env.showNumber False%}checked{% endifequal %}>
+                            </span>
+                            <input type="text" id="maxParallelPctValue" name="maxParallelPctValue" class="form-control" 
+                                    value="{% ifequal env.showNumber False %}{{ env.maxParallelPct }}{% endifequal %}">
+                            <span class="input-group-addon">%</span>
                         </div>
                     </div>
                     <label for="successThreshold" class="deployToolTip control-label col-xs-2"
@@ -269,6 +283,15 @@
                     $("#envConfigId").parent().html(data.html);
                 }
             });
+        });
+
+       $('input:radio[name=maxParallel]').change(function() {
+            if (this.value == 'Number') {
+                $('#maxParallelPctValue').attr('value','');   
+            }
+            else if (this.value == 'Percentage') {
+                 $('#maxParallelValue').attr('value', '');   
+            }
         });
     });
 </script>

--- a/deploy-board/deploy_board/templates/configs/env_config.tmpl
+++ b/deploy-board/deploy_board/templates/configs/env_config.tmpl
@@ -7,13 +7,16 @@
                 <div class="form-group">
                     <label for="maxParallelHosts" class="deployToolTip control-label col-xs-2"
                         data-toggle="tooltip"
-                        title="Maximum number of hosts allowed to deploy at the same time">
-                        Maximum Hosts
+                        title="Maximum number (or percentage) of hosts allowed to deploy at the same time">
+                        Maximum Deploys In Parallel
                     </label>
 
                     <div class="col-xs-4">
-                        <input class="form-control" name="maxParallelHosts" required="true"
-                               type="text" value="{{ env.maxParallel }}"/>
+                        <div class="input-group">
+                            <input class="form-control" name="maxParallelHosts" required="true"
+                               type="text" value="{{ env.finalParallel }}"/>
+                            <span class="input-group-addon">eg. 5 or 20%</span>
+                        </div>
                     </div>
                     <label for="successThreshold" class="deployToolTip control-label col-xs-2"
                         data-toggle="tooltip"
@@ -24,7 +27,7 @@
                     <div class="col-xs-4">
                         <div class="input-group">
                         <input class="form-control" name="successThreshold" required="true"
-                               type="text" value="{{ env.successThreshold|convertSuccThreshold }}"/>
+                               type="text" value="{{ env.successThreshold|convertSuccThreshold }}"/> 
                         <span class="input-group-addon">%</span>
                         </div>
                     </div>

--- a/deploy-board/deploy_board/webapp/helpers/environs_helper.py
+++ b/deploy-board/deploy_board/webapp/helpers/environs_helper.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -166,3 +166,12 @@ def get_config_history(request, env_name, stage_name, index, size):
     params = [('pageIndex', index), ('pageSize', size)]
     return deployclient.get("/envs/%s/%s/history" % (env_name, stage_name),
                             request.teletraan_user_id.token, params=params)
+
+
+def set_final_max_parallel(env):
+    max_parallel_hosts = int(env['maxParallel'])
+    max_parallel_pecentage = int(env['maxParallelDeployPercentage'])
+    if max_parallel_pecentage > 0:
+        env['finalParallel'] = "{0:.0f}%".format(max_parallel_pecentage)
+    else:
+        env['finalParallel'] = str(max_parallel_hosts) if max_parallel_hosts > 0 else "1"

--- a/deploy-board/deploy_board/webapp/helpers/environs_helper.py
+++ b/deploy-board/deploy_board/webapp/helpers/environs_helper.py
@@ -168,10 +168,8 @@ def get_config_history(request, env_name, stage_name, index, size):
                             request.teletraan_user_id.token, params=params)
 
 
-def set_final_max_parallel(env):
-    max_parallel_hosts = int(env['maxParallel'])
-    max_parallel_pecentage = int(env['maxParallelDeployPercentage'])
+def set_active_max_parallel(env):
+    max_parallel_pecentage = int(env['maxParallelPct'])
+    env['showNumber'] = True
     if max_parallel_pecentage > 0:
-        env['finalParallel'] = "{0:.0f}%".format(max_parallel_pecentage)
-    else:
-        env['finalParallel'] = str(max_parallel_hosts) if max_parallel_hosts > 0 else "1"
+        env['showNumber'] = False

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironBean.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2016 Pinterest, Inc.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
- *     http://www.apache.org/licenses/LICENSE-2.0
- *    
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,8 +16,10 @@
 package com.pinterest.deployservice.bean;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.pinterest.deployservice.common.Constants;
 import org.apache.commons.lang.builder.ReflectionToStringBuilder;
 import org.hibernate.validator.constraints.NotEmpty;
+import org.hibernate.validator.constraints.Range;
 
 import java.io.Serializable;
 
@@ -52,6 +54,7 @@ import java.io.Serializable;
  * max_deploy_num      INT           NOT NULL,
  * max_deploy_day      INT           NOT NULL,
  * is_docker           TINYINT(1)    DEFAULT 0,
+ * max_parallel_deploy_percentage TINYINT(1)
  * <p>
  * PRIMARY KEY   (env_id)
  * );
@@ -142,6 +145,10 @@ public class EnvironBean implements Updatable, Serializable {
 
     @JsonProperty("isDocker")
     private Boolean is_docker;
+
+    @Range(min = 0, max = 100)
+    @JsonProperty("maxParallelDeployPercentage")
+    private Integer max_parallel_deploy_percentage;
 
     public String getWebhooks_config_id() {
         return webhooks_config_id;
@@ -367,6 +374,15 @@ public class EnvironBean implements Updatable, Serializable {
         this.is_docker = is_docker;
     }
 
+    public Integer getMax_parallel_deploy_percentage() {
+        return max_parallel_deploy_percentage;
+    }
+
+    public void setMax_parallel_deploy_percentage(Integer max_parallel_deploy_percentage) {
+        this.max_parallel_deploy_percentage = max_parallel_deploy_percentage;
+    }
+
+
     @Override
     public SetClause genSetClause() {
         SetClause clause = new SetClause();
@@ -398,6 +414,7 @@ public class EnvironBean implements Updatable, Serializable {
         clause.addColumn("max_deploy_num", max_deploy_num);
         clause.addColumn("max_deploy_day", max_deploy_day);
         clause.addColumn("is_docker", is_docker);
+        clause.addColumn("max_parallel_deploy_percentage", max_parallel_deploy_percentage);
         return clause;
     }
 
@@ -405,4 +422,5 @@ public class EnvironBean implements Updatable, Serializable {
     public String toString() {
         return ReflectionToStringBuilder.toString(this);
     }
+
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironBean.java
@@ -16,7 +16,6 @@
 package com.pinterest.deployservice.bean;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.pinterest.deployservice.common.Constants;
 import org.apache.commons.lang.builder.ReflectionToStringBuilder;
 import org.hibernate.validator.constraints.NotEmpty;
 import org.hibernate.validator.constraints.Range;
@@ -54,7 +53,7 @@ import java.io.Serializable;
  * max_deploy_num      INT           NOT NULL,
  * max_deploy_day      INT           NOT NULL,
  * is_docker           TINYINT(1)    DEFAULT 0,
- * max_parallel_deploy_percentage TINYINT(1)
+ * max_parallel_pct TINYINT(1)
  * <p>
  * PRIMARY KEY   (env_id)
  * );
@@ -147,8 +146,8 @@ public class EnvironBean implements Updatable, Serializable {
     private Boolean is_docker;
 
     @Range(min = 0, max = 100)
-    @JsonProperty("maxParallelDeployPercentage")
-    private Integer max_parallel_deploy_percentage;
+    @JsonProperty("maxParallelPct")
+    private Integer max_parallel_pct;
 
     public String getWebhooks_config_id() {
         return webhooks_config_id;
@@ -374,12 +373,12 @@ public class EnvironBean implements Updatable, Serializable {
         this.is_docker = is_docker;
     }
 
-    public Integer getMax_parallel_deploy_percentage() {
-        return max_parallel_deploy_percentage;
+    public Integer getMax_parallel_pct() {
+        return max_parallel_pct;
     }
 
-    public void setMax_parallel_deploy_percentage(Integer max_parallel_deploy_percentage) {
-        this.max_parallel_deploy_percentage = max_parallel_deploy_percentage;
+    public void setMax_parallel_pct(Integer max_parallel_pct) {
+        this.max_parallel_pct = max_parallel_pct;
     }
 
 
@@ -414,7 +413,7 @@ public class EnvironBean implements Updatable, Serializable {
         clause.addColumn("max_deploy_num", max_deploy_num);
         clause.addColumn("max_deploy_day", max_deploy_day);
         clause.addColumn("is_docker", is_docker);
-        clause.addColumn("max_parallel_deploy_percentage", max_parallel_deploy_percentage);
+        clause.addColumn("max_parallel_pct", max_parallel_pct);
         return clause;
     }
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/AgentDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/AgentDAO.java
@@ -63,4 +63,7 @@ public interface AgentDAO {
 
     // return how many agent state is PAUSED_BY_SYSTEM, or stuck/failed
     long countStuckAgent(String envId, String deployId) throws Exception;
+
+    // return how many agents that are not first time deploy for the environment
+    long countNonFirstDeployingAgent(String envId) throws Exception;
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBAgentDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBAgentDAOImpl.java
@@ -60,6 +60,8 @@ public class DBAgentDAOImpl implements AgentDAO {
     private static final String GET_STUCK_TOTAL =
         "SELECT COUNT(*) FROM agents " +
             "WHERE env_id=? AND deploy_id=? AND state='PAUSED_BY_SYSTEM'";
+    private static final String GET_NON_FIRST_TIME_DEPLOY_TOTAL =
+            "SELECT COUNT(*) FROM agents WHERE env_id=? AND first_deploy=0";
     private static final String GET_TOTAL =
         "SELECT COUNT(*) FROM agents WHERE env_id=? AND state!='PAUSED_BY_USER'";
     private static final String RESET_FAILED_AGENTS =
@@ -183,6 +185,13 @@ public class DBAgentDAOImpl implements AgentDAO {
     public long countAgentByEnv(String envId) throws Exception {
         Long n = new QueryRunner(dataSource).query(GET_TOTAL,
             SingleResultSetHandlerFactory.<Long>newObjectHandler(), envId);
+        return n == null ? 0 : n;
+    }
+
+    @Override
+    public long countNonFirstDeployingAgent(String envId) throws Exception{
+        Long n = new QueryRunner(dataSource).query(GET_NON_FIRST_TIME_DEPLOY_TOTAL,
+                SingleResultSetHandlerFactory.<Long>newObjectHandler(), envId);
         return n == null ? 0 : n;
     }
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/EnvironHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/EnvironHandler.java
@@ -80,11 +80,11 @@ public class EnvironHandler {
 
         //If the update contains either max parallel number or percentage. We clear the other by set
         //to 0. Note: the null value of bean won't propagate to the database
-        if(envBean.getMax_parallel() != null && envBean.getMax_parallel_deploy_percentage()==null){
-            envBean.setMax_parallel_deploy_percentage(0);
+        if(envBean.getMax_parallel() != null && envBean.getMax_parallel_pct()==null){
+            envBean.setMax_parallel_pct(0);
         }
 
-        if(envBean.getMax_parallel() == null && envBean.getMax_parallel_deploy_percentage()!=null){
+        if(envBean.getMax_parallel() == null && envBean.getMax_parallel_pct()!=null){
             envBean.setMax_parallel(0);
         }
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/EnvironHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/EnvironHandler.java
@@ -78,6 +78,16 @@ public class EnvironHandler {
             }
         }
 
+        //If the update contains either max parallel number or percentage. We clear the other by set
+        //to 0. Note: the null value of bean won't propagate to the database
+        if(envBean.getMax_parallel() != null && envBean.getMax_parallel_deploy_percentage()==null){
+            envBean.setMax_parallel_deploy_percentage(0);
+        }
+
+        if(envBean.getMax_parallel() == null && envBean.getMax_parallel_deploy_percentage()!=null){
+            envBean.setMax_parallel(0);
+        }
+
         envBean.setLast_operator(operator);
         envBean.setLast_update(System.currentTimeMillis());
     }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
@@ -561,8 +561,18 @@ public class PingHandler {
 
         //Ensure the value falls into the range making sense
         if (ret <= 0) {
+            LOG.warn("Unexpected ret value {}. Max parallel:{} Max parallel percentage:{} TotalHosts:{}",
+                    ret,
+                    environBean.getMax_parallel(),
+                    environBean.getMax_parallel_pct(),
+                    totalHosts);
             ret = 1;
         } else if (ret > totalHosts) {
+            LOG.warn("Unexpected ret value {}. Max parallel:{} Max parallel percentage:{} TotalHosts:{}",
+                    ret,
+                    environBean.getMax_parallel(),
+                    environBean.getMax_parallel_pct(),
+                    totalHosts);
             ret = (int) totalHosts;
         }
         return ret;

--- a/deploy-service/common/src/main/resources/sql/deploy.sql
+++ b/deploy-service/common/src/main/resources/sql/deploy.sql
@@ -33,6 +33,7 @@ CREATE TABLE IF NOT EXISTS environs (
     max_deploy_num      INT           NOT NULL,
     max_deploy_day      INT           NOT NULL,
     is_docker           TINYINT(1)    NOT NULL DEFAULT 0,
+    max_parallel_deploy_percentage TINYINT(1), 
     PRIMARY KEY   (env_id)
 );
 CREATE UNIQUE INDEX env_name_stage_idx ON environs (env_name, stage_name);

--- a/deploy-service/common/src/main/resources/sql/deploy.sql
+++ b/deploy-service/common/src/main/resources/sql/deploy.sql
@@ -33,7 +33,7 @@ CREATE TABLE IF NOT EXISTS environs (
     max_deploy_num      INT           NOT NULL,
     max_deploy_day      INT           NOT NULL,
     is_docker           TINYINT(1)    NOT NULL DEFAULT 0,
-    max_parallel_deploy_percentage TINYINT(1), 
+    max_parallel_pct    TINYINT(1), 
     PRIMARY KEY   (env_id)
 );
 CREATE UNIQUE INDEX env_name_stage_idx ON environs (env_name, stage_name);

--- a/deploy-service/common/src/main/resources/sql/upgrade_plan_20160427.txt
+++ b/deploy-service/common/src/main/resources/sql/upgrade_plan_20160427.txt
@@ -1,0 +1,7 @@
+UPDATES
+=================
+ALTER TABLE environs ADD COLUMN max_parallel_deploy_percentage TINYINT(1)    NOT NULL DEFAULT 0;
+
+Rollback
+===========================
+ALTER TABLE environs DROP COLUMN max_parallel_deploy_percentage;

--- a/deploy-service/common/src/main/resources/sql/upgrade_plan_20160427.txt
+++ b/deploy-service/common/src/main/resources/sql/upgrade_plan_20160427.txt
@@ -1,7 +1,7 @@
 UPDATES
 =================
-ALTER TABLE environs ADD COLUMN max_parallel_deploy_percentage TINYINT(1)    NOT NULL DEFAULT 0;
+ALTER TABLE environs ADD COLUMN max_parallel_pct TINYINT(1)    NOT NULL DEFAULT 0;
 
 Rollback
 ===========================
-ALTER TABLE environs DROP COLUMN max_parallel_deploy_percentage;
+ALTER TABLE environs DROP COLUMN max_parallel_pct;

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/handler/PingHandlerTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/handler/PingHandlerTest.java
@@ -24,7 +24,7 @@ public class PingHandlerTest {
 
         //Only percentage set
         bean.setMax_parallel(null);
-        bean.setMax_parallel_deploy_percentage(20);
+        bean.setMax_parallel_pct(20);
         Assert.assertEquals(1, PingHandler.getFinalMaxParallelCount(bean, 1));
         Assert.assertEquals(2, PingHandler.getFinalMaxParallelCount(bean, 10));
         Assert.assertEquals(20, PingHandler.getFinalMaxParallelCount(bean, 100));

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/handler/PingHandlerTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/handler/PingHandlerTest.java
@@ -1,0 +1,39 @@
+package com.pinterest.deployservice.handler;
+
+import com.pinterest.deployservice.bean.EnvironBean;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Created by lidali on 4/26/16.
+ */
+public class PingHandlerTest {
+    @Test
+    public void getGetFinalMaxParallelCount() throws Exception {
+        EnvironBean bean = new EnvironBean();
+        //Always return 1 when nothing set
+        Assert.assertEquals(1, PingHandler.getFinalMaxParallelCount(bean, 1));
+        Assert.assertEquals(1, PingHandler.getFinalMaxParallelCount(bean, 10));
+        Assert.assertEquals(1, PingHandler.getFinalMaxParallelCount(bean, 100));
+
+        //Only hosts set
+        bean.setMax_parallel(10);
+        Assert.assertEquals(1, PingHandler.getFinalMaxParallelCount(bean, 1));
+        Assert.assertEquals(10, PingHandler.getFinalMaxParallelCount(bean, 10));
+        Assert.assertEquals(10, PingHandler.getFinalMaxParallelCount(bean, 100));
+
+        //Only percentage set
+        bean.setMax_parallel(null);
+        bean.setMax_parallel_deploy_percentage(20);
+        Assert.assertEquals(1, PingHandler.getFinalMaxParallelCount(bean, 1));
+        Assert.assertEquals(2, PingHandler.getFinalMaxParallelCount(bean, 10));
+        Assert.assertEquals(20, PingHandler.getFinalMaxParallelCount(bean, 100));
+
+        //Both set, pick the smaller one
+        bean.setMax_parallel(10);
+        Assert.assertEquals(1, PingHandler.getFinalMaxParallelCount(bean, 1));
+        Assert.assertEquals(2, PingHandler.getFinalMaxParallelCount(bean, 10));
+        Assert.assertEquals(10, PingHandler.getFinalMaxParallelCount(bean, 100));
+
+    }
+}


### PR DESCRIPTION
Allowing set a percentage number for maximum number of hosts deployed  in parallel. Originally, only a fixed number of hosts can be specified. This is not ideal for an environment with dynamically scaling. Now, we support set a percentage number. Note: The host number is still there. They are set not he same UI. When the input contains a %, it is treated a percentage. At UI and Bean level, we have tried to clear the other one when one is set.

Tests:
Unit tests coverage for algorithm to pick the right value.
Test set different values in the UI and validate the values have been used.