### PR TITLE
Style configuration history page

### DIFF
--- a/deploy-board/deploy_board/static/css/bootstrap-sortable.css
+++ b/deploy-board/deploy_board/static/css/bootstrap-sortable.css
@@ -1,0 +1,110 @@
+/**
+ * adding sorting ability to HTML tables with Bootstrap styling
+ * @summary HTML tables sorting ability
+ * @version 2.0.0
+ * @requires tinysort, moment.js, jQuery
+ * @license MIT
+ * @author Matus Brlit (drvic10k)
+ * @copyright Matus Brlit (drvic10k), bootstrap-sortable contributors
+ */
+
+table.sortable span.sign {
+    display: block;
+    position: absolute;
+    top: 50%;
+    right: 5px;
+    font-size: 12px;
+    margin-top: -10px;
+    color: #bfbfc1;
+}
+
+table.sortable th:after {
+    display: block;
+    position: absolute;
+    top: 50%;
+    right: 5px;
+    font-size: 12px;
+    margin-top: -10px;
+    color: #bfbfc1;
+}
+
+table.sortable th.arrow:after {
+    content: '';
+}
+
+table.sortable span.arrow, span.reversed, th.arrow.down:after, th.reversedarrow.down:after, th.arrow.up:after, th.reversedarrow.up:after {
+    border-style: solid;
+    border-width: 5px;
+    font-size: 0;
+    border-color: #ccc transparent transparent transparent;
+    line-height: 0;
+    height: 0;
+    width: 0;
+    margin-top: -2px;
+}
+
+    table.sortable span.arrow.up, th.arrow.up:after {
+        border-color: transparent transparent #ccc transparent;
+        margin-top: -7px;
+    }
+
+table.sortable span.reversed, th.reversedarrow.down:after {
+    border-color: transparent transparent #ccc transparent;
+    margin-top: -7px;
+}
+
+    table.sortable span.reversed.up, th.reversedarrow.up:after {
+        border-color: #ccc transparent transparent transparent;
+        margin-top: -2px;
+    }
+
+table.sortable span.az:before, th.az.down:after {
+    content: "a .. z";
+}
+
+table.sortable span.az.up:before, th.az.up:after {
+    content: "z .. a";
+}
+
+table.sortable th.az.nosort:after, th.AZ.nosort:after, th._19.nosort:after, th.month.nosort:after {
+    content: "..";
+}
+
+table.sortable span.AZ:before, th.AZ.down:after {
+    content: "A .. Z";
+}
+
+table.sortable span.AZ.up:before, th.AZ.up:after {
+    content: "Z .. A";
+}
+
+table.sortable span._19:before, th._19.down:after {
+    content: "1 .. 9";
+}
+
+table.sortable span._19.up:before, th._19.up:after {
+    content: "9 .. 1";
+}
+
+table.sortable span.month:before, th.month.down:after {
+    content: "jan .. dec";
+}
+
+table.sortable span.month.up:before, th.month.up:after {
+    content: "dec .. jan";
+}
+
+table.sortable>thead th:not([data-defaultsort=disabled]) {
+    cursor: pointer;
+    position: relative;
+    top: 0;
+    left: 0;
+}
+
+table.sortable>thead th:hover:not([data-defaultsort=disabled]) {
+    background: #efefef;
+}
+
+table.sortable>thead th div.mozilla {
+    position: relative;
+}

