### PR TITLE
Add gzip flag to create gzip tar file for deploy-sentinel

### DIFF
--- a/deploy-sentinel/Makefile
+++ b/deploy-sentinel/Makefile
@@ -4,7 +4,7 @@ clean:
 	rm -fr quickstart-build.tar.gz
 
 build:	clean
-	tar -cf quickstart-build.tar.gz mysite teletraan
+	tar -czf quickstart-build.tar.gz mysite teletraan
 
 publish: build quickstart.py
 	python quickstart.py


### PR DESCRIPTION
I think the intention is to create gzip file as indicated by the file name. However, it didn't add the --gzip/-z flag.

Without gzip flag, it still work because in the agent, the python tarfile package automatically figure out whether the tar file is gzipped or not.