### PR TITLE
when involving the agent reports, we need to consider the environment id

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostDAO.java
@@ -65,9 +65,9 @@ public interface HostDAO {
 
     Collection<String> getRetiredHostIdsByGroup(String groupName) throws Exception;
 
-    Collection<String> getRetiredAndFailedHostIdsByGroup(String groupName) throws Exception;
+    Collection<String> getRetiredAndFailedHostIdsByGroup(String groupName, String envId) throws Exception;
 
-    Collection<String> getCanNotRetireAndServingBuildHostIdsByGroup(String groupName) throws Exception;
+    Collection<String> getCanNotRetireAndServingBuildHostIdsByGroup(String groupName, String envId) throws Exception;
 
-    Collection<String> getFailedHostIdsByGroup(String groupName) throws Exception;
+    Collection<String> getFailedHostIdsByGroup(String groupName, String envId) throws Exception;
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostDAO.java
@@ -15,6 +15,7 @@
  */
 package com.pinterest.deployservice.dao;
 
+import com.pinterest.deployservice.bean.AgentBean;
 import com.pinterest.deployservice.bean.HostBean;
 
 import java.util.Collection;
@@ -63,11 +64,11 @@ public interface HostDAO {
 
     Collection<HostBean> getByEnvIdAndHostName(String envId, String hostName) throws Exception;
 
-    Collection<String> getRetiredHostIdsByGroup(String groupName) throws Exception;
+    Collection<String> getToBeRetiredHostIdsByGroup(String groupName) throws Exception;
 
-    Collection<String> getRetiredAndFailedHostIdsByGroup(String groupName, String envId) throws Exception;
+    Collection<String> getToBeRetiredAndFailedHostIdsByGroup(String groupName) throws Exception;
 
-    Collection<String> getCanNotRetireAndServingBuildHostIdsByGroup(String groupName, String envId) throws Exception;
+    Collection<String> getNewAndServingBuildHostIdsByGroup(String groupName) throws Exception;
 
-    Collection<String> getFailedHostIdsByGroup(String groupName, String envId) throws Exception;
+    Collection<String> getFailedHostIdsByGroup(String groupName) throws Exception;
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostDAO.java
@@ -15,7 +15,6 @@
  */
 package com.pinterest.deployservice.dao;
 
-import com.pinterest.deployservice.bean.AgentBean;
 import com.pinterest.deployservice.bean.HostBean;
 
 import java.util.Collection;

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostDAOImpl.java
@@ -58,13 +58,13 @@ public class DBHostDAOImpl implements HostDAO {
     private static final String GET_HOST_BY_ENVID_AND_HOSTID = "SELECT DISTINCT e.* FROM hosts e INNER JOIN groups_and_envs ge ON ge.group_name = e.group_name WHERE ge.env_id=? AND e.host_id=?";
     private static final String GET_HOST_BY_ENVID_AND_HOSTNAME1 = "SELECT hs.* FROM hosts hs INNER JOIN groups_and_envs ge ON ge.group_name = hs.group_name WHERE ge.env_id=? AND hs.host_name=?";
     private static final String GET_HOST_BY_ENVID_AND_HOSTNAME2 = "SELECT hs.* FROM hosts hs INNER JOIN hosts_and_envs he ON he.host_name = hs.host_name WHERE he.env_id=? AND he.host_name=?";
-    private static final String GET_RETIRED_HOSTIDS_BY_GROUP = "SELECT DISTINCT host_id FROM hosts WHERE can_retire=1 AND group_name=? AND state not in (?,?)";
+    private static final String GET_RETIRED_HOSTIDS_BY_GROUP = "SELECT DISTINCT host_id FROM hosts WHERE can_retire=1 AND group_name=? AND a.env_id = ? AND state not in (?,?)";
     private static final String GET_RETIRED_AND_FAILED_HOSTIDS_BY_GROUP =
-            "SELECT DISTINCT h.host_id FROM hosts h INNER JOIN agents a ON a.host_id=h.host_id WHERE h.can_retire=1 AND h.group_name=? AND h.state not in (?,?) and a.status not in (?,?)";
+            "SELECT DISTINCT h.host_id FROM hosts h INNER JOIN agents a ON a.host_id=h.host_id WHERE h.can_retire=1 AND h.group_name=? AND a.env_id = ? AND h.state not in (?,?) and a.status not in (?,?)";
     private static final String GET_FAILED_HOSTIDS_BY_GROUP =
-            "SELECT DISTINCT h.host_id FROM hosts h INNER JOIN agents a ON a.host_id=h.host_id WHERE h.group_name=? AND h.state not in (?,?) and a.status not in (?,?)";
+            "SELECT DISTINCT h.host_id FROM hosts h INNER JOIN agents a ON a.host_id=h.host_id WHERE h.group_name=? AND a.env_id = ? AND h.state not in (?,?) and a.status not in (?,?)";
     private static final String GET_CAN_NOT_RETIRE_AND_SERVING_BUILD_HOSTIDS_BY_GROUP =
-            "SELECT DISTINCT h.host_id FROM hosts h INNER JOIN agents a ON a.host_id=h.host_id WHERE h.can_retire!=1 AND h.group_name=? AND h.state not in (?,?) AND a.deploy_stage = ? AND a.state = ?";
+            "SELECT DISTINCT h.host_id FROM hosts h INNER JOIN agents a ON a.host_id=h.host_id WHERE h.can_retire!=1 AND h.group_name=? AND a.env_id = ? AND h.state not in (?,?) AND a.deploy_stage = ? AND a.state = ?";
 
     private BasicDataSource dataSource;
 
@@ -238,25 +238,25 @@ public class DBHostDAOImpl implements HostDAO {
     }
 
     @Override
-    public Collection<String> getRetiredAndFailedHostIdsByGroup(String groupName) throws Exception {
+    public Collection<String> getRetiredAndFailedHostIdsByGroup(String groupName, String envId) throws Exception {
         return new QueryRunner(dataSource).query(GET_RETIRED_AND_FAILED_HOSTIDS_BY_GROUP,
-                SingleResultSetHandlerFactory.<String>newListObjectHandler(), groupName,
+                SingleResultSetHandlerFactory.<String>newListObjectHandler(), groupName, envId,
                 HostState.PENDING_TERMINATE.toString(), HostState.TERMINATING.toString(),
                 AgentStatus.UNKNOWN.toString(), AgentStatus.SUCCEEDED.toString());
     }
 
     @Override
-    public Collection<String> getCanNotRetireAndServingBuildHostIdsByGroup(String groupName) throws Exception {
+    public Collection<String> getCanNotRetireAndServingBuildHostIdsByGroup(String groupName, String envId) throws Exception {
         return new QueryRunner(dataSource).query(GET_CAN_NOT_RETIRE_AND_SERVING_BUILD_HOSTIDS_BY_GROUP,
-                SingleResultSetHandlerFactory.<String>newListObjectHandler(), groupName,
+                SingleResultSetHandlerFactory.<String>newListObjectHandler(), groupName, envId,
                 HostState.PENDING_TERMINATE.toString(), HostState.TERMINATING.toString(),
                 DeployStage.SERVING_BUILD.toString(), AgentState.NORMAL.toString());
     }
 
     @Override
-    public Collection<String> getFailedHostIdsByGroup(String groupName) throws Exception {
+    public Collection<String> getFailedHostIdsByGroup(String groupName, String envId) throws Exception {
         return new QueryRunner(dataSource).query(GET_FAILED_HOSTIDS_BY_GROUP,
-                SingleResultSetHandlerFactory.<String>newListObjectHandler(), groupName,
+                SingleResultSetHandlerFactory.<String>newListObjectHandler(), groupName, envId,
                 HostState.PENDING_TERMINATE.toString(), HostState.TERMINATING.toString(),
                 AgentStatus.UNKNOWN.toString(), AgentStatus.SUCCEEDED.toString());
     }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostDAOImpl.java
@@ -15,7 +15,12 @@
  */
 package com.pinterest.deployservice.db;
 
-import com.pinterest.deployservice.bean.*;
+import com.pinterest.deployservice.bean.AgentStatus;
+import com.pinterest.deployservice.bean.DeployStage;
+import com.pinterest.deployservice.bean.AgentState;
+import com.pinterest.deployservice.bean.HostBean;
+import com.pinterest.deployservice.bean.HostState;
+import com.pinterest.deployservice.bean.SetClause;
 import com.pinterest.deployservice.dao.HostDAO;
 
 import org.apache.commons.dbcp.BasicDataSource;

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/db/DBDAOTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/db/DBDAOTest.java
@@ -693,13 +693,13 @@ public class DBDAOTest {
         hostBean7.setCan_retire(true);
         hostDAO.insert(hostBean7);
 
-        Collection<String> retiredHostBeanIds = hostDAO.getRetiredHostIdsByGroup("retire-group");
+        Collection<String> retiredHostBeanIds = hostDAO.getToBeRetiredHostIdsByGroup("retire-group");
         assertEquals(retiredHostBeanIds.size(), 2);
 
         AgentBean agentBean1 = genDefaultAgentBean("i-11", "i-11", "e-1", "d-1", DeployStage.RESTARTING);
         agentBean1.setStatus(AgentStatus.AGENT_FAILED);
         agentDAO.insertOrUpdate(agentBean1);
-        Collection<String> retiredAndFailedHostIds = hostDAO.getRetiredAndFailedHostIdsByGroup("retire-group");
+        Collection<String> retiredAndFailedHostIds = hostDAO.getToBeRetiredAndFailedHostIdsByGroup("retire-group");
         assertEquals(retiredAndFailedHostIds.size(), 1);
 
         Collection<String> failedHostIds = hostDAO.getFailedHostIdsByGroup("retire-group");

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Groups.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Groups.java
@@ -64,6 +64,8 @@ public class Groups {
     public Collection<String> getHostIds(@PathParam("groupName") String groupName,
                                          @NotEmpty @QueryParam("actionType") HostInfoActionType actionType) throws Exception {
         Collection<String> hostIds;
+        EnvironBean env = environDAO.getByCluster(groupName);
+
         switch (actionType) {
             case ALL:
                 hostIds = hostDAO.getHostIdsByGroup(groupName);
@@ -72,13 +74,13 @@ public class Groups {
                 hostIds = hostDAO.getRetiredHostIdsByGroup(groupName);
                 break;
             case FAILED:
-                hostIds = hostDAO.getFailedHostIdsByGroup(groupName);
+                hostIds = hostDAO.getFailedHostIdsByGroup(groupName, env.getEnv_id());
                 break;
             case RETIRED_AND_FAILED:
-                hostIds = hostDAO.getRetiredAndFailedHostIdsByGroup(groupName);
+                hostIds = hostDAO.getRetiredAndFailedHostIdsByGroup(groupName, env.getEnv_id());
                 break;
             case CANNOT_RETIRED_AND_SERVING_BUILD:
-                hostIds = hostDAO.getCanNotRetireAndServingBuildHostIdsByGroup(groupName);
+                hostIds = hostDAO.getCanNotRetireAndServingBuildHostIdsByGroup(groupName, env.getEnv_id());
                 break;
             default:
                 throw new TeletaanInternalException(Response.Status.BAD_REQUEST, "No action found.");

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Groups.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Groups.java
@@ -42,7 +42,7 @@ public class Groups {
         RETIRED,
         FAILED,
         RETIRED_AND_FAILED,
-        CANNOT_RETIRED_AND_SERVING_BUILD
+        NEW_AND_SERVING_BUILD
     }
 
     private EnvironDAO environDAO;
@@ -64,23 +64,21 @@ public class Groups {
     public Collection<String> getHostIds(@PathParam("groupName") String groupName,
                                          @NotEmpty @QueryParam("actionType") HostInfoActionType actionType) throws Exception {
         Collection<String> hostIds;
-        EnvironBean env = environDAO.getByCluster(groupName);
-
         switch (actionType) {
             case ALL:
                 hostIds = hostDAO.getHostIdsByGroup(groupName);
                 break;
             case RETIRED:
-                hostIds = hostDAO.getRetiredHostIdsByGroup(groupName);
+                hostIds = hostDAO.getToBeRetiredHostIdsByGroup(groupName);
                 break;
             case FAILED:
-                hostIds = hostDAO.getFailedHostIdsByGroup(groupName, env.getEnv_id());
+                hostIds = hostDAO.getFailedHostIdsByGroup(groupName);
                 break;
             case RETIRED_AND_FAILED:
-                hostIds = hostDAO.getRetiredAndFailedHostIdsByGroup(groupName, env.getEnv_id());
+                hostIds = hostDAO.getToBeRetiredAndFailedHostIdsByGroup(groupName);
                 break;
-            case CANNOT_RETIRED_AND_SERVING_BUILD:
-                hostIds = hostDAO.getCanNotRetireAndServingBuildHostIdsByGroup(groupName, env.getEnv_id());
+            case NEW_AND_SERVING_BUILD:
+                hostIds = hostDAO.getNewAndServingBuildHostIdsByGroup(groupName);
                 break;
             default:
                 throw new TeletaanInternalException(Response.Status.BAD_REQUEST, "No action found.");


### PR DESCRIPTION
I have 2 hosts (whose agent report as `failed`)

![screen shot 2017-04-10 at 4 37 01 pm](https://cloud.githubusercontent.com/assets/24964493/24886795/faf14020-1e0b-11e7-9ece-245955706d5b.png)

current `get successfully serving build hosts` SQL is:
SELECT DISTINCT h.host_id FROM hosts h INNER JOIN agents a ON a.host_id=h.host_id WHERE h.can_retire!=1 AND h.group_name='suli-test-integ' AND h.state not in ('PENDING_TERMINATE','TERMINATING') AND a.deploy_stage = 'SERVING_BUILD' AND a.state = 'NORMAL';
+---------------------+
| host_id             |
+---------------------+
| i-048777bfa7ce30647 |
| i-0538b5a40cb3afb1f |
| i-05a0da0fb8d43847a |
| i-0620aaa554525ecf7 |
| i-08a212050d7841540 |
| i-09200b6976f6b571b |
| i-099f66ae6c3bd8cca |
| i-0a81682a831fac6d0 |
| i-0c2e1c5214cd1e2f6 |
| i-0e894c4610b420a43 |
+---------------------+
10 rows in set (0.01 sec)


which returns 10, but actually it should be 8, like below:

 SELECT DISTINCT h.host_id FROM hosts h INNER JOIN agents a ON a.host_id=h.host_id WHERE h.can_retire!=1 AND h.group_name='suli-test-integ' AND a.env_id = 'WRqlXgiXTnuk3aoBQXDTKQ' AND h.state not in ('PENDING_TERMINATE','TERMINATING') AND a.deploy_stage = 'SERVING_BUILD' AND a.state = 'NORMAL';
+---------------------+
| host_id             |
+---------------------+
| i-09200b6976f6b571b |
| i-0c2e1c5214cd1e2f6 |
| i-048777bfa7ce30647 |
| i-05a0da0fb8d43847a |
| i-0a81682a831fac6d0 |
| i-0620aaa554525ecf7 |
| i-08a212050d7841540 |
| i-0e894c4610b420a43 |
+---------------------+
8 rows in set (0.00 sec)