--- a/deploy-board/deploy_board/static/js/bootstrap-sortable.js
+++ b/deploy-board/deploy_board/static/js/bootstrap-sortable.js
@@ -1,0 +1,289 @@
+/**
+ * adding sorting ability to HTML tables with Bootstrap styling
+ * @summary HTML tables sorting ability
+ * @version 2.0.0
+ * @requires tinysort, moment.js, jQuery
+ * @license MIT
+ * @author Matus Brlit (drvic10k)
+ * @copyright Matus Brlit (drvic10k), bootstrap-sortable contributors
+ */
+
+/**
+ * TinySort is a small script that sorts HTML elements. It sorts by text- or attribute value, or by that of one of it's children.
+ * @summary A nodeElement sorting script.
+ * @version 2.2.0
+ * @license MIT/GPL
+ * @author Ron Valstar <ron@ronvalstar.nl>
+ * @copyright Ron Valstar <ron@ronvalstar.nl>
+ * @namespace tinysort
+ */
+!function (a, b) { "use strict"; function c() { return b } "function" == typeof define && define.amd ? define("tinysort", c) : a.tinysort = b }(this, function () { "use strict"; function a(a, f) { function j() { 0 === arguments.length ? s({}) : d(arguments, function (a) { s(c(a) ? { selector: a } : a) }), p = D.length } function s(a) { var b = !!a.selector, c = b && ":" === a.selector[0], d = e(a || {}, r); D.push(e({ hasSelector: b, hasAttr: !(d.attr === i || "" === d.attr), hasData: d.data !== i, hasFilter: c, sortReturnNumber: "asc" === d.order ? 1 : -1 }, d)) } function t() { d(a, function (a, b) { y ? y !== a.parentNode && (E = !1) : y = a.parentNode; var c = D[0], d = c.hasFilter, e = c.selector, f = !e || d && a.matchesSelector(e) || e && a.querySelector(e), g = f ? B : C, h = { elm: a, pos: b, posn: g.length }; A.push(h), g.push(h) }), x = B.slice(0) } function u() { B.sort(v) } function v(a, e) { var f = 0; for (0 !== q && (q = 0) ; 0 === f && p > q;) { var i = D[q], j = i.ignoreDashes ? n : m; if (d(o, function (a) { var b = a.prepare; b && b(i) }), i.sortFunction) f = i.sortFunction(a, e); else if ("rand" == i.order) f = Math.random() < .5 ? 1 : -1; else { var k = h, r = b(a, i), s = b(e, i), t = "" === r || r === g, u = "" === s || s === g; if (r === s) f = 0; else if (i.emptyEnd && (t || u)) f = t && u ? 0 : t ? 1 : -1; else { if (!i.forceStrings) { var v = c(r) ? r && r.match(j) : h, w = c(s) ? s && s.match(j) : h; if (v && w) { var x = r.substr(0, r.length - v[0].length), y = s.substr(0, s.length - w[0].length); x == y && (k = !h, r = l(v[0]), s = l(w[0])) } } f = r === g || s === g ? 0 : s > r ? -1 : r > s ? 1 : 0 } } d(o, function (a) { var b = a.sort; b && (f = b(i, k, r, s, f)) }), f *= i.sortReturnNumber, 0 === f && q++ } return 0 === f && (f = a.pos > e.pos ? 1 : -1), f } function w() { var a = B.length === A.length; E && a ? F ? B.forEach(function (a, b) { a.elm.style.order = b }) : (B.forEach(function (a) { z.appendChild(a.elm) }), y.appendChild(z)) : (B.forEach(function (a) { var b = a.elm, c = k.createElement("div"); a.ghost = c, b.parentNode.insertBefore(c, b) }), B.forEach(function (a, b) { var c = x[b].ghost; c.parentNode.insertBefore(a.elm, c), c.parentNode.removeChild(c) })) } c(a) && (a = k.querySelectorAll(a)), 0 === a.length && console.warn("No elements to sort"); var x, y, z = k.createDocumentFragment(), A = [], B = [], C = [], D = [], E = !0, F = a.length && (f === g || f.useFlex !== !1) && -1 !== getComputedStyle(a[0].parentNode, null).display.indexOf("flex"); return j.apply(i, Array.prototype.slice.call(arguments, 1)), t(), u(), w(), B.map(function (a) { return a.elm }) } function b(a, b) { var d, e = a.elm; return b.selector && (b.hasFilter ? e.matchesSelector(b.selector) || (e = i) : e = e.querySelector(b.selector)), b.hasAttr ? d = e.getAttribute(b.attr) : b.useVal ? d = e.value || e.getAttribute("value") : b.hasData ? d = e.getAttribute("data-" + b.data) : e && (d = e.textContent), c(d) && (b.cases || (d = d.toLowerCase()), d = d.replace(/\s+/g, " ")), d } function c(a) { return "string" == typeof a } function d(a, b) { for (var c, d = a.length, e = d; e--;) c = d - e - 1, b(a[c], c) } function e(a, b, c) { for (var d in b) (c || a[d] === g) && (a[d] = b[d]); return a } function f(a, b, c) { o.push({ prepare: a, sort: b, sortBy: c }) } var g, h = !1, i = null, j = window, k = j.document, l = parseFloat, m = /(-?\d+\.?\d*)\s*$/g, n = /(\d+\.?\d*)\s*$/g, o = [], p = 0, q = 0, r = { selector: i, order: "asc", attr: i, data: i, useVal: h, place: "start", returns: h, cases: h, forceStrings: h, ignoreDashes: h, sortFunction: i, useFlex: h, emptyEnd: h }; return j.Element && function (a) { a.matchesSelector = a.matchesSelector || a.mozMatchesSelector || a.msMatchesSelector || a.oMatchesSelector || a.webkitMatchesSelector || function (a) { for (var b = this, c = (b.parentNode || b.document).querySelectorAll(a), d = -1; c[++d] && c[d] != b;); return !!c[d] } }(Element.prototype), e(f, { loop: d }), e(a, { plugin: f, defaults: r }) }());
+
+(function ($) {
+
+    var $document = $(document),
+        signClass,
+        sortEngine,
+        emptyEnd;
+
+    $.bootstrapSortable = function (options) {
+        if (options == undefined) {
+            initialize({});
+        }
+        else if (options.constructor === Boolean) {
+            initialize({ applyLast: options });
+        }
+        else if (options.sortingHeader !== undefined) {
+            sortByColumn(options.sortingHeader);
+        }
+        else {
+            initialize(options);
+        }
+    };
+
+    function initialize(options) {
+        // Check if moment.js is available
+        var momentJsAvailable = (typeof moment !== 'undefined');
+
+        // Set class based on sign parameter
+        signClass = !options.sign ? "arrow" : options.sign;
+
+        // Set sorting algorithm
+        if (options.customSort == 'default')
+            options.customSort = defaultSortEngine;
+        sortEngine = options.customSort || sortEngine || defaultSortEngine;
+
+        emptyEnd = options.emptyEnd;
+
+        // Set attributes needed for sorting
+        $('table.sortable').each(function () {
+            var $this = $(this);
+            var applyLast = (options.applyLast === true);
+            $this.find('span.sign').remove();
+
+            // Add placeholder cells for colspans
+            $this.find('thead [colspan]').each(function () {
+                var colspan = parseFloat($(this).attr('colspan'));
+                for (var i = 1; i < colspan; i++) {
+                    $(this).after('<th class="colspan-compensate">');
+                }
+            });
+
+            // Add placeholder cells for rowspans
+            $this.find('thead [rowspan]').each(function () {
+                var $cell = $(this);
+                var rowspan = parseFloat($cell.attr('rowspan'));
+                for (var i = 1; i < rowspan; i++) {
+                    var parentRow = $cell.parent('tr');
+                    var nextRow = parentRow.next('tr');
+                    var index = parentRow.children().index($cell);
+                    nextRow.children().eq(index).before('<th class="rowspan-compensate">');
+                }
+            });
+
+            // Set indexes to header cells
+            $this.find('thead tr').each(function (rowIndex) {
+                $(this).find('th').each(function (columnIndex) {
+                    var $header = $(this);
+                    $header.addClass('nosort').removeClass('up down');
+                    $header.attr('data-sortcolumn', columnIndex);
+                    $header.attr('data-sortkey', columnIndex + '-' + rowIndex);
+                });
+            });
+
+            // Cleanup placeholder cells
+            $this.find('thead .rowspan-compensate, .colspan-compensate').remove();
+
+            // Initialize sorting values specified in header
+            $this.find('th').each(function () {
+                var $header = $(this);
+                if ($header.attr('data-dateformat') !== undefined && momentJsAvailable) {
+                    var colNumber = parseFloat($header.attr('data-sortcolumn'));
+                    $this.find('td:nth-child(' + (colNumber + 1) + ')').each(function () {
+                        var $cell = $(this);
+                        $cell.attr('data-value', moment($cell.text(), $header.attr('data-dateformat')).format('YYYY/MM/DD/HH/mm/ss'));
+                    });
+                }
+                else if ($header.attr('data-valueprovider') !== undefined) {
+                    var colNumber = parseFloat($header.attr('data-sortcolumn'));
+                    $this.find('td:nth-child(' + (colNumber + 1) + ')').each(function () {
+                        var $cell = $(this);
+                        $cell.attr('data-value', new RegExp($header.attr('data-valueprovider')).exec($cell.text())[0]);
+                    });
+                }
+            });
+
+            // Initialize sorting values
+            $this.find('td').each(function () {
+                var $cell = $(this);
+                if ($cell.attr('data-dateformat') !== undefined && momentJsAvailable) {
+                    $cell.attr('data-value', moment($cell.text(), $cell.attr('data-dateformat')).format('YYYY/MM/DD/HH/mm/ss'));
+                }
+                else if ($cell.attr('data-valueprovider') !== undefined) {
+                    $cell.attr('data-value', new RegExp($cell.attr('data-valueprovider')).exec($cell.text())[0]);
+                }
+                else {
+                    $cell.attr('data-value') === undefined && $cell.attr('data-value', $cell.text());
+                }
+            });
+
+            var context = lookupSortContext($this),
+                bsSort = context.bsSort;
+
+            $this.find('thead th[data-defaultsort!="disabled"]').each(function (index) {
+                var $header = $(this);
+                var $sortTable = $header.closest('table.sortable');
+                $header.data('sortTable', $sortTable);
+                var sortKey = $header.attr('data-sortkey');
+                var thisLastSort = applyLast ? context.lastSort : -1;
+                bsSort[sortKey] = applyLast ? bsSort[sortKey] : $header.attr('data-defaultsort');
+                if (bsSort[sortKey] !== undefined && (applyLast === (sortKey === thisLastSort))) {
+                    bsSort[sortKey] = bsSort[sortKey] === 'asc' ? 'desc' : 'asc';
+                    doSort($header, $sortTable);
+                }
+            });
+            $this.trigger('sorted');
+        });
+    }
+
+    // Add click event to table header
+    $document.on('click', 'table.sortable>thead th[data-defaultsort!="disabled"]', function (e) {
+        sortByColumn(this);
+    });
+
+    // element is the header of the column to sort (the clicked header)
+    function sortByColumn(element) {
+        var $this = $(element), $table = $this.data('sortTable') || $this.closest('table.sortable');
+        $table.trigger('before-sort');
+        doSort($this, $table);
+        $table.trigger('sorted');
+    }
+
+    // Look up sorting data appropriate for the specified table (jQuery element).
+    // This allows multiple tables on one page without collisions.
+    function lookupSortContext($table) {
+        var context = $table.data("bootstrap-sortable-context");
+        if (context === undefined) {
+            context = { bsSort: [], lastSort: undefined };
+            $table.find('thead th[data-defaultsort!="disabled"]').each(function (index) {
+                var $this = $(this);
+                var sortKey = $this.attr('data-sortkey');
+                context.bsSort[sortKey] = $this.attr('data-defaultsort');
+                if (context.bsSort[sortKey] !== undefined) {
+                    context.lastSort = sortKey;
+                }
+            });
+            $table.data("bootstrap-sortable-context", context);
+        }
+        return context;
+    }
+
+    function defaultSortEngine(rows, sortingParams) {
+        tinysort(rows, sortingParams);
+    }
+
+    // Sorting mechanism separated
+    function doSort($this, $table) {
+        var sortColumn = parseFloat($this.attr('data-sortcolumn')),
+            context = lookupSortContext($table),
+            bsSort = context.bsSort;
+
+        var colspan = $this.attr('colspan');
+        if (colspan) {
+            var mainSort = parseFloat($this.data('mainsort')) || 0;
+            var rowIndex = parseFloat($this.data('sortkey').split('-').pop());
+
+            // If there is one more row in header, delve deeper
+            if ($table.find('thead tr').length - 1 > rowIndex) {
+                doSort($table.find('[data-sortkey="' + (sortColumn + mainSort) + '-' + (rowIndex + 1) + '"]'), $table);
+                return;
+            }
+            // Otherwise, just adjust the sortColumn
+            sortColumn = sortColumn + mainSort;
+        }
+
+        var localSignClass = $this.attr('data-defaultsign') || signClass;
+
+        // update arrow icon
+        $table.find('th').each(function () {
+            $(this).removeClass('up').removeClass('down').addClass('nosort');
+        });
+
+        if ($.browser.mozilla) {
+            var moz_arrow = $table.find('div.mozilla');
+            if (moz_arrow !== undefined) {
+                moz_arrow.find('.sign').remove();
+                moz_arrow.parent().html(moz_arrow.html());
+            }
+            $this.wrapInner('<div class="mozilla"></div>');
+            $this.children().eq(0).append('<span class="sign ' + localSignClass + '"></span>');
+        }
+        else {
+            $table.find('span.sign').remove();
+            $this.append('<span class="sign ' + localSignClass + '"></span>');
+        }
+
+        // sort direction
+        var sortKey = $this.attr('data-sortkey');
+        var initialDirection = $this.attr('data-firstsort') !== 'desc' ? 'desc' : 'asc';
+
+        var newDirection = (bsSort[sortKey] || initialDirection);
+        if (context.lastSort === sortKey || bsSort[sortKey] === undefined) {
+            newDirection = newDirection === 'asc' ? 'desc' : 'asc';
+        }
+        bsSort[sortKey] = newDirection;
+        context.lastSort = sortKey;
+
+        if (bsSort[sortKey] === 'desc') {
+            $this.find('span.sign').addClass('up');
+            $this.addClass('up').removeClass('down nosort');
+        } else {
+            $this.addClass('down').removeClass('up nosort');
+        }
+
+        // remove rows that should not be sorted
+        var rows = $table.children('tbody').children('tr');
+        var fixedRows = [];
+        $(rows.filter('[data-disablesort="true"]').get().reverse()).each(function (index, fixedRow) {
+            var $fixedRow = $(fixedRow);
+            fixedRows.push({ index: rows.index($fixedRow), row: $fixedRow });
+            $fixedRow.remove();
+        });
+
+        // sort rows
+        var rowsToSort = rows.not('[data-disablesort="true"]');
+        if (rowsToSort.length != 0) {
+            var emptySorting = bsSort[sortKey] === 'asc' ? emptyEnd : false;
+            sortEngine(rowsToSort, { emptyEnd: emptySorting, selector: 'td:nth-child(' + (sortColumn + 1) + ')', order: bsSort[sortKey], data: 'value' });
+        }
+
+        // add back the fixed rows
+        $(fixedRows.reverse()).each(function (index, row) {
+            if (row.index === 0) {
+                $table.children('tbody').prepend(row.row);
+            } else {
+                $table.children('tbody').children('tr').eq(row.index - 1).after(row.row);
+            }
+        });
+
+        // add class to sorted column cells
+        $table.find('td.sorted, th.sorted').removeClass('sorted');
+        rowsToSort.find('td:eq(' + sortColumn + ')').addClass('sorted');
+        $this.addClass('sorted');
+    }
+
+    // jQuery 1.9 removed this object
+    if (!$.browser) {
+        $.browser = { chrome: false, mozilla: false, opera: false, msie: false, safari: false };
+        var ua = navigator.userAgent;
+        $.each($.browser, function (c) {
+            $.browser[c] = ((new RegExp(c, 'i').test(ua))) ? true : false;
+            if ($.browser.mozilla && c === 'mozilla') { $.browser.mozilla = ((new RegExp('firefox', 'i').test(ua))) ? true : false; }
+            if ($.browser.chrome && c === 'safari') { $.browser.safari = false; }
+        });
+    }
+
+    // Initialise on DOM ready
+    $($.bootstrapSortable);
+
+}(jQuery));

