### PR TITLE
instead of CANNOT_RETIRED_AND_FAILED,  need CANNOT_RETIRED_AND_SERVING_BUILD

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/AgentDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/AgentDAO.java
@@ -72,6 +72,8 @@ public interface AgentDAO {
 
     long countServingTotal(String envId) throws Exception;
 
+    long countServingAndNormalTotal(String envId) throws Exception;
+
     long countFinishedAgentsByDeploy(String deployId) throws Exception;
 
     long countAgentsByDeploy(String deployId) throws Exception;

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostDAO.java
@@ -67,7 +67,7 @@ public interface HostDAO {
 
     Collection<String> getRetiredAndFailedHostIdsByGroup(String groupName) throws Exception;
 
-    Collection<String> getCanNotRetireButFailedHostIdsByGroup(String groupName) throws Exception;
+    Collection<String> getCanNotRetireAndServingBuildHostIdsByGroup(String groupName) throws Exception;
 
     Collection<String> getFailedHostIdsByGroup(String groupName) throws Exception;
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBAgentDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBAgentDAOImpl.java
@@ -16,6 +16,7 @@
 package com.pinterest.deployservice.db;
 
 import com.pinterest.deployservice.bean.AgentBean;
+import com.pinterest.deployservice.bean.AgentState;
 import com.pinterest.deployservice.bean.DeployStage;
 import com.pinterest.deployservice.bean.SetClause;
 import com.pinterest.deployservice.dao.AgentDAO;
@@ -71,7 +72,8 @@ public class DBAgentDAOImpl implements AgentDAO {
     private static final String COUNT_ALL_AGENT_BY_ENV = "SELECT COUNT(*) FROM agents WHERE env_id=?";
     private static final String COUNT_ALL_AGENT_BY_ENV_NAME = "SELECT COUNT(*) FROM agents WHERE env_name=?";
     private static final String COUNT_SERVING_TOTAL = "SELECT COUNT(*) FROM agents WHERE env_id=? AND deploy_stage=?";
-    private static final String COUNT_FINISHED_AGENTS_BY_DEPLOY = 
+    private static final String COUNT_SERVING_AND_NORMAL_TOTAL = "SELECT COUNT(*) FROM agents WHERE env_id=? AND deploy_stage=? AND state=?";
+    private static final String COUNT_FINISHED_AGENTS_BY_DEPLOY =
         "SELECT COUNT(*) FROM agents WHERE deploy_id=? AND (deploy_stage='SERVING_BUILD' OR state='PAUSED_BY_USER' OR state='PAUSED_BY_SYSTEM')";
     private static final String COUNT_AGENTS_BY_DEPLOY =
         "SELECT COUNT(*) FROM agents WHERE deploy_id=?";
@@ -218,6 +220,13 @@ public class DBAgentDAOImpl implements AgentDAO {
     public long countServingTotal(String envId) throws Exception {
         Long n = new QueryRunner(dataSource).query(COUNT_SERVING_TOTAL, SingleResultSetHandlerFactory.<Long>newObjectHandler(),
                 envId, DeployStage.SERVING_BUILD.toString());
+        return n == null ? 0 : n;
+    }
+
+    @Override
+    public long countServingAndNormalTotal(String envId) throws Exception {
+        Long n = new QueryRunner(dataSource).query(COUNT_SERVING_AND_NORMAL_TOTAL, SingleResultSetHandlerFactory.<Long>newObjectHandler(),
+                envId, DeployStage.SERVING_BUILD.toString(), AgentState.NORMAL.toString());
         return n == null ? 0 : n;
     }
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostDAOImpl.java
@@ -16,6 +16,8 @@
 package com.pinterest.deployservice.db;
 
 import com.pinterest.deployservice.bean.AgentStatus;
+import com.pinterest.deployservice.bean.DeployStage;
+import com.pinterest.deployservice.bean.AgentState;
 import com.pinterest.deployservice.bean.HostBean;
 import com.pinterest.deployservice.bean.HostState;
 import com.pinterest.deployservice.bean.SetClause;
@@ -61,8 +63,8 @@ public class DBHostDAOImpl implements HostDAO {
             "SELECT DISTINCT h.host_id FROM hosts h INNER JOIN agents a ON a.host_id=h.host_id WHERE h.can_retire=1 AND h.group_name=? AND h.state not in (?,?) and a.status not in (?,?)";
     private static final String GET_FAILED_HOSTIDS_BY_GROUP =
             "SELECT DISTINCT h.host_id FROM hosts h INNER JOIN agents a ON a.host_id=h.host_id WHERE h.group_name=? AND h.state not in (?,?) and a.status not in (?,?)";
-    private static final String GET_CAN_NOT_RETIRE_AND_FAILED_HOSTIDS_BY_GROUP =
-            "SELECT DISTINCT h.host_id FROM hosts h INNER JOIN agents a ON a.host_id=h.host_id WHERE h.can_retire!=1 AND h.group_name=? AND h.state not in (?,?) and a.status not in (?,?)";
+    private static final String GET_CAN_NOT_RETIRE_AND_SERVING_BUILD_HOSTIDS_BY_GROUP =
+            "SELECT DISTINCT h.host_id FROM hosts h INNER JOIN agents a ON a.host_id=h.host_id WHERE h.can_retire!=1 AND h.group_name=? AND h.state not in (?,?) AND a.deploy_stage = ? AND a.state = ?";
 
     private BasicDataSource dataSource;
 
@@ -244,11 +246,11 @@ public class DBHostDAOImpl implements HostDAO {
     }
 
     @Override
-    public Collection<String> getCanNotRetireButFailedHostIdsByGroup(String groupName) throws Exception {
-        return new QueryRunner(dataSource).query(GET_CAN_NOT_RETIRE_AND_FAILED_HOSTIDS_BY_GROUP,
+    public Collection<String> getCanNotRetireAndServingBuildHostIdsByGroup(String groupName) throws Exception {
+        return new QueryRunner(dataSource).query(GET_CAN_NOT_RETIRE_AND_SERVING_BUILD_HOSTIDS_BY_GROUP,
                 SingleResultSetHandlerFactory.<String>newListObjectHandler(), groupName,
                 HostState.PENDING_TERMINATE.toString(), HostState.TERMINATING.toString(),
-                AgentStatus.UNKNOWN.toString(), AgentStatus.SUCCEEDED.toString());
+                DeployStage.SERVING_BUILD.toString(), AgentState.NORMAL.toString());
     }
 
     @Override

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvAgents.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvAgents.java
@@ -48,6 +48,7 @@ public class EnvAgents {
 
     public enum CountActionType {
         SERVING,
+        SERVING_AND_NORMAL,
         FIRST_DEPLOY,
         FAILED_FIRST_DEPLOY
     }
@@ -141,6 +142,9 @@ public class EnvAgents {
         switch (actionType) {
             case SERVING:
                 count = agentDAO.countServingTotal(envBean.getEnv_id());
+                break;
+            case SERVING_AND_NORMAL:
+                count = agentDAO.countServingAndNormalTotal(envBean.getEnv_id());
                 break;
             case FIRST_DEPLOY:
                 count = agentDAO.countFirstDeployingAgent(envBean.getEnv_id());

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Groups.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Groups.java
@@ -42,7 +42,7 @@ public class Groups {
         RETIRED,
         FAILED,
         RETIRED_AND_FAILED,
-        CANNOT_RETIRED_AND_FAILED
+        CANNOT_RETIRED_AND_SERVING_BUILD
     }
 
     private EnvironDAO environDAO;
@@ -77,8 +77,8 @@ public class Groups {
             case RETIRED_AND_FAILED:
                 hostIds = hostDAO.getRetiredAndFailedHostIdsByGroup(groupName);
                 break;
-            case CANNOT_RETIRED_AND_FAILED:
-                hostIds = hostDAO.getCanNotRetireButFailedHostIdsByGroup(groupName);
+            case CANNOT_RETIRED_AND_SERVING_BUILD:
+                hostIds = hostDAO.getCanNotRetireAndServingBuildHostIdsByGroup(groupName);
                 break;
             default:
                 throw new TeletaanInternalException(Response.Status.BAD_REQUEST, "No action found.");


### PR DESCRIPTION
this is for replace cluster feature. after discussion, i dont need to care about new_but_failed, instead i need to care about new_and_good,  this is the number I can use for next around replacement.