### PR TITLE
A new tagging build UI has been added.

### DIFF
--- a/deploy-board/deploy_board/static/js/private/build_details.js
+++ b/deploy-board/deploy_board/static/js/private/build_details.js
@@ -1,5 +1,4 @@
-/*
- * Copyright 2016 Pinterest, Inc.
+/* Copyright 2016 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,15 +13,13 @@
  * limitations under the License.
  */
 
-package com.pinterest.deployservice.buildtags;
+$(document).ready(function() {
 
-import com.pinterest.deployservice.bean.BuildBean;
-import com.pinterest.deployservice.bean.BuildTagBean;
-import com.pinterest.deployservice.bean.TagBean;
-
-import java.util.List;
-
-public interface BuildTagsManager {
-    List<BuildTagBean> getEffectiveTagsWithBuilds(List<BuildBean> builds) throws Exception;
-    TagBean getEffectiveBuildTag(BuildBean build) throws  Exception;
-}
+    if ($('#buildErrorMsg').length > 0) {
+        $('#errorBannerId').append($('#buildErrorMsg').text());
+        $('#errorBannerId').show();
+    }
+    $('#tagBuildButton').click(function() {
+        $('#tagBuildConfirmId').modal();
+    });
+});

--- a/deploy-board/deploy_board/static/js/private/env_landing.js
+++ b/deploy-board/deploy_board/static/js/private/env_landing.js
@@ -1,5 +1,4 @@
-/*
- * Copyright 2016 Pinterest, Inc.
+/* Copyright 2016 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,16 +12,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-package com.pinterest.deployservice.buildtags;
-
-import com.pinterest.deployservice.bean.BuildBean;
-import com.pinterest.deployservice.bean.BuildTagBean;
-import com.pinterest.deployservice.bean.TagBean;
-
-import java.util.List;
-
-public interface BuildTagsManager {
-    List<BuildTagBean> getEffectiveTagsWithBuilds(List<BuildBean> builds) throws Exception;
-    TagBean getEffectiveBuildTag(BuildBean build) throws  Exception;
-}
+$(document).ready(function() {
+    if ($('#envErrorMsg').length > 0) {
+        if($('#envBannerMessage').length == 0){
+            $('#errorBannerId').append("<span id='envBannerMessage'></span>").text($('#envErrorMsg').text());
+        }
+        else{
+            $('#envBannerMessage').text($('#envErrorMsg').text());
+        }
+        $('#errorBannerId').show();
+    }
+});

--- a/deploy-board/deploy_board/templates/builds/build_details.html
+++ b/deploy-board/deploy_board/templates/builds/build_details.html
@@ -11,14 +11,22 @@
 {% load utils %}
 
 {% block main %}
-
+<input id="hiddenCommit7" type=hidden value="{{ build.commitShort}}" />
 <div class="panel panel-default">
     <div class="panel-heading">
         <h4 class="panel-title">Build Details</h4>
     </div>
     <div class="panel-body table-responsive">
     {% include "builds/build_details.tmpl" %}
+        <br/>
+        <div id="buildsTagging">
+            <button type="button" id="tagBuildButton" class="btn btn-primary btn-sm pull-right">
+                Mark Build As {{ tag|availableBuildTag }}
+            </button>
+        </div>
     </div>
 </div>
+
+{% include "builds/confirm_tag_build.tmpl"%}
 
 {% endblock %}

--- a/deploy-board/deploy_board/templates/builds/build_details.tmpl
+++ b/deploy-board/deploy_board/templates/builds/build_details.tmpl
@@ -1,4 +1,6 @@
 {% load utils %}
+{% load staticfiles %}
+<script src="{% static "js/private/build_details.js" %}" type="text/javascript"></script>
 <table class="table table-striped table-bordered table-condensed table-hover">
     <tr>
         <td>Build Id</td>
@@ -54,4 +56,28 @@
         <td>Publish Date</td>
         <td>{{ build.publishDate|convertTimestamp}}</td>
     </tr>
+{%if tag %}
+{%if tag.value == "BAD_BUILD" or tag.build.id == build.id %}
+    <tr>
+        <td>Tag Value</td>
+        <td id="buildTagValue">{{tag.value}} on <a href="/builds/{{ tag.build.id }}">{{ tag.build|branchAndCommit }}</a></td>
+    </tr>
+    <tr>
+        <td>Tag Comment</td>
+        <td>{{ tag.comments }}</td>
+    </tr>
+    <tr>
+        <td>Tag Operator</td>
+        <td>{{ tag.operator }}</td>
+    </tr>
+    <tr>
+        <td>Tag Created Date</td>
+        <td>{{ tag.createdDate|convertTimestamp }}</td>
+    </tr>
+    {%if tag.value == "BAD_BUILD" %} 
+        <div id="buildErrorMsg" style="display: none;">The build is marked as {{tag.value}} by {{tag.operator}} on {{ tag.createdDate|convertTimestamp }}</div>
+    {% endif %}
+{% endif %}
+{% endif %}
 </table>
+

--- a/deploy-board/deploy_board/templates/builds/builds.tmpl
+++ b/deploy-board/deploy_board/templates/builds/builds.tmpl
@@ -7,24 +7,34 @@
         <th>Repo</th>
         <th>More Info</th>
         <th>Details</th>
+        <th>Tag</th>
     </tr>
-    {% for build in builds %}
+    {% for buildInfo in builds %}
     <tr>
-        <td>{{ build.publishDate|convertTimestamp }}</td>
-        <td><a class="deployToolTip" href="{{ build.commitInfo }}"
-               title="Click to see commit in {{ build.type }}">
-            <i class="{{ build|commitIcon }}"></i> {{ build.commitShort }}
+        <td>{{ buildInfo.build.publishDate|convertTimestamp }}</td>
+        <td><a class="deployToolTip" href="{{ buildInfo.build.commitInfo }}"
+               title="Click to see commit in {{ buildInfo.build.type }}">
+            <i class="{{ buildInfo.build|commitIcon }}"></i> {{ buildInfo.build.commitShort }}
         </a>
         </td>
-        <td>{{ build.branch }}</td>
-        <td>{{ build.repo }}</td>
+        <td>{{ buildInfo.build.branch }}</td>
+        <td>{{ buildInfo.build.repo }}</td>
         <td><a class="deployToolTip" data-toggle="tooltip"
                title="Click to see the details of publish job info"
-               href='{{ build.publishInfo }}'><i class="fa fa-wrench"></i></a>
+               href='{{ buildInfo.build.publishInfo }}'><i class="fa fa-wrench"></i></a>
             <a class="deployToolTip" data-toggle="tooltip" title="Click to download the build"
-               href='{{ build.artifactUrl }}'><i class="fa fa-cloud-download"></i></a>
+               href='{{ buildInfo.build.artifactUrl }}'><i class="fa fa-cloud-download"></i></a>
         </td>
-        <td><a href="/builds/{{ build.id }}">view</a></td>
+        <td><a href="/builds/{{ buildInfo.build.id }}">view</a></td>
+        <td>
+              {% if buildInfo.tag %}
+                {%if buildInfo.tag.value == "BAD_BUILD" %}
+                  <span class="label label-danger">{{buildInfo.tag.value}}</span>
+                {%elif buildInfo.tag|tagBuildId == buildInfo.build.id %}
+                  <span class="label label-success">{{buildInfo.tag.value}}</span>
+                {% endif %}
+              {% endif %}
+        </td>
     </tr>
     {% endfor%}
 </table>

--- a/deploy-board/deploy_board/templates/builds/confirm_tag_build.tmpl
+++ b/deploy-board/deploy_board/templates/builds/confirm_tag_build.tmpl
@@ -1,0 +1,36 @@
+{% load utils %}
+<div class="modal fade" id="tagBuildConfirmId" tabindex="-1" role="dialog"
+     aria-labelledby="tagConfirm" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+        <h4 class="modal-title">Confirm Tag As {{tag|availableBuildTag}}</h4>
+      </div>
+      <form id="confirmTagFormId" method="POST" role="form" class="form-horizontal"
+            action="tags/">
+      <div class="modal-body">
+        Are you sure to tag  <a href="/builds/{{ build.id }}">{{ build|branchAndCommit }}</a> as {{tag|availableBuildTag}}?
+        {% csrf_token %}
+        <div class="row">
+        <div class="form-group">
+          <input name="tag_value" type="hidden" value="{{tag|availableBuildTag}}" />
+          <input class="form-control" name="comments" type="text" required="true"
+                 placeholder="Please put additional comments here" value=""/>
+        </div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <input type="submit" value="Confirm" class="btn btn-primary">
+        <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+      </div>
+      </form>
+    </div><!-- /.modal-content -->
+  </div><!-- /.modal-dialog -->
+</div><!-- /.modal -->
+<script>
+    $('#confirmTagFormId').submit(function () {
+        $(this).find('button[type=submit]').prop('disabled', 'disabled');
+        $(this).find('button[type=submit]').text('Promoting...');
+    });
+</script>

--- a/deploy-board/deploy_board/templates/builds/pick_a_build.tmpl
+++ b/deploy-board/deploy_board/templates/builds/pick_a_build.tmpl
@@ -8,7 +8,7 @@
         <th class="col-lg-2">Repo</th>
         <th class="col-lg-1">Details</th>
     </tr>
-    {% for build in builds %}
+    {% for buildInfo in builds %}
     <tr>
         <td>
             <a class="deployToolTip pointer-cursor" data-toggle="collapse"
@@ -21,24 +21,31 @@
                       class="glyphicon glyphicon-chevron-down">
                       {% endif %}
                 </span>
-                {{ build.publishDate|convertTimestamp }}
+                {{ buildInfo.build.publishDate|convertTimestamp }}
             </a>
-            <input class="hiddenBuildId" type="hidden" value="{{ build.id }}"/>
-            <input class="hiddenCommit" type="hidden" value="{{ build.commit }}"/>
-            <input class="hiddenCommit7" type="hidden" value="{{ build.commitShort }}"/>
-            <input class="hiddenBranch" type="hidden" value="{{ build.branch }}"/>
+            <input class="hiddenBuildId" type="hidden" value="{{ buildInfo.build.id }}"/>
+            <input class="hiddenCommit" type="hidden" value="{{ buildInfo.build.commit }}"/>
+            <input class="hiddenCommit7" type="hidden" value="{{ buildInfo.build.commitShort }}"/>
+            <input class="hiddenBranch" type="hidden" value="{{ buildInfo.build.branch }}"/>
         </td>
-        <td><a class="deployToolTip" href="{{ build.commitInfo }}" target="_blank"
-               title="Click to see commit details in {{ build.type }}">
-                <i class="{{ build|commitIcon }}"></i> {{ build.commitShort }}
+        <td><a class="deployToolTip" href="{{ buildInfo.build.commitInfo }}" target="_blank"
+               title="Click to see commit details in {{ buildInfo.build.type }}">
+                <i class="{{ buildInfo.build|commitIcon }}"></i> {{ buildInfo.build.commitShort }}
             </a>
-            {% if not current_build or build.publishDate > current_build.publishDate %}
+            {% if not current_build or buildInfo.build.publishDate > current_build.publishDate %}
             <span class="label label-info">New</span>
             {% endif %}
+            {% if buildInfo.tag %}
+                {%if buildInfo.tag.value == "BAD_BUILD" %}
+                    <span class="label label-danger">{{buildInfo.tag.value}}</span>
+                {%elif buildInfo.tag|tagBuildId == buildInfo.build.id %}
+                    <span class="label label-success">{{buildInfo.tag.value}}</span>
+                {% endif %}               
+            {% endif %}
         </td>
-        <td>{{ build.branch }}</td>
-        <td>{{ build.repo }}</td>
-        <td><a href="/builds/{{ build.id }}">view</a></td>
+        <td>{{ buildInfo.build.branch }}</td>
+        <td>{{ buildInfo.build.repo }}</td>
+        <td><a href="/builds/{{ buildInfo.build.id }}">view</a></td>
     </tr>
     {% if builds|length > 1 %}
     <tr id="deployAction{{forloop.counter}}" class="collapse out deployActionPanel">

--- a/deploy-board/deploy_board/templates/builds/simple_builds.tmpl
+++ b/deploy-board/deploy_board/templates/builds/simple_builds.tmpl
@@ -13,12 +13,19 @@
     </div>
     <div class="row">
         <ul class="list-group">
-            {% for build in builds %}
-            <a href="/env/{{ env.envName }}/{{ env.stageName }}/build/{{ build.id }}"
+            {% for buildInfo in builds %}
+            <a href="/env/{{ env.envName }}/{{ env.stageName }}/build/{{ buildInfo.build.id }}"
                class="list-group-item">
-                {{ build|branchAndCommit }}
-                {% if not current_publish_date or build.publishDate > current_publish_date %}
-                <span class="label label-info">New</span>
+                {{ buildInfo.build|branchAndCommit }}
+                {% if not current_publish_date or buildInfo.build.publishDate > current_publish_date %}
+                    <span class="label label-info">New</span>
+                {% endif %}
+                {% if buildInfo.tag %}
+                    {% if buildInfo.tag.value == "BAD_BUILD" %}
+                        <span class="label label-danger">{{buildInfo.tag.value}}</span>
+                    {% elif buildInfo.tag|tagBuildId == buildInfo.build.id %}
+                        <span class="label label-success">{{buildInfo.tag.value}}</span>
+                    {% endif %}               
                 {% endif %}
             </a>
             {% endfor%}

--- a/deploy-board/deploy_board/templates/deploys/confirm_deploy.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/confirm_deploy.tmpl
@@ -21,6 +21,7 @@
                 </div>
                 <div class="modal-body">
                     <div id="confirmDeployModalPrecedingDeployWarningId">
+                        Warning
                     </div>
                     <div class="form-group">
                         <label for="description"
@@ -79,7 +80,7 @@
         $('#confirmDeployModalPrecedingDeployWarningId').load(
             '/env/{{ env.envName }}/{{ env.stageName }}/'
             + $('#confirmBuildIdInputId').val()
-            + '/warn_no_succ_deploy_in_pred/'
+            + '/warn_for_deploy/'
         );
     });
 </script>

--- a/deploy-board/deploy_board/templates/deploys/deploy_history.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/deploy_history.tmpl
@@ -54,6 +54,13 @@
             <td>
                 <a href="/builds/{{ deploy_summary.build.id }}">
                     {{ deploy_summary.build|branchAndCommit }}</a>
+                {% if deploy_summary.buildTag %}
+                     {%if deploy_summary.buildTag.value == "BAD_BUILD" %}
+                        <span class="label label-danger">{{deploy_summary.buildTag.value}}</span>
+                     {%elif deploy_summary.buildTag|tagBuildId == deploy_summary.build.id %}
+                        <span class="label label-success">{{deploy_summary.buildTag.value}}</span>
+                     {% endif %}
+                {% endif %}
             </td>
             <td>{{ deploy_summary.deploy.operator }}</td>
             <td><a href="/deploy/{{ deploy_summary.deploy.id }}">Details</a></td>

--- a/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
@@ -1,6 +1,6 @@
 {% load utils %}
 {% load static %}
-{% with deploy=report.currentDeployStat.deploy build=report.currentDeployStat.build %}
+{% with deploy=report.currentDeployStat.deploy build=report.currentDeployStat.build tag=report.currentDeployStat.buildTag %}
 {% include "deploys/deploy_progress_summary.tmpl" %}
 
 {% if report.showMode != "simple" %}

--- a/deploy-board/deploy_board/templates/deploys/deploy_progress_summary.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/deploy_progress_summary.tmpl
@@ -1,5 +1,6 @@
 {% load utils %}
 {% load static %}
+<script type="text/javascript" src="{% static "js/private/env_landing.js"%}"></script>
 <div class="panel panel-default table-responsive">
   <table class="table table-striped table-condensed table-hover">
     <tr>
@@ -19,6 +20,14 @@
            href="/builds/{{ build.id }}">
            {{ build|branchAndCommit }}
         </a>
+        {% if tag %}
+          {%if tag.value == "BAD_BUILD" %}
+            <span class="label label-danger">{{tag.value}}</span>
+            <div id="envErrorMsg" style="display: none;">The environment is running on a bad build tagged by {{tag.operator}} on {{ tag.createdDate|convertTimestamp }}</div>
+          {%elif tag|tagBuildId == build.id %}
+            <span class="label label-success">{{tag.value}}</span>
+          {% endif %}
+        {% endif %}
     </td>
     <td>
         <span class="deployToolTip pointer-cursor glyphicon {{ deploy.type|deployTypeIcon }}"

--- a/deploy-board/deploy_board/templates/environs/env_landing.html
+++ b/deploy-board/deploy_board/templates/environs/env_landing.html
@@ -17,6 +17,7 @@
 {% endif %}
 {% endblock %}
 
+
 {% block side-panel-actions %}
 <div class="panel panel-default">
     <div class="panel-heading clearfix">

--- a/deploy-board/deploy_board/templates/environs/env_rollback.html
+++ b/deploy-board/deploy_board/templates/environs/env_rollback.html
@@ -86,6 +86,13 @@
         <td>
             <a href="/builds/{{ deploy_summary.build.id }}">
                 {{ deploy_summary.build|branchAndCommit }}</a>
+            {% if deploy_summary.tag %}
+                {%if deploy_summary.tag.value == "BAD_BUILD" %}
+                    <span class="label label-danger">{{deploy_summary.tag.value}}</span>
+                {%elif deploy_summary.tag|tagBuildId == build.id %}
+                    <span class="label label-success">{{tag.value}}</span>
+                {% endif %}
+            {% endif %}
         </td>
         <td>
                 <span class="deployToolTip pointer-cursor {{ deploy_summary.deploy.state|deployStateIcon }}"

--- a/deploy-board/deploy_board/templates/warn_deploy_bad_build.tmpl
+++ b/deploy-board/deploy_board/templates/warn_deploy_bad_build.tmpl
@@ -1,0 +1,7 @@
+{% load utils %}
+<div class="alert alert-danger" role="alert">
+    <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+    <span class="sr-only">Error:</span>
+    This build is tagged as <span class="label label-danger">{{tag.value}}</span> by {{tag.operator}} on {{ tag.createdDate|convertTimestamp }}. 
+    Do you really want to deploy this commit?
+</div>

--- a/deploy-board/deploy_board/webapp/agent_report.py
+++ b/deploy-board/deploy_board/webapp/agent_report.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -44,9 +44,10 @@ class AgentStatistics(object):
 
 
 class DeployStatistics(object):
-    def __init__(self, deploy=None, build=None, stageDistMap=None, stateDistMap=None):
+    def __init__(self, deploy=None, build=None, stageDistMap=None, stateDistMap=None, buildTag=None):
         self.deploy = deploy
         self.build = build
+        self.buildTag = buildTag
         self.stageDistMap = stageDistMap
         self.stateDistMap = stateDistMap
         self.total = 0
@@ -139,11 +140,11 @@ def gen_report(request, env, progress, sortByStatus="false"):
 
     # always set the current
     deploy = deploys_helper.get(request, env['deployId'])
-    build = builds_helper.get_build(request, deploy["buildId"])
+    build_info = builds_helper.get_build_and_tag(request, deploy["buildId"])
     stageDistMap = genStageDistMap()
     stateDistMap = genStateDistMap()
-    currentDeployStat = DeployStatistics(deploy=deploy, build=build, stageDistMap=stageDistMap,
-                                         stateDistMap=stateDistMap)
+    currentDeployStat = DeployStatistics(deploy=deploy, build=build_info['build'], stageDistMap=stageDistMap,
+                                         stateDistMap=stateDistMap, buildTag=build_info.get('tag'))
     deployStats[env['deployId']] = currentDeployStat
 
     for agent in progress["agents"]:

--- a/deploy-board/deploy_board/webapp/build_views.py
+++ b/deploy-board/deploy_board/webapp/build_views.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,13 +16,16 @@
 """Collection of builds related views
 """
 import json
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 from django.http import HttpResponse
 from django.template.loader import render_to_string
 import common
-from helpers import builds_helper, systems_helper
+from helpers import builds_helper, systems_helper, tags_helper
 import random
 
+import logging
+
+log = logging.getLogger(__name__)
 
 def builds_landing(request):
     return get_build_names(request)
@@ -42,16 +45,20 @@ def get_build_names(request):
 
 
 def get_build(request, id):
-    build = builds_helper.get_build(request, id)
+    info = builds_helper.get_build_and_tag(request, id)
+    tag = info.get("tag")
+    if tag:
+        tag["build"]=json.loads(tag["metaInfo"])
     return render(request, 'builds/build_details.html', {
-        "build": build,
+        "build": info["build"],
+        "tag": tag
     })
 
 
 def list_builds(request, name):
     index = int(request.GET.get('page_index', '1'))
     size = int(request.GET.get('page_size', common.DEFAULT_BUILD_SIZE))
-    builds = builds_helper.get_builds(request, name=name, pageIndex=index, pageSize=size)
+    builds = builds_helper.get_builds_and_tags(request, name=name, pageIndex=index, pageSize=size)
     return render(request, 'builds/builds.html', {
         'build_name': name,
         'builds': builds,
@@ -67,17 +74,17 @@ def get_all_builds(request):
     branch = request.GET.get('branch')
     index = int(request.GET.get('page_index', '1'))
     size = int(request.GET.get('page_size', common.DEFAULT_BUILD_SIZE))
-    builds = builds_helper.get_builds(request, name=name, branch=branch, pageIndex=index,
+    builds = builds_helper.get_builds_and_tags(request, name=name, branch=branch, pageIndex=index,
                                       pageSize=size)
     scm_url = systems_helper.get_scm_url(request)
     current_build_id = request.GET.get('current_build_id', None)
     current_build = None
     if current_build_id:
-        current_build = builds_helper.get_build(request, current_build_id)
+        current_build = builds_helper.get_build_and_tag(request, current_build_id)
 
     html = render_to_string('builds/pick_a_build.tmpl', {
         "builds": builds,
-        "current_build": current_build,
+        "current_build": current_build['build'],
         "scm_url": scm_url,
         "buildName": name,
         "branch": branch,
@@ -91,7 +98,7 @@ def get_all_builds(request):
 
 # currently we only support search by git commit or SHA, 7 letters or longer
 def search_commit(request, commit):
-    builds = builds_helper.get_builds(request, commit=commit)
+    builds = builds_helper.get_builds_and_tags(request, commit=commit)
     return render(request, 'builds/builds_by_commit.html', {
         'commit': commit,
         'builds': builds,
@@ -161,3 +168,27 @@ def compare_commits_datatables(request):
     })
 
     return HttpResponse(html)
+
+
+def tag_build(request, id):
+    if request.method == "POST":
+        build_info = builds_helper.get_build_and_tag(request, id)
+        current_tag = build_info.get("tag")
+
+        if current_tag:
+            tagged_build = json.loads(current_tag["metaInfo"])
+            if tagged_build["id"] == id:
+                log.info("There is already a tag associated with the build. Remove it")
+                builds_helper.del_build_tag(request, current_tag["id"])
+        tag = {"targetId":id, "targetType":"Build", "comments":request.POST["comments"]}
+        value = request.POST["tag_value"]
+        if value.lower() == "good":
+            tag["value"] = tags_helper.TagValue.GOOD_BUILD
+        elif value.lower()=="bad":
+            tag["value"] = tags_helper.TagValue.BAD_BUILD
+        else:
+            return HttpResponse(status=400)
+        builds_helper.set_build_tag(request, tag)
+        return redirect("/builds/{0}/".format(id))
+    else:
+        return HttpResponse(status=405)

--- a/deploy-board/deploy_board/webapp/helpers/builds_helper.py
+++ b/deploy-board/deploy_board/webapp/helpers/builds_helper.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -53,3 +53,18 @@ def get_commits(request, **kwargs):
 
 def get_commit(request, repo, sha):
     return deploy_client.get("/commits/%s/%s" % (repo, sha), request.teletraan_user_id.token)
+
+def get_builds_and_tags(request, **kwargs):
+    params = deploy_client.gen_params(kwargs);
+    return deploy_client.get("/builds/tags",request.teletraan_user_id, params=params)
+
+def get_build_and_tag(request, id):
+    return deploy_client.get("/builds/{0}/tags".format(id), request.teletraan_user_id.token)
+
+
+def set_build_tag(request, tag):
+    return deploy_client.post("/tags/", request.teletraan_user_id.token, data=tag)
+
+
+def del_build_tag(request, id):
+    return deploy_client.delete("/tags/{0}/".format(id), request.teletraan_user_id)

--- a/deploy-board/deploy_board/webapp/helpers/tags_helper.py
+++ b/deploy-board/deploy_board/webapp/helpers/tags_helper.py
@@ -18,6 +18,11 @@ from deploy_board.webapp.helpers.deployclient import DeployClient
 
 deploy_client = DeployClient()
 
+#In sync with deploy-service/common/src/main/java/com/pinterest/deployservice/bean/TagValue.java
+class TagValue(object):
+    BAD_BUILD="BAD_BUILD"
+    GOOD_BUILD="GOOD_BUILD"
 
 def get_latest_by_targe_id(request, target_id):
     return deploy_client.get("/tags/targets/%s/latest" % target_id, request.teletraan_user_id.token)
+

--- a/deploy-board/deploy_board/webapp/urls.py
+++ b/deploy-board/deploy_board/webapp/urls.py
@@ -77,8 +77,8 @@ urlpatterns = [
     url(r'^env/(?P<name>[a-zA-Z0-9\-_]+)/(?P<stage>[a-zA-Z0-9\-_]+)/pred_deploys/$',
         env_views.get_pred_deploys),
     url(r'^env/(?P<name>[a-zA-Z0-9\-_]+)/(?P<stage>[a-zA-Z0-9\-_]+)/'
-        r'(?P<buildId>[a-zA-Z0-9\-_]+)/warn_no_succ_deploy_in_pred/$',
-        env_views.warn_no_succ_deploy_in_pred),
+        r'(?P<buildId>[a-zA-Z0-9\-_]+)/warn_for_deploy/$',
+        env_views.warn_for_deploy),
     url(r'^env/(?P<name>[a-zA-Z0-9\-_]+)/(?P<stage>[a-zA-Z0-9\-_]+)/builds/$',
         env_views.get_builds),
     url(r'^env/(?P<name>[a-zA-Z0-9\-_]+)/(?P<stage>[a-zA-Z0-9\-_]+)/groups/$',
@@ -166,6 +166,7 @@ urlpatterns = [
         build_views.list_build_branches),
     url(r'^builds/names/$', build_views.get_build_names),
     url(r'^builds/(?P<id>[a-zA-Z0-9\-_]+)/$', build_views.get_build),
+    url(r'^builds/(?P<id>[a-zA-Z0-9\-_]+)/tags/$', build_views.tag_build),
     url(r'^builds/$', build_views.builds_landing),
 
     # Commits related

--- a/deploy-board/tools/publish_build.py
+++ b/deploy-board/tools/publish_build.py
@@ -20,10 +20,10 @@ import commons
 
 
 def main():
-    for x in xrange(10):
+    for x in xrange(1):
         commons.publish_build("sample-build", "master")
-    for x in xrange(10):
-        commons.publish_build("sample-build", "hotfix")
+#    for x in xrange(1):
+#        commons.publish_build("sample-build", "hotfix")
 
 
 if __name__ == "__main__":

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/TagBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/TagBean.java
@@ -16,6 +16,7 @@
 package com.pinterest.deployservice.bean;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 import org.apache.commons.lang.builder.ReflectionToStringBuilder;
 
@@ -39,7 +40,7 @@ import java.beans.Transient;
  */
 public class TagBean implements Updatable {
 
-    private static final Gson gson = new Gson();
+    private static final ObjectMapper mapper = new ObjectMapper();
 
     @JsonProperty("id")
     private String id;
@@ -127,13 +128,13 @@ public class TagBean implements Updatable {
 
 
     @Transient
-    public <T> T deserializeTagMetaInfo(Class<T> theClass) {
-        return gson.fromJson(this.getMeta_info(), theClass);
+    public <T> T deserializeTagMetaInfo(Class<T> theClass) throws Exception{
+        return mapper.readValue(this.getMeta_info(), theClass);
     }
 
     @Transient
-    public void serializeTagMetaInfo(Object object) {
-        this.setMeta_info(gson.toJson(object));
+    public void serializeTagMetaInfo(Object object) throws Exception{
+        this.setMeta_info(mapper.writeValueAsString(object));
     }
 
     @Override

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/buildtags/BuildTagsManagerImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/buildtags/BuildTagsManagerImpl.java
@@ -53,6 +53,7 @@ public class BuildTagsManagerImpl implements BuildTagsManager {
         return ret;
     }
 
+    @Override
     public TagBean getEffectiveBuildTag(BuildBean build) throws Exception {
         if (!this.currentTags.containsKey(build.getBuild_name())) {
             LOG.debug("Retrieve Tag List for build {}", build.getBuild_name());

--- a/deploy-service/common/src/main/resources/sql/upgrade_plan_20160502.txt
+++ b/deploy-service/common/src/main/resources/sql/upgrade_plan_20160502.txt
@@ -13,7 +13,7 @@ CREATE TABLE IF NOT EXISTS tags (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
  CREATE INDEX tags_target_id_idx ON tags(target_id, target_type, created_date);
  CREATE INDEX tags_value_target_type_idx ON tags(value, target_type, created_date);
- CREATE INDEX tags_target_type_idx ON tags(target_type, created_date)
+ CREATE INDEX tags_target_type_idx ON tags(target_type, created_date);
 
  Rollback
  ===========================

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/buildtags/BuildTagsManagerImplTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/buildtags/BuildTagsManagerImplTest.java
@@ -131,11 +131,11 @@ public class BuildTagsManagerImplTest {
         return ret;
     }
 
-    private BuildTagBean genBuildTagBean(BuildBean build, TagValue value) {
+    private BuildTagBean genBuildTagBean(BuildBean build, TagValue value) throws Exception{
         return new BuildTagBean(build, genTagOnBuild(build, value));
     }
 
-    private TagBean genTagOnBuild(BuildBean build, TagValue value) {
+    private TagBean genTagOnBuild(BuildBean build, TagValue value) throws Exception {
         TagBean tag = new TagBean();
         tag.setId(CommonUtils.getBase64UUID());
         tag.setTarget_id(build.getBuild_name());

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/db/DBDAOTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/db/DBDAOTest.java
@@ -15,34 +15,19 @@
  */
 package com.pinterest.deployservice.db;
 
+import com.ibatis.common.jdbc.ScriptRunner;
+import com.mysql.management.driverlaunched.ServerLauncherSocketFactory;
 import com.pinterest.arcee.bean.*;
 import com.pinterest.arcee.common.AutoScalingConstants;
 import com.pinterest.arcee.dao.*;
 import com.pinterest.arcee.db.*;
-import com.pinterest.clusterservice.bean.CloudProvider;
-import com.pinterest.clusterservice.bean.ClusterBean;
-import com.pinterest.clusterservice.bean.HostTypeBean;
-import com.pinterest.clusterservice.bean.BaseImageBean;
-import com.pinterest.clusterservice.bean.SecurityZoneBean;
-import com.pinterest.clusterservice.bean.PlacementBean;
-import com.pinterest.clusterservice.dao.ClusterDAO;
-import com.pinterest.clusterservice.dao.HostTypeDAO;
-import com.pinterest.clusterservice.dao.BaseImageDAO;
-import com.pinterest.clusterservice.dao.SecurityZoneDAO;
-import com.pinterest.clusterservice.dao.PlacementDAO;
-import com.pinterest.clusterservice.db.DBBaseImageDAOImpl;
-import com.pinterest.clusterservice.db.DBClusterDAOImpl;
-import com.pinterest.clusterservice.db.DBHostTypeDAOImpl;
-import com.pinterest.clusterservice.db.DBPlacementDAOImpl;
-import com.pinterest.clusterservice.db.DBSecurityZoneDAOImpl;
+import com.pinterest.clusterservice.bean.*;
+import com.pinterest.clusterservice.dao.*;
+import com.pinterest.clusterservice.db.*;
 import com.pinterest.deployservice.bean.*;
 import com.pinterest.deployservice.common.CommonUtils;
 import com.pinterest.deployservice.common.Constants;
 import com.pinterest.deployservice.dao.*;
-
-import com.ibatis.common.jdbc.ScriptRunner;
-import com.mysql.management.driverlaunched.ServerLauncherSocketFactory;
-
 import org.apache.commons.dbcp.BasicDataSource;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.junit.AfterClass;
@@ -1588,7 +1573,8 @@ public class DBDAOTest {
         return dataBean;
     }
 
-    private TagBean genTagBean(TagValue val, String target_id, String target_type, Object meta_info){
+    private TagBean genTagBean(TagValue val, String target_id, String target_type, Object meta_info)
+        throws Exception {
         TagBean bean = new TagBean();
         bean.setId(CommonUtils.getBase64UUID());
         bean.setCreated_date(System.currentTimeMillis());


### PR DESCRIPTION
It allows engineers to mark a build as Bad, then all the subsequential builds will also be marked as bad until the engineer makred one build as good. Also a warning message is added when engineers try to deploy a bad build. Detailed screenshots can be found in https://docs.google.com/document/d/1hlZwmlXvHxqp51LOPQc4OBRv44qwQLeqQoZaoelJfm0/edit 

The details of changes include:
1. Add UI to show the tag in variant pages  of builds, environment.
2. Service API got two changes: 
      a. Use Jackson instead of Gson so that the metainfo deserialization respects jsonproperty on beans
      b. API changes to search search by commit.

 @sbaogang @yujunglo 