--- a/deploy-board/deploy_board/templates/base.html
+++ b/deploy-board/deploy_board/templates/base.html
@@ -24,6 +24,7 @@
     <link href="{% static "css/bootstrap-chosen.css" %}" rel="stylesheet" >
     <link href="{% static "datatables/css/dataTables.bootstrap.min.css" %}" rel="stylesheet" >
     <link href="{% static "editable/css/bootstrap-editable.css" %}" rel="stylesheet">
+    <link href="{% static "css/bootstrap-sortable.css" %}" rel="stylesheet" >
 
     <!-- Just for debugging purposes. Don't actually copy this line! -->
     <!--[if lt IE 9]><script src="../../assets/js/ie8-responsive-file-warning.js"></script><![endif]-->
@@ -48,7 +49,7 @@
 <script src="{% static "datatables/js/dataTables.bootstrap.min.js" %}"></script>
 <script src="{% static "editable/js/bootstrap-editable.js" %}"></script>
 <script src="{% static "js/bootstrap-uploadprogress.js" %}"></script>
-
+<script src="{% static "js/bootstrap-sortable.js" %}"></script>
 </head>
 
 <body>

--- a/deploy-board/deploy_board/templates/configs/config_history.tmpl
+++ b/deploy-board/deploy_board/templates/configs/config_history.tmpl
@@ -2,7 +2,8 @@
 {% load static %}
 
 <form name="env_config_history_list">
