### PR TITLE
Autopromoter may be stuck forever if trying to rollback in an environment with no successful deploys 

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
@@ -395,7 +395,8 @@ public class DeployHandler implements DeployHandlerInterface{
         filterBean.setPageIndex(index);
         filterBean.setPageSize(size);
         int maxPages = 50; //This makes us check at most 5000 deploys
-        while (maxPages-- > 0) {
+        int tocheckPages = maxPages;
+        while (tocheckPages-- > 0) {
             DeployQueryFilter filter = new DeployQueryFilter(filterBean);
             DeployQueryResultBean resultBean = deployDAO.getAllDeploys(filter);
             if (resultBean.getTotal() < 1) {
@@ -411,7 +412,7 @@ public class DeployHandler implements DeployHandlerInterface{
             index += 1;
             filterBean.setPageIndex(index);
         }
-        LOG.warn("Latest 100000 deploys are all failed for {}. Give up", envBean.getEnv_id());
+        LOG.warn("Latest {} deploys are all failed for {}. Give up", size*maxPages, envBean.getEnv_id());
         return null;
 
     }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
@@ -389,12 +389,13 @@ public class DeployHandler implements DeployHandlerInterface{
 
     DeployBean getLastSucceededDeploy(EnvironBean envBean) throws Exception {
         int index = 1;
-        int size = 10;
+        int size = 100;
         DeployFilterBean filterBean = new DeployFilterBean();
         filterBean.setEnvIds(Arrays.asList(envBean.getEnv_id()));
         filterBean.setPageIndex(index);
         filterBean.setPageSize(size);
-        while (true) {
+        int maxPages = 100; //This makes us check at most 10000 deploys
+        while (maxPages-->0) {
             DeployQueryFilter filter = new DeployQueryFilter(filterBean);
             DeployQueryResultBean resultBean = deployDAO.getAllDeploys(filter);
             if (resultBean.getTotal() < 1) {
@@ -407,7 +408,11 @@ public class DeployHandler implements DeployHandlerInterface{
                 }
             }
             index += 1;
+            filterBean.setPageIndex(index);
         }
+        LOG.warn("Latest 100000 deploys are all failed for {}. Give up", envBean.getEnv_id());
+        return null;
+
     }
 
     public String rollback(EnvironBean envBean, String toDeployId, String description, String operator) throws Exception {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
@@ -394,12 +394,13 @@ public class DeployHandler implements DeployHandlerInterface{
         filterBean.setEnvIds(Arrays.asList(envBean.getEnv_id()));
         filterBean.setPageIndex(index);
         filterBean.setPageSize(size);
-        int maxPages = 100; //This makes us check at most 10000 deploys
-        while (maxPages-->0) {
+        int maxPages = 50; //This makes us check at most 5000 deploys
+        while (maxPages-- > 0) {
             DeployQueryFilter filter = new DeployQueryFilter(filterBean);
             DeployQueryResultBean resultBean = deployDAO.getAllDeploys(filter);
             if (resultBean.getTotal() < 1) {
-                LOG.warn("Could not find any previous succeeded deploy in env {}", envBean.getEnv_id());
+                LOG.warn("Could not find any previous succeeded deploy in env {}",
+                    envBean.getEnv_id());
                 return null;
             }
             for (DeployBean deploy : resultBean.getDeploys()) {


### PR DESCRIPTION
Fix the bug that autopromoter entering the infinite loop if there are no succeeded deployments. The old code has a bug that not set the page index which is pretty bad. Surprisingly, we just saw it now as it looks like we always found one successful deploy in the first 10. Also adding some guardian for maximum check latest 10000 deploys.