### PR TITLE
Better cluster deterministic logic

### DIFF
--- a/deploy-board/deploy_board/templates/configs/capacity.html
+++ b/deploy-board/deploy_board/templates/configs/capacity.html
@@ -67,7 +67,7 @@ window.groups = info.groups;
 window.showExistingCapacity = !window.info.is_pinterest || getUrlParameter("addexisting") || (hosts!=null && hosts.length>0)||(groups!=null && groups.length>0)
 
 if (info.is_pinterest){
-    hasCMPCluster = env.clusterName || $.inArray(env.envName+"-"+env.stageName, groups) >= 0;
+    hasCMPCluster = (info.basic_cluster_info != null) || $.inArray(env.envName+"-"+env.stageName, groups) >= 0;
 }
 else{
     hasCMPCluster = false


### PR DESCRIPTION
Use basic_cluster_info to detect if there is a cmp cluster instead of using cluster name in case the cluster has been removed but the environment association still exists.