### PR TITLE
Hide deploy/rollback/hotfix action from the special ngapp2-A and ngapp2-B

### DIFF
--- a/deploy-board/deploy_board/templates/environs/env_landing.html
+++ b/deploy-board/deploy_board/templates/environs/env_landing.html
@@ -24,6 +24,7 @@
         <h4 class="panel-title pull-left">Current Deploy</h4>
     </div>
     {% if env|isEnvEnabled %}
+    {% if env.envName != "ngapp2-A" and env.envName != "ngapp2-B" %}
 	<div class="row">
         <a href="/env/{{ env.envName }}/{{ env.stageName }}/new_deploy/"
             type="button" class="deployToolTip btn btn-default btn-block"
@@ -31,7 +32,9 @@
             <span class="glyphicon glyphicon-file"></span> Create Deploy
         </a>
     </div>
+    {% endif %}
     {% if has_deploy %}
+    {% if env.envName != "ngapp2-A" and env.envName != "ngapp2-B" %}
 	<div class="row">
         <a href="/env/{{ env.envName }}/{{ env.stageName }}/rollback/"
             type="button" class="deployToolTip btn btn-default btn-block"
@@ -39,7 +42,8 @@
             <span class="glyphicon glyphicon-repeat icon-flipped"></span> Rollback
         </a>
     </div>
-    {% if stages|length > 1 %}
+    {% endif %}
+    {% if stages|length > 1 and env.envName != "ngapp2-A" and env.envName != "ngapp2-B" %}
 	<div class="row">
         <a href="/env/{{ env.envName }}/{{ env.stageName }}/promote/{{ env.deployId }}"
             type="button" class="deployToolTip btn btn-default btn-block"
@@ -48,7 +52,7 @@
         </a>
     </div>
     {% endif %}
-    {% if pinterest %}
+    {% if pinterest and env.envName != "ngapp2-A" and env.envName != "ngapp2-B" %}
     <div class="row">
         <a href="/env/{{ env.envName }}/{{ env.stageName }}/hotfixes/"
             type="button" class="deployToolTip btn btn-default btn-block"

--- a/deploy-board/deploy_board/webapp/host_views.py
+++ b/deploy-board/deploy_board/webapp/host_views.py
@@ -85,7 +85,13 @@ def get_host_details(host_id):
         return None
     host_url = CMDB_API_HOST + CMDB_INSTANCE_URL + host_id
     response = requests.get(host_url)
-    instance = response.json()
+
+    try:
+        instance = response.json()
+    except:
+        # the host not found in CMDB
+        return None
+
     cloud_info = _get_cloud(instance)
     if not cloud_info:
         return None


### PR DESCRIPTION
This is specific to Pinterest. 
The special env ngapp2-A and B should never able to do deploy etc actions on them because of the A/B deploy with the need to do special handling on varnish. "ngapp2" env should be used to go ngapp deploy/rollback/hotfix.