-    <table id="envConfigHistoryTableId" class="table table-condensed table-striped table-hover">
+    <table id="envConfigHistoryTableId" class="table table-condensed table-striped table-hover sortable">
+        <thead>
         <tr>
             <th class="col-sm-1"></th>
             <th class="col-lg-2">Time</th>
@@ -10,6 +11,7 @@
             <th class="col-lg-2">Type</th>
             <th class="col-lg-4">Configuration Change</th>
         </tr>
+        </thead>
         {% for config in configs %}
         <tr>
             <td>
@@ -18,7 +20,23 @@
             <td> {{ config.createTime | convertTimestamp }} </td>
             <td> {{ config.operator }} </td>
             <td> {{ config.type }}  </td>
-            <td> {{ config.configChange }} </td>
+            <td> 
+            {% with type=config.configChange|convertConfigHistoryString|getType value=config.configChange|convertConfigHistoryString %}
+            {% if type == 'dict' %}
+                {% for k, v in value.items %}
+                <div class="row" style="height: 15px;">
+                <i>{{ k }}: </i>{{ v }} 
+                </div>
+                {% endfor %}
+            {% elif type == 'list' %}
+                {% for item in value %}
+                {{ item }}, 
+                {% endfor %}
+            {% else %}
+                {{ value }}
+            {% endif %}
+            {% endwith %}
+            </td>
         </tr>
         {% endfor %}
     </table>

