### PR TITLE
Google OAUTH2 Support

### DIFF
--- a/deploy-board/deploy_board/settings.py
+++ b/deploy-board/deploy_board/settings.py
@@ -45,6 +45,7 @@ if OAUTH_ENABLED_STR == "OFF":
     OAUTH_ENABLED = False
 else:
     OAUTH_ENABLED = True
+    OAUTH_PROVIDER = os.getenv("OAUTH_PROVIDER", "pinadmin")
     OAUTH_CLIENT_ID = os.getenv("OAUTH_CLIENT_ID")
     OAUTH_CLIENT_SECRET = os.getenv("OAUTH_CLIENT_SECRET")
     OAUTH_CALLBACK = os.getenv("OAUTH_CALLBACK")

--- a/deploy-board/deploy_board/webapp/security.py
+++ b/deploy-board/deploy_board/webapp/security.py
@@ -125,7 +125,12 @@ def login_authorized(request):
         data = oauth.handle_oauth2_response(code, state, session=request.session)
         user_name = oauth.oauth_data(user_info_uri=settings.OAUTH_USER_INFO_URI,
                                      key=settings.OAUTH_USERNAME_INFO_KEY,
-                                     session=request.session)['username']
+                                     session=request.session)
+        # Google Returns the username as a string directly. Pinadmin returns an array.
+        if(settings.OAUTH_PROVIDER == "pinadmin"):
+            user_name = user_name['username']
+        
+
     except OAuthException as e:
         # failed to login for some reason, do something
         logger.error(traceback.format_exc())

--- a/deploy-board/manage.py
+++ b/deploy-board/manage.py
@@ -42,16 +42,21 @@ if __name__ == "__main__":
     #
     os.environ.setdefault("OAUTH_ENABLED", "OFF")
     #os.environ.setdefault("OAUTH_ENABLED", "ON")
-    #os.environ.setdefault("OAUTH_CLIENT_ID", <OAUTH_CLIENT_ID>)
+
+    #Provider for OAUTH. Currently supports 'pinadmin' (internal) and 'googlev2'
+    #os.environ.setdefault("OAUTH_PROVIDER", "<OAUTH_PROVIDER>")
+
+    #os.environ.setdefault("OAUTH_CLIENT_ID", "<OAUTH_CLIENT_ID>")
     #os.environ.setdefault("OAUTH_CALLBACK", "<DEPLOYBOARD_URL>/auth")
-    #os.environ.setdefault("OAUTH_DOMAIN", <YOUR_DOMAIN>)
-    #os.environ.setdefault("OAUTH_CLIENT_TYPE", <CLIENT_TYPE>)
-    #os.environ.setdefault("OAUTH_USER_INFO_URI", <USER_INFO_URL>)
-    #os.environ.setdefault("ACCESS_TOKEN_URL", <ACCESS_TOKEN_URL>)
-    #os.environ.setdefault("OAUTH_AUTHORIZE_URL", <OAUTH_AUTH_URL>)
-    #os.environ.setdefault("OAUTH_DEFAULT_SCOPE", <DEFAULT_SCOP>)
+    #os.environ.setdefault("OAUTH_DOMAIN", "<YOUR_DOMAIN>")
+    #os.environ.setdefault("OAUTH_CLIENT_TYPE", "<CLIENT_TYPE>")
+    #os.environ.setdefault("OAUTH_USER_INFO_URI", "<USER_INFO_URL>")
+    #os.environ.setdefault("OAUTH_ACCESS_TOKEN_URL", "<ACCESS_TOKEN_URL>")
+    #os.environ.setdefault("OAUTH_AUTHORIZE_URL", "<OAUTH_AUTH_URL>")
+    #os.environ.setdefault("OAUTH_DEFAULT_SCOPE", "<DEFAULT_SCOPE>")
+    #os.environ.setdefault("OAUTH_CLIENT_SECRET", "<SECRET_KEY>")    
     # Key for user response, which key is associated with the username in the response. Emails are parsed for prefix.
-    #os.environ.setdefault("OAUTH_USERNAME_INFO_KEY", <USERNAME_KEY>)
+    #os.environ.setdefault("OAUTH_USERNAME_INFO_KEY", "<USERNAME_KEY>"")
 
     from django.core.management import execute_from_command_line
     execute_from_command_line(sys.argv)

--- a/deploy-board/manage.py
+++ b/deploy-board/manage.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     #os.environ.setdefault("OAUTH_DEFAULT_SCOPE", "<DEFAULT_SCOPE>")
     #os.environ.setdefault("OAUTH_CLIENT_SECRET", "<SECRET_KEY>")    
     # Key for user response, which key is associated with the username in the response. Emails are parsed for prefix.
-    #os.environ.setdefault("OAUTH_USERNAME_INFO_KEY", "<USERNAME_KEY>"")
+    #os.environ.setdefault("OAUTH_USERNAME_INFO_KEY", "<USERNAME_KEY>")
 
     from django.core.management import execute_from_command_line
     execute_from_command_line(sys.argv)

