### PR TITLE
Agent update should update the hostname sent from ping request

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/AgentBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/AgentBean.java
@@ -230,6 +230,7 @@ public class AgentBean implements Updatable {
 
     public final static String UPDATE_CLAUSE =
         "host_id=VALUES(host_id)," +
+            "host_name=VALUES(host_name),"+
             "deploy_id=VALUES(deploy_id)," +
             "deploy_stage=VALUES(deploy_stage)," +
             "start_date=VALUES(start_date)," +


### PR DESCRIPTION
In Agent ping request it contains the host name, we should update the agents table with the name it sent. This resolve some issue when the name was not available in the first ping