### PR TITLE
get not serving agent count should include those in STOP state

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/AgentDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/AgentDAO.java
@@ -49,7 +49,7 @@ public interface AgentDAO {
 
     void deleteAllById(String hostId) throws Exception;
 
-    // return how many agents are deploying for this env, regardless of deployId
+    // return how many agents are deploying and agent state is STOP (because agent with STOP state won't deploy in future) for this env, regardless of deployId
     long countDeployingAgent(String envId) throws Exception;
 
     // return how many agents are doing first time deploy for this env.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/AgentDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/AgentDAO.java
@@ -49,7 +49,7 @@ public interface AgentDAO {
 
     void deleteAllById(String hostId) throws Exception;
 
-    // return how many agents are deploying and agent state is STOP (because agent with STOP state won't deploy in future) for this env, regardless of deployId
+    // return how many agents are deploying for this env, including agents whose state is STOP
     long countDeployingAgent(String envId) throws Exception;
 
     // return how many agents are doing first time deploy for this env.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBAgentDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBAgentDAOImpl.java
@@ -56,7 +56,7 @@ public class DBAgentDAOImpl implements AgentDAO {
         "SELECT * FROM agents WHERE host_id=? AND env_id=?";
     private static final String GET_DEPLOYING_TOTAL =
         "SELECT COUNT(*) FROM agents " +
-            "WHERE env_id=? AND deploy_stage!=? AND state!='PAUSED_BY_USER' AND first_deploy=?";
+            "WHERE env_id=? AND ((deploy_stage!=? AND state!='PAUSED_BY_USER' AND first_deploy=?) OR state = 'STOP' )";
     private static final String GET_FAILED_FIRST_DEPLOY_TOTAL =
         "SELECT COUNT(*) FROM agents " +
                 "WHERE env_id=? AND deploy_stage!=? AND status !='SUCCEEDED' AND status!= 'UNKNOWN' AND first_deploy=1";

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
@@ -204,10 +204,10 @@ public class PingHandler {
         long parallelThreshold = getFinalMaxParallelCount(envBean, totalNonFirstDeployAgents);
 
         try {
-            //Note: This count already excludes first deploy agents
-            long totalActiveagents = agentDAO.countDeployingAgent(envId);
-            if (totalActiveagents >= parallelThreshold) {
-                LOG.debug("There are currently {} agent is actively deploying for env {}, host {} will have to wait for its turn.", totalActiveagents, envId, host);
+            //Note: This count already excludes first deploy agents, includes agents in STOP state
+            long totalDeployingAgents = agentDAO.countDeployingAgent(envId);
+            if (totalDeployingAgents >= parallelThreshold) {
+                LOG.debug("There are currently {} agent is actively deploying for env {}, host {} will have to wait for its turn.", totalDeployingAgents, envId, host);
                 return false;
             }
         } catch (Exception e) {


### PR DESCRIPTION
Host can be marked as PENDING_TERMINATING, then its agent state will be immediate marked as STOP. (the whole process takes a few mins)  but during this few mins, we should include those in STOP state as part of `totalDeployingAgents` count.