### PR TITLE
Clarify duplicate commit warning message when deploying

### DIFF
--- a/deploy-board/deploy_board/templates/deploys/duplicate_commit_deploy_message.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/duplicate_commit_deploy_message.tmpl
@@ -1,3 +1,3 @@
 <div id="duplicateCommitDeployMessageId" class="alert alert-warning" role="alert">
-    <strong>Notice: </strong> The selected build is currently deployed.
+    <strong>Notice: </strong> Commit {{commit}} is currently being deployed
 </div>

--- a/deploy-board/deploy_board/webapp/deploy_views.py
+++ b/deploy-board/deploy_board/webapp/deploy_views.py
@@ -86,7 +86,8 @@ def get_duplicate_commit_deploy_message(request, name, stage, buildId):
     next_commit = next_build['commit']
 
     if current_commit == next_commit:
-        return render(request, 'deploys/duplicate_commit_deploy_message.tmpl')
+        return render(request, 'deploys/duplicate_commit_deploy_message.tmpl',{
+                      "commit":next_build['commitShort']})
     return HttpResponse('')
 
 


### PR DESCRIPTION
Change the warning message to clarify that it is the currently selected
commit which is already deployed.