### PR TITLE
Remove image, aws_role from basic cmp settings and change aws_role 

### DIFF
--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -39,7 +39,7 @@
             <form id="clusterConfigFormId" class="form-horizontal" role="form">
                 <fieldset id="clusterConfigFieldSetId">
                     <cloudprovider-select v-bind:cloudproviders="providers" v-bind:value="currentProvider" v-show="inAdvanced"></cloudprovider-select>
-                    <baseimage-select v-bind:imagenames="imagenames" v-bind:baseimages="baseimages" v-bind:imagenamevalue="imageNameValue" v-bind:baseImageValue="baseImageValue" 
+                    <baseimage-select v-show="inAdvanced" v-bind:imagenames="imagenames" v-bind:baseimages="baseimages" v-bind:imagenamevalue="imageNameValue" v-bind:baseImageValue="baseImageValue" 
                     v-on:baseimagechange="baseImageChange" v-on:imagenamechange="imageNameChange" v-bind:inadvanced="inAdvanced" showhelp="true" v-on:helpclick="baseImageHelpClick">
                     </baseimage-select>
                     <base-image-help v-show="showBaseImageHelp" v-bind:data="baseImageHelpData"></base-image-help>
@@ -51,7 +51,6 @@
                     <placements-select label="Placements" title="Placements" v-bind:selectoptions="placements" v-bind:assignpublicip="assignPublicIP" 
                     showhelp="true" v-on:helpclick="placementsHelpClick" v-on:assignpublicipclick="selectpublicip"></placements-select>
                     <placements-help v-show="showPlacementsHelp" v-bind:data="placementsHelpData"></placements-help>
-                    <label-input v-if="!inAdvanced" label="aws_role" v-bind:value="awsRole" v-on:input="updateAwsRole"></label-input>
                     <div v-if="inAdvanced">
                         <div class="form-group"></div>
                         <div class="form-group">

--- a/deploy-board/deploy_board/templates/configs/new_capacity.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity.html
@@ -51,15 +51,11 @@
                 <div class="row">
                     <label>This is for CMP docker only hosts. For other type, click the Advanced Settings on the left</label>
                 </div>
-                <baseimage-select v-bind:imagenames="imagenames" v-bind:baseimages="baseimages" v-bind:imagenamevalue="imageNameValue" v-bind:baseImageValue="baseImageValue"
-                        v-on:baseimagechange="baseImageChange">
-                </baseimage-select>
                 <label-input label="Capacity" placeholder="# of instances" v-model="instanceCount"></label-input>
                 <label-select label="Host Type" title="Compute Capability of the host" v-model="selectedHostTypeValue" v-bind:selectoptions="hostTypeOptions"></label-select>
                 <label-select label="Security Zone" title="Security zone to control inbound/outboud traffic" v-model="selectedSecurityZoneValue" v-bind:selectoptions="securityZoneOptions"></label-select>
                 <placements-select label="Placements" title="Placements" v-bind:assignpublicip="assignPublicIP" 
                 v-bind:selectoptions="placements" v-on:assignpublicipclick="selectpublicip"></placements-select>
-                <label-input label="aws_role" v-bind:value="awsRole" v-on:input="updateAwsRole"></label-input>
             </form>
         </div>
     </div>
@@ -100,7 +96,7 @@ var capacitySetting = new Vue({
     el:"#capacityPanel",
     data:{
         assignPublicIP: false,
-        awsRole: "base",
+        iamRole: "base",
         baseimages: capacityCreationInfo.baseImages.map(
             function (o) {
                 return {
@@ -144,9 +140,6 @@ var capacitySetting = new Vue({
             }
             return true
         },
-        baseImageChange: function (value) {
-            this.baseImageValue = value
-        },
         sendRequest: function(clusterInfo){
                 $.ajax({
                     type: 'POST',
@@ -184,7 +177,7 @@ var capacitySetting = new Vue({
             }
 
             clusterInfo['configs'] = capacityCreationInfo['defaultCMPConfigs']
-            clusterInfo.configs['aws_role'] = this.awsRole
+            clusterInfo.configs['iam_role'] = this.iamRole
             if (this.assignPublicIP){
                 clusterInfo.configs['assign_public_ip'] = true
             }

--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -361,7 +361,7 @@ var capacitySetting = new Vue({
             clusterInfo['baseImageId'] = this.baseImageValue;
             clusterInfo['hostType'] = this.selectedHostTypeValue;
             clusterInfo['securityZone'] = this.selectedSecurityZoneValue;
-            if (this.selectedPlacements != null){
+            if (this.selectedPlacements != null && this.selectedPlacements.length>0){
                 clusterInfo['placement'] = this.selectedPlacements.join(',');
             }
             else{

--- a/deploy-board/deploy_board/webapp/cluster_view.py
+++ b/deploy-board/deploy_board/webapp/cluster_view.py
@@ -471,7 +471,7 @@ def parse_configs(query_dict):
 
 def get_default_cmp_configs(name, stage):
     config_map = {}
-    config_map['aws_role'] = 'base'
+    config_map['iam_role'] = 'base'
     config_map['cmp_group'] = 'CMP,{}-{}'.format(name, stage)
     config_map['pinfo_environment'] = 'prod'
     config_map['pinfo_team'] = 'cloudeng'
@@ -513,7 +513,7 @@ def delete_cluster(request, name, stage):
 
 def get_aws_config_name_list_by_image(image_name):
     config_map = {}
-    config_map['aws_role'] = 'base'
+    config_map['iam_role'] = 'base'
     config_map['assign_public_ip'] = 'true'
     if IS_PINTEREST:
         config_map['pinfo_environment'] = 'prod'


### PR DESCRIPTION
AMI Image and aws_role are removed from basic settings.
aws is renamed to iam_role
Fix an issue in adv creation mode, placements was not set if user doesn't click the placement input

Tested with both basic and adv creation page and cluster configuration in both basic and advanced mode