--- a/deploy-service/teletraanservice/bin/server.yaml
+++ b/deploy-service/teletraanservice/bin/server.yaml
@@ -75,6 +75,9 @@ db:
   # OAuth provider url
   #userDataUrl: https://auth.pinadmin.com/api/me/
 
+  # OAuth provider - either pinadmin (internal) or googlev2
+  # oauthProvider: pinadmin
+
   # Optional. token cache
   #tokenCacheSpec: maximumSize=1000,expireAfterWrite=10m
 

--- a/deploy-service/teletraanservice/bin/server.yaml
+++ b/deploy-service/teletraanservice/bin/server.yaml
@@ -75,7 +75,7 @@ db:
   # OAuth provider url
   #userDataUrl: https://auth.pinadmin.com/api/me/
 
-  # OAuth provider - either pinadmin (internal) or googlev2
+  # OAuth provider - either pinadmin (internal) or openid
   # oauthProvider: pinadmin
 
   # Optional. token cache

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/TokenAuthenticationFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/TokenAuthenticationFactory.java
@@ -30,6 +30,9 @@ public class TokenAuthenticationFactory implements AuthenticationFactory {
     private String userDataUrl;
 
     @JsonProperty
+    private String oauthProvider;
+
+    @JsonProperty
     private String groupDataUrl;
 
     @JsonProperty
@@ -59,8 +62,12 @@ public class TokenAuthenticationFactory implements AuthenticationFactory {
         this.groupDataUrl = groupDataUrl;
     }
 
+    public String getOauthProvider() {
+        return this.oauthProvider;
+    }
+
     @Override
     public ContainerRequestFilter create(TeletraanServiceContext context) throws Exception {
-        return new TokenAuthFilter(userDataUrl, groupDataUrl, tokenCacheSpec, context);
+        return new TokenAuthFilter(userDataUrl, groupDataUrl, tokenCacheSpec, oauthProvider, context);
     }
 }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/TokenAuthFilter.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/TokenAuthFilter.java
@@ -41,8 +41,8 @@ public class TokenAuthFilter implements ContainerRequestFilter {
 
     private UserDataHelper userDataHelper;
 
-    public TokenAuthFilter(String userDataUrl, String groupDataUrl, String tokenCacheSpec, TeletraanServiceContext context) throws Exception {
-        userDataHelper = new UserDataHelper(userDataUrl, groupDataUrl, tokenCacheSpec, context);
+    public TokenAuthFilter(String userDataUrl, String groupDataUrl, String tokenCacheSpec, String oauthProvider, TeletraanServiceContext context) throws Exception {
+        userDataHelper = new UserDataHelper(userDataUrl, groupDataUrl, tokenCacheSpec, oauthProvider, context);
     }
 
     @Override

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/UserDataHelper.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/UserDataHelper.java
@@ -84,15 +84,15 @@ public class UserDataHelper {
         Map<String, String> params = ImmutableMap.of("access_token", token);
         String jsonPayload = httpClient.get(userDataUrl, params, null, 3);
         JsonObject jsonObject = new JsonParser().parse(jsonPayload).getAsJsonObject();
-        final String user;
-        if (oauthProvider.equals("googlev2")){
-            String email = jsonObject.getAsJsonPrimitive("email").getAsString();
-            user = email.split("@")[0];
-        } else { 
-            // fall back to pinadmin
-            jsonObject = jsonObject.getAsJsonObject("user");
-            user = jsonObject.get("username").getAsString();
-        } 
+        String user;
+        switch(oauthProvider) {
+            case "pinadmin": {
+                user = jsonObject.getAsJsonObject("user").get("username").getAsString();
+            }
+            default: {
+                user = jsonObject.getAsJsonPrimitive("email").getAsString().split("@")[0];
+            }
+        }
         LOG.info("Retrieved username " + user + " from token.");
         return user;
     }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/UserDataHelper.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/UserDataHelper.java
@@ -84,14 +84,14 @@ public class UserDataHelper {
         Map<String, String> params = ImmutableMap.of("access_token", token);
         String jsonPayload = httpClient.get(userDataUrl, params, null, 3);
         JsonObject jsonObject = new JsonParser().parse(jsonPayload).getAsJsonObject();
-        String user;
+        final String user;
         switch(oauthProvider) {
-            case "pinadmin": {
+            case "pinadmin": 
                 user = jsonObject.getAsJsonObject("user").get("username").getAsString();
-            }
-            default: {
+                break;
+            default: 
                 user = jsonObject.getAsJsonPrimitive("email").getAsString().split("@")[0];
-            }
+                break;
         }
         LOG.info("Retrieved username " + user + " from token.");
         return user;


### PR DESCRIPTION
This provides the ability to specify Google’s OAUTH2 service and have
Teletraan auth against it. If the option is not explicitly set, the default
is to fall back to Pinadmin as the OAUTH2 provider. 

Fixed spellings, formatting (quotes), and added SECRET_KEY environment variable to default settings file (since it is a required variable for OAUTH2).

While I have tested this against Google's endpoints, I have not been able to (for obvious reasons) test against pinadmin. 

This should help solve questions like: https://github.com/pinterest/teletraan/issues/161
