### PR TITLE
Reimplement autopromote

### DIFF
--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/worker/AutoPromotBuildTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/worker/AutoPromotBuildTest.java
@@ -13,7 +13,6 @@ import com.pinterest.deployservice.bean.EnvironBean;
 import com.pinterest.deployservice.bean.PromoteBean;
 import com.pinterest.deployservice.dao.BuildDAO;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.joda.time.DateTime;
 import org.junit.Assert;
 import org.junit.Before;
@@ -71,7 +70,7 @@ public class AutoPromotBuildTest {
 
   @Test
   public void testGetScheduledCheckDueResult() throws Exception{
-    PromoteBean promoteBean = new PromoteBean();
+   /* PromoteBean promoteBean = new PromoteBean();
     AutoPromoter promoter = new AutoPromoter(context);
     DeployBean currentDeploy = new DeployBean();
     currentDeploy.setStart_date(DateTime.now().minusDays(1).getMillis());
@@ -97,8 +96,8 @@ public class AutoPromotBuildTest {
       DateTime
           start =
           new DateTime(now.getYear(), now.getMonthOfYear(), now.getDayOfMonth(), 10, 0, 0);
-      Assert.assertEquals(result.getRight().longValue(), start.getMillis());
-    }
+      Assert.assertEquals(result.getRight().longValue(), start.getMillis());*/
+    //}
   }
 
   /* Autopromote enabled for any new build. But no builds and no prev deploys*/
@@ -107,7 +106,7 @@ public class AutoPromotBuildTest {
     PromoteBean promoteBean = new PromoteBean();
     AutoPromoter promoter = new AutoPromoter(context);
     //No build. No previous deploy
-    PromoteResult result = promoter.computePromoteBuildResult(environBean, null, 10, promoteBean);
+    PromoteResult result = promoter.computePromoteBuildResult(environBean, null, 1, promoteBean);
     Assert.assertEquals(PromoteResult.ResultCode.NoAvailableBuild, result.getResult());
 
    }
@@ -123,7 +122,7 @@ public class AutoPromotBuildTest {
     build.setPublish_date(DateTime.now().minusHours(1).getMillis());
     when(buildDAO.getAcceptedBuilds(anyString(), anyString(), anyObject(), anyInt()))
         .thenReturn(Arrays.asList(build));
-    PromoteResult result = promoter.computePromoteBuildResult(environBean, null, 10, promoteBean);
+    PromoteResult result = promoter.computePromoteBuildResult(environBean, null, 1, promoteBean);
     Assert.assertEquals(PromoteResult.ResultCode.PromoteBuild, result.getResult());
     Assert.assertEquals("123", result.getPromotedBuild());
   }
@@ -143,7 +142,7 @@ public class AutoPromotBuildTest {
     preBuild.setPublish_date(DateTime.now().minusHours(3).getMillis());
 
     when(buildDAO.getById("prev123")).thenReturn(preBuild);
-    PromoteResult result = promoter.computePromoteBuildResult(environBean, previousDeploy, 10, promoteBean);
+    PromoteResult result = promoter.computePromoteBuildResult(environBean, previousDeploy, 1, promoteBean);
     Assert.assertEquals(PromoteResult.ResultCode.NoAvailableBuild, result.getResult());
   }
 
@@ -167,7 +166,7 @@ public class AutoPromotBuildTest {
     when(buildDAO.getById("prev123")).thenReturn(preBuild);
     when(buildDAO.getAcceptedBuilds(anyString(), anyString(), anyObject(), anyInt()))
         .thenReturn(Arrays.asList(build));
-    PromoteResult result = promoter.computePromoteBuildResult(environBean, previousDeploy, 10, promoteBean);
+    PromoteResult result = promoter.computePromoteBuildResult(environBean, previousDeploy, 1, promoteBean);
     Assert.assertEquals(PromoteResult.ResultCode.PromoteBuild, result.getResult());
     Assert.assertEquals("123", result.getPromotedBuild());
   }
@@ -182,7 +181,7 @@ public class AutoPromotBuildTest {
     AutoPromoter promoter = new AutoPromoter(context);
 
     //No build. No previous deploy
-    PromoteResult result = promoter.computePromoteBuildResult(environBean, null, 10, promoteBean);
+    PromoteResult result = promoter.computePromoteBuildResult(environBean, null, 1, promoteBean);
     Assert.assertEquals(PromoteResult.ResultCode.NoAvailableBuild, result.getResult());
   }
 
@@ -193,6 +192,7 @@ public class AutoPromotBuildTest {
     promoteBean.setEnv_id(environBean.getEnv_id());
     promoteBean.setSchedule(CronTenAMPerDay);
     promoteBean.setLast_update(0L);
+    promoteBean.setDelay(0);
 
     AutoPromoter promoter = new AutoPromoter(context);
     //Has builds. Have previous deploy
@@ -208,7 +208,7 @@ public class AutoPromotBuildTest {
     }
     when(buildDAO.getAcceptedBuilds(anyString(), anyString(), anyObject(), anyInt()))
         .thenReturn(Arrays.asList(build));
-    PromoteResult result = promoter.computePromoteBuildResult(environBean, null, 10, promoteBean);
+    PromoteResult result = promoter.computePromoteBuildResult(environBean, null, 1, promoteBean);
     Assert.assertEquals(PromoteResult.ResultCode.PromoteBuild, result.getResult());
     Assert.assertEquals("123", result.getPromotedBuild());
   }
@@ -220,7 +220,7 @@ public class AutoPromotBuildTest {
     promoteBean.setEnv_id(environBean.getEnv_id());
     promoteBean.setSchedule(CronTenAMPerDay);
     promoteBean.setLast_update(0L);
-
+    promoteBean.setDelay(0);
     AutoPromoter promoter = new AutoPromoter(context);
     //Has builds. Have previous deploy
     BuildBean build = new BuildBean();
@@ -235,8 +235,8 @@ public class AutoPromotBuildTest {
     }
     when(buildDAO.getAcceptedBuilds(anyString(), anyString(), anyObject(), anyInt()))
         .thenReturn(Arrays.asList(build));
-    PromoteResult result = promoter.computePromoteBuildResult(environBean, null, 10, promoteBean);
-    Assert.assertEquals(PromoteResult.ResultCode.NotInScheduledTime, result.getResult());
+    PromoteResult result = promoter.computePromoteBuildResult(environBean, null, 1, promoteBean);
+    Assert.assertEquals(PromoteResult.ResultCode.NoAvailableBuild, result.getResult());
   }
 
   /* Autopromote enabled for 10:00 AM every day. Have old previous deploy but no new build*/
@@ -246,6 +246,7 @@ public class AutoPromotBuildTest {
     promoteBean.setEnv_id(environBean.getEnv_id());
     promoteBean.setSchedule(CronTenAMPerDay);
     promoteBean.setLast_update(0L);
+    promoteBean.setDelay(0);
     AutoPromoter promoter = new AutoPromoter(context);
 
     DeployBean previousDeploy = new DeployBean();
@@ -257,7 +258,7 @@ public class AutoPromotBuildTest {
     preBuild.setPublish_date(DateTime.now().minusHours(3).getMillis());
 
     when(buildDAO.getById("prev123")).thenReturn(preBuild);
-    PromoteResult result = promoter.computePromoteBuildResult(environBean, previousDeploy, 10, promoteBean);
+    PromoteResult result = promoter.computePromoteBuildResult(environBean, previousDeploy, 1, promoteBean);
     Assert.assertEquals(PromoteResult.ResultCode.NoAvailableBuild, result.getResult());
   }
 
@@ -267,7 +268,7 @@ public class AutoPromotBuildTest {
     PromoteBean promoteBean = new PromoteBean();
     promoteBean.setEnv_id(environBean.getEnv_id());
     promoteBean.setSchedule(CronTenAMPerDay);
-
+    promoteBean.setDelay(0);
     AutoPromoter promoter = new AutoPromoter(context);
 
     DeployBean previousDeploy = new DeployBean();
@@ -279,8 +280,8 @@ public class AutoPromotBuildTest {
     preBuild.setPublish_date(DateTime.now().minusHours(3).getMillis());
 
     when(buildDAO.getById("prev123")).thenReturn(preBuild);
-    PromoteResult result = promoter.computePromoteBuildResult(environBean, previousDeploy, 10, promoteBean);
-    Assert.assertEquals(PromoteResult.ResultCode.NotInScheduledTime, result.getResult());
+    PromoteResult result = promoter.computePromoteBuildResult(environBean, previousDeploy, 1, promoteBean);
+    Assert.assertEquals(PromoteResult.ResultCode.NoAvailableBuild, result.getResult());
   }
 
 
@@ -290,6 +291,7 @@ public class AutoPromotBuildTest {
     promoteBean.setEnv_id(environBean.getEnv_id());
     promoteBean.setSchedule(CronTenAMPerDay);
     promoteBean.setLast_update(0L);
+    promoteBean.setDelay(0);
     AutoPromoter promoter = new AutoPromoter(context);
     //Has builds. No previous deploy
     DeployBean previousDeploy = new DeployBean();
@@ -311,7 +313,7 @@ public class AutoPromotBuildTest {
     when(buildDAO.getById("prev123")).thenReturn(preBuild);
     when(buildDAO.getAcceptedBuilds(anyString(), anyString(), anyObject(), anyInt()))
         .thenReturn(Arrays.asList(build));
-    PromoteResult result = promoter.computePromoteBuildResult(environBean, previousDeploy, 10, promoteBean);
+    PromoteResult result = promoter.computePromoteBuildResult(environBean, previousDeploy, 1, promoteBean);
     Assert.assertEquals(PromoteResult.ResultCode.PromoteBuild, result.getResult());
     Assert.assertEquals("123", result.getPromotedBuild());
   }

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/worker/AutoPromoteDeployTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/worker/AutoPromoteDeployTest.java
@@ -1,5 +1,6 @@
 package com.pinterest.teletraan.worker;
 
+import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -36,6 +37,7 @@ public class AutoPromoteDeployTest {
   EnvironDAO environDAO;
   DeployDAO deployDAO;
   final static String CronTenAMPerDay = "0 0 10 * * ?";
+  final static String CronWorkTimePerDay = "0 40 9-17 ? * *";
 
   List<DeployBean> allDeployBeans = new ArrayList<>();
 
@@ -135,7 +137,7 @@ public class AutoPromoteDeployTest {
     allDeployBeans.add(prevDeploy);
     when(environDAO.getByStage(environBean.getEnv_name(), "pred")).thenReturn(predEnvironBean);
     when(deployDAO.getById("deploy1")).thenReturn(prevDeploy);
-    when(deployDAO.getAcceptedDeploysDelayed(anyString(), anyObject())).thenAnswer(
+    when(deployDAO.getAcceptedDeploys(anyString(), anyObject(), anyInt())).thenAnswer(
         new Answer<List<DeployBean>>(){
           @Override
           public List<DeployBean> answer(InvocationOnMock invocationOnMock) throws Throwable {
@@ -181,7 +183,7 @@ public class AutoPromoteDeployTest {
     when(environDAO.getByStage(environBean.getEnv_name(), "pred")).thenReturn(predEnvironBean);
     when(deployDAO.getById(prevDeploy.getDeploy_id())).thenReturn(prevDeploy);
     when(deployDAO.getById(newDeploy.getDeploy_id())).thenReturn(newDeploy);
-    when(deployDAO.getAcceptedDeploysDelayed(anyString(), anyObject())).thenAnswer(
+    when(deployDAO.getAcceptedDeploys(anyString(), anyObject(), anyInt())).thenAnswer(
         new Answer<List<DeployBean>>(){
           @Override
           public List<DeployBean> answer(InvocationOnMock invocationOnMock) throws Throwable {
@@ -193,12 +195,12 @@ public class AutoPromoteDeployTest {
     AutoPromoter promoter = new AutoPromoter(context);
     //Pre deploy is 6 minutes ago, delay is 10 minutes
     newDeploy.setStart_date(now.minusMinutes(6).getMillis());
-    PromoteResult result = promoter.computePromoteDeployResult(environBean, currentDeploy, 10, promoteBean);
+    PromoteResult result = promoter.computePromoteDeployResult(environBean, currentDeploy, 1, promoteBean);
     Assert.assertEquals(PromoteResult.ResultCode.NoCandidateWithinDelayPeriod, result.getResult());
 
     //Set predeploy to 11 minutes, delay is 10 minutes
     newDeploy.setStart_date(now.minusMinutes(11).getMillis());
-    result = promoter.computePromoteDeployResult(environBean, currentDeploy, 10, promoteBean);
+    result = promoter.computePromoteDeployResult(environBean, currentDeploy, 1, promoteBean);
     Assert.assertEquals(PromoteResult.ResultCode.PromoteDeploy, result.getResult());
 
   }
@@ -221,7 +223,7 @@ public class AutoPromoteDeployTest {
     allDeployBeans.add(newDeploy);
     when(environDAO.getByStage(environBean.getEnv_name(), "pred")).thenReturn(predEnvironBean);
     when(deployDAO.getById("deploy1")).thenReturn(newDeploy);
-    when(deployDAO.getAcceptedDeploysDelayed(anyString(), anyObject())).thenAnswer(
+    when(deployDAO.getAcceptedDeploys(anyString(), anyObject(),anyInt())).thenAnswer(
         new Answer<List<DeployBean>>(){
           @Override
           public List<DeployBean> answer(InvocationOnMock invocationOnMock) throws Throwable {
@@ -233,12 +235,12 @@ public class AutoPromoteDeployTest {
     AutoPromoter promoter = new AutoPromoter(context);
     //Pre deploy is 6 minutes ago, delay is 10 minutes
     newDeploy.setStart_date(now.minusMinutes(6).getMillis());
-    PromoteResult result = promoter.computePromoteDeployResult(environBean, currentDeploy, 10, promoteBean);
+    PromoteResult result = promoter.computePromoteDeployResult(environBean, currentDeploy, 1, promoteBean);
     Assert.assertEquals(PromoteResult.ResultCode.NoCandidateWithinDelayPeriod, result.getResult());
 
     //Set predeploy to 11 minutes, delay is 10 minutes
     newDeploy.setStart_date(now.minusMinutes(11).getMillis());
-    result = promoter.computePromoteDeployResult(environBean, currentDeploy, 10, promoteBean);
+    result = promoter.computePromoteDeployResult(environBean, currentDeploy, 1, promoteBean);
     Assert.assertEquals(PromoteResult.ResultCode.PromoteDeploy, result.getResult());
 
   }
@@ -269,7 +271,7 @@ public class AutoPromoteDeployTest {
     when(environDAO.getByStage(environBean.getEnv_name(), "pred")).thenReturn(predEnvironBean);
     when(deployDAO.getById(prevDeploy.getDeploy_id())).thenReturn(prevDeploy);
     when(deployDAO.getById(newDeploy.getDeploy_id())).thenReturn(newDeploy);
-    when(deployDAO.getAcceptedDeploysDelayed(anyString(), anyObject())).thenAnswer(
+    when(deployDAO.getAcceptedDeploys(anyString(), anyObject(), anyInt())).thenAnswer(
         new Answer<List<DeployBean>>(){
           @Override
           public List<DeployBean> answer(InvocationOnMock invocationOnMock) throws Throwable {
@@ -286,10 +288,10 @@ public class AutoPromoteDeployTest {
       currentDeploy.setStart_date(cuttingPoint.minusHours(2).getMillis());
       newDeploy.setStart_date(cuttingPoint.minusHours(1).getMillis());
       AutoPromoter promoter = new AutoPromoter(context);
-      PromoteResult result = promoter.computePromoteDeployResult(environBean, currentDeploy, 10, promoteBean);
+      PromoteResult result = promoter.computePromoteDeployResult(environBean, currentDeploy, 1, promoteBean);
       Assert.assertEquals(PromoteResult.ResultCode.PromoteDeploy, result.getResult());
       promoteBean.setDelay(1+(int)(now.getMillis() - newDeploy.getStart_date())/60000);
-      result = promoter.computePromoteDeployResult(environBean, currentDeploy, 10, promoteBean);
+      result = promoter.computePromoteDeployResult(environBean, currentDeploy, 1, promoteBean);
       Assert.assertEquals(PromoteResult.ResultCode.NoCandidateWithinDelayPeriod, result.getResult());
 
     }
@@ -299,7 +301,7 @@ public class AutoPromoteDeployTest {
       currentDeploy.setStart_date(now.minusHours(26).getMillis());
       newDeploy.setStart_date(now.minusHours(25).getMillis());
       AutoPromoter promoter = new AutoPromoter(context);
-      PromoteResult result = promoter.computePromoteDeployResult(environBean, currentDeploy, 10, promoteBean);
+      PromoteResult result = promoter.computePromoteDeployResult(environBean, currentDeploy, 1, promoteBean);
       Assert.assertEquals(PromoteResult.ResultCode.PromoteDeploy, result.getResult());
       promoteBean.setDelay(1+(int)(now.getMillis() - newDeploy.getStart_date())/60000);
       result = promoter.computePromoteDeployResult(environBean, currentDeploy, 10, promoteBean);
@@ -308,5 +310,67 @@ public class AutoPromoteDeployTest {
 
   }
 
+  @Test
+  public void testScheduledPromote2() throws Exception{
+    DateTime now = DateTime.now();
+    PromoteBean promoteBean = new PromoteBean();
+    promoteBean.setSchedule(CronWorkTimePerDay);
+    promoteBean.setPred_stage("pred");
+    promoteBean.setDelay(10); //minutes
+
+    predEnvironBean.setDeploy_id("deploy1");
+    DeployBean prevDeploy = new DeployBean();
+    prevDeploy.setDeploy_id("deploy1");
+    prevDeploy.setEnv_id(predEnvironBean.getEnv_id());
+
+    DeployBean newDeploy = new DeployBean();
+    newDeploy.setDeploy_id("newDeploy");
+    newDeploy.setEnv_id(predEnvironBean.getEnv_id());
+
+    DeployBean currentDeploy = new DeployBean();
+    currentDeploy.setDeploy_id("deploy2");
+    currentDeploy.setFrom_deploy("deploy1");
+
+    allDeployBeans.addAll(Arrays.asList(prevDeploy, newDeploy));
+
+    when(environDAO.getByStage(environBean.getEnv_name(), "pred")).thenReturn(predEnvironBean);
+    when(deployDAO.getById(prevDeploy.getDeploy_id())).thenReturn(prevDeploy);
+    when(deployDAO.getById(newDeploy.getDeploy_id())).thenReturn(newDeploy);
+    when(deployDAO.getAcceptedDeploys(anyString(), anyObject(), anyInt())).thenAnswer(
+        new Answer<List<DeployBean>>(){
+          @Override
+          public List<DeployBean> answer(InvocationOnMock invocationOnMock) throws Throwable {
+            return getAcceptedDeploysDelayed((String)invocationOnMock.getArguments()[0],
+                (Interval) invocationOnMock.getArguments()[1]);
+          }
+        }
+    );
+
+    if (now.getHourOfDay()>=9 && now.getHourOfDay()<=17) {
+      prevDeploy.setStart_date(now.minusHours(25).getMillis());
+      currentDeploy.setStart_date(now.minusHours(24).getMillis());
+      newDeploy.setStart_date(now.minusHours(now.getHourOfDay()).getMillis());
+      AutoPromoter promoter = new AutoPromoter(context);
+      PromoteResult result = promoter.computePromoteDeployResult(environBean, currentDeploy, 1, promoteBean);
+      Assert.assertEquals(PromoteResult.ResultCode.PromoteDeploy, result.getResult());
+
+      promoteBean.setDelay(1+(int)(now.getMillis() - newDeploy.getStart_date())/60000);
+      result = promoter.computePromoteDeployResult(environBean, currentDeploy, 1, promoteBean);
+      Assert.assertEquals(PromoteResult.ResultCode.NoCandidateWithinDelayPeriod, result.getResult());
+
+    }
+    else{
+      prevDeploy.setStart_date(now.minusHours(27).getMillis());
+      currentDeploy.setStart_date(now.minusHours(26).getMillis());
+      newDeploy.setStart_date(now.minusHours(25).getMillis());
+      AutoPromoter promoter = new AutoPromoter(context);
+      PromoteResult result = promoter.computePromoteDeployResult(environBean, currentDeploy, 1, promoteBean);
+      Assert.assertEquals(PromoteResult.ResultCode.PromoteDeploy, result.getResult());
+      promoteBean.setDelay(1+(int)(now.getMillis() - newDeploy.getStart_date())/60000);
+      result = promoter.computePromoteDeployResult(environBean, currentDeploy, 10, promoteBean);
+      Assert.assertEquals(PromoteResult.ResultCode.NoCandidateWithinDelayPeriod, result.getResult());
+    }
+
+  }
 
 }


### PR DESCRIPTION
The previous causes a few regressions. I feel it has some flaws in the  way of implementation and it is very hard to understand and maintain. So I rewrite another implementation.

Basically, the workflow changes from the old way
1. Find out the right time window
2. Find all builds and deploys in the window

TO
1. Find out all builds and deploys since last build/deploy to now (or now - required delay)
2. For each of candidates, starting from the latest one and check the due on cron based on build and deploy time. If the due time is before now. Deploy it

The difference is how to check cron. To check cron, we need to provide a time to check against.
In the old way, we tried hard to last deploy, last schedule update etc. But it turns out to be very hard to cover all cases. Right now, we directly check the candidate build and deploy against cron. I personally think it is clearer and easier to understand. This gives me more confidence on avoiding regressions


