### PR TITLE
Postdeploywebhook moves the ShouldSendFinishMessage

### DIFF
--- a/deploy-agent/deployd/common/helper.py
+++ b/deploy-agent/deployd/common/helper.py
@@ -45,7 +45,6 @@ class Helper(object):
         finally:
             return builds
 
-
     @staticmethod
     def get_build_id(filename, env_name):
         """

--- a/deploy-agent/deployd/common/helper.py
+++ b/deploy-agent/deployd/common/helper.py
@@ -45,6 +45,7 @@ class Helper(object):
         finally:
             return builds
 
+
     @staticmethod
     def get_build_id(filename, env_name):
         """


### PR DESCRIPTION
This is a fix trying to address the issue below:
https://github.com/pinterest/teletraan/issues/517

It tries to consolidate when to send a deploy finish message. FinishNotifyJob was used to send slack notification today