### PR TITLE
add system priority to env, we will use it for sidecar deploys

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/DeployPriority.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/DeployPriority.java
@@ -16,7 +16,7 @@
 package com.pinterest.deployservice.bean;
 
 public enum DeployPriority {
-    NORMAL(30), HIGH(20), LOW(40), HIGHER(10), LOWER(60);
+    NORMAL(3000), HIGH(2000), LOW(4000), HIGHER(1000), LOWER(5000);
 
     private final int value;
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironBean.java
@@ -38,6 +38,7 @@ import java.io.Serializable;
  * deploy_type   VARCHAR(32),
  * max_parallel  INT                 NOT NULL,
  * priority      VARCHAR(16)         NOT NULL,
+ * system_priority  INT,
  * stuck_th      INT                 NOT NULL,
  * success_th    INT                 NOT NULL,
  * adv_config_id VARCHAR(22),
@@ -97,6 +98,9 @@ public class EnvironBean implements Updatable, Serializable {
 
     @JsonProperty("priority")
     private DeployPriority priority;
+
+    @JsonProperty("systemPriority")
+    private Integer system_priority;
 
     @JsonProperty("stuckThreshold")
     private Integer stuck_th;
@@ -305,6 +309,14 @@ public class EnvironBean implements Updatable, Serializable {
         this.priority = priority;
     }
 
+    public Integer getSystem_priority() {
+        return system_priority;
+    }
+
+    public void setSystem_priority(Integer system_priority) {
+        this.system_priority = system_priority;
+    }
+
     public AcceptanceType getAccept_type() {
         return accept_type;
     }
@@ -408,6 +420,7 @@ public class EnvironBean implements Updatable, Serializable {
         clause.addColumn("deploy_type", deploy_type);
         clause.addColumn("max_parallel", max_parallel);
         clause.addColumn("priority", priority);
+        clause.addColumn("system_priority", system_priority);
         clause.addColumn("stuck_th", stuck_th);
         clause.addColumn("success_th", success_th);
         clause.addColumn("adv_config_id", adv_config_id);

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java
@@ -28,8 +28,10 @@ import java.util.*;
 
 class GoalAnalyst {
     private static final Logger LOG = LoggerFactory.getLogger(GoalAnalyst.class);
-    private static final int HOT_FIX_PRIORITY = 0;
-    private static final int ROLL_BACK_PRIORITY = 1;
+    // Define lower value for hotfix and rollback priority to make sure they deploy first
+    // Notice hotfix and rollback priority should still lower than system service priority
+    private static final int HOT_FIX_PRIORITY = DeployPriority.HIGHER.getValue() - 20;
+    private static final int ROLL_BACK_PRIORITY = DeployPriority.HIGHER.getValue() - 10;
 
     private String host;
     private String host_id;
@@ -90,9 +92,17 @@ class GoalAnalyst {
 
         int getDeployPriority(EnvironBean env) {
             if (env.getDeploy_type() == null) {
-                return 100;
+              return DeployPriority.NORMAL.getValue();
             } else {
-                DeployType deployType = env.getDeploy_type();
+              // System level deploy, or sidecar service deploy mostly, will use dedicated system
+              // priority. Notice for system level deploy, we disregard the priorities of hotfix
+              // or rollback.
+              Integer systemPriority = env.getSystem_priority();
+              if (systemPriority != null) {
+                return systemPriority;
+              }
+
+              DeployType deployType = env.getDeploy_type();
                 if (deployType == DeployType.HOTFIX) {
                     return HOT_FIX_PRIORITY;
                 } else if (deployType == DeployType.ROLLBACK) {

--- a/deploy-service/common/src/main/resources/sql/deploy.sql
+++ b/deploy-service/common/src/main/resources/sql/deploy.sql
@@ -15,6 +15,7 @@ CREATE TABLE IF NOT EXISTS environs (
     deploy_type   VARCHAR(32),
     max_parallel  INT                 NOT NULL,
     priority      VARCHAR(16)         NOT NULL,
+    system_priority INT,
     stuck_th      INT                 NOT NULL,
     success_th    INT                 NOT NULL,
     adv_config_id VARCHAR(22),

--- a/deploy-service/common/src/main/resources/sql/upgrade_plan_20160516.txt
+++ b/deploy-service/common/src/main/resources/sql/upgrade_plan_20160516.txt
@@ -1,0 +1,7 @@
+UPDATES
+=================
+ALTER TABLE environs ADD COLUMN system_priority INT;
+
+Rollback
+===========================
+ALTER TABLE environs DROP COLUMN system_priority;


### PR DESCRIPTION
This change will not break users. I would think this is long term solution as well. I am not convinced regular deploys need such finer level of control on deploy orders, it might just complicate Teletraan and confuse users. Plan to keep this five higher level priority, and keep this system_priority hidden from user for now. (we could expose this through system level UI or API in the future).
