### PR TITLE
Add ability to specify custom script directory

### DIFF
--- a/deploy-agent/deployd/common/config.py
+++ b/deploy-agent/deployd/common/config.py
@@ -150,8 +150,11 @@ class Config(object):
 
     def get_script_directory(self):
         script_dir = '{}/teletraan/'.format(self.get_target())
+        subscript_dir_env = os.path.join(script_dir, os.environ['TELETRAAN_SCRIPT_DIR']
         subscript_dir = os.path.join(script_dir, os.environ['ENV_NAME'])
-        if os.path.exists(subscript_dir):
+        if os.path.exists(subscript_dir_env):
+            return subscript_dir_env
+        elif os.path.exists(subscript_dir):
             return subscript_dir
         else:
             return script_dir


### PR DESCRIPTION
There are cases where we would like to replicate a service under a
different environment for management and access control. When this
happens, the current setup of teletraan forces to replicate the script
directory. Adding an option where we can over ride the assumed the
teletraan script directory. If variable TELETRAAN_SCRIPT_DIR is set, it
will supersede, the ENV_NAME / default teletraan directory.