### PR TITLE
move replacement link inside capacity, and fix bugs

### DIFF
--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -22,6 +22,9 @@
     <div v-if="!noCluster" class="row">
         <side-button-nolink styleclass="fa fa-gears" v-on:click="buttonClick" v-bind:text="settingText" title="Cluster Configuration"></side-button-nolink>
     </div>
+    <div v-if="!noCluster" class="row">
+        <side-button styleclass="glyphicon glyphicon-time" text="Replacement History" href="/env/{{ env.envName }}/{{ env.stageName }}/replacement" title="Replacement History"></side-button>
+    </div>
     <replace-cluster v-bind:clusterstate="clusterState" v-on:input="clusterAction"></replace-cluster>
 </div>
 {% endblock %} {% block new-builds-panel %} {% endblock %} {% block new-pred-deploys-panel %} {% endblock %} {% block main %}
@@ -83,7 +86,9 @@
     <div class="panel-heading clearfix">
         <h4 class="panel-title pull-left pointer-cursor">
             <a data-toggle="collapse" data-target="#activeClusterReplaceId">
-                <span class="glyphicon glyphicon-chevron-down"></span><div v-if="state == 'REPLACE'">Active Replacement</div><div v-if="state == 'PAUSE'">Active Replacement (Paused)</div>
+                <span class="glyphicon glyphicon-chevron-down"></span>
+                <span v-if="state == 'REPLACE'">Active Replacement</span>
+                <span v-if="state == 'PAUSE'">Active Replacement (Paused)</span>
             </a>
         </h4>
     </div>

--- a/deploy-board/deploy_board/templates/clusters/replace_details.tmpl
+++ b/deploy-board/deploy_board/templates/clusters/replace_details.tmpl
@@ -55,7 +55,7 @@
             <th>Operator</th>
             <th>Action Type</th>
             <th>Change</th>
-            <th>Update Time(-08:00)</th>
+            <th>Update Time</th>
         </tr>
         {% for config_history in config_histories %}
         <tr>

--- a/deploy-board/deploy_board/templates/clusters/replace_histories.html
+++ b/deploy-board/deploy_board/templates/clusters/replace_histories.html
@@ -39,8 +39,8 @@
         <div class="container-fluid">
             <table id="deployHistoryTableId" class="table table-condensed table-striped table-hover">
                     <tr>
-                        <th>Start(-08:00)</th>
-                        <th>Finish(-08:00)</th>
+                        <th>Start</th>
+                        <th>Finish</th>
                         <th>Status</th>
                         <th>Success</th>
                         <th>Details</th>

--- a/deploy-board/deploy_board/templates/clusters/replace_progress.tmpl
+++ b/deploy-board/deploy_board/templates/clusters/replace_progress.tmpl
@@ -7,7 +7,6 @@
         <th class="col-lg-1">Status</th>
         <th class="col-lg-2">Cluster Replace Progress</th>
         <th class="col-lg-1">Elapsed</th>
-        <th class="col-lg-1">Operator</th>
         <th class="col-lg-1">Details</th>
         <th class="col-lg-1">Schedule</th>
    </tr>
@@ -42,7 +41,6 @@
                     {{ replace_progress_report.startDate|computeDuration }}
                 </span>
             </td>
-            <td>{{ replace_progress_report.operator }}</td>
             <td><a href="/env/{{ env.envName }}/{{ env.stageName }}/replacement/{{ replace_progress_report.id }}/details/">view</a></td>
             <td><a href="/env/{{ env.envName }}/{{ env.stageName }}/replacement/{{ replace_progress_report.id }}/schedule/">view</a></td>
        </tr>

--- a/deploy-board/deploy_board/templates/environs/env_landing.html
+++ b/deploy-board/deploy_board/templates/environs/env_landing.html
@@ -123,9 +123,6 @@
     <div v-if="showCluster" class="row">
         <side-button styleclass="fa fa-database" text="Capacity" href="/env/{{ env.envName }}/{{ env.stageName }}/config/capacity" title="Configure capacity"></side-button>
     </div>
-    <div v-if="" class="row">
-        <side-button styleclass="glyphicon glyphicon-time" text="Replacement History" href="/env/{{ env.envName }}/{{ env.stageName }}/replacement" title="Replacement History"></side-button>
-    </div>
     <div v-if="!showCluster" id="groupsDiv">
     </div>
 </div>


### PR DESCRIPTION
1.replacement history page, whenever capacity updates from 2  to 10, the success column should be:
"100% (2/2)" for previous replacement event, instead of using current capacity showing as "100% (10/10)"
2. remove (-08:00)
3. move 'Replacement History' inside 'capacity'
 