### PR TITLE
Assert always pass in test_local_download_helper.py

### DIFF
--- a/deploy-agent/tests/unit/deploy/download/test_local_download_helper.py
+++ b/deploy-agent/tests/unit/deploy/download/test_local_download_helper.py
@@ -45,7 +45,7 @@ class LocalDownloadFunctionsTest(unittest.TestCase):
             downloader = LocalDownloadHelper(self.url)
             downloader.download(self.target)
             log_contents = log_capture_string.getvalue()
-            assert('Failed' in log_contents, False)
+            assert 'Failed' not in log_contents
         finally:
             log_capture_string.close()
             logger.removeHandler(stream_handler)


### PR DESCRIPTION
assert('Failed' not in log_contents, False) always pass because ('Failed' not in log_contents, False) is an expression that is evaluated to be True. assert is not a function in Python, which probably causes the confusion, please see:
https://docs.python.org/2/reference/simple_stmts.html#the-assert-statement