### PR TITLE
add NEW_AND_FAILED option

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostDAO.java
@@ -67,5 +67,7 @@ public interface HostDAO {
 
     Collection<String> getRetiredAndFailedHostIdsByGroup(String groupName) throws Exception;
 
+    Collection<String> getCanNotRetireButFailedHostIdsByGroup(String groupName) throws Exception;
+
     Collection<String> getFailedHostIdsByGroup(String groupName) throws Exception;
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostDAOImpl.java
@@ -61,6 +61,8 @@ public class DBHostDAOImpl implements HostDAO {
             "SELECT DISTINCT h.host_id FROM hosts h INNER JOIN agents a ON a.host_id=h.host_id WHERE h.can_retire=1 AND h.group_name=? AND h.state not in (?,?) and a.status not in (?,?)";
     private static final String GET_FAILED_HOSTIDS_BY_GROUP =
             "SELECT DISTINCT h.host_id FROM hosts h INNER JOIN agents a ON a.host_id=h.host_id WHERE h.group_name=? AND h.state not in (?,?) and a.status not in (?,?)";
+    private static final String GET_CAN_NOT_RETIRE_AND_FAILED_HOSTIDS_BY_GROUP =
+            "SELECT DISTINCT h.host_id FROM hosts h INNER JOIN agents a ON a.host_id=h.host_id WHERE h.can_retire!=1 AND h.group_name=? AND h.state not in (?,?) and a.status not in (?,?)";
 
     private BasicDataSource dataSource;
 
@@ -236,6 +238,14 @@ public class DBHostDAOImpl implements HostDAO {
     @Override
     public Collection<String> getRetiredAndFailedHostIdsByGroup(String groupName) throws Exception {
         return new QueryRunner(dataSource).query(GET_RETIRED_AND_FAILED_HOSTIDS_BY_GROUP,
+                SingleResultSetHandlerFactory.<String>newListObjectHandler(), groupName,
+                HostState.PENDING_TERMINATE.toString(), HostState.TERMINATING.toString(),
+                AgentStatus.UNKNOWN.toString(), AgentStatus.SUCCEEDED.toString());
+    }
+
+    @Override
+    public Collection<String> getCanNotRetireButFailedHostIdsByGroup(String groupName) throws Exception {
+        return new QueryRunner(dataSource).query(GET_CAN_NOT_RETIRE_AND_FAILED_HOSTIDS_BY_GROUP,
                 SingleResultSetHandlerFactory.<String>newListObjectHandler(), groupName,
                 HostState.PENDING_TERMINATE.toString(), HostState.TERMINATING.toString(),
                 AgentStatus.UNKNOWN.toString(), AgentStatus.SUCCEEDED.toString());

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Groups.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Groups.java
@@ -41,7 +41,8 @@ public class Groups {
         ALL,
         RETIRED,
         FAILED,
-        RETIRED_AND_FAILED
+        RETIRED_AND_FAILED,
+        NEW_AND_FAILED
     }
 
     private EnvironDAO environDAO;
@@ -75,6 +76,9 @@ public class Groups {
                 break;
             case RETIRED_AND_FAILED:
                 hostIds = hostDAO.getRetiredAndFailedHostIdsByGroup(groupName);
+                break;
+            case NEW_AND_FAILED:
+                hostIds = hostDAO.getCanNotRetireButFailedHostIdsByGroup(groupName);
                 break;
             default:
                 throw new TeletaanInternalException(Response.Status.BAD_REQUEST, "No action found.");

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Groups.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Groups.java
@@ -42,7 +42,7 @@ public class Groups {
         RETIRED,
         FAILED,
         RETIRED_AND_FAILED,
-        NEW_AND_FAILED
+        CANNOT_RETIRED_AND_FAILED
     }
 
     private EnvironDAO environDAO;
@@ -77,7 +77,7 @@ public class Groups {
             case RETIRED_AND_FAILED:
                 hostIds = hostDAO.getRetiredAndFailedHostIdsByGroup(groupName);
                 break;
-            case NEW_AND_FAILED:
+            case CANNOT_RETIRED_AND_FAILED:
                 hostIds = hostDAO.getCanNotRetireButFailedHostIdsByGroup(groupName);
                 break;
             default:


### PR DESCRIPTION
this option is for replace cluster feature.

we did have an option to get can_retire=1, however I want to have can_retire!=1 hosts. instead of use <get_all> - <can_retire=1> = <can_retire!=1>. maybe its easier to just provide this new option.