--- a/deploy-board/deploy_board/webapp/templatetags/utils.py
+++ b/deploy-board/deploy_board/webapp/templatetags/utils.py
@@ -27,6 +27,7 @@ from deploy_board.webapp.agent_report import UNKNOWN_HOSTS_CODE, PROVISION_HOST_
 from deploy_board.webapp.common import is_agent_failed, BUILD_STAGE
 from deploy_board.webapp.helpers import environs_helper
 from deploy_board.webapp.helpers.tags_helper import TagValue
+import ast
 
 register = template.Library()
 logger = logging.getLogger(__name__)
@@ -912,3 +913,16 @@ def canReplaceCluster(cluster):
 def get_type(object):
     return type(object).__name__
 
+
+@register.filter("convertConfigHistoryString")
+def convertConfigHistoryString(change):
+    change = str(change)
+    change = change.replace("false", "False")
+    change = change.replace("true", "True")
+    if change[:1] == "{" or change[:1] == "[":
+        try: 
+            converted_string = ast.literal_eval(change)
+            return converted_string
+        except: 
+            pass
+    return change


### PR DESCRIPTION
Reviewers:
@yujunglo 
@jinruh 

- Allow filtering by columns (Time, Operator, Type, Configuration Change) 
- Style configuration changes into a readable format 

**Column filtering UI:**
Click the column header to toggle between descending/ascending order 
![image](https://cloud.githubusercontent.com/assets/8731793/17537433/7151e5d8-5e51-11e6-9381-5622470754b7.png)

**Configuration change UI:**
![image](https://cloud.githubusercontent.com/assets/8731793/17537453/99adf6ca-5e51-11e6-9a45-8ad1d4dbd626.png)

