### PR TITLE
fix committer mention in slack message

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
@@ -217,7 +217,7 @@ public class DeployHandler {
                     continue;
                 }
                 // TODO hipchat is different, screw it for now
-                authors.add(String.format("<@%s>", commit.getAuthor()));
+                authors.add(String.format("<@%s|%s>", commit.getAuthor(), commit.getAuthor()));
             }
 
             String mentions = Joiner.on(",").join(authors);


### PR DESCRIPTION
this is to fix the deploy slack notification message having "..." if the committer id does not exists in slack. such as "@build", or a non pinterest email id.  if the id not exist in slack, this fix will still show the plain id without the mention link.