### PR TITLE
Delete cluster should set env cluster_name to null

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/EnvironDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/EnvironDAO.java
@@ -66,4 +66,6 @@ public interface EnvironDAO {
 
     void deleteSchedule(String envName, String stageName) throws Exception;
 
+    void deleteCluster(String envName, String stageName) throws Exception;
+
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBEnvironDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBEnvironDAOImpl.java
@@ -90,6 +90,8 @@ public class DBEnvironDAOImpl implements EnvironDAO {
         "SELECT env_id FROM environs";
     private static final String DELETE_SCHEDULE =
         "UPDATE environs SET schedule_id=null where env_name=? AND stage_name=?";
+    private static final String DELETE_CLUSTER =
+        "UPDATE environs SET cluster_name=null where env_name=? AND stage_name=?";
 
     private BasicDataSource dataSource;
 
@@ -234,5 +236,10 @@ public class DBEnvironDAOImpl implements EnvironDAO {
     @Override
     public void deleteSchedule(String envName, String stageName) throws Exception {
         new QueryRunner(dataSource).update(DELETE_SCHEDULE, envName, stageName);
+    }
+
+    @Override
+    public void deleteCluster(String envName, String stageName) throws Exception {
+        new QueryRunner(dataSource).update(DELETE_CLUSTER, envName, stageName);
     }
 }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanService.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanService.java
@@ -24,7 +24,7 @@ import com.pinterest.teletraan.resource.Deploys;
 import com.pinterest.teletraan.resource.EnvAgentConfigs;
 import com.pinterest.teletraan.resource.EnvAgents;
 import com.pinterest.teletraan.resource.EnvAlarms;
-import com.pinterest.teletraan.resource.EnvCapacitys;
+import com.pinterest.teletraan.resource.EnvCapacities;
 import com.pinterest.teletraan.resource.EnvDeploys;
 import com.pinterest.teletraan.resource.EnvGroupRoles;
 import com.pinterest.teletraan.resource.EnvHistory;
@@ -107,7 +107,7 @@ public class TeletraanService extends Application<TeletraanServiceConfiguration>
         EnvDeploys envDeploys = new EnvDeploys(context);
         environment.jersey().register(envDeploys);
 
-        EnvCapacitys envCapacitys = new EnvCapacitys(context);
+        EnvCapacities envCapacitys = new EnvCapacities(context);
         environment.jersey().register(envCapacitys);
 
         Environs envs = new Environs(context);


### PR DESCRIPTION
Right now. Delete cluster only deletes group and remove association with cluster. It doesn't set cluster_name of environment to be null. This is the fix for that change. It also renames 
EnvCapacitys to EnvCapacities