### PR TITLE
Capacity to envlanding

### DIFF
--- a/deploy-board/deploy_board/templates/configs/capacity.html
+++ b/deploy-board/deploy_board/templates/configs/capacity.html
@@ -67,7 +67,7 @@ window.groups = info.groups;
 window.showExistingCapacity = !window.info.is_pinterest || getUrlParameter("addexisting") || (hosts!=null && hosts.length>0)||(groups!=null && groups.length>0)
 
 if (info.is_pinterest){
-    hasCMPCluster = env.clusterName || $.inArray(env.envName+"-"+env.stageName, groups) >= 0;
+    hasCMPCluster = (info.basic_cluster_info != null) || $.inArray(env.envName+"-"+env.stageName, groups) >= 0;
 }
 else{
     hasCMPCluster = false

--- a/deploy-board/deploy_board/templates/configs/new_capacity.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity.html
@@ -159,10 +159,7 @@ var capacitySetting = new Vue({
                     },
                     success: function (data) {
                         globalNotificationBanner.info = "Request sent successfully"
-                        window.location.href='/env/'+environment.envName+'/'+environment.stageName
-                    },
-                    success: function (data) {
-                        globalNotificationBanner.info = "Request sent successfully"
+                        window.location.href='/env/'+environment.envName+'/'+environment.stageName+'/config/capacity/'
                     },
                     error: function (data) {
                         globalNotificationBanner.error = data

--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -346,7 +346,7 @@ var capacitySetting = new Vue({
                 },
                 success: function (data) {
                     globalNotificationBanner.info = "Request sent successfully"
-                    window.location.href='/env/'+environment.envName+'/'+environment.stageName 
+                    window.location.href='/env/'+environment.envName+'/'+environment.stageName+'/config/capacity/'
                 },
                 error: function (data) {
                     globalNotificationBanner.error = "Request Error: "+data.status+" " +data.statusText

--- a/deploy-board/deploy_board/templates/environs/env_landing.html
+++ b/deploy-board/deploy_board/templates/environs/env_landing.html
@@ -109,13 +109,20 @@
 </div>
 
 {% if pinterest %}
-<div class="panel panel-default">
+<script type="text/javascript" src="{% static "js/components/sharedcomponents.js?changedate=2017.1.4.140000"%}"></script>
+<div class="panel panel-default" id="capacityPanel">
     <div class="panel-heading clearfix">
-        <h4 class="panel-title pull-left">Deploy Groups</h4>
+        {% verbatim %}
+        <h4 class="panel-title pull-left">{{title}}</h4>
+        {% endverbatim %}
     </div>
-    <div id="groupsDiv">
+    <div v-if="showCluster" class="row">
+        <side-button styleclass="fa fa-database" text="Capacity" href="/env/{{ env.envName }}/{{ env.stageName }}/config/capacity" title="Configure capacity"></side-button>
+    </div>
+    <div v-if="!showCluster" id="groupsDiv">
     </div>
 </div>
+
 {% endif %}
 
 <div class="modal fade" id="restartConfirmModelId" tabindex="-1" role="dialog"
@@ -184,6 +191,8 @@
 
 {% if pinterest %}
 <script>
+
+var cluster_info = {{basic_cluster_json | safe}}
 function loadGroupConfig() {
     var selected_value = $("#group_name option:selected").val();
     var config_url = "/aws_info/get_configs/?group_name=" + selected_value;
@@ -191,15 +200,22 @@ function loadGroupConfig() {
         $("#config_div_id").html(response);
     });
 }
-$(document).ready(function() {
-    loadGroupConfig();
-});
 
-$(function () {
-    $('#groupsDiv').load('/env/{{ env.envName }}/{{ env.stageName }}/groups/');
-    $("#group_name").change(function() {
-        loadGroupConfig();
-    });
+var capacityPanel = new Vue({
+            el:"#capacityPanel",
+            data:{
+               title: cluster_info != null ? "Cluster" : "Deploy Groups",
+               showCluster: cluster_info != null,
+
+            },
+            mounted: function(){
+                if (cluster_info == null){
+                    $('#groupsDiv').load('/env/{{ env.envName }}/{{ env.stageName }}/groups/');
+                    $("#group_name").change(function() {
+                            loadGroupConfig();
+                    })
+                }
+            },
 });
 
 $('#privateBldUploadBtnId button').click(function () {

--- a/deploy-board/deploy_board/webapp/env_views.py
+++ b/deploy-board/deploy_board/webapp/env_views.py
@@ -236,6 +236,7 @@ class EnvLandingView(View):
                 "capacity_hosts": capacity_hosts,
                 "provisioning_hosts": provisioning_hosts,
                 "basic_cluster_info": basic_cluster_info,
+                "basic_cluster_json": json.dumps(basic_cluster_info),
                 "env_tag": env_tag,
                 "pinterest": IS_PINTEREST,
                 "csrf_token": get_token(request),


### PR DESCRIPTION
@haom-pinterest @sbaogang 
For CMP environment, we are not show deploy groups on env landing. Instead, we are showing cluster with the capacity button for easy accessing capacity settings.

CMP environment:
![screen shot 2017-01-04 at 2 14 39 pm](https://cloud.githubusercontent.com/assets/2219571/21661313/50777a84-d288-11e6-947b-9708b785eca0.png)

Non CMP environment:
![screen shot 2017-01-04 at 2 14 50 pm](https://cloud.githubusercontent.com/assets/2219571/21661320/5a79e6d4-d288-11e6-89d1-8b2371007ebd.png)
