### PR TITLE
handle the case if the host is not found in CMDB

### DIFF
--- a/deploy-board/deploy_board/webapp/host_views.py
+++ b/deploy-board/deploy_board/webapp/host_views.py
@@ -85,7 +85,13 @@ def get_host_details(host_id):
         return None
     host_url = CMDB_API_HOST + CMDB_INSTANCE_URL + host_id
     response = requests.get(host_url)
-    instance = response.json()
+
+    try:
+        instance = response.json()
+    except:
+        # the host not found in CMDB
+        return None
+
     cloud_info = _get_cloud(instance)
     if not cloud_info:
         return None


### PR DESCRIPTION
when the host is defined in host_info file and not registered in CMDB or for whatever reason that the host is not found in CMDB, this change protects the following exception otherwise:

Traceback (most recent call last): File "/mnt/virtualenv/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 114, in get_response response = wrapped_callback(request, *callback_args, **callback_kwargs) File "/mnt/virtualenv/local/lib/python2.7/site-packages/django/views/generic/base.py", line 69, in view return self.dispatch(request, *args, **kwargs) File "/mnt/virtualenv/local/lib/python2.7/site-packages/django/views/generic/base.py", line 87, in dispatch return handler(request, *args, **kwargs) File "/mnt/deploy_board/deploy_board/webapp/host_views.py", line 161, in get host_details = get_host_details(host_id) File "/mnt/deploy_board/deploy_board/webapp/host_views.py", line 88, in get_host_details instance = response.json() File "/mnt/virtualenv/local/lib/python2.7/site-packages/requests/models.py", line 805, in json return complexjson.loads(self.text, **kwargs) File "/usr/lib/python2.7/json/__init__.py", line 326, in loads return _default_decoder.decode(s) File "/usr/lib/python2.7/json/decoder.py", line 366, in decode obj, end = self.raw_decode(s, idx=_w(s, 0).end()) File "/usr/lib/python2.7/json/decoder.py", line 384, in raw_decode raise ValueError("No JSON object could be decoded") ValueError: No JSON object could be decoded
