### PR TITLE
Read aws launch config directly instead of reading from db

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/arcee/autoscaling/AutoScalingManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/arcee/autoscaling/AutoScalingManager.java
@@ -54,7 +54,9 @@ public interface AutoScalingManager {
 
     AutoScalingGroupBean getAutoScalingGroupInfoByName(String asgName) throws Exception;
 
-    AwsVmBean getAutoScalingGroupInfo(String groupName) throws Exception;
+    AwsVmBean getAutoScalingGroupInfo(String clusterName) throws Exception;
+
+    AwsVmBean getLaunchConfigInfo(String launchConfigId) throws Exception;
 
     ASGStatus getAutoScalingGroupStatus(String groupName) throws Exception;
 

--- a/deploy-service/common/src/main/java/com/pinterest/arcee/handler/HealthCheckHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/arcee/handler/HealthCheckHandler.java
@@ -48,6 +48,7 @@ public class HealthCheckHandler {
     private GroupInfoDAO groupInfoDAO;
     private EnvironDAO environDAO;
     private ImageDAO imageDAO;
+    private GroupHandler groupHandler;
 
     public HealthCheckHandler(ServiceContext serviceContext) {
         healthCheckDAO = serviceContext.getHealthCheckDAO();
@@ -55,6 +56,7 @@ public class HealthCheckHandler {
         groupInfoDAO = serviceContext.getGroupInfoDAO();
         environDAO = serviceContext.getEnvironDAO();
         imageDAO = serviceContext.getImageDAO();
+        groupHandler = new GroupHandler(serviceContext);
     }
 
     String addNewHealthCheckRecord(String groupName, String envId, String amiId, String deployId, HealthCheckType type) throws Exception {
@@ -95,7 +97,7 @@ public class HealthCheckHandler {
                 return new ArrayList<>();
             }
 
-            GroupBean group = groupInfoDAO.getGroupInfo(groupName);
+            GroupBean group = groupHandler.getGroupInfoByClusterName(groupName);
             if (!group.getHealthcheck_state()) {
                 LOG.info("Health check isn't enabled yet");
                 return new ArrayList<>();

--- a/deploy-service/common/src/main/java/com/pinterest/arcee/handler/ProvisionHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/arcee/handler/ProvisionHandler.java
@@ -35,16 +35,18 @@ public class ProvisionHandler {
     private HostInfoDAO hostInfoDAO;
     private GroupInfoDAO groupInfoDAO;
     private AutoScalingManager asgDAO;
+    private GroupHandler groupHandler;
 
     public ProvisionHandler(ServiceContext serviceContext) {
         hostDAO = serviceContext.getHostDAO();
         hostInfoDAO = serviceContext.getHostInfoDAO();
         groupInfoDAO = serviceContext.getGroupInfoDAO();
         asgDAO = serviceContext.getAutoScalingManager();
+        groupHandler = new GroupHandler(serviceContext);
     }
 
     public List<String> launchNewInstances(String groupName, int instanceCnt, String subnet, String operator) throws Exception {
-        GroupBean groupBean = groupInfoDAO.getGroupInfo(groupName);
+        GroupBean groupBean = groupHandler.getGroupInfoByClusterName(groupName);
         if (groupBean != null) {
             if (groupBean.getAsg_status() == ASGStatus.ENABLED) {  // AutoScaling is enabled, increase the ASG capacity
                 LOG.info(String.format("Launch %d EC2 instances in AutoScalingGroup %s", instanceCnt, groupName));

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/ConfigHistoryHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/ConfigHistoryHandler.java
@@ -131,8 +131,6 @@ public class ConfigHistoryHandler {
                 if (type.equals(Constants.TYPE_ASG_GENERAL)) {
                     GroupBean newBean = gson.fromJson(configChange, GroupBean.class);
                     newBean.setGroup_name(groupName);
-                    String userData = new String(Base64.decodeBase64(newBean.getUser_data()));
-                    newBean.setUser_data(userData);
                     groupHandler.updateLaunchConfig(groupName, newBean);
                     updateConfigHistory(groupName, type, newBean, operator);
                 } else if (type.equals(Constants.TYPE_ASG_SCALING)) {

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/ConfigHelper.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/ConfigHelper.java
@@ -127,7 +127,7 @@ public class ConfigHelper {
             // TODO we should just use AwsConfigManager and get rid of the above 3
             context.setAwsConfigManager(awsFactory.buildAwsConfigManager());
             // TODO rename to manager
-            context.setHostInfoDAO(new EC2HostInfoDAOImpl(ec2Client));
+            context.setHostInfoDAO(new EC2HostInfoDAOImpl(ec2Client, context.getAwsConfigManager()));
             context.setReservedInstanceInfoDAO(new ReservedInstanceFetcher(ec2Client));
             context.setClusterManager(new AwsVmManager(context));
             context.setAwsManager(new AwsManagerImpl(context.getAwsConfigManager()));

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Groups.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Groups.java
@@ -97,7 +97,7 @@ public class Groups {
     @GET
     @Path("/{groupName: [a-zA-Z0-9\\-_]+}")
     public GroupBean get(@PathParam("groupName") String groupName) throws Exception {
-        return groupHandler.getLaunchConfig(groupName);
+        return groupHandler.getGroupInfoByClusterName(groupName);
     }
 
     @GET

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/HealthChecker.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/HealthChecker.java
@@ -44,7 +44,6 @@ import com.pinterest.deployservice.dao.UtilDAO;
 import com.pinterest.deployservice.handler.CommonHandler;
 import com.pinterest.deployservice.common.NotificationJob;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -409,10 +408,10 @@ public class HealthChecker implements Runnable {
                         Connection connection = utilDAO.getLock(lockName);
                         if (connection != null) {
                             try {
-                                groupBean.setImage_id(healthCheckBean.getAmi_id());
-                                String userData = new String(Base64.decodeBase64(groupBean.getUser_data()));
-                                groupBean.setUser_data(userData);
-                                groupHandler.updateLaunchConfig(groupName, groupBean);
+                                GroupBean newBean = new GroupBean();
+                                newBean.setImage_id(healthCheckBean.getAmi_id());
+                                groupHandler.updateLaunchConfig(groupName, newBean);
+
                                 newImageBean.setQualified(true);
                                 imageDAO.insertOrUpdate(newImageBean);
                             } catch (Exception ex) {
@@ -437,7 +436,7 @@ public class HealthChecker implements Runnable {
     }
 
     private void processHealthCheck(HealthCheckBean healthCheckBean) throws Exception {
-        GroupBean groupBean = groupInfoDAO.getGroupInfo(healthCheckBean.getGroup_name());
+        GroupBean groupBean = groupHandler.getGroupInfoByClusterName(healthCheckBean.getGroup_name());
         if (shouldTimeoutHealthCheck(healthCheckBean, groupBean)) {
             return;
         }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/SpotAutoScalingScheduler.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/SpotAutoScalingScheduler.java
@@ -27,6 +27,7 @@ import com.pinterest.arcee.dao.AlarmDAO;
 import com.pinterest.arcee.dao.GroupInfoDAO;
 import com.pinterest.arcee.dao.ReservedInstanceInfoDAO;
 import com.pinterest.arcee.dao.SpotAutoScalingDAO;
+import com.pinterest.arcee.handler.GroupHandler;
 import com.pinterest.clusterservice.bean.AwsVmBean;
 import com.pinterest.deployservice.ServiceContext;
 
@@ -46,6 +47,7 @@ public class SpotAutoScalingScheduler implements Runnable {
     private AlarmDAO asgAlarmDAO;
     private int spotAutoScalingThreshold;
     private AlarmManager alarmManager;
+    private GroupHandler groupHandler;
 
     public SpotAutoScalingScheduler(ServiceContext serviceContext) {
         spotAutoScalingDAO = serviceContext.getSpotAutoScalingDAO();
@@ -56,6 +58,7 @@ public class SpotAutoScalingScheduler implements Runnable {
         spotAutoScalingThreshold = serviceContext.getSpotAutoScalingThreshold();
         asgAlarmDAO = serviceContext.getAlarmDAO();
         alarmManager = serviceContext.getAlarmManager();
+        groupHandler = new GroupHandler(serviceContext);
         LOG.info(String.format("Set spot auto scaling threshold to %d", spotAutoScalingThreshold));
     }
 
@@ -81,7 +84,7 @@ public class SpotAutoScalingScheduler implements Runnable {
     }
 
     private void processSpotAutoScaling(String clusterName, SpotAutoScalingBean spotAutoScalingBean) throws Exception {
-        GroupBean groupBean = groupInfoDAO.getGroupInfo(clusterName);
+        GroupBean groupBean = groupHandler.getGroupInfoByClusterName(clusterName);
         if (groupBean == null) {
             return;
         }


### PR DESCRIPTION
@jinruh @sbaogang 
encoding user data and transforming role name into instance profile will be taken care by createLaunchConfigInternal (in AwsAutoScalingManager) and launchEC2Instances (in EC2HostInfoDAOImpl). 

decoding user data and transforming instance profile to role name will be take care by getLaunchConfigInfo (in AwsAutoScalingManager).