### PR TITLE
Enable flake8 style check in deploy-agent, and fix related style issues, and fix some typos

### DIFF
--- a/deploy-agent/deployd/__init__.py
+++ b/deploy-agent/deployd/__init__.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/deploy-agent/deployd/agent.py
+++ b/deploy-agent/deployd/agent.py
@@ -91,7 +91,6 @@ class DeployAgent(object):
         # start to ping server to get the latest deploy goal
         self._response = self._client.send_reports(self._envs)
 
-        # self._response = response
         if self._response:
             report = self._update_internal_deploy_goal(self._response)
             # failed to update

--- a/deploy-agent/deployd/agent.py
+++ b/deploy-agent/deployd/agent.py
@@ -43,12 +43,14 @@ class PingServer(object):
     def __call__(self, deploy_report):
         return self._agent.update_deploy_status(deploy_report=deploy_report)
 
+
 class AgentRunMode(object):
     SERVERLESS = "serverless"
 
     @staticmethod
     def is_serverless(mode):
         return AgentRunMode.SERVERLESS == mode
+
 
 class DeployAgent(object):
     _STATUS_FILE = None
@@ -87,9 +89,9 @@ class DeployAgent(object):
             self._executor = Executor(callback=PingServer(self), config=self._config)
 
         # start to ping server to get the latest deploy goal
-        response = self._client.send_reports(self._envs)
+        self._response = self._client.send_reports(self._envs)
 
-        self._response = response
+        # self._response = response
         if self._response:
             report = self._update_internal_deploy_goal(self._response)
             # failed to update
@@ -146,7 +148,6 @@ class DeployAgent(object):
                 time.sleep(self._config.get_daemon_sleep_time())
                 self.load_status_file()
 
-
     def serve_once(self):
         log.info("Running deploy agent in non daemon mode")
         try:
@@ -162,15 +163,15 @@ class DeployAgent(object):
             log.exception("Deploy Agent got exceptions: {}".format(traceback.format_exc()))
 
     def _resolve_deleted_env_name(self, envName, envId):
-        # When server return DELETE goal, the envName might be empty if the env has already been deleted.
-        # This function would try to figure out the envName based on the envId in the DELETE goal
+        # When server return DELETE goal, the envName might be empty if the env has already been
+        # deleted. This function would try to figure out the envName based on the envId in the
+        # DELETE goal.
         if envName:
             return envName
         for name, value in self._envs.iteritems():
             if envId == value.report.envId:
                 return name
         return None
-
 
     def process_deploy(self, response):
         op_code = response.opCode
@@ -299,13 +300,13 @@ class DeployAgent(object):
         if (self._envs is None) or (self._envs.get(env_name) is None):
             self._envs[env_name] = DeployStatus()
 
-        # update deploy_status from response for the environemnt
+        # update deploy_status from response for the environment
         self._envs[env_name].update_by_response(response)
 
-        # update script varibales
+        # update script variables
         if deploy_goal.scriptVariables:
             log.info('Start to generate script variables for deploy: {}'.
-            format(deploy_goal.deployId))
+                     format(deploy_goal.deployId))
             env_dir = self._config.get_agent_directory()
             working_dir = os.path.join(env_dir, "{}_SCRIPT_CONFIG".format(env_name))
             with open(working_dir, "w+") as f:
@@ -352,6 +353,7 @@ class DeployAgent(object):
             return True
 
         return False
+
 
 # make sure only one instance is running
 instance = SingleInstance()
@@ -405,7 +407,8 @@ def main():
         logging.basicConfig(filename=log_filename, level=config.get_log_level())
 
     log.info("Start to run deploy-agent.")
