### PR TITLE
Create a new index for CPU peak usage on super large environment.

### DIFF
--- a/deploy-agent/deployd/common/helper.py
+++ b/deploy-agent/deployd/common/helper.py
@@ -45,7 +45,6 @@ class Helper(object):
         finally:
             return builds
 
-
     @staticmethod
     def get_build_id(filename, env_name):
         """

--- a/deploy-agent/deployd/common/helper.py
+++ b/deploy-agent/deployd/common/helper.py
@@ -45,6 +45,7 @@ class Helper(object):
         finally:
             return builds
 
+
     @staticmethod
     def get_build_id(filename, env_name):
         """

--- a/deploy-service/common/src/main/resources/sql/deploy.sql
+++ b/deploy-service/common/src/main/resources/sql/deploy.sql
@@ -171,6 +171,7 @@ CREATE TABLE IF NOT EXISTS agents (
 CREATE INDEX agent_env_idx ON agents (env_id, host_name);
 CREATE INDEX agent_name_idx ON agents (host_name);
 CREATE INDEX agent_stage_idx ON agents (env_id,deploy_stage);
+CREATE INDEX agent_first_deploy_state_idx ON agents (env_id,first_deploy, deploy_stage ,state);
 
 /*
 Agent detailed error message
@@ -305,4 +306,4 @@ CREATE TABLE IF NOT EXISTS schema_versions (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- Make sure to update the version everytime we change the schema
-INSERT INTO schema_versions (version) VALUES (1);
+INSERT INTO schema_versions (version) VALUES (2);

--- a/tools/mysql/schema-update-2.sql
+++ b/tools/mysql/schema-update-2.sql
@@ -1,0 +1,8 @@
+-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+-- ALWAYS BACKUP YOUR DATA BEFORE EXECUTING THIS SCRIPT   
+-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+CREATE INDEX agent_first_deploy_state_idx ON agents (env_id,first_deploy, deploy_stage ,state);
+
+-- make sure to update the schema version to 1
+UPDATE schema_versions SET version=2;


### PR DESCRIPTION
In a super large environment, the query below becomes a CPU bottleneck as we only have CREATE index on (env_id,deploy_stage); The index cannot be applied with first_deploy in the condition.
The query below is used for making the decision of scheduling on counting agents in each stage:

 private static final String GET_DEPLOYING_TOTAL =
        "SELECT COUNT(*) FROM agents " +
            "WHERE env_id=? AND ((deploy_stage!=? AND state!='PAUSED_BY_USER' AND first_deploy=?) OR state = 'STOP' )";


The fix adds a new index which gets rid of this CPU peak (reduce 75% time on this query) and brings down CPU usage significantly.
