### PR TITLE
new api to get serving and normal agent

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/AgentDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/AgentDAO.java
@@ -72,6 +72,8 @@ public interface AgentDAO {
 
     long countServingTotal(String envId) throws Exception;
 
+    long countServingAndNormalTotal(String envId) throws Exception;
+
     long countFinishedAgentsByDeploy(String deployId) throws Exception;
 
     long countAgentsByDeploy(String deployId) throws Exception;

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBAgentDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBAgentDAOImpl.java
@@ -16,6 +16,7 @@
 package com.pinterest.deployservice.db;
 
 import com.pinterest.deployservice.bean.AgentBean;
+import com.pinterest.deployservice.bean.AgentState;
 import com.pinterest.deployservice.bean.DeployStage;
 import com.pinterest.deployservice.bean.SetClause;
 import com.pinterest.deployservice.dao.AgentDAO;
@@ -71,7 +72,8 @@ public class DBAgentDAOImpl implements AgentDAO {
     private static final String COUNT_ALL_AGENT_BY_ENV = "SELECT COUNT(*) FROM agents WHERE env_id=?";
     private static final String COUNT_ALL_AGENT_BY_ENV_NAME = "SELECT COUNT(*) FROM agents WHERE env_name=?";
     private static final String COUNT_SERVING_TOTAL = "SELECT COUNT(*) FROM agents WHERE env_id=? AND deploy_stage=?";
-    private static final String COUNT_FINISHED_AGENTS_BY_DEPLOY = 
+    private static final String COUNT_SERVING_AND_NORMAL_TOTAL = "SELECT COUNT(*) FROM agents WHERE env_id=? AND deploy_stage=? AND state=?";
+    private static final String COUNT_FINISHED_AGENTS_BY_DEPLOY =
         "SELECT COUNT(*) FROM agents WHERE deploy_id=? AND (deploy_stage='SERVING_BUILD' OR state='PAUSED_BY_USER' OR state='PAUSED_BY_SYSTEM')";
     private static final String COUNT_AGENTS_BY_DEPLOY =
         "SELECT COUNT(*) FROM agents WHERE deploy_id=?";
@@ -218,6 +220,13 @@ public class DBAgentDAOImpl implements AgentDAO {
     public long countServingTotal(String envId) throws Exception {
         Long n = new QueryRunner(dataSource).query(COUNT_SERVING_TOTAL, SingleResultSetHandlerFactory.<Long>newObjectHandler(),
                 envId, DeployStage.SERVING_BUILD.toString());
+        return n == null ? 0 : n;
+    }
+
+    @Override
+    public long countServingAndNormalTotal(String envId) throws Exception {
+        Long n = new QueryRunner(dataSource).query(COUNT_SERVING_AND_NORMAL_TOTAL, SingleResultSetHandlerFactory.<Long>newObjectHandler(),
+                envId, DeployStage.SERVING_BUILD.toString(), AgentState.NORMAL.toString());
         return n == null ? 0 : n;
     }
 

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvAgents.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvAgents.java
@@ -48,6 +48,7 @@ public class EnvAgents {
 
     public enum CountActionType {
         SERVING,
+        SERVING_AND_NORMAL,
         FIRST_DEPLOY,
         FAILED_FIRST_DEPLOY
     }
@@ -141,6 +142,9 @@ public class EnvAgents {
         switch (actionType) {
             case SERVING:
                 count = agentDAO.countServingTotal(envBean.getEnv_id());
+                break;
+            case SERVING_AND_NORMAL:
+                count = agentDAO.countServingAndNormalTotal(envBean.getEnv_id());
                 break;
             case FIRST_DEPLOY:
                 count = agentDAO.countFirstDeployingAgent(envBean.getEnv_id());


### PR DESCRIPTION
in the event of replace cluster, I marked the can_retire host's agent to be STOP.  but this agent's deploy_stage is still SERVING_BUILD

next time, when I query for all agent status, I dont want to include deploy_stage = 'SERVING_BUILD' and state = 'STOP' agents.

I purely wants agents whose  deploy_stage = 'SERVING_BUILD' and state = 'NORMAL'  means currently healthy and serving build agent.