-    client = Client(config=config, hostname=args.hostname, hostgroup=args.hostgroup, use_facter=args.use_facter)
+    client = Client(config=config, hostname=args.hostname, hostgroup=args.hostgroup,
+                    use_facter=args.use_facter)
     if is_serverless_mode:
         log.info("Running agent with severless client")
         client = ServerlessClient(env_name=args.env_name, stage=args.stage, build=args.build,

--- a/deploy-agent/deployd/client/__init__.py
+++ b/deploy-agent/deployd/client/__init__.py
@@ -3,12 +3,11 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/deploy-agent/deployd/client/base_client.py
+++ b/deploy-agent/deployd/client/base_client.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,13 +21,13 @@ class BaseClient:
     """
 
     __metaclass__ = ABCMeta
-    
+
     @abstractmethod
     def send_reports(self, env_reports=None):
         """Args:
             env_reports: a dict with env name as key and DeployStatus as value.
 
         Returns:
-            PingResponse describing next action for deploy agent.  
+            PingResponse describing next action for deploy agent.
         """
         pass

--- a/deploy-agent/deployd/client/client.py
+++ b/deploy-agent/deployd/client/client.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -77,7 +77,8 @@ class Client(BaseClient):
                     if host_group:
                         self._hostgroup = host_group.split(",")
             else:
-                log.warn("Cannot find host information file {}. See doc for more details".format(host_info_fn))
+                log.warn("Cannot find host information file {}. See doc for more details".format(
+                    host_info_fn))
 
         # patch missing part
         if not self._hostname:
@@ -85,7 +86,7 @@ class Client(BaseClient):
 
         if not self._id:
             if self._use_facter:
-                #Must fail here as it cannot identify the host if id is missing
+                # Must fail here as it cannot identify the host if id is missing
                 return False
             else:
                 self._id = self._hostname
@@ -115,8 +116,9 @@ class Client(BaseClient):
                     # https://app.asana.com/0/11815463290546/40714916594784
                     if report.errorMessage:
                         report.errorMessage = report.errorMessage.encode('ascii', 'ignore')
-                ping_request = PingRequest(hostId=self._id, hostName=self._hostname, hostIp=self._ip,
-                                        groups=self._hostgroup, reports=reports)
+                ping_request = PingRequest(hostId=self._id, hostName=self._hostname,
+                                           hostIp=self._ip, groups=self._hostgroup,
+                                           reports=reports)
 
                 with create_stats_timer('deploy.agent.request.latency',
                                         sample_rate=1.0,
@@ -128,8 +130,8 @@ class Client(BaseClient):
             else:
                 log.error("Fail to read host info")
                 create_sc_increment(stats='deploy.failed.agent.hostinfocollection',
-                                sample_rate=1.0,
-                                tags={'host': self._hostname})
+                                    sample_rate=1.0,
+                                    tags={'host': self._hostname})
         except Exception:
             log.error(traceback.format_exc())
             create_sc_increment(stats='deploy.failed.agent.requests',

--- a/deploy-agent/deployd/client/restfulclient.py
+++ b/deploy-agent/deployd/client/restfulclient.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -35,14 +35,16 @@ class RestfulClient(object):
         def api(path, params=None, data=None):
             url = '%s/%s%s' % (self.url_prefix, self.url_version, path)
             if self.token:
-                headers = {'Authorization': 'token %s' % self.token, 'Content-type': 'application/json'}
+                headers = {'Authorization': 'token %s' % self.token,
+                           'Content-type': 'application/json'}
             else:
                 headers = {'Content-type': 'application/json'}
             response = getattr(requests, method)(url, headers=headers, params=params, json=data,
                                                  timeout=self.default_timeout, verify=False)
 
             if response.status_code > 300:
-                msg = "Teletraan failed to call backend server. Hint: %s, %s" % (response.status_code, response.content)
+                msg = "Teletraan failed to call backend server. Hint: %s, %s" % (
+                    response.status_code, response.content)
                 log.error(msg)
                 raise AgentException(msg)
 

--- a/deploy-agent/deployd/common/__init__.py
+++ b/deploy-agent/deployd/common/__init__.py
@@ -3,12 +3,11 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/deploy-agent/deployd/common/caller.py
+++ b/deploy-agent/deployd/common/caller.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/deploy-agent/deployd/common/config.py
+++ b/deploy-agent/deployd/common/config.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -224,7 +224,7 @@ class Config(object):
 
     def get_daemon_sleep_time(self):
         return self.get_intvar("daemon_sleep_time", 30)
-    
+
     def get_init_sleep_time(self):
         return self.get_intvar("init_sleep_time", 50)
 
@@ -247,5 +247,3 @@ class Config(object):
 
     def get_facter_group_key(self):
         return self.get_var('agent_group_key', None)
-    
-

--- a/deploy-agent/deployd/common/decorators.py
+++ b/deploy-agent/deployd/common/decorators.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/deploy-agent/deployd/common/env_status.py
+++ b/deploy-agent/deployd/common/env_status.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/deploy-agent/deployd/common/exceptions.py
+++ b/deploy-agent/deployd/common/exceptions.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/deploy-agent/deployd/common/executor.py
+++ b/deploy-agent/deployd/common/executor.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -47,8 +47,8 @@ class Executor(object):
         self._config = config
         log.debug('Executor configs have been updated: '
                   'PING_INTERVAL={}, TIME_OUT={}, MAX_RETRY={}'.format(self.MIN_RUNNING_TIME,
-                                                                      self.MAX_RUNNING_TIME,
-                                                                      self.MAX_RETRY))
+                                                                       self.MAX_RUNNING_TIME,
+                                                                       self.MAX_RETRY))
 
     def get_subprocess_output(self, fd, file_pos):
         curr_pos = fd.tell()

--- a/deploy-agent/deployd/common/helper.py
+++ b/deploy-agent/deployd/common/helper.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/deploy-agent/deployd/common/single_instance.py
+++ b/deploy-agent/deployd/common/single_instance.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,8 +18,6 @@ import stat
 import tempfile
 import fcntl
 import utils
-import subprocess
-from deployd import IS_PINTEREST
 
 log = logging.getLogger(__name__)
 

--- a/deploy-agent/deployd/common/stats.py
+++ b/deploy-agent/deployd/common/stats.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/deploy-agent/deployd/common/status_code.py
+++ b/deploy-agent/deployd/common/status_code.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/deploy-agent/deployd/common/types.py
+++ b/deploy-agent/deployd/common/types.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/deploy-agent/deployd/common/utils.py
+++ b/deploy-agent/deployd/common/utils.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -121,8 +121,8 @@ def get_info_from_facter(key):
         log.error("Failed to get info from facter by key {}".format(key))
         return None
 
+
 def check_not_none(arg, msg=None):
     if arg is None:
         raise ValueError(msg)
     return arg
-

--- a/deploy-agent/deployd/conf/__init__.py
+++ b/deploy-agent/deployd/conf/__init__.py
@@ -3,12 +3,11 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/deploy-agent/deployd/download/__init__.py
+++ b/deploy-agent/deployd/download/__init__.py
@@ -3,12 +3,11 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/deploy-agent/deployd/download/download_helper.py
+++ b/deploy-agent/deployd/download/download_helper.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/deploy-agent/deployd/download/download_helper_factory.py
+++ b/deploy-agent/deployd/download/download_helper_factory.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,7 +16,6 @@ from boto.s3.connection import S3Connection
 from deployd.download.s3_download_helper import S3DownloadHelper
 from deployd.download.http_download_helper import HTTPDownloadHelper
 from deployd.download.local_download_helper import LocalDownloadHelper
-from deployd.common.config import Config
 from urlparse import urlparse
 import logging
 

--- a/deploy-agent/deployd/download/downloader.py
+++ b/deploy-agent/deployd/download/downloader.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -117,6 +117,7 @@ def main():
     else:
         log.info("Download succeeded.")
         sys.exit(0)
+
 
 if __name__ == '__main__':
     main()

--- a/deploy-agent/deployd/download/http_download_helper.py
+++ b/deploy-agent/deployd/download/http_download_helper.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/deploy-agent/deployd/download/local_download_helper.py
+++ b/deploy-agent/deployd/download/local_download_helper.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/deploy-agent/deployd/download/s3_download_helper.py
+++ b/deploy-agent/deployd/download/s3_download_helper.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -58,7 +58,7 @@ class S3DownloadHelper(DownloadHelper):
             if "-" not in etag:
                 if etag.startswith('"') and etag.endswith('"'):
                     etag = etag[1:-1]
-            
+
                 md5 = self.md5_file(local_full_fn)
                 if md5 != etag:
                     log.error("MD5 verification failed. tarball is corrupt.")

--- a/deploy-agent/deployd/staging/__init__.py
+++ b/deploy-agent/deployd/staging/__init__.py
@@ -3,12 +3,11 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/deploy-agent/deployd/staging/stager.py
+++ b/deploy-agent/deployd/staging/stager.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/deploy-agent/deployd/staging/transformer.py
+++ b/deploy-agent/deployd/staging/transformer.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/deploy-agent/deployd/types/__init__.py
+++ b/deploy-agent/deployd/types/__init__.py
@@ -3,12 +3,11 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/deploy-agent/deployd/types/agent_status.py
+++ b/deploy-agent/deployd/types/agent_status.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/deploy-agent/deployd/types/build.py
+++ b/deploy-agent/deployd/types/build.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -45,8 +45,9 @@ class Build(object):
 
     def __str__(self):
         return "Build(buildId={}, buildName={}, buildVersion={}, artifactUrl={}, scm={}, " \
-               "scmRepo={}, scmBranch={}, scmCommit={}, scmInfo={}, commitDate={}, publishInfo={}, " \
-               "publishDate={})".format(self.buildId, self.buildName, self.buildVersion,
-                                        self.artifactUrl, self.scm, self.scmRepo, self.scmBranch,
-                                        self.scmCommit, self.scmInfo, self.commitDate,
-                                        self.publishInfo, self.publishDate)
+               "scmRepo={}, scmBranch={}, scmCommit={}, scmInfo={}, commitDate={}, " \
+               "publishInfo={}, publishDate={})".format(
+                self.buildId, self.buildName, self.buildVersion,
+                self.artifactUrl, self.scm, self.scmRepo, self.scmBranch,
+                self.scmCommit, self.scmInfo, self.commitDate,
+                self.publishInfo, self.publishDate)

--- a/deploy-agent/deployd/types/deploy_goal.py
+++ b/deploy-agent/deployd/types/deploy_goal.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -53,8 +53,9 @@ class DeployGoal(object):
     def __str__(self):
         return "DeployGoal(deployId={}, envId={}, envName={}, stageName={}, " \
                "deployStage={}, build={}, deployAlias={}, agentConfig={}," \
-               "scriptVariables={}, firstDeploy={}, isDocker={})".format(self.deployId, self.envId, self.envName,
-                                                            self.stageName, self.deployStage,
-                                                            self.build, self.deployAlias,
-                                                            self.config, self.scriptVariables,
-                                                            self.firstDeploy, self.isDocker)
+               "scriptVariables={}, firstDeploy={}, isDocker={})".format(
+                self.deployId, self.envId, self.envName,
+                self.stageName, self.deployStage,
+                self.build, self.deployAlias,
+                self.config, self.scriptVariables,
+                self.firstDeploy, self.isDocker)

--- a/deploy-agent/deployd/types/deploy_stage.py
+++ b/deploy-agent/deployd/types/deploy_stage.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/deploy-agent/deployd/types/deploy_type.py
+++ b/deploy-agent/deployd/types/deploy_type.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/deploy-agent/deployd/types/opcode.py
+++ b/deploy-agent/deployd/types/opcode.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/deploy-agent/deployd/types/ping_report.py
+++ b/deploy-agent/deployd/types/ping_report.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/deploy-agent/deployd/types/ping_request.py
+++ b/deploy-agent/deployd/types/ping_request.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/deploy-agent/deployd/types/ping_response.py
+++ b/deploy-agent/deployd/types/ping_response.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/deploy-agent/tests/__init__.py
+++ b/deploy-agent/tests/__init__.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/deploy-agent/tests/integration/__init__.py
+++ b/deploy-agent/tests/integration/__init__.py
@@ -3,12 +3,11 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/deploy-agent/tests/integration/test_agent.py
+++ b/deploy-agent/tests/integration/test_agent.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/deploy-agent/tests/unit/__init__.py
+++ b/deploy-agent/tests/unit/__init__.py
@@ -3,12 +3,11 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/deploy-agent/tests/unit/deploy/__init__.py
+++ b/deploy-agent/tests/unit/deploy/__init__.py
@@ -3,12 +3,11 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/deploy-agent/tests/unit/deploy/client/__init__.py
+++ b/deploy-agent/tests/unit/deploy/client/__init__.py
@@ -3,12 +3,11 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/deploy-agent/tests/unit/deploy/client/test_base_client.py
+++ b/deploy-agent/tests/unit/deploy/client/test_base_client.py
@@ -3,18 +3,15 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import unittest
-import mock
 import tests
 
 from deployd.client.base_client import BaseClient
@@ -28,4 +25,4 @@ class TestBaseClient(tests.TestCase):
             pass
 
         with self.assertRaises(TypeError):
-            myclient = MyClient()
+            MyClient()

--- a/deploy-agent/tests/unit/deploy/client/test_serverless_client.py
+++ b/deploy-agent/tests/unit/deploy/client/test_serverless_client.py
@@ -3,27 +3,21 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import unittest
-import mock
 import tests
 
-from deployd.agent import DeployAgent
 from deployd.client.serverless_client import ServerlessClient
-from deployd.common.utils import ensure_dirs
-from deployd.common.types import DeployReport, DeployStatus, OpCode, DeployStage, AgentStatus
-from deployd.types.deploy_goal import DeployGoal
+from deployd.common.types import DeployStatus, AgentStatus
 from deployd.types.ping_report import PingReport
-from deployd.types.ping_response import PingResponse
 
 
 class TestServerlessClient(tests.TestCase):
@@ -32,31 +26,32 @@ class TestServerlessClient(tests.TestCase):
         self.env_name = "test"
         self.stage = "prod"
         self.env_id = "12343434"
-        self.build = '{"commit":"c5a7f50453fa70fefa41dc5b75e9b053fc5bba4b","id":"S2dUHIrFSMyDzdwO-6mgeA_c81d6b3","branch":"master","artifactUrl":"https://deployrepo.pinadmin.com/pinboard/pinboard-c5a7f50.tar.gz","repo":"P","name": "pinboard"}' 
+        self.build = '{"commit":"c5a7f50453fa70fefa41dc5b75e9b053fc5bba4b","id":"S2dUHIrFSMyDzdwO-6mgeA_c81d6b3","branch":"master","artifactUrl":"https://deployrepo.pinadmin.com/pinboard/pinboard-c5a7f50.tar.gz","repo":"P","name": "pinboard"}'  # noqa: E501
         self.script_variables = '{"IS_DOCKER": "True"}'
         self.client = ServerlessClient(env_name=self.env_name, stage=self.stage, build=self.build,
-                                       script_variables=self.script_variables) 
+                                       script_variables=self.script_variables)
 
     def _new_report(self):
         report = PingReport()
         report.envName = self.env_name
         report.stageName = self.stage
         report.erroCode = 0
-        report.envId  = self.env_id
+        report.envId = self.env_id
         report.deployStage = None
         report.status = AgentStatus.SUCCEEDED
         return report
-              
+
     def test_deploy_stage_trnasition(self):
         report = self._new_report()
         deploy_status = DeployStatus()
         deploy_status.report = report
-        env_status = {self.env_name : deploy_status}
+        env_status = {self.env_name: deploy_status}
 
-        deployStages = ['PRE_DOWNLOAD', 'DOWNLOADING', 'POST_DOWNLOAD', 'STAGING', 'PRE_RESTART', 'RESTARTING', 'POST_RESTART', 'SERVING_BUILD']
+        deployStages = ['PRE_DOWNLOAD', 'DOWNLOADING', 'POST_DOWNLOAD', 'STAGING',
+                        'PRE_RESTART', 'RESTARTING', 'POST_RESTART', 'SERVING_BUILD']
 
         for i in range(0, len(deployStages)):
-            response = self.client.send_reports(env_status) 
+            response = self.client.send_reports(env_status)
             self.assertEqual(response.opCode, "DEPLOY")
             self.assertEqual(response.deployGoal.deployStage, deployStages[i])
             report.deployStage = response.deployGoal.deployStage
@@ -65,15 +60,15 @@ class TestServerlessClient(tests.TestCase):
         # test ending case
         response = self.client.send_reports(env_status)
         self.assertEqual(response.deployGoal, None)
- 
+
     def test_errorcode_stop_deployment(self):
         report = self._new_report()
         deploy_status = DeployStatus()
         deploy_status.report = report
-        env_status = {self.env_name : deploy_status}
+        env_status = {self.env_name: deploy_status}
 
         # first try is allowed.
-        report.errorCode = 123 
+        report.errorCode = 123
         response = self.client.send_reports(env_status)
         report.deployStage = response.deployGoal.deployStage
         report.deployId = response.deployGoal.deployId
@@ -85,16 +80,16 @@ class TestServerlessClient(tests.TestCase):
         report = self._new_report()
         deploy_status = DeployStatus()
         deploy_status.report = report
-        env_status = {self.env_name : deploy_status}
+        env_status = {self.env_name: deploy_status}
 
-        report.status = AgentStatus.UNKNOWN 
+        report.status = AgentStatus.UNKNOWN
         response = self.client.send_reports(env_status)
         report.deployStage = response.deployGoal.deployStage
         report.deployId = response.deployGoal.deployId
 
         response = self.client.send_reports(env_status)
         self.assertEqual(response.deployGoal.deployStage, 'PRE_DOWNLOAD')
- 
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/deploy-agent/tests/unit/deploy/common/__init__.py
+++ b/deploy-agent/tests/unit/deploy/common/__init__.py
@@ -3,12 +3,11 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/deploy-agent/tests/unit/deploy/common/test_config.py
+++ b/deploy-agent/tests/unit/deploy/common/test_config.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/deploy-agent/tests/unit/deploy/common/test_helper.py
+++ b/deploy-agent/tests/unit/deploy/common/test_helper.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/deploy-agent/tests/unit/deploy/download/__init__.py
+++ b/deploy-agent/tests/unit/deploy/download/__init__.py
@@ -3,12 +3,11 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/deploy-agent/tests/unit/deploy/download/test_download_helper.py
+++ b/deploy-agent/tests/unit/deploy/download/test_download_helper.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -56,6 +56,7 @@ class DownloadFunctionsTest(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         shutil.rmtree(cls.base_dir)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/deploy-agent/tests/unit/deploy/download/test_local_download_helper.py
+++ b/deploy-agent/tests/unit/deploy/download/test_local_download_helper.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -53,6 +53,7 @@ class LocalDownloadFunctionsTest(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         shutil.rmtree(cls.base_dir)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/deploy-agent/tests/unit/deploy/server/__init__.py
+++ b/deploy-agent/tests/unit/deploy/server/__init__.py
@@ -3,12 +3,11 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/deploy-agent/tests/unit/deploy/server/test_agent.py
+++ b/deploy-agent/tests/unit/deploy/server/test_agent.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -460,6 +460,7 @@ class TestDeployAgent(tests.TestCase):
 
     def test_switch_goal_download_variable_failed(self):
         pass
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/deploy-agent/tests/unit/deploy/staging/__init__.py
+++ b/deploy-agent/tests/unit/deploy/staging/__init__.py
@@ -3,12 +3,11 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/deploy-agent/tests/unit/deploy/staging/test_helper.py
+++ b/deploy-agent/tests/unit/deploy/staging/test_helper.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/deploy-agent/tests/unit/deploy/staging/test_transformer.py
+++ b/deploy-agent/tests/unit/deploy/staging/test_transformer.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -100,7 +100,6 @@ class TransformTest(unittest.TestCase):
         transformer.transform_scripts(self.template_dir, self.template_dir, self.script_dir)
 
         fn1 = os.path.join(self.script_dir, 'test1')
-        fn2 = os.path.join(self.script_dir, 'test2')
 
         value1 = "foo-foo-foo"
         values = {

--- a/deploy-agent/tests/unit/deploy/utils/__init__.py
+++ b/deploy-agent/tests/unit/deploy/utils/__init__.py
@@ -3,12 +3,11 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/deploy-agent/tests/unit/deploy/utils/test_agent.py
+++ b/deploy-agent/tests/unit/deploy/utils/test_agent.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/deploy-agent/tests/unit/deploy/utils/test_exec.py
+++ b/deploy-agent/tests/unit/deploy/utils/test_exec.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import subprocess
 import tempfile
 import unittest
 import mock

--- a/deploy-agent/tests/unit/deploy/utils/test_status.py
+++ b/deploy-agent/tests/unit/deploy/utils/test_status.py
@@ -3,16 +3,15 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 import os
 import tempfile
 import unittest
@@ -86,6 +85,7 @@ class TestStatusFunction(tests.TestCase):
         envs = env_status.load_envs()
         self.assertEqual(envs, {})
         os.remove(fn)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/deploy-agent/tox.ini
+++ b/deploy-agent/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27
+envlist=py27,flake8
 
 [flake8]
 exclude=.tox
@@ -8,3 +8,8 @@ max-line-length=100
 [testenv:py27]
 deps=-rrequirements.txt
 commands=py.test {posargs}
+
+[testenv:flake8]
+deps=
+  flake8==3.4.1
+commands=flake8


### PR DESCRIPTION
deploy-agent has flake8 in its requirements file, but is not enabled in tox. This change enabled flake8 style check when running tox so that style problems can be caught more easily.