### PR TITLE
Append cmp_group when cluster config is changed

### DIFF
--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -354,6 +354,9 @@
                         return map
                     }, {})
 
+                    clusterInfo['configs']['cmp_group'] = currentCluster.configs['cmp_group']
+            
+
                     if (!this.inAdvanced){
                         clusterInfo.configs['aws_role'] = this.awsRole
                     }


### PR DESCRIPTION
@haom-pinterest @sjoshi6  Can you take a look at this urgent fix. Right now, if user change cluster configuration, we will remove the cmp_group from user data