### PR TITLE
spelling fixes

### DIFF
--- a/deploy-agent/deployd/agent.py
+++ b/deploy-agent/deployd/agent.py
@@ -299,7 +299,7 @@ class DeployAgent(object):
         # update deploy_status from response for the environment
         self._envs[env_name].update_by_response(response)
 
-        # update script varibales
+        # update script variables
         if deploy_goal.scriptVariables:
             log.info('Start to generate script variables for deploy: {}'.
             format(deploy_goal.deployId))

--- a/deploy-agent/deployd/agent.py
+++ b/deploy-agent/deployd/agent.py
@@ -122,7 +122,7 @@ class DeployAgent(object):
             if deploy_report.status_code in [AgentStatus.AGENT_FAILED,
                                              AgentStatus.TOO_MANY_RETRY,
                                              AgentStatus.SCRIPT_TIMEOUT]:
-                log.error('Unexpeted exceptions: {}, error message {}'.format(
+                log.error('Unexpected exceptions: {}, error message {}'.format(
                     deploy_report.status_code, deploy_report.output_msg))
                 return
 

--- a/deploy-agent/deployd/agent.py
+++ b/deploy-agent/deployd/agent.py
@@ -296,7 +296,7 @@ class DeployAgent(object):
         if (self._envs is None) or (self._envs.get(env_name) is None):
             self._envs[env_name] = DeployStatus()
 
-        # update deploy_status from response for the environemnt
+        # update deploy_status from response for the environment
         self._envs[env_name].update_by_response(response)
 
         # update script varibales

--- a/deploy-agent/deployd/agent.py
+++ b/deploy-agent/deployd/agent.py
@@ -194,7 +194,7 @@ class DeployAgent(object):
             if curr_stage == DeployStage.DOWNLOADING:
                 return self._executor.run_cmd(self.get_download_script(deploy_goal=deploy_goal))
             elif curr_stage == DeployStage.STAGING:
-                log.info("set up symbolink for the package: {}".format(deploy_goal.deployId))
+                log.info("set up symlink for the package: {}".format(deploy_goal.deployId))
                 return self._executor.run_cmd(self.get_staging_script())
             else:
                 return self._executor.execute_command(curr_stage)

--- a/deploy-agent/deployd/client/client.py
+++ b/deploy-agent/deployd/client/client.py
@@ -105,7 +105,7 @@ class Client(BaseClient):
                 if isinstance(report.errorMessage, str):
                     report.errorMessage = unicode(report.errorMessage, "utf-8")
 
-                # We ignore non-ascii charater for now, we should further solve this problem on
+                # We ignore non-ascii character for now, we should further solve this problem on
                 # the server side:
                 # https://app.asana.com/0/11815463290546/40714916594784
                 if report.errorMessage:

--- a/deploy-agent/deployd/common/config.py
+++ b/deploy-agent/deployd/common/config.py
@@ -198,7 +198,7 @@ class Config(object):
     def get_subprocess_running_timeout(self):
         return self.get_intvar('process_timeout', 1800)
 
-    def get_subproces_max_retry(self):
+    def get_subprocess_max_retry(self):
         return self.get_intvar('max_retry', 3)
 
     def get_subprocess_max_log_bytes(self):

--- a/deploy-agent/deployd/common/decorators.py
+++ b/deploy-agent/deployd/common/decorators.py
@@ -42,7 +42,7 @@ def retry(ExceptionToCheck, tries=4, delay=3, backoff=2):
     Similar to utils.decorators.retry() but customized slightly for operations tools.
 
     :param ExceptionToCheck: the exception to check. may be a tuple of
-        excpetions to check
+        exceptions to check
     :type ExceptionToCheck: Exception or tuple
     :param tries: number of times to try (not retry) before giving up
     :type tries: int

--- a/deploy-agent/deployd/common/executor.py
+++ b/deploy-agent/deployd/common/executor.py
@@ -39,7 +39,7 @@ class Executor(object):
         self.LOG_FILENAME = config.get_subprocess_log_name()
         self.MAX_RUNNING_TIME = config.get_subprocess_running_timeout()
         self.MIN_RUNNING_TIME = config.get_agent_ping_interval()
-        self.MAX_RETRY = config.get_subproces_max_retry()
+        self.MAX_RETRY = config.get_subprocess_max_retry()
         self.MAX_TAIL_BYTES = config.get_subprocess_max_log_bytes()
         self.PROCESS_POLL_INTERVAL = config.get_subprocess_poll_interval()
         self.BACK_OFF = config.get_backoff_factor()

--- a/deploy-agent/deployd/common/utils.py
+++ b/deploy-agent/deployd/common/utils.py
@@ -69,7 +69,7 @@ def debug(sig, frame):
     d.update(frame.f_locals)
 
     i = code.InteractiveConsole(d)
-    message = "Signal recieved : entering python shell.\nTraceback:\n"
+    message = "Signal received : entering python shell.\nTraceback:\n"
     message += ''.join(traceback.format_stack(frame))
     i.interact(message)
 

--- a/deploy-board/README.md
+++ b/deploy-board/README.md
@@ -1,3 +1,3 @@
-deploy-board is Django based web UI to perfrom day to day deploy works.
+deploy-board is Django based web UI to perform day to day deploy works.
 
 See https://github.com/pinterest/teletraan/wiki for more details.

--- a/deploy-board/integ_test/agent_tests.py
+++ b/deploy-board/integ_test/agent_tests.py
@@ -103,9 +103,9 @@ class TestPings(unittest.TestCase):
         env = environs_helper.get_env_by_stage(commons.REQUEST, envName, stageName)
         deploy = deploys_helper.get(commons.REQUEST, env["deployId"])
         if deploy['state'] == 'SUCCEEDING':
-            print "Deploy has compelted successfully!"
+            print "Deploy has completed successfully!"
             return True
-        print "Deploy has not compelted yet, success rate is %d/%d" % (deploy['successTotal'],
+        print "Deploy has not completed yet, success rate is %d/%d" % (deploy['successTotal'],
                                                                        deploy['total'])
         return False
 

--- a/deploy-board/tools/README
+++ b/deploy-board/tools/README
@@ -11,7 +11,7 @@ To pump test data into Teletraan server:
 ./run.sh create_env.py
 ./run.sh create_deploy.py
 
-To run agent_simulator, which simulates 100 agents run forever, will install any new deply
+To run agent_simulator, which simulates 100 agents run forever, will install any new deploy
 successfully. You will need to create an env on the server, and add a group into env capacity,
 pass this group name when run the simulator
 ===========================================================

--- a/deploy-board/tools/tmux/devserver
+++ b/deploy-board/tools/tmux/devserver
@@ -91,7 +91,7 @@ function start_tmux() {
 }
 
 function tmux_windows() {
-	echo "Starting Teletran Processes ... one moment please ..."
+	echo "Starting Teletraan Processes ... one moment please ..."
 
 	# ----------------------
 	# Teletraan Local Server

--- a/deploy-board/tools/tmux/teletraan.tmux.conf
+++ b/deploy-board/tools/tmux/teletraan.tmux.conf
@@ -21,7 +21,7 @@ set -g history-limit 100000
 # ----------------------
 # pretty colors
 # ----------------------
-# set pane colors - hilight the active pane
+# set pane colors - highlight the active pane
 set-option -g pane-border-fg colour235 #base02
 set-option -g pane-active-border-fg colour240 #base01
 

--- a/deploy-board/tools/tmux/teletraan.tmux.conf
+++ b/deploy-board/tools/tmux/teletraan.tmux.conf
@@ -35,7 +35,7 @@ set-option -g message-fg brightred #orange
 # If you don't want you want to use your terminal's scrolling, enable the line below
 #set-option -g status off
 
-set -g status-interval 5               # set update frequencey (default 15 seconds)
+set -g status-interval 5               # set update frequency (default 15 seconds)
 set -g status-justify centre           # center window list for clarity
 
 # set color for status bar

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/AcceptanceStatus.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/AcceptanceStatus.java
@@ -18,7 +18,7 @@ package com.pinterest.deployservice.bean;
 /**
  * - PENDING_DEPLOY
  *    Deploy has not completed yet
- * OUSTANDING:
+ * OUTSTANDING:
  *    Deploy has not completed yet
  */
 public enum AcceptanceStatus {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/AcceptanceStatus.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/AcceptanceStatus.java
@@ -17,9 +17,9 @@ package com.pinterest.deployservice.bean;
 
 /**
  * - PENDING_DEPLOY
- *    Deploy has not compelted yet
+ *    Deploy has not completed yet
  * OUSTANDING:
- *    Deploy has not compelted yet
+ *    Deploy has not completed yet
  */
 public enum AcceptanceStatus {
     /*

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/AgentState.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/AgentState.java
@@ -18,7 +18,7 @@ package com.pinterest.deployservice.bean;
 /**
  * NORMAL:
  *      Normal state
- * PAUSED_BY_STSTEM:
+ * PAUSED_BY_SYSTEM:
  *      Agent being paused by system automatically
  * PAUSED_BY_USER:
  *      Agent being paused by user manually

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/PromoteFailPolicy.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/PromoteFailPolicy.java
@@ -21,7 +21,7 @@ public enum PromoteFailPolicy {
      */
     CONTINUE,
     /*
-     * Auto prmote is disabled, leave the failed deploy in place
+     * Auto promote is disabled, leave the failed deploy in place
      */
     DISABLE,
     /*

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/CommonUtils.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/CommonUtils.java
@@ -27,7 +27,7 @@ import java.text.SimpleDateFormat;
 
 public class CommonUtils {
     /**
-     * TODO figure out how to use guava to achive this
+     * TODO figure out how to use guava to achieve this
      *
      * @return base64 encoded shorten UUID, e.g. 11YozyYYTvKmuUXpRDvoJA
      */

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/AgentDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/AgentDAO.java
@@ -36,7 +36,7 @@ public interface AgentDAO {
 
     void delete(String hostId, String envId) throws Exception;
 
-    // TODO refector this
+    // TODO refactor this
     List<AgentBean> getByHost(String hostName) throws Exception;
 
     List<AgentBean> getByHostId(String hostId) throws Exception;

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/DataDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/DataDAO.java
@@ -18,7 +18,7 @@ package com.pinterest.deployservice.dao;
 import com.pinterest.deployservice.bean.DataBean;
 
 /**
- * A collection of methods to help arbitary data
+ * A collection of methods to help arbitrary data
  */
 public interface DataDAO {
     DataBean getById(String id) throws Exception;

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/DeployDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/DeployDAO.java
@@ -49,7 +49,7 @@ public interface DeployDAO {
     // Return upto size number of ACCEPTED deploy whose suc_date is before before and build publish time is after after
     Long countNonRegularDeploys(String envId, long after) throws Exception;
 
-    // Update state, and other colums, if only if state == currentState
+    // Update state, and other columns, if only if state == currentState
     // Return affected rows, 0 means not updated
     int updateStateSafely(String deployId, String currentState, DeployBean updateBean) throws Exception;
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DeployQueryFilter.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DeployQueryFilter.java
@@ -61,7 +61,7 @@ public class DeployQueryFilter {
             sb.append("=? OR ");
             values.add(value);
         }
-        // remove the trialing OR and space
+        // remove the trailing OR and space
         sb.setLength(sb.length() - 3);
         sb.append(") AND ");
         return sb;
@@ -78,7 +78,7 @@ public class DeployQueryFilter {
             sb.append("=? OR ");
             values.add(value.toString());
         }
-        // remove the trialing OR and space
+        // remove the trailing OR and space
         sb.setLength(sb.length() - 3);
         sb.append(") AND ");
         return sb;
@@ -124,7 +124,7 @@ public class DeployQueryFilter {
 
 
         if (sb.length() > 1) {
-            // remove the trialing AND and space
+            // remove the trailing AND and space
             sb.setLength(sb.length() - 4);
             sb.insert(0, "WHERE ");
         }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/CommonHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/CommonHandler.java
@@ -71,7 +71,7 @@ public class CommonHandler {
             try {
                 message = generateMessage(buildId, envBean, state, deployBean);
             } catch (Exception e) {
-                LOG.error("Failed to genereate message", e);
+                LOG.error("Failed to generate message", e);
                 return;
             }
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/CommonHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/CommonHandler.java
@@ -268,11 +268,11 @@ public class CommonHandler {
         long succeeded = agentDAO.countSucceededAgent(envId, deployId);
         LOG.debug("Among them, {} agents are succeeded", succeeded);
 
-        long stucked = agentDAO.countStuckAgent(envId, deployId);
-        LOG.debug("Among them, {} agents are stuck", stucked);
+        long stuck = agentDAO.countStuckAgent(envId, deployId);
+        LOG.debug("Among them, {} agents are stuck", stuck);
 
         newDeployBean.setSuc_total((int) succeeded);
-        newDeployBean.setFail_total((int) stucked);
+        newDeployBean.setFail_total((int) stuck);
         newDeployBean.setTotal((int) total);
         newDeployBean.setState(oldState);
         newDeployBean.setLast_update(System.currentTimeMillis());
@@ -301,9 +301,9 @@ public class CommonHandler {
             return;
         }
 
-        if (stucked * 10000 > (10000 - sucThreshold) * total) {
+        if (stuck * 10000 > (10000 - sucThreshold) * total) {
             newDeployBean.setState(DeployState.FAILING);
-            LOG.info("Set deploy {} as FAILING since {} agents are stuck.", deployId, stucked);
+            LOG.info("Set deploy {} as FAILING since {} agents are stuck.", deployId, stuck);
             return;
         }
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/CommonHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/CommonHandler.java
@@ -100,7 +100,7 @@ public class CommonHandler {
                 LOG.info("Start to work on FinishNotifyJob for deploy {}", deployBean.getDeploy_id());
                 sendMessage();
                 sendDeployEvents(deployBean, newPartialDeployBean, envBean);
-                LOG.info("Completed NoitfyJob for deploy {}", deployBean.getDeploy_id());
+                LOG.info("Completed NotifyJob for deploy {}", deployBean.getDeploy_id());
             } catch (Throwable t) {
                 LOG.error("FinishNotifyJob job failed for deploy !" + deployBean.getDeploy_id(), t);
             }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/CommonHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/CommonHandler.java
@@ -287,7 +287,7 @@ public class CommonHandler {
                 EnvWebHookBean webhooks = dataHandler.getDataById(envBean.getWebhooks_config_id(), WebhookDataFactory.class);
                 if (webhooks != null && !CollectionUtils.isEmpty(webhooks.getPostDeployHooks())) {
                     jobPool.submit(new WebhookJob(webhooks.getPostDeployHooks(), deployBean, envBean));
-                    LOG.info("Submited post deploy hook job for deploy {}.", deployId);
+                    LOG.info("Submitted post deploy hook job for deploy {}.", deployId);
                 }
 
                 if (envBean.getAccept_type() == AcceptanceType.AUTO) {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/CommonHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/CommonHandler.java
@@ -192,7 +192,7 @@ public class CommonHandler {
         List<String> watchers = Arrays.asList(watcherStr.split(","));
         for (String watcher : watchers) {
             try {
-                // TODO verify that send to peoper actually works
+                // TODO verify that send to operator actually works
                 chatManager.sendToUser(operator, watcher.trim(), message, color);
             } catch (Exception e) {
                 LOG.error(String.format("Failed to send message '%s' to watcher %s",

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
@@ -154,8 +154,8 @@ public class DeployHandler {
         }
 
         public Void call() {
-            String additonalMessage = generateMentions(envBean, newDeployBean, oldDeployBean);
-            sendStartDeployMessage(additonalMessage);
+            String additionalMessage = generateMentions(envBean, newDeployBean, oldDeployBean);
+            sendStartDeployMessage(additionalMessage);
             LOG.info("Successfully send deploy start message for deploy {}", newDeployBean.getDeploy_id());
 
             if (!StringUtils.isEmpty(changeFeedUrl)) {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/EnvironHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/EnvironHandler.java
@@ -391,7 +391,7 @@ public class EnvironHandler {
         }
         */
 
-        // TODO make the following transcational
+        // TODO make the following transactional
         environDAO.delete(envId);
         promoteDAO.delete(envId);
         if (envBean.getAdv_config_id() != null) {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java
@@ -575,7 +575,7 @@ class GoalAnalyst {
                         return;
                     } else {
                         /**
-                         * TODO how do we make sure to NOT interupt this deploy
+                         * TODO how do we make sure to NOT interrupt this deploy
                          * Case 1.4: This is the case we retry deploy step, or just simply record
                          * the statue while agent is still working on the same stage ( status=UNKNOWN ).
                          * We allow agent to retry either because user explicitly set AgentState to RESET, or the

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
@@ -352,7 +352,7 @@ public class PingHandler {
         String hostId = pingRequest.getHostId();
         if (StringUtils.isEmpty(hostId)) {
             LOG.error("Missing host id in request: ", pingRequest);
-            throw new DeployInternalException("Missing host id in PingReqest");
+            throw new DeployInternalException("Missing host id in PingRequest");
         }
 
         if (StringUtils.isEmpty(pingRequest.getHostName())) {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
@@ -523,7 +523,7 @@ public class PingHandler {
             }
         }
 
-        // Pass step specfic agent configurations
+        // Pass step specific agent configurations
         Map<String, String> configs = null;
         String agentConfigId = envBean.getAdv_config_id();
         if (agentConfigId != null) {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
@@ -230,7 +230,7 @@ public class PingHandler {
         if (connection != null) {
             LOG.info("Successfully get lock on {}", deployLockName);
             try {
-                LOG.debug("Got lock on behavor of host {}, verify active agents", host);
+                LOG.debug("Got lock on behavior of host {}, verify active agents", host);
                 long totalActiveAgents = agentDAO.countDeployingAgent(envId);
                 if (totalActiveAgents >= parallelThreshold) {
                     LOG.debug("Got lock, but there are currently {} agent is actively deploying for env {}, host {} will have to wait for its turn.", totalActiveAgents, envId, host);

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
@@ -519,7 +519,7 @@ public class PingHandler {
             if (scriptConfigId != null) {
                 Map<String, String> variables = dataHandler.getMapById(scriptConfigId);
                 goal.setScriptVariables(variables);
-                LOG.debug("Add script varibles {} to goal at {} stage", variables, updateBean.getDeploy_stage());
+                LOG.debug("Add script variables {} to goal at {} stage", variables, updateBean.getDeploy_stage());
             }
         }
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
@@ -586,7 +586,7 @@ public class PingHandler {
     public final static int getFinalMaxParallelCount(EnvironBean environBean, long totalHosts) throws Exception {
 
         int ret = Constants.DEFAULT_MAX_PARALLEL_HOSTS;
-        LOG.debug("Get final maximum parallel count for total capactiy {}", totalHosts);
+        LOG.debug("Get final maximum parallel count for total capacity {}", totalHosts);
         boolean numIsApplicable = isApplicable(environBean.getMax_parallel());
         boolean percentageIsApplicable = isApplicable(environBean.getMax_parallel_pct());
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/scm/BaseManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/scm/BaseManager.java
@@ -40,7 +40,7 @@ public abstract class BaseManager implements SourceControlManager {
             startSha = Constants.DEFAULT_BRANCH_NAME;
         }
 
-        // get a special reference commit firts
+        // get a special reference commit first
         List<CommitBean> fullCommits = new ArrayList<>();
         Queue<CommitBean> commits = new LinkedList<>();
         Queue<CommitBean> referenceCommits = new LinkedList<>();

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/scm/DefaultSourceControlManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/scm/DefaultSourceControlManager.java
@@ -40,7 +40,7 @@ public class DefaultSourceControlManager implements SourceControlManager {
 
     @Override
     public String getType() {
-        return "UNKOWN";
+        return "UNKNOWN";
     }
 
     @Override

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/scm/GithubManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/scm/GithubManager.java
@@ -58,8 +58,8 @@ public class GithubManager extends BaseManager {
     }
 
     private long getDate(Map<String, Object> jsonMap) {
-        Map<String, Object> commiterMap = (Map<String, Object>) jsonMap.get("committer");
-        String dateGMTStr = (String) commiterMap.get("date");
+        Map<String, Object> committerMap = (Map<String, Object>) jsonMap.get("committer");
+        String dateGMTStr = (String) committerMap.get("date");
         DateTimeFormatter parser = ISODateTimeFormat.dateTimeNoMillis();
         DateTime dt = parser.parseDateTime(dateGMTStr);
         return dt.getMillis();

--- a/deploy-service/common/src/main/resources/sql/cleanup.sql
+++ b/deploy-service/common/src/main/resources/sql/cleanup.sql
@@ -2,7 +2,7 @@ CREATE DATABASE IF NOT EXISTS deploy;
 
 USE deploy;
 
-/* This is for unit tests only - it will wipe all data - do NOT run it in prodution!*/
+/* This is for unit tests only - it will wipe all data - do NOT run it in production!*/
 
 DROP TABLE IF EXISTS schema_versions;
 DROP TABLE IF EXISTS agents;

--- a/deploy-service/common/src/main/resources/sql/deploy.sql
+++ b/deploy-service/common/src/main/resources/sql/deploy.sql
@@ -57,7 +57,7 @@ CREATE TABLE IF NOT EXISTS promotes (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 /*
-Arbitrary text data table, leave the application to interprate the text
+Arbitrary text data table, leave the application to interpret the text
 The data_kind could be config, envvar or script
 */
 CREATE TABLE IF NOT EXISTS datas (

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/handler/GoalAnalystTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/handler/GoalAnalystTest.java
@@ -421,7 +421,7 @@ public class GoalAnalystTest {
         assertEquals(candidate.updateBean.getLast_err_no(), new Integer(100));
     }
 
-    // Case 1.4: failed on current step, noneretryable, but agent RESET,
+    // Case 1.4: failed on current step, nonretryable, but agent RESET,
     // give it one more chance, start from beginning
     @Test
     public void test1Env1ReportStageFailButReset() throws Exception {
@@ -721,7 +721,7 @@ public class GoalAnalystTest {
         report9.setErrorCode(100);
         reports.put(report9.getEnvId(), report9);
 
-        // Case 1.4: failed on current step, noneretryable, but agent RESET,
+        // Case 1.4: failed on current step, nonretryable, but agent RESET,
         // give it one more chance, candidate
         EnvironBean envBean11 = genDefaultEnvBean();
         envBean11.setEnv_id("e11");

--- a/deploy-service/teletraanservice/bin/server.yaml
+++ b/deploy-service/teletraanservice/bin/server.yaml
@@ -122,7 +122,7 @@ db:
 
 #
 # Chat application settings: by default is disabled.
-# Uncomment the following to allow Teletran send deploy state changes notify and other
+# Uncomment the following to allow Teletraan send deploy state changes notify and other
 # informations to chatrooms. See documentations for more details.
 # Currently Teletraan supports Slack and Hipchat
 #

--- a/deploy-service/teletraanservice/bin/server.yaml
+++ b/deploy-service/teletraanservice/bin/server.yaml
@@ -164,7 +164,7 @@ workers:
       period: 30
 
   # AutoPromoter provides the Auto Deploy support. It finds the deploy
-  # cadidates from preceeding stage and promote them to next stages.
+  # candidates from preceeding stage and promote them to next stages.
   - name: AutoPromoter
     properties:
       initialDelay: 20

--- a/deploy-service/teletraanservice/bin/server.yaml
+++ b/deploy-service/teletraanservice/bin/server.yaml
@@ -106,7 +106,7 @@ db:
 # Source Code Management settings: by default is disabled.
 # Uncomment the following to get better UI support, such as showing commit info,
 # deploy diffs and etc. See documentations for more details.
-# Currently Teletraan supports Github and Phabricator. Uncommment one of the
+# Currently Teletraan supports Github and Phabricator. Uncomment one of the
 # following sections to enable the SCM support.
 #
 #scm:

--- a/deploy-service/teletraanservice/bin/server.yaml
+++ b/deploy-service/teletraanservice/bin/server.yaml
@@ -43,7 +43,7 @@ logging:
 
 #
 # Mysql connection config. By default, we use the real mysql as the backend.
-# Note: the embeded mysql is for demo or test purpose only. Use the official Mysql
+# Note: the embedded mysql is for demo or test purpose only. Use the official Mysql
 # installs for production usage.
 #
 db:

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/ConfigHelper.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/ConfigHelper.java
@@ -79,7 +79,7 @@ public class ConfigHelper {
         context.setTagDAO(new DBTagDAOImpl(dataSource));
         context.setScheduleDAO(new DBScheduleDAOImpl(dataSource));
 
-        // Inject proper implemetation based on config
+        // Inject proper implementation based on config
         context.setAuthorizer(configuration.getAuthorizationFactory().create(context));
         context.setSourceControlManager(configuration.getSourceControlFactory().create());
         context.setChatManager(configuration.getChatFactory().create());

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/ConfigHelper.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/ConfigHelper.java
@@ -111,7 +111,7 @@ public class ConfigHelper {
          unit - the time unit for the keepAliveTime argument
          workQueue - the queue to use for holding tasks before they are executed. This queue will hold only the Runnable tasks submitted by the execute method.
          */
-        // TODO make the thread configrable
+        // TODO make the thread configurable
         ExecutorService jobPool = new ThreadPoolExecutor(1, 10, 30, TimeUnit.SECONDS, new LinkedBlockingQueue<>());
         context.setJobPool(jobPool);
 

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/ConfigHelper.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/ConfigHelper.java
@@ -163,7 +163,7 @@ public class ConfigHelper {
                 ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
                 int minStaleHostThreshold = MapUtils.getIntValue(properties, "minStaleHostThreshold", DEFAULT_MIN_STALE_HOST_THRESHOLD);
                 int maxStaleHostThreshold = MapUtils.getIntValue(properties, "maxStaleHostThreshold", DEFAULT_MAX_STALE_HOST_THRESHOLD);
-                int maxLaunchLatencyThreshold = MapUtils.getIntValue(properties, "maxLaunchLaencyThreshold", DEFAULT_LAUNCH_LATENCY_THRESHOLD);
+                int maxLaunchLatencyThreshold = MapUtils.getIntValue(properties, "maxLaunchLatencyThreshold", DEFAULT_LAUNCH_LATENCY_THRESHOLD);
                 Runnable worker = new AgentJanitor(serviceContext, minStaleHostThreshold, maxStaleHostThreshold, maxLaunchLatencyThreshold);
                 scheduler.scheduleAtFixedRate(worker, initDelay, period, TimeUnit.SECONDS);
                 LOG.info("Scheduled AgentJanitor.");

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/exception/TeletraanInternalException.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/exception/TeletraanInternalException.java
@@ -19,8 +19,8 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-public class TeletaanInternalException extends WebApplicationException {
-    public TeletaanInternalException(Response.Status code, String message) {
+public class TeletraanInternalException extends WebApplicationException {
+    public TeletraanInternalException(Response.Status code, String message) {
         super(Response.status(code)
             .entity(String.format("{\"code\":%d,\"message\":\"%s\"}", code.getStatusCode(), message))
             .type(MediaType.APPLICATION_JSON).build());

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/health/GenericHealthCheck.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/health/GenericHealthCheck.java
@@ -48,7 +48,7 @@ public class GenericHealthCheck extends HealthCheck {
             return Result.healthy("Teletraan looks healthy!");
         } else {
             return Result.unhealthy("Teletraan failed on Healthcheck, " +
-                "incorrect ammount of deploys returned: " + deploys.size());
+                "incorrect amount of deploys returned: " + deploys.size());
         }
     }
 }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Builds.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Builds.java
@@ -24,7 +24,7 @@ import com.pinterest.deployservice.dao.BuildDAO;
 import com.pinterest.deployservice.dao.TagDAO;
 import com.pinterest.deployservice.scm.SourceControlManager;
 import com.pinterest.teletraan.TeletraanServiceContext;
-import com.pinterest.teletraan.exception.TeletaanInternalException;
+import com.pinterest.teletraan.exception.TeletraanInternalException;
 import com.pinterest.teletraan.security.Authorizer;
 import io.swagger.annotations.*;
 import org.apache.commons.lang3.StringUtils;
@@ -92,7 +92,7 @@ public class Builds {
             @ApiParam(value = "BUILD id", required = true)@PathParam("id") String id) throws Exception {
         BuildBean buildBean = buildDAO.getById(id);
         if (buildBean == null) {
-            throw new TeletaanInternalException(Response.Status.NOT_FOUND, String.format("BUILD %s does not exist.", id));
+            throw new TeletraanInternalException(Response.Status.NOT_FOUND, String.format("BUILD %s does not exist.", id));
         }
         return buildBean;
     }
@@ -107,7 +107,7 @@ public class Builds {
         @ApiParam(value = "BUILD id", required = true)@PathParam("id") String id) throws Exception {
         BuildBean buildBean = buildDAO.getById(id);
         if (buildBean == null) {
-            throw new TeletaanInternalException(Response.Status.NOT_FOUND, String.format("BUILD %s does not exist.", id));
+            throw new TeletraanInternalException(Response.Status.NOT_FOUND, String.format("BUILD %s does not exist.", id));
         }
 
         BuildTagsManager manager = new BuildTagsManagerImpl(this.tagDAO);
@@ -124,7 +124,7 @@ public class Builds {
 
 
         if (StringUtils.isEmpty(scmCommit) && StringUtils.isEmpty(buildName)) {
-            throw new TeletaanInternalException(Response.Status.BAD_REQUEST,
+            throw new TeletraanInternalException(Response.Status.BAD_REQUEST,
                 "Require either commit id or build name in the request.");
         }
 
@@ -146,7 +146,7 @@ public class Builds {
         @QueryParam("after") Long after) throws Exception {
 
         if (StringUtils.isEmpty(buildName) && StringUtils.isEmpty(scmCommit)) {
-            throw new TeletaanInternalException(Response.Status.BAD_REQUEST,
+            throw new TeletraanInternalException(Response.Status.BAD_REQUEST,
                 "Require either commit or build name in the request.");
         }
 
@@ -219,7 +219,7 @@ public class Builds {
         authorizer.authorize(sc, new Resource(Resource.ALL, Resource.Type.SYSTEM), Role.OPERATOR);
         BuildBean buildBean = buildDAO.getById(id);
         if (buildBean == null) {
-            throw new TeletaanInternalException(Response.Status.NOT_FOUND, String.format("BUILD %s does not exist.", id));
+            throw new TeletraanInternalException(Response.Status.NOT_FOUND, String.format("BUILD %s does not exist.", id));
         }
         buildDAO.delete(id);
         LOG.info("{} successfully deleted build {}", sc.getUserPrincipal().getName(), id);

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Deploys.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Deploys.java
@@ -32,7 +32,7 @@ import com.pinterest.deployservice.dao.EnvironDAO;
 import com.pinterest.deployservice.db.DeployQueryFilter;
 import com.pinterest.deployservice.handler.DeployHandler;
 import com.pinterest.teletraan.TeletraanServiceContext;
-import com.pinterest.teletraan.exception.TeletaanInternalException;
+import com.pinterest.teletraan.exception.TeletraanInternalException;
 import com.pinterest.teletraan.security.Authorizer;
 
 import org.slf4j.Logger;
@@ -93,7 +93,7 @@ public class Deploys {
             @ApiParam(value = "Deploy id", required = true)@PathParam("id") String id) throws Exception {
         DeployBean deployBean = deployDAO.getById(id);
         if (deployBean == null) {
-            throw new TeletaanInternalException(Response.Status.NOT_FOUND,
+            throw new TeletraanInternalException(Response.Status.NOT_FOUND,
                 String.format("Deploy %s does not exist.", id));
         }
         return deployBean;

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvDeploys.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvDeploys.java
@@ -24,7 +24,7 @@ import com.pinterest.deployservice.handler.ConfigHistoryHandler;
 import com.pinterest.deployservice.handler.DeployHandler;
 import com.pinterest.deployservice.handler.EnvironHandler;
 import com.pinterest.teletraan.TeletraanServiceContext;
-import com.pinterest.teletraan.exception.TeletaanInternalException;
+import com.pinterest.teletraan.exception.TeletraanInternalException;
 import com.pinterest.teletraan.security.Authorizer;
 
 import io.swagger.annotations.Api;
@@ -124,7 +124,7 @@ public class EnvDeploys {
                 newDeployId = deployHandler.promote(envBean, fromDeployId, description, operator);
                 break;
             default:
-                throw new TeletaanInternalException(Response.Status.BAD_REQUEST, "No action found.");
+                throw new TeletraanInternalException(Response.Status.BAD_REQUEST, "No action found.");
         }
 
         configHistoryHandler.updateConfigHistory(envBean.getEnv_id(), Constants.TYPE_ENV_ACTION, actionType.toString(), operator);

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
@@ -28,7 +28,7 @@ import com.pinterest.deployservice.handler.EnvTagHandler;
 import com.pinterest.deployservice.handler.EnvironHandler;
 import com.pinterest.deployservice.handler.TagHandler;
 import com.pinterest.teletraan.TeletraanServiceContext;
-import com.pinterest.teletraan.exception.TeletaanInternalException;
+import com.pinterest.teletraan.exception.TeletraanInternalException;
 import com.pinterest.teletraan.security.Authorizer;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -136,7 +136,7 @@ public class EnvStages {
                 tagBean.setValue(TagValue.DISABLE_ENV);
                 break;
             default:
-                throw new TeletaanInternalException(Response.Status.BAD_REQUEST, "No action found.");
+                throw new TeletraanInternalException(Response.Status.BAD_REQUEST, "No action found.");
         }
 
         tagBean.setTarget_id(envBean.getEnv_id());

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvTokenRoles.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvTokenRoles.java
@@ -66,7 +66,7 @@ public class EnvTokenRoles extends TokenRoles {
     @PUT
     @Path("/{scriptName : [a-zA-Z0-9\\-_]+}")
     @ApiOperation(
-            value = "Update an envrionment's script token",
+            value = "Update an environment's script token",
             notes = "Update a specific environment script token given environment and script names.")
     public void update(@Context SecurityContext sc,
                        @ApiParam(value = "Environment name.", required = true)@PathParam("envName") String envName,

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Environs.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Environs.java
@@ -29,7 +29,7 @@ import com.pinterest.deployservice.handler.EnvTagHandler;
 import com.pinterest.deployservice.handler.EnvironHandler;
 import com.pinterest.deployservice.handler.TagHandler;
 import com.pinterest.teletraan.TeletraanServiceContext;
-import com.pinterest.teletraan.exception.TeletaanInternalException;
+import com.pinterest.teletraan.exception.TeletraanInternalException;
 import com.pinterest.teletraan.security.Authorizer;
 import com.pinterest.teletraan.security.OpenAuthorizer;
 import io.swagger.annotations.*;
@@ -92,7 +92,7 @@ public class Environs {
             @ApiParam(value = "Environment id", required = true)@PathParam("id") String id) throws Exception {
         EnvironBean environBean = environDAO.getById(id);
         if (environBean == null) {
-            throw new TeletaanInternalException(Response.Status.NOT_FOUND,
+            throw new TeletraanInternalException(Response.Status.NOT_FOUND,
                 String.format("Environment %s does not exist.", id));
         }
         return environBean;
@@ -129,7 +129,7 @@ public class Environs {
             return environDAO.getEnvsByGroups(Arrays.asList(groupName));
         }
 
-        throw new TeletaanInternalException(Response.Status.BAD_REQUEST, "Require either environment name or group name in the request.");
+        throw new TeletraanInternalException(Response.Status.BAD_REQUEST, "Require either environment name or group name in the request.");
     }
 
     @POST
@@ -182,7 +182,7 @@ public class Environs {
                 tagBean.setValue(TagValue.DISABLE_ENV);
                 break;
             default:
-                throw new TeletaanInternalException(Response.Status.BAD_REQUEST, "No action found.");
+                throw new TeletraanInternalException(Response.Status.BAD_REQUEST, "No action found.");
         }
 
         tagBean.setTarget_type(TagTargetType.TELETRAAN);

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Environs.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Environs.java
@@ -139,7 +139,7 @@ public class Environs {
             response = Response.class)
     public Response create(
             @Context SecurityContext sc,
-            @ApiParam(value = "Environemnt object to create in database", required = true)@Valid EnvironBean environBean) throws Exception {
+            @ApiParam(value = "Environment object to create in database", required = true)@Valid EnvironBean environBean) throws Exception {
         String operator = sc.getUserPrincipal().getName();
         String envName = environBean.getEnv_name();
         List<EnvironBean> environBeans = environDAO.getByName(envName);

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Groups.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Groups.java
@@ -21,7 +21,7 @@ import com.pinterest.deployservice.bean.HostBean;
 import com.pinterest.deployservice.dao.EnvironDAO;
 import com.pinterest.deployservice.dao.HostDAO;
 import com.pinterest.teletraan.TeletraanServiceContext;
-import com.pinterest.teletraan.exception.TeletaanInternalException;
+import com.pinterest.teletraan.exception.TeletraanInternalException;
 
 import org.hibernate.validator.constraints.NotEmpty;
 
@@ -77,7 +77,7 @@ public class Groups {
                 hostIds = hostDAO.getRetiredAndFailedHostIdsByGroup(groupName);
                 break;
             default:
-                throw new TeletaanInternalException(Response.Status.BAD_REQUEST, "No action found.");
+                throw new TeletraanInternalException(Response.Status.BAD_REQUEST, "No action found.");
         }
         return hostIds;
     }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Hotfixs.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Hotfixs.java
@@ -24,7 +24,7 @@ import com.pinterest.deployservice.dao.HotfixDAO;
 import com.pinterest.deployservice.scm.GithubManager;
 import com.pinterest.deployservice.scm.SourceControlManager;
 import com.pinterest.teletraan.TeletraanServiceContext;
-import com.pinterest.teletraan.exception.TeletaanInternalException;
+import com.pinterest.teletraan.exception.TeletraanInternalException;
 import com.pinterest.teletraan.security.Authorizer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,7 +62,7 @@ public class Hotfixs {
     private HotfixBean getHotfixBean(String id) throws Exception {
         HotfixBean hotfixBean = hotfixDAO.getByHotfixId(id);
         if (hotfixBean == null) {
-            throw new TeletaanInternalException(Response.Status.NOT_FOUND, String.format("Hotfix %s does not exist.", id));
+            throw new TeletraanInternalException(Response.Status.NOT_FOUND, String.format("Hotfix %s does not exist.", id));
         }
         return hotfixBean;
     }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Systems.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Systems.java
@@ -105,6 +105,6 @@ public class Systems {
         for (String chatroom : chatrooms) {
             chatManager.send(request.getFrom(), chatroom.trim(), request.getMessage(), "yellow");
         }
-        LOG.info("Successfully handled send message requset {}", request);
+        LOG.info("Successfully handled send message request {}", request);
     }
 }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Tags.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Tags.java
@@ -24,7 +24,7 @@ import com.pinterest.deployservice.dao.TagDAO;
 import com.pinterest.deployservice.handler.BuildTagHandler;
 import com.pinterest.deployservice.handler.TagHandler;
 import com.pinterest.teletraan.TeletraanServiceContext;
-import com.pinterest.teletraan.exception.TeletaanInternalException;
+import com.pinterest.teletraan.exception.TeletraanInternalException;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.apache.commons.lang3.StringUtils;
@@ -65,7 +65,7 @@ public class Tags {
         throws Exception {
         TagBean ret = tagDAO.getById(id);
         if (ret == null) {
-            throw new TeletaanInternalException(Response.Status.NOT_FOUND,
+            throw new TeletraanInternalException(Response.Status.NOT_FOUND,
                 String.format("Tag %s does not exist.", id));
         }
         return ret;
@@ -80,7 +80,7 @@ public class Tags {
     public List<TagBean> getByTargetId(@PathParam("id") String targetId) throws Exception {
 
         if (StringUtils.isEmpty(targetId)) {
-            throw new TeletaanInternalException(Response.Status.BAD_REQUEST,
+            throw new TeletraanInternalException(Response.Status.BAD_REQUEST,
                 "Require at least one of targetId, targetType, value specified in the request.");
         }
 
@@ -95,7 +95,7 @@ public class Tags {
             response = List.class)
     public TagBean getLatestByTargetId(@PathParam("id") String targetId) throws Exception {
         if (StringUtils.isEmpty(targetId)) {
-            throw new TeletaanInternalException(Response.Status.BAD_REQUEST,
+            throw new TeletraanInternalException(Response.Status.BAD_REQUEST,
                     "Require at least one of targetId, targetType, value specified in the request.");
         }
         return tagDAO.getLatestByTargetId(targetId);
@@ -112,7 +112,7 @@ public class Tags {
         throws Exception {
 
         if (StringUtils.isEmpty(value)) {
-            throw new TeletaanInternalException(Response.Status.BAD_REQUEST,
+            throw new TeletraanInternalException(Response.Status.BAD_REQUEST,
                 "Require at least one of targetId, targetType, value specified in the request.");
         }
 
@@ -120,7 +120,7 @@ public class Tags {
             return tagDAO.getByValue(TagValue.valueOf(value.toUpperCase()));
 
         } catch (IllegalArgumentException e) {
-            throw new TeletaanInternalException(Response.Status.BAD_REQUEST,
+            throw new TeletraanInternalException(Response.Status.BAD_REQUEST,
                 String.format("%s is not a valid tag Value.", value));
         }
     }
@@ -166,7 +166,7 @@ public class Tags {
         @ApiParam(value = "tag id", required = true) @PathParam("id") String id) throws Exception {
         TagBean tagBean = tagDAO.getById(id);
         if (tagBean == null) {
-            throw new TeletaanInternalException(Response.Status.NOT_FOUND,
+            throw new TeletraanInternalException(Response.Status.NOT_FOUND,
                 String.format("Tag %s does not exist.", id));
         }
         tagDAO.delete(id);

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Utils.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Utils.java
@@ -21,7 +21,7 @@ import com.pinterest.deployservice.bean.Resource;
 import com.pinterest.deployservice.bean.Role;
 import com.pinterest.deployservice.dao.DeployDAO;
 import com.pinterest.deployservice.dao.EnvironDAO;
-import com.pinterest.teletraan.exception.TeletaanInternalException;
+import com.pinterest.teletraan.exception.TeletraanInternalException;
 import com.pinterest.teletraan.security.Authorizer;
 import org.apache.commons.collections.CollectionUtils;
 import org.slf4j.Logger;
@@ -39,7 +39,7 @@ public class Utils {
         String stageName) throws Exception {
         EnvironBean environBean = environDAO.getByStage(envName, stageName);
         if (environBean == null) {
-            throw new TeletaanInternalException(Response.Status.NOT_FOUND,
+            throw new TeletraanInternalException(Response.Status.NOT_FOUND,
                 String.format("Environment %s/%s does not exist.", envName, stageName));
         }
         return environBean;
@@ -48,7 +48,7 @@ public class Utils {
     public static EnvironBean getEnvStage(EnvironDAO environDAO, String envId) throws Exception {
         EnvironBean environBean = environDAO.getById(envId);
         if (environBean == null) {
-            throw new TeletaanInternalException(Response.Status.NOT_FOUND,
+            throw new TeletraanInternalException(Response.Status.NOT_FOUND,
                 String.format("Environment %s does not exist.", envId));
         }
         return environBean;
@@ -67,7 +67,7 @@ public class Utils {
                     sc.getUserPrincipal().getName(), environBean.getEnv_name(), role);
             }
         }
-        throw new TeletaanInternalException(Response.Status.FORBIDDEN, "Not authorized!");
+        throw new TeletraanInternalException(Response.Status.FORBIDDEN, "Not authorized!");
     }
 
     public static void authorizeGroup(EnvironDAO environDAO, String groupName,
@@ -97,7 +97,7 @@ public class Utils {
     public static DeployBean getDeploy(DeployDAO deployDAO, String deployId) throws Exception {
         DeployBean deployBean = deployDAO.getById(deployId);
         if (deployBean == null) {
-            throw new TeletaanInternalException(Response.Status.NOT_FOUND,
+            throw new TeletraanInternalException(Response.Status.NOT_FOUND,
                 String.format("Deploy %s does not exist.", deployId));
         }
         return deployBean;

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/Authorizer.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/Authorizer.java
@@ -22,5 +22,5 @@ import com.pinterest.deployservice.bean.Role;
 import javax.ws.rs.core.SecurityContext;
 
 public interface Authorizer {
-    void authorize(SecurityContext securityContext, Resource resoure, Role requiredRole) throws Exception;
+    void authorize(SecurityContext securityContext, Resource resource, Role requiredRole) throws Exception;
 }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/RoleAuthorizer.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/RoleAuthorizer.java
@@ -41,7 +41,7 @@ public class RoleAuthorizer implements Authorizer {
         // Consider group role(s)
         Set<String> groupsSet = new HashSet<>();
         if(groups != null && !groups.isEmpty()) {
-            // Convert to Set for lookup convienience
+            // Convert to Set for lookup convenience
             groupsSet.addAll(groups);
 
             List<GroupRolesBean> resourceGroupBeans = groupRolesDAO.getByResource(resource.getId(), resource.getType());

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/RoleAuthorizer.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/RoleAuthorizer.java
@@ -19,7 +19,7 @@ import com.pinterest.deployservice.ServiceContext;
 import com.pinterest.deployservice.bean.*;
 import com.pinterest.deployservice.dao.GroupRolesDAO;
 import com.pinterest.deployservice.dao.UserRolesDAO;
-import com.pinterest.teletraan.exception.TeletaanInternalException;
+import com.pinterest.teletraan.exception.TeletraanInternalException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,7 +83,7 @@ public class RoleAuthorizer implements Authorizer {
         }
 
         // Otherwise not authorized
-        throw new TeletaanInternalException(Response.Status.FORBIDDEN, "Not authorized!");
+        throw new TeletraanInternalException(Response.Status.FORBIDDEN, "Not authorized!");
     }
 
     public void checkAPITokenPermission(TokenRolesBean bean, Resource requiredResource, Role requiredRole) throws Exception {
@@ -100,7 +100,7 @@ public class RoleAuthorizer implements Authorizer {
         }
 
         // Otherwise, no way
-        throw new TeletaanInternalException(Response.Status.FORBIDDEN, "Not authorized!");
+        throw new TeletraanInternalException(Response.Status.FORBIDDEN, "Not authorized!");
     }
 
     @Override

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/TokenAuthFilter.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/TokenAuthFilter.java
@@ -17,7 +17,7 @@ package com.pinterest.teletraan.security;
 
 import com.pinterest.deployservice.common.DeployInternalException;
 import com.pinterest.teletraan.TeletraanServiceContext;
-import com.pinterest.teletraan.exception.TeletaanInternalException;
+import com.pinterest.teletraan.exception.TeletraanInternalException;
 
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -56,7 +56,7 @@ public class TokenAuthFilter implements ContainerRequestFilter {
                 securityContext = authenticate(context);
             } catch (Exception e) {
                 LOG.info("Authentication failed. Reason: " + e.getMessage());
-                throw new TeletaanInternalException(Response.Status.UNAUTHORIZED,
+                throw new TeletraanInternalException(Response.Status.UNAUTHORIZED,
                         "Failed to authenticate user. " + e.getMessage());
             }
             context.setSecurityContext(securityContext);

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AgentJanitor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AgentJanitor.java
@@ -31,7 +31,7 @@ import java.util.*;
  * Housekeeping on stuck and dead agents
  * <p>
  * if an agent has not ping server for certain time, we will cross check with
- * authoritive source to confirm if the host is terminated, and handle the agent
+ * authoritative source to confirm if the host is terminated, and handle the agent
  * status accordingly
  */
 public class AgentJanitor extends SimpleAgentJanitor {

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AutoPromoter.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AutoPromoter.java
@@ -283,15 +283,15 @@ public class AutoPromoter implements Runnable {
             if (deployBean == null) {
                 return true;
             }
-            Date lastDeloyDate = new Date(deployBean.getStart_date());
-            Date nextDeployDate = cronExpression.getNextValidTimeAfter(lastDeloyDate);
+            Date lastDeployDate = new Date(deployBean.getStart_date());
+            Date nextDeployDate = cronExpression.getNextValidTimeAfter(lastDeployDate);
             // Only run the cron deploy when the current date is equal or after the scheduled deploy date
             // since last deploy.
             //
             // If current date is before the next scheduled deploy date since last deploy, return false.
             if (date.before(nextDeployDate)) {
                 LOG.info(String.format("The next scheduled deploy after last deploy %tc is %tc, now is: %tc",
-                    nextDeployDate, lastDeloyDate, date));
+                    nextDeployDate, lastDeployDate, date));
                 return false;
             } else {
                 return true;

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/DeployJanitor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/DeployJanitor.java
@@ -82,7 +82,7 @@ public class DeployJanitor implements Job {
         try {
             schedulerContext = context.getScheduler().getContext();
         } catch (SchedulerException e) {
-            LOG.error("Cannot retrive job context!", e);
+            LOG.error("Cannot retrieve job context!", e);
             return;
         }
 

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/HostTerminator.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/HostTerminator.java
@@ -109,7 +109,7 @@ public class HostTerminator implements Runnable {
             LOG.info("Start to run HostTerminator");
             processBatch();
         } catch (Throwable t) {
-            LOG.error("Faile to run HostTerminator", t);
+            LOG.error("Failed to run HostTerminator", t);
         }
     }
 }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/SimpleAgentJanitor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/SimpleAgentJanitor.java
@@ -113,7 +113,7 @@ public class SimpleAgentJanitor implements Runnable {
             minStaleHostIds.add(host.getHost_id());
         }
         if (!minStaleHostIds.isEmpty()) {
-            LOG.info("AgentJanitor found following hosts (Explicite capacity) excceeded minStaleThreshold: ",
+            LOG.info("AgentJanitor found following hosts (Explicite capacity) exceeded minStaleThreshold: ",
                 minStaleHostIds);
             processStaleHosts(minStaleHostIds, false);
         }
@@ -144,12 +144,12 @@ public class SimpleAgentJanitor implements Runnable {
         }
 
         if (!maxStaleHostIds.isEmpty()) {
-            LOG.info("AgentJanitor found the following hosts excceeded maxStaleThreshold: ",
+            LOG.info("AgentJanitor found the following hosts exceeded maxStaleThreshold: ",
                 maxStaleHostIds);
             processStaleHosts(maxStaleHostIds, true);
         }
         if (!minStaleHostIds.isEmpty()) {
-            LOG.info("AgentJanitor found the following hosts excceeded minStaleThreshold: ",
+            LOG.info("AgentJanitor found the following hosts exceeded minStaleThreshold: ",
                 minStaleHostIds);
             processStaleHosts(minStaleHostIds, false);
         }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/SimpleAgentJanitor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/SimpleAgentJanitor.java
@@ -35,7 +35,7 @@ import java.util.*;
  * Housekeeping on stuck and dead agents
  * <p>
  * if an agent has not ping server for certain time, we will cross check with
- * authoritive source to confirm if the host is terminated, and set agent status
+ * authoritative source to confirm if the host is terminated, and set agent status
  * accordingly
  */
 public class SimpleAgentJanitor implements Runnable {

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/SimpleAgentJanitor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/SimpleAgentJanitor.java
@@ -98,7 +98,7 @@ public class SimpleAgentJanitor implements Runnable {
             maxStaleHostIds.add(host.getHost_id());
         }
         if (!maxStaleHostIds.isEmpty()) {
-            LOG.info("AgentJanitor found the following hosts (Explicite capacity) exceeded maxStaleThreshold: ",
+            LOG.info("AgentJanitor found the following hosts (Explicit capacity) exceeded maxStaleThreshold: ",
                 maxStaleHostIds);
             processStaleHosts(maxStaleHostIds, true);
         }
@@ -113,7 +113,7 @@ public class SimpleAgentJanitor implements Runnable {
             minStaleHostIds.add(host.getHost_id());
         }
         if (!minStaleHostIds.isEmpty()) {
-            LOG.info("AgentJanitor found following hosts (Explicite capacity) exceeded minStaleThreshold: ",
+            LOG.info("AgentJanitor found following hosts (Explicit capacity) exceeded minStaleThreshold: ",
                 minStaleHostIds);
             processStaleHosts(minStaleHostIds, false);
         }
@@ -171,7 +171,7 @@ public class SimpleAgentJanitor implements Runnable {
         }
 
         // For those hosts do not belong to any host, but still associate with certain envs
-        LOG.info("AgentJanitor process explicite capacity hosts");
+        LOG.info("AgentJanitor process explicit capacity hosts");
         processIndividualHosts();
     }
 

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/ScriptTokenAuthorizerTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/ScriptTokenAuthorizerTest.java
@@ -19,7 +19,7 @@ import com.pinterest.deployservice.ServiceContext;
 import com.pinterest.deployservice.bean.Resource;
 import com.pinterest.deployservice.bean.Role;
 import com.pinterest.deployservice.bean.TokenRolesBean;
-import com.pinterest.teletraan.exception.TeletaanInternalException;
+import com.pinterest.teletraan.exception.TeletraanInternalException;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -87,7 +87,7 @@ public class ScriptTokenAuthorizerTest {
     private void checkNegative(TokenRolesBean bean, Resource resource, Role role) throws Exception {
         try {
             authorizer.checkAPITokenPermission(bean, resource, role);
-        } catch (TeletaanInternalException e) {
+        } catch (TeletraanInternalException e) {
             // expected
             return;
         }

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/UserTokenAuthorizerTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/UserTokenAuthorizerTest.java
@@ -20,7 +20,7 @@ import com.pinterest.deployservice.bean.Resource;
 import com.pinterest.deployservice.bean.Role;
 import com.pinterest.deployservice.bean.UserRolesBean;
 import com.pinterest.deployservice.dao.UserRolesDAO;
-import com.pinterest.teletraan.exception.TeletaanInternalException;
+import com.pinterest.teletraan.exception.TeletraanInternalException;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -81,7 +81,7 @@ public class UserTokenAuthorizerTest {
     private void checkNegative(String userName, Resource resource, Role role) throws Exception {
         try {
             authorizer.checkUserPermission(userName, resource, null, role);
-        } catch (TeletaanInternalException e) {
+        } catch (TeletraanInternalException e) {
             // expected
             return;
         }

--- a/docs/api/Environments.md
+++ b/docs/api/Environments.md
@@ -105,7 +105,7 @@ Creates a new environment given an environment object
 ##### Parameters
 |Type|Name|Description|Required|Schema|Default|
 |----|----|----|----|----|----|
-|BodyParameter|body|Environemnt object to create in database|true|EnvironBean||
+|BodyParameter|body|Environment object to create in database|true|EnvironBean||
 
 
 ##### Responses

--- a/docs/api/ScriptTokens.md
+++ b/docs/api/ScriptTokens.md
@@ -261,7 +261,7 @@ Deletes a script token by given environment and script name.
 
 * application/json
 
-#### Update an envrionment's script token
+#### Update an environment's script token
 ```
 PUT /v1/envs/{envName}/token_roles/{scriptName}
 ```

--- a/docs/api/definitions.md
+++ b/docs/api/definitions.md
@@ -277,7 +277,7 @@
 
      Deploy has not completed yet
 
-  OUSTANDING:
+  OUTSTANDING:
 
      Deploy has not completed yet
 

--- a/docs/api/definitions.md
+++ b/docs/api/definitions.md
@@ -299,7 +299,7 @@
 
        Normal state
 
-  PAUSED_BY_STSTEM:
+  PAUSED_BY_SYSTEM:
 
        Agent being paused by system automatically
 

--- a/docs/docs_generator/gradlew.bat
+++ b/docs/docs_generator/gradlew.bat
@@ -46,7 +46,7 @@ echo location of your Java installation.
 goto fail
 
 :init
-@rem Get command-line arguments, handling Windowz variants
+@rem Get command-line arguments, handling Windows variants
 
 if not "%OS%" == "Windows_NT" goto win9xME_args
 if "%@eval[2+2]" == "4" goto 4NT_args


### PR DESCRIPTION
I didn't fix every spelling error, specifically, `actity_type` is in a database schema, and fixing that would almost certainly result in people being unhappy. -- It is possible to fix schemas, but generally that involves migration code, and coordinating with people.

I've tried to tag API change commits w/ `(API)` and `(config break)` as applicable.

I can certainly squash commits, or split the API stuff out into a distinct pull request. But until someone considers the general content, it's much better for individual fixes to be distinct -- so someone could ask me to drop a certain change.
