### PR TITLE
progress bar should move inside the warning banner

### DIFF
--- a/deploy-board/deploy_board/templates/clusters/clusters.html
+++ b/deploy-board/deploy_board/templates/clusters/clusters.html
@@ -95,9 +95,6 @@
         <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
         <strong>Warning!</strong> This environment stage has scheduled cluster rolling upgrade.
         You cannot update this page unless you cancel cluster replacement.
-        <div id="activeClusterReplaceId" class="collapse in panel-body">
-            {% include "clusters/replace_progress.tmpl" %}
-         </div>
     </div>
 {% endif %}
 

--- a/deploy-board/deploy_board/templates/clusters/clusters.html
+++ b/deploy-board/deploy_board/templates/clusters/clusters.html
@@ -95,10 +95,10 @@
         <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
         <strong>Warning!</strong> This environment stage has scheduled cluster rolling upgrade.
         You cannot update this page unless you cancel cluster replacement.
+        <div id="activeClusterReplaceId" class="collapse in panel-body">
+            {% include "clusters/replace_progress.tmpl" %}
+         </div>
     </div>
-    <div id="activeClusterReplaceId" class="collapse in panel-body">
-        {% include "clusters/replace_progress.tmpl" %}
-     </div>
 {% endif %}
 
 {% include "environs/env_tabs.tmpl" with envTabKind="config/clusters" %}

--- a/deploy-board/deploy_board/templates/clusters/replace_progress.tmpl
+++ b/deploy-board/deploy_board/templates/clusters/replace_progress.tmpl
@@ -46,14 +46,29 @@
 
     $(function () {
         // include this tmpl, meaning a cluster replace is going-on, need to check its progress
-        var startTime = new Date().getTime();
-        var replaceProgressInterval = setInterval(function() {
-            if(new Date().getTime() - startTime > 3600000) {
+
+        function setIntervalAndExecute(fn, t) {
+            fn();
+            return(setInterval(fn, t));
+        }
+        // update every 1 min, and execute now
+        var replaceProgressInterval = setIntervalAndExecute(function() {
+            if(new Date().getTime() - replaceStartTime > 1800000) {  // if more than 30 mins, clear it
+                console.log('cleared time interval');
                 clearInterval(replaceProgressInterval);
             }
-            $('#activeClusterReplaceId').load('/env/{{ env.envName }}/{{ env.stageName }}/update_cluster_replace_progress/');
-        }, 30000);
-        //TODO: need to hide it when replace finished
-        //$('.replaceToolTip').tooltip({container: "#toolTipContent", delay: { show: 400, hide: 10 }});
+            $('#activeClusterReplaceId').load(
+                    '/env/{{ env.envName }}/{{ env.stageName }}/update_cluster_replace_progress/',
+                    function(response, status, xhr) {
+                        console.log(response);
+                        if(response == 'There is no on-going replacement.') {
+                            clearInterval(replaceProgressInterval);
+                            console.log('cleared time interval');
+                            // hide the parent warning banner when replace finished as well
+                            $('#activeClusterReplaceId').closest(".alert").alert('close');
+                        }
+                    }
+            );
+        }, 60000);
     });
 </script>

--- a/deploy-board/deploy_board/templates/clusters/replace_progress.tmpl
+++ b/deploy-board/deploy_board/templates/clusters/replace_progress.tmpl
@@ -52,6 +52,8 @@
             return(setInterval(fn, t));
         }
         // update every 1 min, and execute now
+        
+        var startTime = new Date().getTime();
         var replaceProgressInterval = setIntervalAndExecute(function() {
             if(new Date().getTime() - replaceStartTime > 1800000) {  // if more than 30 mins, clear it
                 console.log('cleared time interval');

--- a/deploy-board/deploy_board/templates/configs/new_capacity.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity.html
@@ -35,10 +35,10 @@
         <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
         <strong>Warning!</strong> This environment stage has scheduled cluster rolling upgrade.
         You cannot update this page unless you cancel cluster replacement.
+        <div id="activeClusterReplaceId" class="collapse in panel-body">
+            {% include "clusters/replace_progress.tmpl" %}
+         </div>
     </div>
-    <div id="activeClusterReplaceId" class="collapse in panel-body">
-        {% include "clusters/replace_progress.tmpl" %}
-     </div>
 {% endif %}
 
 {% include "environs/env_tabs.tmpl" with envTabKind="config/capacity" %}

--- a/deploy-board/deploy_board/templates/configs/new_capacity.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity.html
@@ -35,9 +35,6 @@
         <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
         <strong>Warning!</strong> This environment stage has scheduled cluster rolling upgrade.
         You cannot update this page unless you cancel cluster replacement.
-        <div id="activeClusterReplaceId" class="collapse in panel-body">
-            {% include "clusters/replace_progress.tmpl" %}
-         </div>
     </div>
 {% endif %}
 

--- a/deploy-board/deploy_board/templates/environs/env_landing.html
+++ b/deploy-board/deploy_board/templates/environs/env_landing.html
@@ -253,10 +253,11 @@ $('#privateBldUploadBtnId button').click(function () {
     <div class="alert alert-info">
         <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
         <strong>Warning!</strong> This environment stage has scheduled cluster rolling upgrade.
+        <div id="activeClusterReplaceId" class="collapse in panel-body">
+            {% include "clusters/replace_progress.tmpl" %}
+         </div>
     </div>
-    <div id="activeClusterReplaceId" class="collapse in panel-body">
-        {% include "clusters/replace_progress.tmpl" %}
-     </div>
+
 {% endif %}
 
 {% if messages %}


### PR DESCRIPTION
![screen shot 2017-03-31 at 4 54 48 pm](https://cloud.githubusercontent.com/assets/24964493/24573091/b8cb57ec-1633-11e7-9846-83dbf8174a68.png)
tested cluster replacement with progress bar, there are some room to improve this UI, maybe should move to cluster page only, not inside environment page. 