### PR TITLE
Builds clean up now is done per environment

### DIFF
--- a/deploy-agent/deployd/agent.py
+++ b/deploy-agent/deployd/agent.py
@@ -275,18 +275,18 @@ class DeployAgent(object):
                           if status.build_info]
         builds_dir = self._config.get_builds_directory()
         num_retain_builds = self._config.get_num_builds_retain()
-        build_name = self._curr_report.report.envName
+        env_name = self._curr_report.report.envName
         # clear stale builds
         if len(builds_to_keep) > 0:
-            self.clean_stale_files(build_name, builds_dir, builds_to_keep, num_retain_builds)
+            self.clean_stale_files(env_name, builds_dir, builds_to_keep, num_retain_builds)
 
-    def clean_stale_files(self, build_name, dir, files_to_keep, num_file_to_retain):
-        for build in self._helper.get_stale_builds(self._helper.builds_available_locally(dir),
+    def clean_stale_files(self, env_name, dir, files_to_keep, num_file_to_retain):
+        for build in self._helper.get_stale_builds(self._helper.builds_available_locally(dir,env_name),
                                                    num_file_to_retain):
             if build not in files_to_keep:
                 log.info("Stale file {} found in {}... removing.".format(
                     build, dir))
-                self._helper.clean_package(dir, build, build_name)
+                self._helper.clean_package(dir, build, env_name)
 
     # private functions: update per deploy step configuration specified by services owner on the
     # environment config page

--- a/deploy-agent/deployd/common/helper.py
+++ b/deploy-agent/deployd/common/helper.py
@@ -33,7 +33,7 @@ class Helper(object):
                 path = os.path.join(builds_dir, filename)
                 if os.path.isfile(path):
                     #Only check downloaded file
-                    found, build = get_build_id(path, env_name)
+                    found, build = Helper.get_build_id(filename, env_name)
                     #Builds are downloaded as env_name-build_id.tar.gz
                     if found:  
                         # We only care about the actual builds.
@@ -45,16 +45,17 @@ class Helper(object):
         finally:
             return builds
 
-    def get_build_id(fullname, env_name):
+    @staticmethod
+    def get_build_id(filename, env_name):
         """
         Extract build id from the file name
         In downloader.py, we have the following name convenion
              local_fn = u'{}-{}.{}'.format(self._build_name, self._build, extension)
         """
         prefix = "{0}-".format(env_name)
-        extension_index = build.index(".")
-        if build.startswith(prefix) and extension_index>0:
-            return True, build[len(prefix):extension_index]
+       
+        if filename.startswith(prefix) and "." in filename:
+            return True, filename[len(prefix):filename.index(".")]
         return False, None
 
     @staticmethod

--- a/deploy-agent/deployd/common/helper.py
+++ b/deploy-agent/deployd/common/helper.py
@@ -90,11 +90,11 @@ class Helper(object):
         local_fn = '{}-{}.*'.format(build_name, build)
         try:
             # Remove extracted pointer from disk
-            extracted_file = os.path.join(base_dir, '{}.extracted'.format(builds))
+            extracted_file = os.path.join(base_dir, '{}.extracted'.format(build))
             if os.path.exists(extracted_file):
                 os.remove(extracted_file)
             # Remove staged pointer from disk
-            staged_file = os.path.join(base_dir, '{}.staged'.format(builds))
+            staged_file = os.path.join(base_dir, '{}.staged'.format(build))
             if os.path.exists(staged_file):
                 os.remove(staged_file)
         except OSError:
@@ -102,7 +102,7 @@ class Helper(object):
 
         try:
             # Remove build directory from disk
-            shutil.rmtree(os.path.join(base_dir, builds))
+            shutil.rmtree(os.path.join(base_dir, build))
         except BaseException:
             # Catch base exception class, as there's a multitude of reasons a rmtree can fail
             log.exception("Failed: remove build directory from disk")

--- a/deploy-agent/setup.py
+++ b/deploy-agent/setup.py
@@ -15,7 +15,7 @@
 from setuptools import setup
 import os
 
-__version__ = '1.2.13'
+__version__ = '1.2.14'
 
 markdown_contents = open(os.path.join(os.path.dirname(__file__),
                                       'README.md')).read()

--- a/deploy-agent/tests/unit/deploy/utils/test_agent.py
+++ b/deploy-agent/tests/unit/deploy/utils/test_agent.py
@@ -72,6 +72,17 @@ class TestAgentHelperFunctions(tests.FileTestCase):
                 [('abuild', time1), ('abuild2', time2), ('abuild3', time3)],
                 2)), ['abuild3'])
 
+    def test_get_build_id(self):
+        """
+         Test get_build_id method 
+        """
+        self.assertEqual(Helper.get_build_id("cmp_test-r4TTZfrWQEmgyaYic8uU6w_8ef9007.tar.gz", "cmp_test")[1],
+            "r4TTZfrWQEmgyaYic8uU6w_8ef9007")
+        self.assertEqual(Helper.get_build_id("cmp_test-r4TTZfrWQEmgyaYic8uU6w_8ef9007.zip", "cmp_test")[1],
+            "r4TTZfrWQEmgyaYic8uU6w_8ef9007")
+        self.assertFalse(Helper.get_build_id("whateverfile", "cmp_test")[0])
+        self.assertFalse(Helper.get_build_id("whateverfile.tar.gz", "cmp_test")[0])
+        self.assertFalse(Helper.get_build_id("cmp_test-tmp", "cmp_test")[0])
 
 if __name__ == '__main__':
     unittest.main()

--- a/deploy-agent/tests/unit/deploy/utils/test_agent.py
+++ b/deploy-agent/tests/unit/deploy/utils/test_agent.py
@@ -27,12 +27,13 @@ class TestAgentHelperFunctions(tests.FileTestCase):
         """This uses the filesystem."""
         config = mock.Mock()
         config.get_var = mock.Mock(return_value=self.builds_dir)
-        self.assertEqual([], Helper(config).builds_available_locally(self.builds_dir))
-        os.mkdir(os.path.join(self.builds_dir, 'fakebuild'))
+        helper = Helper(config)
+        self.assertEqual([], helper.builds_available_locally(self.builds_dir,'fakeenv'))
+        open(os.path.join(self.builds_dir, 'fakeenv-fakebuild.tar.gz'),'a').close()
         # builds_available_locally returns a tuple with buildname and timestamp.
         # let's just look at buildname
         self.assertEqual('fakebuild',
-                         Helper(config).builds_available_locally(self.builds_dir)[0][0])
+                         helper.builds_available_locally(self.builds_dir,'fakeenv')[0][0])
 
     def test_get_stale_builds(self):
         """Test the ``get_stale_builds`` method.


### PR DESCRIPTION
The build clean now looks at all envname-xxx.yy files and sort them by mtime on the file. It then tries to extract build from it and follow the old clean up code