### PR TITLE
Fix variable env_name not defined in agent.py

### DIFF
--- a/deploy-agent/deployd/agent.py
+++ b/deploy-agent/deployd/agent.py
@@ -180,7 +180,7 @@ class DeployAgent(object):
             if envName in self._envs:
                 del self._envs[envName]
             else:
-                log.info('Cannot find env {} in the ping report'.format(env_name))
+                log.info('Cannot find env {} in the ping report'.format(envName))
 
             if self._curr_report.report.envName == deploy_goal.envName:
                 self._curr_report = None


### PR DESCRIPTION
Variable env_name not defined. This is probably causes by a typo, and also not being consistent with the naming conventions in different files.