### PR TITLE
Quick stage removal typo fix

### DIFF
--- a/deploy-board/deploy_board/templates/environs/remove_stage_modal.tmpl
+++ b/deploy-board/deploy_board/templates/environs/remove_stage_modal.tmpl
@@ -9,7 +9,8 @@
                 <h4 class="modal-title" id="removeStageModalLabel">Remove Stage</h4>
             </div>
             <div class="modal-body">
-                Are you sure to remove stage <strong>{{ stage }}</strong>?
+                Are you sure you would like to remove stage <strong>{{ stageName }}</strong>?<br/>
+                If there are no other stages in your environment, this will remove the environment as well.
             </div>
             <div class="modal-footer">
                 <a href="/env/{{ envName }}/{{ stageName }}/remove" class="btn btn-primary">

--- a/deploy-board/deploy_board/templates/environs/remove_stage_modal.tmpl
+++ b/deploy-board/deploy_board/templates/environs/remove_stage_modal.tmpl
@@ -10,7 +10,9 @@
             </div>
             <div class="modal-body">
                 Are you sure you would like to remove stage <strong>{{ stageName }}</strong>?<br/>
-                If there are no other stages in your environment, this will remove the environment as well.
+                {% if stages|length == 1 %}
+                This is the last stage, so its removal will remove the environment as well.
+                {% endif %}
             </div>
             <div class="modal-footer">
                 <a href="/env/{{ envName }}/{{ stageName }}/remove" class="btn btn-primary">


### PR DESCRIPTION
Stage name wasn't displaying in remove stage modal because of a typo. Fixed that and added notice to the user if they are about to delete the environment (by removing the last stage).