### PR TITLE
optionally display STOPPING and STOPPED hosts

### DIFF
--- a/deploy-board/deploy_board/settings.py
+++ b/deploy-board/deploy_board/settings.py
@@ -194,7 +194,7 @@ SITE_METRICS_CONFIGS = []
 TELETRAAN_SERVICE_HEALTHCHECK_URL = os.getenv("TELETRAAN_SERVICE_HEALTHCHECK_URL", None)
 
 # Show hosts that are STOPPING or STOPPED in the environments page
-DISPLAY_STOPPING_HOSTS = os.getenv("DISPLAY_STOPPING_HOSTS", "false")
+DISPLAY_STOPPING_HOSTS = os.getenv("DISPLAY_STOPPING_HOSTS", "true")
 
 # Pinterest specific settings
 IS_PINTEREST = True if os.getenv("IS_PINTEREST", "false") == "true" else False

--- a/deploy-board/deploy_board/settings.py
+++ b/deploy-board/deploy_board/settings.py
@@ -193,6 +193,9 @@ SITE_METRICS_CONFIGS = []
 # Deep Teletraan backend health check url
 TELETRAAN_SERVICE_HEALTHCHECK_URL = os.getenv("TELETRAAN_SERVICE_HEALTHCHECK_URL", None)
 
+# Show hosts that are STOPPING or STOPPED in the environments page
+DISPLAY_STOPPING_HOSTS = os.getenv("DISPLAY_STOPPING_HOSTS", "false")
+
 # Pinterest specific settings
 IS_PINTEREST = True if os.getenv("IS_PINTEREST", "false") == "true" else False
 BUILD_URL = "https://jenkins.pinadmin.com/job/"

--- a/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
@@ -70,13 +70,12 @@
 </div>
 {% endif %}
 
-
 <div class="panel panel-default table-responsive">
     <table class="table table-condensed table-hover">
         <tr>
             <td class="col-lg-1 text-right"></td>
             {% for key, value in report.currentDeployStat.stageDistMap.items %}
-                {% if key != "STOPPING" and key != "STOPPED" %}
+                {% if display_stopping_hosts == "true" or key != "STOPPING" and key != "STOPPED" %}
                 <td class="text-right">
                     <span class="pointer-cursor deployToolTip" data-toggle="tooltip" title="{{ key|deployStageTip }}">
                         <small>{{ key }}</small>
@@ -86,7 +85,6 @@
             {% endfor %}
             <td class="col-lg-1 text-right"><small>Total</small></td>
         </tr>
-
         <tr>
             <td>
                 <span class="deployToolTip" data-toggle="tooltip" title="Detailed deploy steps statistics for current deploy.">
@@ -94,7 +92,7 @@
                 </span>
             </td>
             {% for key, value in report.currentDeployStat.stageDistMap.items %}
-                {% if key != "STOPPING" and key != "STOPPED" %}
+                {% if display_stopping_hosts == "true" or key != "STOPPING" and key != "STOPPED" %}
                 <td class="text-right">
                     <small>
                         <a href="/env/{{ report.envName }}/{{ report.stageName }}/{{ report.currentDeployStat.deploy.id }}/hosts?hostStage={{ key }}"
@@ -125,7 +123,7 @@
                 </a>
             </td>
             {% for key, value in deployStat.stageDistMap.items %}
-                {% if key != "STOPPING" and key != "STOPPED" %}
+                {% if display_stopping_hosts == "true" or key != "STOPPING" and key != "STOPPED" %}
                 <td class="text-right">
                   <small>
                   <a href="/env/{{ report.envName }}/{{ report.stageName }}/{{ deployStat.deploy.id }}/hosts?hostStage={{ key }}" class="deployToolTip" data-toggle="tooltip"

--- a/deploy-board/deploy_board/webapp/env_views.py
+++ b/deploy-board/deploy_board/webapp/env_views.py
@@ -22,6 +22,7 @@ from django.template.loader import render_to_string
 from django.http import HttpResponse
 from django.contrib import messages
 from deploy_board.settings import IS_PINTEREST
+from deploy_board.settings import DISPLAY_STOPPING_HOSTS
 from django.conf import settings
 import agent_report
 import common
@@ -119,6 +120,7 @@ def update_deploy_progress(request, name, stage):
     html = render_to_string('deploys/deploy_progress.tmpl', {
         "report": report,
         "env": env,
+        "display_stopping_hosts": DISPLAY_STOPPING_HOSTS,
     })
 
     response = HttpResponse(html)
@@ -231,6 +233,7 @@ class EnvLandingView(View):
                 "env_tag": env_tag,
                 "pinterest": IS_PINTEREST,
                 "csrf_token": get_token(request),
+                "display_stopping_hosts": DISPLAY_STOPPING_HOSTS,
             })
             showMode = 'complete'
             sortByStatus = 'true'
@@ -259,6 +262,7 @@ class EnvLandingView(View):
                 "capacity_info": json.dumps(capacity_info),
                 "env_tag": env_tag,
                 "pinterest": IS_PINTEREST,
+                "display_stopping_hosts": DISPLAY_STOPPING_HOSTS,
             })
 
         # save preferences

--- a/deploy-board/manage.py
+++ b/deploy-board/manage.py
@@ -70,5 +70,8 @@ if __name__ == "__main__":
     # If username is email address, use the part before @ as the final username
     #os.environ.setdefault("OAUTH_EXTRACT_USERNAME_FROM_EMAIL", 'TRUE')
 
+    # If true, display STOPPING and STOPPED hosts on the environment status page
+    os.environ.setdefault("DISPLAY_STOPPING_HOSTS", "false")
+
     from django.core.management import execute_from_command_line
     execute_from_command_line(sys.argv)

--- a/deploy-board/manage.py
+++ b/deploy-board/manage.py
@@ -71,7 +71,7 @@ if __name__ == "__main__":
     #os.environ.setdefault("OAUTH_EXTRACT_USERNAME_FROM_EMAIL", 'TRUE')
 
     # If true, display STOPPING and STOPPED hosts on the environment status page
-    os.environ.setdefault("DISPLAY_STOPPING_HOSTS", "false")
+    os.environ.setdefault("DISPLAY_STOPPING_HOSTS", "true")
 
     from django.core.management import execute_from_command_line
     execute_from_command_line(sys.argv)


### PR DESCRIPTION
Previously, the environment overview page only showed hosts in the deploy
status that were not STOPPING or STOPPED. The only way to look at them is to
look in "Total" hosts.

First of all, it doesn't make sense to me to to have an agent state that shows
up in the TOTAL but isn't available in the board.

This adds an extra configuration parameter to display STOPPING and STOPPED
hosts. It is disabled by default, in case you have some reason you do not
display those states.

Related: #354

Current behavior:

![screen shot 2017-03-15 at 9 24 35 pm](https://cloud.githubusercontent.com/assets/1385140/23977807/c8747dd2-09c6-11e7-938c-d68d928e2644.png)

Notice the TOTAL for the *Previous(a2f66f1)* build is `1`, even though none of the state columns actually display 1 host!

With `os.environ.setdefault("DISPLAY_STOPPING_HOSTS", "true")` in `manage.py`, we can see even the stopped hosts:

![screen shot 2017-03-15 at 9 24 59 pm](https://cloud.githubusercontent.com/assets/1385140/23977810/cce587d0-09c6-11e7-8343-0e7690646817.png)

