### PR TITLE
add db schema upgrade script

### DIFF
--- a/deploy-service/common/src/main/resources/sql/README
+++ b/deploy-service/common/src/main/resources/sql/README
@@ -1,4 +1,0 @@
-To upgrade DB schema to release 1.0.2, run something like the following:
-mysql -uroot -f < teletraan/schema-upgrade-r1.0.1-to-r1.0.2.sql
-
-You can safely ignore the duplicate column error if any

--- a/deploy-service/common/src/main/resources/sql/deploy.sql
+++ b/deploy-service/common/src/main/resources/sql/deploy.sql
@@ -276,3 +276,11 @@ CREATE TABLE IF NOT EXISTS schedules (
     state_start_time    BIGINT          NOT NULL,
     PRIMARY KEY (id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE IF NOT EXISTS schema_versions (
+    version INT NOT NULL DEFAULT 0,
+    PRIMARY KEY (version)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- Make sure to update the version everytime we change the schema
+INSERT INTO schema_versions (version) VALUES (1);

--- a/tools/mysql/README
+++ b/tools/mysql/README
@@ -1,0 +1,13 @@
+-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+-- ALWAYS BACKUP YOUR DATA BEFORE EXECUTING THIS SCRIPT   
+-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+This dir contains scripts to upgrade db schema to the latest version. Simply execute:
+./upgrade.sh [-H|--host HOST] [-P|--port PORT] [-u|--user USERNAME] [-p|--password PASSWORD] [-d|--database DATABASE]
+It will upgrade db schema from the current version to the latest.
+
+In any case if the upgrade failed, you would have to look at all the schema-update-* files and manually apply the changes,
+and then update the version in database_schemas table to be the latest.
+
+We do not support rollback yet.
+

--- a/tools/mysql/README.dev
+++ b/tools/mysql/README.dev
@@ -1,0 +1,7 @@
+Follow the steps below to update deploy DB schema ( assume current DB schema version is 10)
+
+1. Create file schema-update-11.sql, and put the DB schema change statements there
+2. Make sure the last statement reads:
+   UPDATE schema_versions SET version=11;
+3. Make sure you update the last statement in ../../deploy-service/common/src/main/resources/sql/deploy.sql as well:
+   INSERT INTO schema_versions (version) VALUES (11);

--- a/tools/mysql/check_version.sql
+++ b/tools/mysql/check_version.sql
@@ -1,0 +1,13 @@
+# Create schema_versions if necessary, and set the current version to 0
+CREATE TABLE IF NOT EXISTS schema_versions (
+    version INT NOT NULL DEFAULT 0,
+    PRIMARY KEY (version)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+# Insert if not already
+INSERT INTO schema_versions (version)
+SELECT 0 FROM DUAL
+WHERE NOT EXISTS (SELECT * FROM schema_versions);
+
+# Return the actual version
+SELECT version FROM schema_versions;

--- a/tools/mysql/schema-update-1.sql
+++ b/tools/mysql/schema-update-1.sql
@@ -1,14 +1,9 @@
-# !!!!!!!!!!!!!!!!!!!!!!!!!!!!
-# BACKUP YOUR DATA BEFORE EXECUTING THIS SCRIPT
-# !!!!!!!!!!!!!!!!!!!!!!!!!!!!
+-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+-- ALWAYS BACKUP YOUR DATA BEFORE EXECUTING THIS SCRIPT   
+-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-# This script assumes your current DB schema is the same as release 1.0.1(SHA #fdd68c0) or newer
-# It will upgrade the schema to release 1.0.2, or SHA #xxxxx
+# This script upgrade DB schema from version 0 to version 1
 
-# Change the following statement to use your DB if needed
-USE deploy;
-
-# Delete all the tables not needed in release 1.0.2
 DROP TABLE IF EXISTS groups;
 DROP TABLE IF EXISTS asg_alarms;
 DROP TABLE IF EXISTS images;
@@ -16,7 +11,6 @@ DROP TABLE IF EXISTS health_checks;
 DROP TABLE IF EXISTS healthcheck_errors;
 DROP TABLE IF EXISTS new_instances_reports;
 
-# Create new tables not in release 1.0.1
 CREATE TABLE IF NOT EXISTS tags (
   id VARCHAR(30) NOT NULL,
   value VARCHAR(30) NOT NULL,
@@ -28,9 +22,9 @@ CREATE TABLE IF NOT EXISTS tags (
   meta_info text,
   PRIMARY KEY (id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-#CREATE INDEX tags_target_id_idx ON tags(target_id, target_type, created_date);
-#CREATE INDEX tags_value_target_type_idx ON tags(value, target_type, created_date);
-#CREATE INDEX tags_target_type_idx ON tags(target_type, created_date);
+CREATE INDEX tags_target_id_idx ON tags(target_id, target_type, created_date);
+CREATE INDEX tags_value_target_type_idx ON tags(value, target_type, created_date);
+CREATE INDEX tags_target_type_idx ON tags(target_type, created_date);
 
 CREATE TABLE IF NOT EXISTS schedules (
     id                  VARCHAR(22)     NOT NULL,
@@ -43,7 +37,6 @@ CREATE TABLE IF NOT EXISTS schedules (
     PRIMARY KEY (id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-# Add new columns for release 1.0.2. Ignore any errors if column already exists, no harm done
 ALTER TABLE builds ADD COLUMN publisher VARCHAR(64);
 ALTER TABLE hosts ADD COLUMN can_retire TINYINT(1) NOT NULL DEFAULT 0;
 ALTER TABLE environs ADD COLUMN system_priority INT;
@@ -55,3 +48,5 @@ ALTER TABLE environs ADD COLUMN max_parallel_rp INT NOT NULL DEFAULT 1;
 ALTER TABLE environs ADD COLUMN override_policy VARCHAR(32) NOT NULL DEFAULT "OVERRIDE";
 ALTER TABLE environs ADD COLUMN schedule_id VARCHAR(22);
 
+-- make sure to update the schema version to 1
+UPDATE schema_versions SET version=1;

--- a/tools/mysql/upgrade.sh
+++ b/tools/mysql/upgrade.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+# Exit upon any errors
+set -e
+
+# Set defaults
+HOST=
+PORT=
+USER=root
+PASSWORD=
+DATABASE=deploy
+CURRENT_VERSION=
+TARGET_VERSION=
+DRYRUN=false
+
+usage() { 
+  echo "Usage: upgrade [-H|--host HOST] [-P|--port PORT]"
+  echo "               [-u|--user USERNAME] [-p|--password PASSWORD]"
+  echo "               [-d|--database DATABASE] [-v|--version VERSION]"
+  echo "               [--dry-run] [-h|--help]" 
+  echo "optional arguments:"
+  echo "-h, --help              show this help message and exit"
+  echo "-H, --host HOST         DB server host name, default is localhost"
+  echo "-P, --port HOST         DB server port number, default is 3306"
+  echo "-u, --user USERNAME     DB server user name, default is root"
+  echo "-p, --password PASSWORD DB server password, default is empty"
+  echo "-d, --database DATABASE database to use, default is deploy"
+  echo "-v, --version VERSION   the schema version to upgrade to, default is the highest version possible"
+  echo "--dry-run               print upgrade route without action"
+}
+
+resolve_target_version() {
+  # list all files like schema-update-N.sql, and use the largest N as the target version
+  TARGET_VERSION=0
+  for f in schema-update-*.sql
+  do
+    tmp=${f#schema-update*-}
+    num=${tmp%.sql}
+    if (( num > TARGET_VERSION )); then
+        TARGET_VERSION=$num
+    fi
+  done
+}
+
+while [[ $# -ge 1 ]]
+do
+key="$1"
+
+case $key in
+    -H|--host)
+    HOST="$2"
+    shift # past argument
+    ;;
+    -P|--port)
+    PORT="$2"
+    shift # past argument
+    ;;
+    -u|--user)
+    USER="$2"
+    shift # past argument
+    ;;
+    -p|--password)
+    PASSWORD="$2"
+    shift # past argument
+    ;;
+    -d|--database)
+    DATABASE="$2"
+    shift # past argument
+    ;;
+    -v|--version)
+    TARGET_VERSION="$2"
+    shift # past argument
+    ;;
+    -h|--help)
+    usage #unknown option
+    exit 0
+    ;;
+    --dry-run)
+    DRYRUN=true
+    ;;
+    *)
+    echo "Unknown option $1"
+    usage #unknown option
+    exit 1
+    ;;
+esac
+shift # past argument or value
+done
+
+[ ! -z "$HOST" ] && HOST="--host=$HOST" 
+[ ! -z "$PORT" ] && PORT="--port=$PORT" 
+[ ! -z "$PASSWORD" ] && PASSWORD="--password=$PASSWORD" 
+
+CURRENT_VERSION=$(mysql $HOST $PORT -u $USER $PASSWORD $DATABASE -s -N < check_version.sql)
+[ -z "$TARGET_VERSION" ] && resolve_target_version
+echo "Will upgrade schema from version ${CURRENT_VERSION} to version ${TARGET_VERSION}"
+
+for ((i=CURRENT_VERSION+1;i<=TARGET_VERSION;i++)); do
+    echo "upgrading to version ${i} with schema-update-$i.sql..."
+    if [ "$DRYRUN" == "true" ]; then
+        continue
+    fi
+    mysql $HOST $PORT -u $USER $PASSWORD $DATABASE < schema-update-$i.sql
+done
+
+echo "Successfully upgraded schema from version ${CURRENT_VERSION} to version ${TARGET_VERSION}"


### PR DESCRIPTION
Create schema-versions table which will track DB schema versions and use upgrade.sh to upgrade it. For example, assume current schema version is 2, the upgrade script will first read the current schema version, and run only schema-upgrade-3.sql,  schema-upgrade-4.sql... until the latest version.

From this version on, when we change schema, we need to create the schema-upgrade-N+1.sql, assume current version is N

This is believed to be much effective and easier to track and upgrade than the upgrade text file we kept before. Let us use this new approach from now on. 

