### PR TITLE
Adding timestamp logging to deploy scripts.

### DIFF
--- a/deploy-agent/deployd/common/caller.py
+++ b/deploy-agent/deployd/common/caller.py
@@ -27,13 +27,14 @@ class Caller(object):
     @staticmethod
     def call_and_log(cmd, **kwargs):
         output = ""
+        start = time.time()
         try:
             process = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                                        stderr=subprocess.PIPE, **kwargs)
             while process.poll() is None:
                 line = process.stdout.readline()
                 if line:
-                    output = output + "[%s]" % time.time() + line
+                    output = output + "[%s]" % (time.time() - start) + line
             temp, error = process.communicate()
             return output.strip(), error.strip(), process.poll()
         except Exception as e:

--- a/deploy-agent/deployd/common/caller.py
+++ b/deploy-agent/deployd/common/caller.py
@@ -15,6 +15,7 @@
 import subprocess
 import traceback
 import logging
+import time
 
 log = logging.getLogger(__name__)
 
@@ -25,10 +26,15 @@ class Caller(object):
 
     @staticmethod
     def call_and_log(cmd, **kwargs):
+        output = ""
         try:
             process = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                                        stderr=subprocess.PIPE, **kwargs)
-            output, error = process.communicate()
+            while process.poll() is None:
+                line = process.stdout.readline()
+                if line:
+                    output = output + "[%s]" % time.time() + line
+            temp, error = process.communicate()
             return output.strip(), error.strip(), process.poll()
         except Exception as e:
             log.error(traceback.format_exc())


### PR DESCRIPTION
We currently don't log timestamps on the deploy scripts and that makes it very difficult to identify pain points.  This change causes all logs to be prepended with the current time.