### PR TITLE
Handle large number of build tags more efficient

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/TagDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/TagDAO.java
@@ -34,6 +34,8 @@ public interface TagDAO {
     List<TagBean> getByTargetIdAndType(String target_name, TagTargetType target_type)
         throws Exception;
 
+    List<TagBean> getLatestByTargetIdAndType(String target_name, TagTargetType target_type, int size);
+
     List<TagBean> getByValue(TagValue value) throws Exception;
 
     TagBean getLatestByTargetId(String targetId) throws Exception;

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/TagDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/TagDAO.java
@@ -23,6 +23,7 @@ import com.pinterest.deployservice.bean.TagValue;
 import java.util.List;
 
 public interface TagDAO {
+
     void insert(TagBean bean) throws Exception;
 
     void delete(String id) throws Exception;
@@ -34,7 +35,8 @@ public interface TagDAO {
     List<TagBean> getByTargetIdAndType(String target_name, TagTargetType target_type)
         throws Exception;
 
-    List<TagBean> getLatestByTargetIdAndType(String target_name, TagTargetType target_type, int size);
+    List<TagBean> getLatestByTargetIdAndType(String target_name, TagTargetType target_type,
+                                             int size) throws Exception;
 
     List<TagBean> getByValue(TagValue value) throws Exception;
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBTagDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBTagDAOImpl.java
@@ -49,9 +49,9 @@ public class DBTagDAOImpl implements TagDAO {
         "SELECT * FROM tags WHERE target_id=? AND "
             + " target_type=? ORDER BY created_date DESC";
 
-    private static final String GET_TAG_BY_TARGET_ID_AND_TYPE_TEMPLATE =
+    private static final String GET_LATEST_TAG_BY_TARGET_ID_AND_TYPE_TEMPLATE =
         "SELECT * FROM tags WHERE target_id=? AND "
-            + " target_type=? ORDER BY created_date DESC LIMIT ";
+            + " target_type=? ORDER BY created_date DESC LIMIT ?";
 
     private static final String GET_LATEST_TAG_BY_TARGET_ID =
         "SELECT * FROM tags WHERE target_id=? ORDER BY created_date DESC LIMIT 0,1";
@@ -93,16 +93,18 @@ public class DBTagDAOImpl implements TagDAO {
     }
 
     @Override
-    List<TagBean> getLatestByTargetIdAndType(String target_id, TagTargetType target_type, int size){
-        Preconditions.checkArgument(size>0);
+    public List<TagBean> getLatestByTargetIdAndType(String target_id, TagTargetType target_type,
+                                                    int size) throws Exception {
+        Preconditions.checkArgument(size > 0);
         ResultSetHandler<List<TagBean>> h = new BeanListHandler<TagBean>(TagBean.class);
         return new QueryRunner(basicDataSource)
-            .query(GET_TAG_BY_TARGET_ID_AND_TYPE_TEMPLATE, h, target_id, target_type.toString());
+            .query(GET_LATEST_TAG_BY_TARGET_ID_AND_TYPE_TEMPLATE, h, target_id,
+                target_type.toString(), size);
 
     }
 
     @Override
-    public List<TagBean> getByValue(TagValue value) throws Exception{
+    public List<TagBean> getByValue(TagValue value) throws Exception {
         ResultSetHandler<List<TagBean>> h = new BeanListHandler<TagBean>(TagBean.class);
         return new QueryRunner(basicDataSource)
             .query(GET_TAG_BY_VALUE, h, value.toString());
@@ -112,6 +114,6 @@ public class DBTagDAOImpl implements TagDAO {
     @Override
     public TagBean getLatestByTargetId(String targetId) throws Exception {
         return new QueryRunner(basicDataSource).query(GET_LATEST_TAG_BY_TARGET_ID,
-                new BeanHandler<>(TagBean.class), targetId);
+            new BeanHandler<>(TagBean.class), targetId);
     }
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBTagDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBTagDAOImpl.java
@@ -21,6 +21,8 @@ import com.pinterest.deployservice.bean.TagBean;
 import com.pinterest.deployservice.bean.TagTargetType;
 import com.pinterest.deployservice.bean.TagValue;
 import com.pinterest.deployservice.dao.TagDAO;
+
+import com.google.common.base.Preconditions;
 import org.apache.commons.dbcp.BasicDataSource;
 import org.apache.commons.dbutils.QueryRunner;
 import org.apache.commons.dbutils.ResultSetHandler;
@@ -46,6 +48,10 @@ public class DBTagDAOImpl implements TagDAO {
     private static final String GET_TAG_BY_TARGET_ID_AND_TYPE_TEMPLATE =
         "SELECT * FROM tags WHERE target_id=? AND "
             + " target_type=? ORDER BY created_date DESC";
+
+    private static final String GET_TAG_BY_TARGET_ID_AND_TYPE_TEMPLATE =
+        "SELECT * FROM tags WHERE target_id=? AND "
+            + " target_type=? ORDER BY created_date DESC LIMIT ";
 
     private static final String GET_LATEST_TAG_BY_TARGET_ID =
         "SELECT * FROM tags WHERE target_id=? ORDER BY created_date DESC LIMIT 0,1";
@@ -84,6 +90,15 @@ public class DBTagDAOImpl implements TagDAO {
         ResultSetHandler<List<TagBean>> h = new BeanListHandler<TagBean>(TagBean.class);
         return new QueryRunner(basicDataSource)
             .query(GET_TAG_BY_TARGET_ID_AND_TYPE_TEMPLATE, h, target_id, target_type.toString());
+    }
+
+    @Override
+    List<TagBean> getLatestByTargetIdAndType(String target_id, TagTargetType target_type, int size){
+        Preconditions.checkArgument(size>0);
+        ResultSetHandler<List<TagBean>> h = new BeanListHandler<TagBean>(TagBean.class);
+        return new QueryRunner(basicDataSource)
+            .query(GET_TAG_BY_TARGET_ID_AND_TYPE_TEMPLATE, h, target_id, target_type.toString());
+
     }
 
     @Override

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
@@ -397,7 +397,6 @@ public class DeployHandler implements DeployHandlerInterface{
         int maxPages = 50; //This makes us check at most 5000 deploys
         int tocheckPages = maxPages;
         while (tocheckPages-- > 0) {
-        while (maxPages-- > 0) {
             DeployQueryFilter filter = new DeployQueryFilter(filterBean);
             DeployQueryResultBean resultBean = deployDAO.getAllDeploys(filter);
             if (resultBean.getTotal() < 1) {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
@@ -397,6 +397,7 @@ public class DeployHandler implements DeployHandlerInterface{
         int maxPages = 50; //This makes us check at most 5000 deploys
         int tocheckPages = maxPages;
         while (tocheckPages-- > 0) {
+        while (maxPages-- > 0) {
             DeployQueryFilter filter = new DeployQueryFilter(filterBean);
             DeployQueryResultBean resultBean = deployDAO.getAllDeploys(filter);
             if (resultBean.getTotal() < 1) {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
@@ -413,6 +413,7 @@ public class DeployHandler implements DeployHandlerInterface{
             filterBean.setPageIndex(index);
         }
         LOG.warn("Latest {} deploys are all failed for {}. Give up", size*maxPages, envBean.getEnv_id());
+
         return null;
 
     }

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/worker/AutoPromotBuildTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/worker/AutoPromotBuildTest.java
@@ -18,6 +18,7 @@ import com.pinterest.deployservice.bean.TagBean;
 import com.pinterest.deployservice.bean.TagTargetType;
 import com.pinterest.deployservice.bean.TagValue;
 import com.pinterest.deployservice.buildtags.BuildTagsManager;
+import com.pinterest.deployservice.buildtags.BuildTagsManagerImpl;
 import com.pinterest.deployservice.common.CommonUtils;
 import com.pinterest.deployservice.dao.BuildDAO;
 import com.pinterest.deployservice.dao.TagDAO;
@@ -35,58 +36,59 @@ import java.util.Date;
 
 public class AutoPromotBuildTest {
 
-  ServiceContext context;
-  DeployBean first = new DeployBean();
-  DeployBean second = new DeployBean();
-  EnvironBean environBean = new EnvironBean();
-  BuildDAO buildDAO;
-  TagDAO tagDAO;
-  BuildTagsManager buildTagsManager;
-  final static String CronTenAMPerDay = "0 0 10 * * ?";
+    final static String CronTenAMPerDay = "0 0 10 * * ?";
+    ServiceContext context;
+    DeployBean first = new DeployBean();
+    DeployBean second = new DeployBean();
+    EnvironBean environBean = new EnvironBean();
+    BuildDAO buildDAO;
+    TagDAO tagDAO;
+    BuildTagsManager buildTagsManager;
 
-  @Before
-  public void setUp() throws Exception {
-    context = new ServiceContext();
-    buildDAO = mock(BuildDAO.class);
-    tagDAO = mock(TagDAO.class);
-    buildTagsManager = mock(BuildTagsManager.class);
-    context.setBuildTagsManager(buildTagsManager);
-    context.setBuildDAO(buildDAO);
-    context.setTagDAO(tagDAO);
-    first.setBuild_id("0000001");
-    second.setBuild_id("0000002");
-    environBean.setEnv_id("test1");
+    @Before
+    public void setUp() throws Exception {
+        context = new ServiceContext();
+        buildDAO = mock(BuildDAO.class);
+        tagDAO = mock(TagDAO.class);
+        buildTagsManager = mock(BuildTagsManager.class);
+        context.setBuildTagsManager(buildTagsManager);
+        context.setBuildDAO(buildDAO);
+        context.setTagDAO(tagDAO);
+        first.setBuild_id("0000001");
+        second.setBuild_id("0000002");
+        environBean.setEnv_id("test1");
 
-  }
-
-
-
-  @Test
-  public void testGetScheduledCheckDueTime() throws Exception{
-    DeployBean currentDeploy = new DeployBean();
-    AutoPromoter promoter = new AutoPromoter(context);
-    DateTime now = new DateTime(new Date());
-    currentDeploy.setStart_date(now.minusDays(1).getMillis());
-    DateTime due =
-        new DateTime(promoter.getScheduledCheckDueTime(currentDeploy.getStart_date(), CronTenAMPerDay));
-
-    if (now.getHourOfDay() < 10) {
-      DateTime yesterday = now.minusDays(-1);
-      DateTime
-          start =
-          new DateTime(yesterday.getYear(), yesterday.getMonthOfYear(), yesterday.getDayOfMonth(),
-              10, 0, 0);
-      Assert.assertEquals(due, start);
-    } else {
-      DateTime
-          start =
-          new DateTime(now.getYear(), now.getMonthOfYear(), now.getDayOfMonth(), 10, 0, 0);
-      Assert.assertEquals(due, start);
     }
-  }
 
-  @Test
-  public void testGetScheduledCheckDueResult() throws Exception{
+
+    @Test
+    public void testGetScheduledCheckDueTime() throws Exception {
+        DeployBean currentDeploy = new DeployBean();
+        AutoPromoter promoter = new AutoPromoter(context);
+        DateTime now = new DateTime(new Date());
+        currentDeploy.setStart_date(now.minusDays(1).getMillis());
+        DateTime due =
+            new DateTime(
+                promoter.getScheduledCheckDueTime(currentDeploy.getStart_date(), CronTenAMPerDay));
+
+        if (now.getHourOfDay() < 10) {
+            DateTime yesterday = now.minusDays(-1);
+            DateTime
+                start =
+                new DateTime(yesterday.getYear(), yesterday.getMonthOfYear(),
+                    yesterday.getDayOfMonth(),
+                    10, 0, 0);
+            Assert.assertEquals(due, start);
+        } else {
+            DateTime
+                start =
+                new DateTime(now.getYear(), now.getMonthOfYear(), now.getDayOfMonth(), 10, 0, 0);
+            Assert.assertEquals(due, start);
+        }
+    }
+
+    @Test
+    public void testGetScheduledCheckDueResult() throws Exception {
    /* PromoteBean promoteBean = new PromoteBean();
     AutoPromoter promoter = new AutoPromoter(context);
     DeployBean currentDeploy = new DeployBean();
@@ -114,310 +116,339 @@ public class AutoPromotBuildTest {
           start =
           new DateTime(now.getYear(), now.getMonthOfYear(), now.getDayOfMonth(), 10, 0, 0);
       Assert.assertEquals(result.getRight().longValue(), start.getMillis());*/
-    //}
-  }
+        //}
+    }
 
-  /* Autopromote enabled for any new build. But no builds and no prev deploys*/
-  @Test
-  public void testNoBuildNoPreviousDeployPromote() throws Exception {
-    PromoteBean promoteBean = new PromoteBean();
-    AutoPromoter promoter = new AutoPromoter(context);
-    //No build. No previous deploy
-    PromoteResult result = promoter.computePromoteBuildResult(environBean, null, 1, promoteBean);
-    Assert.assertEquals(PromoteResult.ResultCode.NoAvailableBuild, result.getResult());
+    /* Autopromote enabled for any new build. But no builds and no prev deploys*/
+    @Test
+    public void testNoBuildNoPreviousDeployPromote() throws Exception {
+        PromoteBean promoteBean = new PromoteBean();
+        AutoPromoter promoter = new AutoPromoter(context);
+        //No build. No previous deploy
+        PromoteResult
+            result =
+            promoter.computePromoteBuildResult(environBean, null, 1, promoteBean);
+        Assert.assertEquals(PromoteResult.ResultCode.NoAvailableBuild, result.getResult());
 
-   }
+    }
 
-  /* Autopromote enabled for any new build. no previous deploy and one new build*/
-  @Test
-  public void testOneBuildNoPreviousDeployPromote() throws Exception {
-    PromoteBean promoteBean = new PromoteBean();
-    AutoPromoter promoter = new AutoPromoter(context);
-    //Has builds. Have previous deploy
-    BuildBean build = new BuildBean();
-    build.setBuild_name("xxx");
-    build.setBuild_id("123");
-    build.setPublish_date(DateTime.now().minusHours(1).getMillis());
-    when(buildDAO.getAcceptedBuilds(anyString(), anyString(), anyObject(), anyInt()))
-        .thenReturn(Arrays.asList(build));
-    PromoteResult result = promoter.computePromoteBuildResult(environBean, null, 1, promoteBean);
-    Assert.assertEquals(PromoteResult.ResultCode.PromoteBuild, result.getResult());
-    Assert.assertEquals("123", result.getPromotedBuild());
-  }
+    /* Autopromote enabled for any new build. no previous deploy and one new build*/
+    @Test
+    public void testOneBuildNoPreviousDeployPromote() throws Exception {
+        PromoteBean promoteBean = new PromoteBean();
+        AutoPromoter promoter = new AutoPromoter(context);
+        //Has builds. Have previous deploy
+        BuildBean build = new BuildBean();
+        build.setBuild_name("xxx");
+        build.setBuild_id("123");
+        build.setPublish_date(DateTime.now().minusHours(1).getMillis());
+        when(buildDAO.getAcceptedBuilds(anyString(), anyString(), anyObject(), anyInt()))
+            .thenReturn(Arrays.asList(build));
+        PromoteResult
+            result =
+            promoter.computePromoteBuildResult(environBean, null, 1, promoteBean);
+        Assert.assertEquals(PromoteResult.ResultCode.PromoteBuild, result.getResult());
+        Assert.assertEquals("123", result.getPromotedBuild());
+    }
 
-  @Test
-  public void testOneBadBuildPromote() throws Exception {
-    String buildName = "xxx";
-    String buildId = "123";
-    PromoteBean promoteBean = new PromoteBean();
-    AutoPromoter promoter = new AutoPromoter(context);
-    AutoPromoter promoterSpy = Mockito.spy(promoter);
-    BuildBean build = new BuildBean();
-    build.setBuild_id(buildId);
-    build.setBuild_name(buildName);
-    build.setCommit_date(DateTime.now().minusHours(1).getMillis());
-    build.setPublish_date(DateTime.now().plusHours(1).getMillis());
-    build.setScm_commit("abcde");
+    @Test
+    public void testOneBadBuildPromote() throws Exception {
+        String buildName = "xxx";
+        String buildId = "123";
+        PromoteBean promoteBean = new PromoteBean();
+        AutoPromoter promoter = new AutoPromoter(context);
+        AutoPromoter promoterSpy = Mockito.spy(promoter);
+        BuildBean build = new BuildBean();
+        build.setBuild_id(buildId);
+        build.setBuild_name(buildName);
+        build.setCommit_date(DateTime.now().minusHours(1).getMillis());
+        build.setPublish_date(DateTime.now().plusHours(1).getMillis());
+        build.setScm_commit("abcde");
 
-    TagBean tagBean = new TagBean();
-    tagBean.setId(CommonUtils.getBase64UUID());
-    tagBean.setTarget_type(TagTargetType.BUILD);
-    tagBean.setTarget_id(build.getBuild_id());
-    tagBean.setValue(TagValue.BAD_BUILD);
-    tagBean.serializeTagMetaInfo(build);
-    when(tagDAO.getByTargetIdAndType(buildName, TagTargetType.BUILD))
-        .thenReturn(new ArrayList<TagBean>(Arrays.asList(tagBean)));
-    when(buildDAO.getAcceptedBuilds(anyString(), anyString(), anyObject(), anyInt()))
-        .thenReturn(Arrays.asList(build));
-    PromoteResult result = promoter.computePromoteBuildResult(environBean, null, 1, promoteBean);
-    Assert.assertEquals(PromoteResult.ResultCode.NoAvailableBuild, result.getResult());
+        TagBean tagBean = new TagBean();
+        tagBean.setId(CommonUtils.getBase64UUID());
+        tagBean.setTarget_type(TagTargetType.BUILD);
+        tagBean.setTarget_id(build.getBuild_id());
+        tagBean.setValue(TagValue.BAD_BUILD);
+        tagBean.serializeTagMetaInfo(build);
+        when(tagDAO.getLatestByTargetIdAndType(buildName, TagTargetType.BUILD,
+            BuildTagsManagerImpl.MAXCHECKTAGS))
+            .thenReturn(new ArrayList<TagBean>(Arrays.asList(tagBean)));
+        when(buildDAO.getAcceptedBuilds(anyString(), anyString(), anyObject(), anyInt()))
+            .thenReturn(Arrays.asList(build));
+        PromoteResult
+            result =
+            promoter.computePromoteBuildResult(environBean, null, 1, promoteBean);
+        Assert.assertEquals(PromoteResult.ResultCode.NoAvailableBuild, result.getResult());
 
-    promoter.promoteBuild(environBean, null, 1, promoteBean);
-    // bad build, safe promote never gets called
-    verify(promoterSpy, never()).safePromote(anyObject(), anyString(), anyString(), anyObject(), anyObject());
-  }
+        promoter.promoteBuild(environBean, null, 1, promoteBean);
+        // bad build, safe promote never gets called
+        verify(promoterSpy, never())
+            .safePromote(anyObject(), anyString(), anyString(), anyObject(), anyObject());
+    }
 
-  @Test
-  public void testOneBadBuildOneGoodBuildPromote() throws Exception {
+    @Test
+    public void testOneBadBuildOneGoodBuildPromote() throws Exception {
 //    build1, bad
 //    build2, good
 //    build3, current
-    BuildBean build1 = new BuildBean();
-    build1.setBuild_id("build1bad");
-    build1.setBuild_name("build1bad");
-    build1.setCommit_date(DateTime.now().minusHours(10).getMillis());
-    build1.setPublish_date(DateTime.now().minusHours(10).getMillis());
-    build1.setScm_commit("abcde");
+        BuildBean build1 = new BuildBean();
+        build1.setBuild_id("build1bad");
+        build1.setBuild_name("build1bad");
+        build1.setCommit_date(DateTime.now().minusHours(10).getMillis());
+        build1.setPublish_date(DateTime.now().minusHours(10).getMillis());
+        build1.setScm_commit("abcde");
 
-    BuildBean build2 = new BuildBean();
-    build2.setBuild_id("build2good");
-    build2.setBuild_name("build2good");
-    build2.setCommit_date(DateTime.now().minusHours(9).getMillis());
-    build2.setPublish_date(DateTime.now().minusHours(9).getMillis());
-    build2.setScm_commit("abcdxe");
+        BuildBean build2 = new BuildBean();
+        build2.setBuild_id("build2good");
+        build2.setBuild_name("build2good");
+        build2.setCommit_date(DateTime.now().minusHours(9).getMillis());
+        build2.setPublish_date(DateTime.now().minusHours(9).getMillis());
+        build2.setScm_commit("abcdxe");
 
-    TagBean tagBean = new TagBean();
-    tagBean.setId(CommonUtils.getBase64UUID());
-    tagBean.setTarget_type(TagTargetType.BUILD);
-    tagBean.setTarget_id(build1.getBuild_id());
-    tagBean.setValue(TagValue.BAD_BUILD);
-    tagBean.serializeTagMetaInfo(build1);
+        TagBean tagBean = new TagBean();
+        tagBean.setId(CommonUtils.getBase64UUID());
+        tagBean.setTarget_type(TagTargetType.BUILD);
+        tagBean.setTarget_id(build1.getBuild_id());
+        tagBean.setValue(TagValue.BAD_BUILD);
+        tagBean.serializeTagMetaInfo(build1);
 
-    DeployBean currentDeploy = new DeployBean();
-    currentDeploy.setEnv_id("testenv");
-    currentDeploy.setBuild_id("build3");
+        DeployBean currentDeploy = new DeployBean();
+        currentDeploy.setEnv_id("testenv");
+        currentDeploy.setBuild_id("build3");
 
-    when(tagDAO.getByTargetIdAndType("build1bad", TagTargetType.BUILD))
-        .thenReturn(new ArrayList<TagBean>(Arrays.asList(tagBean)));
+        when(tagDAO.getLatestByTargetIdAndType("build1bad", TagTargetType.BUILD,
+            BuildTagsManagerImpl.MAXCHECKTAGS))
+            .thenReturn(new ArrayList<TagBean>(Arrays.asList(tagBean)));
 
-    when(buildDAO.getAcceptedBuilds(anyString(), anyString(), anyObject(), anyInt()))
-        .thenReturn(Arrays.asList(build1, build2));
-    // build1 is bad
-    when(buildTagsManager.getEffectiveTagsWithBuilds(Arrays.asList(build1)))
-        .thenReturn(Arrays.asList(BuildTagBean.createFromTagBean(tagBean)));
+        when(buildDAO.getAcceptedBuilds(anyString(), anyString(), anyObject(), anyInt()))
+            .thenReturn(Arrays.asList(build1, build2));
+        // build1 is bad
+        when(buildTagsManager.getEffectiveTagsWithBuilds(Arrays.asList(build1)))
+            .thenReturn(Arrays.asList(BuildTagBean.createFromTagBean(tagBean)));
 
-    AutoPromoter promoter = new AutoPromoter(context);
-    PromoteBean promoteBean = new PromoteBean();
-    PromoteResult result = promoter.computePromoteBuildResult(environBean, null, 1, promoteBean);
-    Assert.assertEquals(PromoteResult.ResultCode.PromoteBuild, result.getResult());
-    Assert.assertEquals("build2good", result.getPromotedBuild());
-  }
-
-  /* Autopromote enabled for any new build. Have previous deploy but no new build*/
-  @Test
-  public void testNoBuildWithPreviousDeploy() throws Exception{
-    PromoteBean promoteBean = new PromoteBean();
-    AutoPromoter promoter = new AutoPromoter(context);
-    //Has builds. No previous deploy
-    DeployBean previousDeploy = new DeployBean();
-    previousDeploy.setStart_date(DateTime.now().minusHours(2).getMillis());
-    previousDeploy.setBuild_id("prev123");
-
-    BuildBean preBuild = new BuildBean();
-    preBuild.setBuild_id("prev123");
-    preBuild.setPublish_date(DateTime.now().minusHours(3).getMillis());
-
-    when(buildDAO.getById("prev123")).thenReturn(preBuild);
-    PromoteResult result = promoter.computePromoteBuildResult(environBean, previousDeploy, 1, promoteBean);
-    Assert.assertEquals(PromoteResult.ResultCode.NoAvailableBuild, result.getResult());
-  }
-
-  /* Autopromote enabled for any new build. Have previous deploy and one new build*/
-  @Test
-  public void testOneBuildwithPreviousDeploy() throws Exception {
-    PromoteBean promoteBean = new PromoteBean();
-    AutoPromoter promoter = new AutoPromoter(context);
-    //Has builds. No previous deploy
-    DeployBean previousDeploy = new DeployBean();
-    previousDeploy.setStart_date(DateTime.now().minusHours(2).getMillis());
-    previousDeploy.setBuild_id("prev123");
-
-    BuildBean preBuild = new BuildBean();
-    preBuild.setBuild_id("prev123");
-    preBuild.setPublish_date(DateTime.now().minusHours(3).getMillis());
-
-    BuildBean build = new BuildBean();
-    build.setBuild_name("buildName");
-    build.setBuild_id("123");
-    build.setPublish_date(DateTime.now().minusHours(1).getMillis());
-    when(buildDAO.getById("prev123")).thenReturn(preBuild);
-    when(buildDAO.getAcceptedBuilds(anyString(), anyString(), anyObject(), anyInt()))
-        .thenReturn(Arrays.asList(build));
-    PromoteResult result = promoter.computePromoteBuildResult(environBean, previousDeploy, 1, promoteBean);
-    Assert.assertEquals(PromoteResult.ResultCode.PromoteBuild, result.getResult());
-    Assert.assertEquals("123", result.getPromotedBuild());
-  }
-
-  /* Autopromote enabled for daily schedule. But no builds and no prev deploys*/
-  @Test
-  public void testNoBuildNoPreviousDeployScheduledPromote() throws Exception {
-    PromoteBean promoteBean = new PromoteBean();
-    promoteBean.setEnv_id(environBean.getEnv_id());
-    promoteBean.setSchedule(CronTenAMPerDay);
-    promoteBean.setLast_update(0L);
-    AutoPromoter promoter = new AutoPromoter(context);
-
-    //No build. No previous deploy
-    PromoteResult result = promoter.computePromoteBuildResult(environBean, null, 1, promoteBean);
-    Assert.assertEquals(PromoteResult.ResultCode.NoAvailableBuild, result.getResult());
-  }
-
-  /* Autopromote enabled for 10:00 AM every day. no previous deploy and one new build*/
-  @Test
-  public void testOneBuildNoPreviousDeploySchedulePromote() throws Exception {
-    PromoteBean promoteBean = new PromoteBean();
-    promoteBean.setEnv_id(environBean.getEnv_id());
-    promoteBean.setSchedule(CronTenAMPerDay);
-    promoteBean.setLast_update(0L);
-    promoteBean.setDelay(0);
-
-    AutoPromoter promoter = new AutoPromoter(context);
-    //Has builds. Have previous deploy
-    BuildBean build = new BuildBean();
-    build.setBuild_name("buildName");
-    build.setBuild_id("123");
-    DateTime now = DateTime.now();
-
-    //Set build time to be before 10 am today
-    if (now.getHourOfDay()>= 10){
-      build.setPublish_date(now.minusHours(now.getHourOfDay()-10+1).getMillis());
-    }else {
-      build.setPublish_date(DateTime.now().getMillis());
+        AutoPromoter promoter = new AutoPromoter(context);
+        PromoteBean promoteBean = new PromoteBean();
+        PromoteResult
+            result =
+            promoter.computePromoteBuildResult(environBean, null, 1, promoteBean);
+        Assert.assertEquals(PromoteResult.ResultCode.PromoteBuild, result.getResult());
+        Assert.assertEquals("build2good", result.getPromotedBuild());
     }
-    when(buildDAO.getAcceptedBuilds(anyString(), anyString(), anyObject(), anyInt()))
-        .thenReturn(Arrays.asList(build));
-    PromoteResult result = promoter.computePromoteBuildResult(environBean, null, 1, promoteBean);
-    Assert.assertEquals(PromoteResult.ResultCode.PromoteBuild, result.getResult());
-    Assert.assertEquals("123", result.getPromotedBuild());
-  }
 
-  /* Autopromote enabled for 10:00 AM every day. no previous deploy and one new build after schedule*/
-  @Test
-  public void testOneBuildNoPreviousDeploySchedulePromote2() throws Exception {
-    PromoteBean promoteBean = new PromoteBean();
-    promoteBean.setEnv_id(environBean.getEnv_id());
-    promoteBean.setSchedule(CronTenAMPerDay);
-    promoteBean.setLast_update(0L);
-    promoteBean.setDelay(0);
-    AutoPromoter promoter = new AutoPromoter(context);
-    //Has builds. Have previous deploy
-    BuildBean build = new BuildBean();
-    build.setBuild_name("buildName");
-    build.setBuild_id("123");
-    DateTime now = DateTime.now();
+    /* Autopromote enabled for any new build. Have previous deploy but no new build*/
+    @Test
+    public void testNoBuildWithPreviousDeploy() throws Exception {
+        PromoteBean promoteBean = new PromoteBean();
+        AutoPromoter promoter = new AutoPromoter(context);
+        //Has builds. No previous deploy
+        DeployBean previousDeploy = new DeployBean();
+        previousDeploy.setStart_date(DateTime.now().minusHours(2).getMillis());
+        previousDeploy.setBuild_id("prev123");
 
-    //Set build time to be after 10 am today
-    if (now.getHourOfDay()< 10){
-      build.setPublish_date(now.plusHours(10-now.getHourOfDay()+1).getMillis());
-    }else {
-      build.setPublish_date(DateTime.now().getMillis());
+        BuildBean preBuild = new BuildBean();
+        preBuild.setBuild_id("prev123");
+        preBuild.setPublish_date(DateTime.now().minusHours(3).getMillis());
+
+        when(buildDAO.getById("prev123")).thenReturn(preBuild);
+        PromoteResult
+            result =
+            promoter.computePromoteBuildResult(environBean, previousDeploy, 1, promoteBean);
+        Assert.assertEquals(PromoteResult.ResultCode.NoAvailableBuild, result.getResult());
     }
-    when(buildDAO.getAcceptedBuilds(anyString(), anyString(), anyObject(), anyInt()))
-        .thenReturn(Arrays.asList(build));
-    PromoteResult result = promoter.computePromoteBuildResult(environBean, null, 1, promoteBean);
-    Assert.assertEquals(PromoteResult.ResultCode.NoAvailableBuild, result.getResult());
-  }
 
-  /* Autopromote enabled for 10:00 AM every day. Have old previous deploy but no new build*/
-  @Test
-  public void testNoBuildWithPreviousDeploySchedule() throws Exception{
-    PromoteBean promoteBean = new PromoteBean();
-    promoteBean.setEnv_id(environBean.getEnv_id());
-    promoteBean.setSchedule(CronTenAMPerDay);
-    promoteBean.setLast_update(0L);
-    promoteBean.setDelay(0);
-    AutoPromoter promoter = new AutoPromoter(context);
+    /* Autopromote enabled for any new build. Have previous deploy and one new build*/
+    @Test
+    public void testOneBuildwithPreviousDeploy() throws Exception {
+        PromoteBean promoteBean = new PromoteBean();
+        AutoPromoter promoter = new AutoPromoter(context);
+        //Has builds. No previous deploy
+        DeployBean previousDeploy = new DeployBean();
+        previousDeploy.setStart_date(DateTime.now().minusHours(2).getMillis());
+        previousDeploy.setBuild_id("prev123");
 
-    DeployBean previousDeploy = new DeployBean();
-    previousDeploy.setStart_date(DateTime.now().minusDays(1).getMillis());
-    previousDeploy.setBuild_id("prev123");
+        BuildBean preBuild = new BuildBean();
+        preBuild.setBuild_id("prev123");
+        preBuild.setPublish_date(DateTime.now().minusHours(3).getMillis());
 
-    BuildBean preBuild = new BuildBean();
-    preBuild.setBuild_name("buildName");
-    preBuild.setBuild_id("prev123");
-    preBuild.setPublish_date(DateTime.now().minusHours(3).getMillis());
-
-    when(buildDAO.getById("prev123")).thenReturn(preBuild);
-    PromoteResult result = promoter.computePromoteBuildResult(environBean, previousDeploy, 1, promoteBean);
-    Assert.assertEquals(PromoteResult.ResultCode.NoAvailableBuild, result.getResult());
-  }
-
-  /* Autopromote enabled for 10:00 AM every day. Have a very recent previous deploy and no new build*/
-  @Test
-  public void testNoBuildWithPreviousDeploySchedule2() throws Exception{
-    PromoteBean promoteBean = new PromoteBean();
-    promoteBean.setEnv_id(environBean.getEnv_id());
-    promoteBean.setSchedule(CronTenAMPerDay);
-    promoteBean.setDelay(0);
-    AutoPromoter promoter = new AutoPromoter(context);
-
-    DeployBean previousDeploy = new DeployBean();
-    previousDeploy.setStart_date(DateTime.now().minusMinutes(1).getMillis());
-    previousDeploy.setBuild_id("prev123");
-
-    BuildBean preBuild = new BuildBean();
-    preBuild.setBuild_name("buildName");
-    preBuild.setBuild_id("prev123");
-    preBuild.setPublish_date(DateTime.now().minusHours(3).getMillis());
-
-    when(buildDAO.getById("prev123")).thenReturn(preBuild);
-    PromoteResult result = promoter.computePromoteBuildResult(environBean, previousDeploy, 1, promoteBean);
-    Assert.assertEquals(PromoteResult.ResultCode.NoAvailableBuild, result.getResult());
-  }
-
-
-  @Test
-  public void testOneBuildwithPreviousDeploySchedule() throws Exception {
-    PromoteBean promoteBean = new PromoteBean();
-    promoteBean.setEnv_id(environBean.getEnv_id());
-    promoteBean.setSchedule(CronTenAMPerDay);
-    promoteBean.setLast_update(0L);
-    promoteBean.setDelay(0);
-    AutoPromoter promoter = new AutoPromoter(context);
-    //Has builds. No previous deploy
-    DeployBean previousDeploy = new DeployBean();
-    previousDeploy.setStart_date(DateTime.now().minusDays(1).getMillis());
-    previousDeploy.setBuild_id("prev123");
-
-    BuildBean preBuild = new BuildBean();
-    preBuild.setBuild_name("buildName");
-    preBuild.setBuild_id("prev123");
-    preBuild.setPublish_date(DateTime.now().minusHours(25).getMillis());
-
-    BuildBean build = new BuildBean();
-    build.setBuild_name("buildName");
-    build.setBuild_id("123");
-    DateTime now = DateTime.now();
-    if (now.getHourOfDay()>10) {
-      build.setPublish_date((now.minusHours(now.getHourOfDay()-10+1)).getMillis());
-    }else{
-      build.setPublish_date(DateTime.now().minusHours(1).getMillis());
+        BuildBean build = new BuildBean();
+        build.setBuild_name("buildName");
+        build.setBuild_id("123");
+        build.setPublish_date(DateTime.now().minusHours(1).getMillis());
+        when(buildDAO.getById("prev123")).thenReturn(preBuild);
+        when(buildDAO.getAcceptedBuilds(anyString(), anyString(), anyObject(), anyInt()))
+            .thenReturn(Arrays.asList(build));
+        PromoteResult
+            result =
+            promoter.computePromoteBuildResult(environBean, previousDeploy, 1, promoteBean);
+        Assert.assertEquals(PromoteResult.ResultCode.PromoteBuild, result.getResult());
+        Assert.assertEquals("123", result.getPromotedBuild());
     }
-    when(buildDAO.getById("prev123")).thenReturn(preBuild);
-    when(buildDAO.getAcceptedBuilds(anyString(), anyString(), anyObject(), anyInt()))
-        .thenReturn(Arrays.asList(build));
-    PromoteResult result = promoter.computePromoteBuildResult(environBean, previousDeploy, 1, promoteBean);
-    Assert.assertEquals(PromoteResult.ResultCode.PromoteBuild, result.getResult());
-    Assert.assertEquals("123", result.getPromotedBuild());
-  }
+
+    /* Autopromote enabled for daily schedule. But no builds and no prev deploys*/
+    @Test
+    public void testNoBuildNoPreviousDeployScheduledPromote() throws Exception {
+        PromoteBean promoteBean = new PromoteBean();
+        promoteBean.setEnv_id(environBean.getEnv_id());
+        promoteBean.setSchedule(CronTenAMPerDay);
+        promoteBean.setLast_update(0L);
+        AutoPromoter promoter = new AutoPromoter(context);
+
+        //No build. No previous deploy
+        PromoteResult
+            result =
+            promoter.computePromoteBuildResult(environBean, null, 1, promoteBean);
+        Assert.assertEquals(PromoteResult.ResultCode.NoAvailableBuild, result.getResult());
+    }
+
+    /* Autopromote enabled for 10:00 AM every day. no previous deploy and one new build*/
+    @Test
+    public void testOneBuildNoPreviousDeploySchedulePromote() throws Exception {
+        PromoteBean promoteBean = new PromoteBean();
+        promoteBean.setEnv_id(environBean.getEnv_id());
+        promoteBean.setSchedule(CronTenAMPerDay);
+        promoteBean.setLast_update(0L);
+        promoteBean.setDelay(0);
+
+        AutoPromoter promoter = new AutoPromoter(context);
+        //Has builds. Have previous deploy
+        BuildBean build = new BuildBean();
+        build.setBuild_name("buildName");
+        build.setBuild_id("123");
+        DateTime now = DateTime.now();
+
+        //Set build time to be before 10 am today
+        if (now.getHourOfDay() >= 10) {
+            build.setPublish_date(now.minusHours(now.getHourOfDay() - 10 + 1).getMillis());
+        } else {
+            build.setPublish_date(DateTime.now().getMillis());
+        }
+        when(buildDAO.getAcceptedBuilds(anyString(), anyString(), anyObject(), anyInt()))
+            .thenReturn(Arrays.asList(build));
+        PromoteResult
+            result =
+            promoter.computePromoteBuildResult(environBean, null, 1, promoteBean);
+        Assert.assertEquals(PromoteResult.ResultCode.PromoteBuild, result.getResult());
+        Assert.assertEquals("123", result.getPromotedBuild());
+    }
+
+    /* Autopromote enabled for 10:00 AM every day. no previous deploy and one new build after
+    schedule*/
+    @Test
+    public void testOneBuildNoPreviousDeploySchedulePromote2() throws Exception {
+        PromoteBean promoteBean = new PromoteBean();
+        promoteBean.setEnv_id(environBean.getEnv_id());
+        promoteBean.setSchedule(CronTenAMPerDay);
+        promoteBean.setLast_update(0L);
+        promoteBean.setDelay(0);
+        AutoPromoter promoter = new AutoPromoter(context);
+        //Has builds. Have previous deploy
+        BuildBean build = new BuildBean();
+        build.setBuild_name("buildName");
+        build.setBuild_id("123");
+        DateTime now = DateTime.now();
+
+        //Set build time to be after 10 am today
+        if (now.getHourOfDay() < 10) {
+            build.setPublish_date(now.plusHours(10 - now.getHourOfDay() + 1).getMillis());
+        } else {
+            build.setPublish_date(DateTime.now().getMillis());
+        }
+        when(buildDAO.getAcceptedBuilds(anyString(), anyString(), anyObject(), anyInt()))
+            .thenReturn(Arrays.asList(build));
+        PromoteResult
+            result =
+            promoter.computePromoteBuildResult(environBean, null, 1, promoteBean);
+        Assert.assertEquals(PromoteResult.ResultCode.NoAvailableBuild, result.getResult());
+    }
+
+    /* Autopromote enabled for 10:00 AM every day. Have old previous deploy but no new build*/
+    @Test
+    public void testNoBuildWithPreviousDeploySchedule() throws Exception {
+        PromoteBean promoteBean = new PromoteBean();
+        promoteBean.setEnv_id(environBean.getEnv_id());
+        promoteBean.setSchedule(CronTenAMPerDay);
+        promoteBean.setLast_update(0L);
+        promoteBean.setDelay(0);
+        AutoPromoter promoter = new AutoPromoter(context);
+
+        DeployBean previousDeploy = new DeployBean();
+        previousDeploy.setStart_date(DateTime.now().minusDays(1).getMillis());
+        previousDeploy.setBuild_id("prev123");
+
+        BuildBean preBuild = new BuildBean();
+        preBuild.setBuild_name("buildName");
+        preBuild.setBuild_id("prev123");
+        preBuild.setPublish_date(DateTime.now().minusHours(3).getMillis());
+
+        when(buildDAO.getById("prev123")).thenReturn(preBuild);
+        PromoteResult
+            result =
+            promoter.computePromoteBuildResult(environBean, previousDeploy, 1, promoteBean);
+        Assert.assertEquals(PromoteResult.ResultCode.NoAvailableBuild, result.getResult());
+    }
+
+    /* Autopromote enabled for 10:00 AM every day. Have a very recent previous deploy and no new
+    build*/
+    @Test
+    public void testNoBuildWithPreviousDeploySchedule2() throws Exception {
+        PromoteBean promoteBean = new PromoteBean();
+        promoteBean.setEnv_id(environBean.getEnv_id());
+        promoteBean.setSchedule(CronTenAMPerDay);
+        promoteBean.setDelay(0);
+        AutoPromoter promoter = new AutoPromoter(context);
+
+        DeployBean previousDeploy = new DeployBean();
+        previousDeploy.setStart_date(DateTime.now().minusMinutes(1).getMillis());
+        previousDeploy.setBuild_id("prev123");
+
+        BuildBean preBuild = new BuildBean();
+        preBuild.setBuild_name("buildName");
+        preBuild.setBuild_id("prev123");
+        preBuild.setPublish_date(DateTime.now().minusHours(3).getMillis());
+
+        when(buildDAO.getById("prev123")).thenReturn(preBuild);
+        PromoteResult
+            result =
+            promoter.computePromoteBuildResult(environBean, previousDeploy, 1, promoteBean);
+        Assert.assertEquals(PromoteResult.ResultCode.NoAvailableBuild, result.getResult());
+    }
+
+
+    @Test
+    public void testOneBuildwithPreviousDeploySchedule() throws Exception {
+        PromoteBean promoteBean = new PromoteBean();
+        promoteBean.setEnv_id(environBean.getEnv_id());
+        promoteBean.setSchedule(CronTenAMPerDay);
+        promoteBean.setLast_update(0L);
+        promoteBean.setDelay(0);
+        AutoPromoter promoter = new AutoPromoter(context);
+        //Has builds. No previous deploy
+        DeployBean previousDeploy = new DeployBean();
+        previousDeploy.setStart_date(DateTime.now().minusDays(1).getMillis());
+        previousDeploy.setBuild_id("prev123");
+
+        BuildBean preBuild = new BuildBean();
+        preBuild.setBuild_name("buildName");
+        preBuild.setBuild_id("prev123");
+        preBuild.setPublish_date(DateTime.now().minusHours(25).getMillis());
+
+        BuildBean build = new BuildBean();
+        build.setBuild_name("buildName");
+        build.setBuild_id("123");
+        DateTime now = DateTime.now();
+        if (now.getHourOfDay() > 10) {
+            build.setPublish_date((now.minusHours(now.getHourOfDay() - 10 + 1)).getMillis());
+        } else {
+            build.setPublish_date(DateTime.now().minusHours(1).getMillis());
+        }
+        when(buildDAO.getById("prev123")).thenReturn(preBuild);
+        when(buildDAO.getAcceptedBuilds(anyString(), anyString(), anyObject(), anyInt()))
+            .thenReturn(Arrays.asList(build));
+        PromoteResult
+            result =
+            promoter.computePromoteBuildResult(environBean, previousDeploy, 1, promoteBean);
+        Assert.assertEquals(PromoteResult.ResultCode.PromoteBuild, result.getResult());
+        Assert.assertEquals("123", result.getPromotedBuild());
+    }
 }

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/worker/AutoPromoteDeployTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/worker/AutoPromoteDeployTest.java
@@ -3,17 +3,28 @@ package com.pinterest.teletraan.worker;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.pinterest.deployservice.ServiceContext;
-import com.pinterest.deployservice.bean.*;
+import com.pinterest.deployservice.bean.BuildBean;
+import com.pinterest.deployservice.bean.BuildTagBean;
+import com.pinterest.deployservice.bean.DeployBean;
+import com.pinterest.deployservice.bean.EnvironBean;
+import com.pinterest.deployservice.bean.PromoteBean;
+import com.pinterest.deployservice.bean.TagBean;
+import com.pinterest.deployservice.bean.TagTargetType;
+import com.pinterest.deployservice.bean.TagValue;
 import com.pinterest.deployservice.buildtags.BuildTagsManager;
+import com.pinterest.deployservice.buildtags.BuildTagsManagerImpl;
 import com.pinterest.deployservice.common.CommonUtils;
 import com.pinterest.deployservice.dao.BuildDAO;
 import com.pinterest.deployservice.dao.DeployDAO;
 import com.pinterest.deployservice.dao.EnvironDAO;
-
 import com.pinterest.deployservice.dao.TagDAO;
+
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.junit.After;
@@ -30,449 +41,488 @@ import java.util.HashSet;
 import java.util.List;
 
 public class AutoPromoteDeployTest {
-  ServiceContext context;
-  DeployBean first = new DeployBean();
-  DeployBean second = new DeployBean();
-  EnvironBean environBean = new EnvironBean();
-  EnvironBean predEnvironBean = new EnvironBean();
-  BuildDAO buildDAO;
-  EnvironDAO environDAO;
-  DeployDAO deployDAO;
-  TagDAO tagDAO;
-  BuildTagsManager buildTagsManager;
-  final static String CronTenAMPerDay = "0 0 10 * * ?";
-  final static String CronWorkTimePerDay = "0 40 9-17 ? * *";
 
-  List<DeployBean> allDeployBeans = new ArrayList<>();
+    final static String CronTenAMPerDay = "0 0 10 * * ?";
+    final static String CronWorkTimePerDay = "0 40 9-17 ? * *";
+    ServiceContext context;
+    DeployBean first = new DeployBean();
+    DeployBean second = new DeployBean();
+    EnvironBean environBean = new EnvironBean();
+    EnvironBean predEnvironBean = new EnvironBean();
+    BuildDAO buildDAO;
+    EnvironDAO environDAO;
+    DeployDAO deployDAO;
+    TagDAO tagDAO;
+    BuildTagsManager buildTagsManager;
+    List<DeployBean> allDeployBeans = new ArrayList<>();
 
-  public List<DeployBean> getAcceptedDeploysDelayed(String envId, Interval interval){
-    List<DeployBean> ret = new ArrayList<>();
-    for (DeployBean bean:allDeployBeans){
-      if (bean.getEnv_id().equals(envId) &&
-          interval.contains(bean.getStart_date())&&
-          //contains is inclusive for beginning
-          interval.getStartMillis()!= bean.getStart_date()){
-        ret.add(bean);
-      }
-    }
-    return ret;
-  }
-
-  @Before
-  public void setUp() throws Exception {
-    context = new ServiceContext();
-    buildDAO = mock(BuildDAO.class);
-    environDAO = mock(EnvironDAO.class);
-    deployDAO = mock(DeployDAO.class);
-    tagDAO = mock(TagDAO.class);
-    buildTagsManager = mock(BuildTagsManager.class);
-    context.setBuildTagsManager(buildTagsManager);
-    context.setTagDAO(tagDAO);
-    context.setBuildDAO(buildDAO);
-    context.setEnvironDAO(environDAO);
-    context.setDeployDAO(deployDAO);
-    first.setBuild_id("0000001");
-    second.setBuild_id("0000002");
-    environBean.setEnv_id("test1");
-    environBean.setEnv_name("testenv");
-    predEnvironBean.setEnv_id("predtest1");
-    predEnvironBean.setEnv_name("testenv");
-  }
-
-  @After
-  public void clean() throws Exception{
-    allDeployBeans.clear();
-  }
-
-  /* Autopromote enabled. But no current deploy and no prev deploys environ*/
-  @Test
-  public void testNoPredEnvironmentPromote() throws Exception {
-    PromoteBean promoteBean = new PromoteBean();
-    promoteBean.setPred_stage("pred");
-    when(environDAO.getByStage(environBean.getEnv_name(), "pred")).thenReturn(null);
-
-    AutoPromoter promoter = new AutoPromoter(context);
-    //No build. No previous deploy
-    PromoteResult result = promoter.computePromoteDeployResult(environBean, null, 10, promoteBean);
-    Assert.assertEquals(PromoteResult.ResultCode.NoPredEnvironment, result.getResult());
-
-    //Ensure same for scheduled build
-    promoteBean.setSchedule(CronTenAMPerDay);
-    result = promoter.computePromoteDeployResult(environBean, null, 10, promoteBean);
-    Assert.assertEquals(PromoteResult.ResultCode.NoPredEnvironment, result.getResult());
-
-  }
-
-  @Test
-  public void testOneBadDeployPromote() throws Exception {
-    // pred badbuild1
-    // current goodbuild2
-    PromoteBean promoteBean = new PromoteBean();
-    promoteBean.setPred_stage("pred");
-    promoteBean.setDelay(100); //minutes
-    DateTime now = DateTime.now();
-
-    String badBuildId = "badbuild1";
-    String goodBuildId = "goodBuild2";
-
-    BuildBean badBuild = new BuildBean();
-    badBuild.setBuild_id(badBuildId);
-    badBuild.setBuild_name(badBuildId);
-    badBuild.setCommit_date(now.minusHours(24).getMillis());
-    badBuild.setPublish_date(now.minusHours(24).getMillis());
-    badBuild.setScm_commit("abcde");
-
-    TagBean tagBean = new TagBean();
-    tagBean.setId(CommonUtils.getBase64UUID());
-    tagBean.setTarget_type(TagTargetType.BUILD);
-    tagBean.setTarget_id(badBuildId);
-    tagBean.setValue(TagValue.BAD_BUILD);
-    tagBean.serializeTagMetaInfo(badBuild);
-
-    predEnvironBean.setDeploy_id("deploy1");
-
-    DeployBean prevDeploy = new DeployBean();
-    prevDeploy.setDeploy_id("deploy1");
-    prevDeploy.setEnv_id(predEnvironBean.getEnv_id());
-    prevDeploy.setStart_date(now.minusHours(23).getMillis());
-    prevDeploy.setBuild_id(badBuildId);
-
-    DeployBean currentDeploy = new DeployBean();
-    currentDeploy.setDeploy_id("deploy2");
-    currentDeploy.setFrom_deploy(prevDeploy.getDeploy_id());
-    currentDeploy.setEnv_id(environBean.getEnv_id());
-    currentDeploy.setStart_date(now.minusHours(22).plusMinutes(40).getMillis());
-    currentDeploy.setBuild_id(goodBuildId);
-
-    allDeployBeans.add(prevDeploy);
-    allDeployBeans.add(currentDeploy);
-
-    when(deployDAO.getById("deploy1")).thenReturn(prevDeploy);
-    when(environDAO.getByStage(environBean.getEnv_name(), "pred")).thenReturn(predEnvironBean);
-    when(deployDAO.getAcceptedDeploys(anyString(), anyObject(), anyInt())).thenReturn(Arrays.asList(prevDeploy));
-    when(buildDAO.getBuildsFromIds(new HashSet<>(Arrays.asList(badBuildId)))).thenReturn(Arrays.asList(badBuild));
-
-    when(buildTagsManager.getEffectiveTagsWithBuilds(Arrays.asList(badBuild)))
-        .thenReturn(Arrays.asList(BuildTagBean.createFromTagBean(tagBean)));
-
-    when(tagDAO.getByTargetIdAndType(badBuildId, TagTargetType.BUILD)).thenReturn(Arrays.asList(tagBean));
-
-    AutoPromoter promoter = new AutoPromoter(context);
-    AutoPromoter promoterSpy = Mockito.spy(promoter);
-    promoter.promoteDeploy(environBean, currentDeploy, 1, promoteBean);
-
-    PromoteResult result = promoter.computePromoteDeployResult(environBean, currentDeploy, 1, promoteBean);
-    Assert.assertEquals(PromoteResult.ResultCode.NoCandidateWithinDelayPeriod, result.getResult());
-    // bad build, safe promote never gets called
-    verify(promoterSpy, never()).safePromote(anyObject(), anyString(), anyString(), anyObject(), anyObject());
-  }
-
-  /* Autopromote enabled. Has pred env but it has no deploys*/
-  @Test
-  public void testNoPredEnvironDeployPromote() throws Exception {
-    PromoteBean promoteBean = new PromoteBean();
-    promoteBean.setPred_stage("pred");
-    predEnvironBean.setDeploy_id(null);
-    when(environDAO.getByStage(environBean.getEnv_name(), "pred")).thenReturn(predEnvironBean);
-
-    AutoPromoter promoter = new AutoPromoter(context);
-    //No build. No previous deploy
-    PromoteResult result = promoter.computePromoteDeployResult(environBean, null, 10, promoteBean);
-    Assert.assertEquals(PromoteResult.ResultCode.NoPredEnvironmentDeploy, result.getResult());
-
-    //Ensure same for scheduled build
-    promoteBean.setSchedule(CronTenAMPerDay);
-    result = promoter.computePromoteDeployResult(environBean, null, 10, promoteBean);
-    Assert.assertEquals(PromoteResult.ResultCode.NoPredEnvironmentDeploy, result.getResult());
-
-  }
-
-  /*
-  Autopromote enabled with no delay. Have pred environ and already promote one deploy.
-  No current deploy available
-  */
-  @Test
-  public void testPredDeployAlreadyPromote() throws Exception{
-    DateTime now = DateTime.now();
-    PromoteBean promoteBean = new PromoteBean();
-    promoteBean.setPred_stage("pred");
-    promoteBean.setDelay(0); //minutes
-    predEnvironBean.setDeploy_id("deploy1");
-    DeployBean prevDeploy = new DeployBean();
-    prevDeploy.setDeploy_id("deploy1");
-    prevDeploy.setEnv_id(predEnvironBean.getEnv_id());
-    prevDeploy.setStart_date(now.minusHours(26).getMillis());
-    DeployBean currentDeploy = new DeployBean();
-    currentDeploy.setDeploy_id("deploy2");
-    currentDeploy.setFrom_deploy("deploy1");
-    currentDeploy.setStart_date(now.minusHours(25).getMillis());
-    allDeployBeans.add(prevDeploy);
-    when(environDAO.getByStage(environBean.getEnv_name(), "pred")).thenReturn(predEnvironBean);
-    when(deployDAO.getById("deploy1")).thenReturn(prevDeploy);
-    when(deployDAO.getAcceptedDeploys(anyString(), anyObject(), anyInt())).thenAnswer(
-        new Answer<List<DeployBean>>(){
-          @Override
-          public List<DeployBean> answer(InvocationOnMock invocationOnMock) throws Throwable {
-            return getAcceptedDeploysDelayed((String)invocationOnMock.getArguments()[0],
-                (Interval)invocationOnMock.getArguments()[1]);
-          }
+    public List<DeployBean> getAcceptedDeploysDelayed(String envId, Interval interval) {
+        List<DeployBean> ret = new ArrayList<>();
+        for (DeployBean bean : allDeployBeans) {
+            if (bean.getEnv_id().equals(envId) &&
+                interval.contains(bean.getStart_date()) &&
+                //contains is inclusive for beginning
+                interval.getStartMillis() != bean.getStart_date()) {
+                ret.add(bean);
+            }
         }
-    );
-
-
-    AutoPromoter promoter = new AutoPromoter(context);
-    //No build. No previous deploy
-    PromoteResult result = promoter.computePromoteDeployResult(environBean, currentDeploy, 10, promoteBean);
-    Assert.assertEquals(PromoteResult.ResultCode.NoCandidateWithinDelayPeriod, result.getResult());
-
-    promoteBean.setSchedule(CronTenAMPerDay);
-    result = promoter.computePromoteDeployResult(environBean, currentDeploy, 10, promoteBean);
-    Assert.assertEquals(PromoteResult.ResultCode.NoCandidateWithinDelayPeriod, result.getResult());
-  }
-
-  /* Autopromote enabled for any new build. Have previous deploy but from different deploy*/
-  @Test
-  public void testPredDeployDelayPromote() throws Exception{
-    DateTime now = DateTime.now();
-    PromoteBean promoteBean = new PromoteBean();
-    promoteBean.setPred_stage("pred");
-    promoteBean.setDelay(10); //minutes
-    predEnvironBean.setDeploy_id("deploy1");
-    DeployBean prevDeploy = new DeployBean();
-    prevDeploy.setDeploy_id("deploy1");
-    prevDeploy.setEnv_id(predEnvironBean.getEnv_id());
-    prevDeploy.setStart_date(now.minusMinutes(60).getMillis());
-    DeployBean currentDeploy = new DeployBean();
-    currentDeploy.setDeploy_id("deploy2");
-    currentDeploy.setStart_date(now.minusMinutes(25).getMillis());
-    currentDeploy.setFrom_deploy(prevDeploy.getDeploy_id());
-
-    DeployBean newDeploy = new DeployBean();
-    newDeploy.setEnv_id(prevDeploy.getEnv_id());
-    newDeploy.setDeploy_id("deploy3");
-    newDeploy.setBuild_id("build3");
-
-    BuildBean build3 = new BuildBean();
-    build3.setBuild_name("buildname");
-    build3.setBuild_id("build3");
-
-    allDeployBeans.add(prevDeploy);
-    allDeployBeans.add(newDeploy);
-    when(environDAO.getByStage(environBean.getEnv_name(), "pred")).thenReturn(predEnvironBean);
-    when(deployDAO.getById(prevDeploy.getDeploy_id())).thenReturn(prevDeploy);
-    when(deployDAO.getById(newDeploy.getDeploy_id())).thenReturn(newDeploy);
-    when(deployDAO.getAcceptedDeploys(anyString(), anyObject(), anyInt())).thenAnswer(
-        new Answer<List<DeployBean>>(){
-          @Override
-          public List<DeployBean> answer(InvocationOnMock invocationOnMock) throws Throwable {
-            return getAcceptedDeploysDelayed((String)invocationOnMock.getArguments()[0],
-                (Interval) invocationOnMock.getArguments()[1]);
-          }
-        }
-    );
-    AutoPromoter promoter = new AutoPromoter(context);
-    //Pre deploy is 6 minutes ago, delay is 10 minutes
-    newDeploy.setStart_date(now.minusMinutes(6).getMillis());
-    PromoteResult result = promoter.computePromoteDeployResult(environBean, currentDeploy, 1, promoteBean);
-    Assert.assertEquals(PromoteResult.ResultCode.NoCandidateWithinDelayPeriod, result.getResult());
-
-    when(buildDAO.getBuildsFromIds(new HashSet<>(Arrays.asList("build3")))).thenReturn(Arrays.asList(build3));
-
-    //Set predeploy to 11 minutes, delay is 10 minutes
-    newDeploy.setStart_date(now.minusMinutes(11).getMillis());
-    result = promoter.computePromoteDeployResult(environBean, currentDeploy, 1, promoteBean);
-    Assert.assertEquals(PromoteResult.ResultCode.PromoteDeploy, result.getResult());
-
-  }
-
-
-  /* Autopromote enabled for any new build. Have previous deploy but from different deploy*/
-  @Test
-  public void testPredDeployWithDelayPromote() throws Exception{
-    DateTime now = DateTime.now();
-    PromoteBean promoteBean = new PromoteBean();
-    promoteBean.setPred_stage("pred");
-    promoteBean.setDelay(10); //minutes
-    predEnvironBean.setDeploy_id("deploy1");
-
-    DeployBean newDeploy = new DeployBean();
-    newDeploy.setDeploy_id("deploy1");
-    newDeploy.setBuild_id("build1");
-    newDeploy.setEnv_id(predEnvironBean.getEnv_id());
-    DeployBean currentDeploy = new DeployBean();
-    currentDeploy.setDeploy_id("deploy2");
-
-
-    BuildBean build1 = new BuildBean();
-    build1.setBuild_name("buildname");
-    build1.setBuild_id("build1");
-
-    currentDeploy.setStart_date(now.minusMinutes(25).getMillis());
-    allDeployBeans.add(newDeploy);
-    when(environDAO.getByStage(environBean.getEnv_name(), "pred")).thenReturn(predEnvironBean);
-    when(deployDAO.getById("deploy1")).thenReturn(newDeploy);
-    when(deployDAO.getAcceptedDeploys(anyString(), anyObject(),anyInt())).thenAnswer(
-        new Answer<List<DeployBean>>(){
-          @Override
-          public List<DeployBean> answer(InvocationOnMock invocationOnMock) throws Throwable {
-            return getAcceptedDeploysDelayed((String)invocationOnMock.getArguments()[0],
-                (Interval) invocationOnMock.getArguments()[1]);
-          }
-        }
-    );
-    AutoPromoter promoter = new AutoPromoter(context);
-    //Pre deploy is 6 minutes ago, delay is 10 minutes
-    newDeploy.setStart_date(now.minusMinutes(6).getMillis());
-    PromoteResult result = promoter.computePromoteDeployResult(environBean, currentDeploy, 1, promoteBean);
-    Assert.assertEquals(PromoteResult.ResultCode.NoCandidateWithinDelayPeriod, result.getResult());
-
-    when(buildDAO.getBuildsFromIds(new HashSet<>(Arrays.asList("build1")))).thenReturn(Arrays.asList(build1));
-
-    //Set predeploy to 11 minutes, delay is 10 minutes
-    newDeploy.setStart_date(now.minusMinutes(11).getMillis());
-    result = promoter.computePromoteDeployResult(environBean, currentDeploy, 1, promoteBean);
-    Assert.assertEquals(PromoteResult.ResultCode.PromoteDeploy, result.getResult());
-
-  }
-
-  @Test
-  public void testScheduledPromote() throws Exception{
-    DateTime now = DateTime.now();
-    PromoteBean promoteBean = new PromoteBean();
-    promoteBean.setSchedule(CronTenAMPerDay);
-    promoteBean.setPred_stage("pred");
-    promoteBean.setDelay(0); //minutes
-
-    predEnvironBean.setDeploy_id("deploy1");
-    DeployBean prevDeploy = new DeployBean();
-    prevDeploy.setDeploy_id("deploy1");
-    prevDeploy.setEnv_id(predEnvironBean.getEnv_id());
-
-    BuildBean newBuild = new BuildBean();
-    newBuild.setBuild_name("buildName");
-    newBuild.setBuild_id("newBuild");
-    when(buildDAO.getBuildsFromIds(new HashSet<>(Arrays.asList("newBuild")))).thenReturn(Arrays.asList(newBuild));
-
-    DeployBean newDeploy = new DeployBean();
-    newDeploy.setDeploy_id("newDeploy");
-    newDeploy.setBuild_id("newBuild");
-    newDeploy.setEnv_id(predEnvironBean.getEnv_id());
-
-    DeployBean currentDeploy = new DeployBean();
-    currentDeploy.setDeploy_id("deploy2");
-    currentDeploy.setFrom_deploy("deploy1");
-
-    allDeployBeans.addAll(Arrays.asList(prevDeploy, newDeploy));
-
-    when(environDAO.getByStage(environBean.getEnv_name(), "pred")).thenReturn(predEnvironBean);
-    when(deployDAO.getById(prevDeploy.getDeploy_id())).thenReturn(prevDeploy);
-    when(deployDAO.getById(newDeploy.getDeploy_id())).thenReturn(newDeploy);
-    when(deployDAO.getAcceptedDeploys(anyString(), anyObject(), anyInt())).thenAnswer(
-        new Answer<List<DeployBean>>(){
-          @Override
-          public List<DeployBean> answer(InvocationOnMock invocationOnMock) throws Throwable {
-            return getAcceptedDeploysDelayed((String)invocationOnMock.getArguments()[0],
-                (Interval) invocationOnMock.getArguments()[1]);
-          }
-        }
-    );
-
-    if (now.getHourOfDay()>=10) {
-      DateTime cuttingPoint = new DateTime(now.getYear(),now.getMonthOfYear(),now.getDayOfMonth(), 10,0,0);
-
-      prevDeploy.setStart_date(cuttingPoint.minusHours(3).getMillis());
-      currentDeploy.setStart_date(cuttingPoint.minusHours(2).getMillis());
-      newDeploy.setStart_date(cuttingPoint.minusHours(1).getMillis());
-      AutoPromoter promoter = new AutoPromoter(context);
-      PromoteResult result = promoter.computePromoteDeployResult(environBean, currentDeploy, 1, promoteBean);
-      Assert.assertEquals(PromoteResult.ResultCode.PromoteDeploy, result.getResult());
-      promoteBean.setDelay(1+(int)(now.getMillis() - newDeploy.getStart_date())/60000);
-      result = promoter.computePromoteDeployResult(environBean, currentDeploy, 1, promoteBean);
-      Assert.assertEquals(PromoteResult.ResultCode.NoCandidateWithinDelayPeriod, result.getResult());
-
-    }
-    else{
-      //Before 10 am. Need newdeploy to be >25 hours
-      prevDeploy.setStart_date(now.minusHours(27).getMillis());
-      currentDeploy.setStart_date(now.minusHours(26).getMillis());
-      newDeploy.setStart_date(now.minusHours(25).getMillis());
-      AutoPromoter promoter = new AutoPromoter(context);
-      PromoteResult result = promoter.computePromoteDeployResult(environBean, currentDeploy, 1, promoteBean);
-      Assert.assertEquals(PromoteResult.ResultCode.PromoteDeploy, result.getResult());
-      promoteBean.setDelay(1+(int)(now.getMillis() - newDeploy.getStart_date())/60000);
-      result = promoter.computePromoteDeployResult(environBean, currentDeploy, 10, promoteBean);
-      Assert.assertEquals(PromoteResult.ResultCode.NoCandidateWithinDelayPeriod, result.getResult());
+        return ret;
     }
 
-  }
+    @Before
+    public void setUp() throws Exception {
+        context = new ServiceContext();
+        buildDAO = mock(BuildDAO.class);
+        environDAO = mock(EnvironDAO.class);
+        deployDAO = mock(DeployDAO.class);
+        tagDAO = mock(TagDAO.class);
+        buildTagsManager = mock(BuildTagsManager.class);
+        context.setBuildTagsManager(buildTagsManager);
+        context.setTagDAO(tagDAO);
+        context.setBuildDAO(buildDAO);
+        context.setEnvironDAO(environDAO);
+        context.setDeployDAO(deployDAO);
+        first.setBuild_id("0000001");
+        second.setBuild_id("0000002");
+        environBean.setEnv_id("test1");
+        environBean.setEnv_name("testenv");
+        predEnvironBean.setEnv_id("predtest1");
+        predEnvironBean.setEnv_name("testenv");
+    }
 
-  @Test
-  public void testScheduledPromote2() throws Exception{
-    DateTime now = DateTime.now();
-    PromoteBean promoteBean = new PromoteBean();
-    promoteBean.setSchedule(CronWorkTimePerDay);
-    promoteBean.setPred_stage("pred");
-    promoteBean.setDelay(10); //minutes
+    @After
+    public void clean() throws Exception {
+        allDeployBeans.clear();
+    }
 
-    predEnvironBean.setDeploy_id("deploy1");
-    DeployBean prevDeploy = new DeployBean();
-    prevDeploy.setDeploy_id("deploy1");
-    prevDeploy.setEnv_id(predEnvironBean.getEnv_id());
+    /* Autopromote enabled. But no current deploy and no prev deploys environ*/
+    @Test
+    public void testNoPredEnvironmentPromote() throws Exception {
+        PromoteBean promoteBean = new PromoteBean();
+        promoteBean.setPred_stage("pred");
+        when(environDAO.getByStage(environBean.getEnv_name(), "pred")).thenReturn(null);
 
-    BuildBean newBuild = new BuildBean();
-    newBuild.setBuild_name("buildname");
-    newBuild.setBuild_id("newBuild");
-    when(buildDAO.getBuildsFromIds(new HashSet<>(Arrays.asList("newBuild")))).thenReturn(Arrays.asList(newBuild));
+        AutoPromoter promoter = new AutoPromoter(context);
+        //No build. No previous deploy
+        PromoteResult
+            result =
+            promoter.computePromoteDeployResult(environBean, null, 10, promoteBean);
+        Assert.assertEquals(PromoteResult.ResultCode.NoPredEnvironment, result.getResult());
 
-    DeployBean newDeploy = new DeployBean();
-    newDeploy.setDeploy_id("newDeploy");
-    newDeploy.setBuild_id("newBuild");
-    newDeploy.setEnv_id(predEnvironBean.getEnv_id());
+        //Ensure same for scheduled build
+        promoteBean.setSchedule(CronTenAMPerDay);
+        result = promoter.computePromoteDeployResult(environBean, null, 10, promoteBean);
+        Assert.assertEquals(PromoteResult.ResultCode.NoPredEnvironment, result.getResult());
 
-    DeployBean currentDeploy = new DeployBean();
-    currentDeploy.setDeploy_id("deploy2");
-    currentDeploy.setFrom_deploy("deploy1");
+    }
 
-    allDeployBeans.addAll(Arrays.asList(prevDeploy, newDeploy));
+    @Test
+    public void testOneBadDeployPromote() throws Exception {
+        // pred badbuild1
+        // current goodbuild2
+        PromoteBean promoteBean = new PromoteBean();
+        promoteBean.setPred_stage("pred");
+        promoteBean.setDelay(100); //minutes
+        DateTime now = DateTime.now();
 
-    when(environDAO.getByStage(environBean.getEnv_name(), "pred")).thenReturn(predEnvironBean);
-    when(deployDAO.getById(prevDeploy.getDeploy_id())).thenReturn(prevDeploy);
-    when(deployDAO.getById(newDeploy.getDeploy_id())).thenReturn(newDeploy);
-    when(deployDAO.getAcceptedDeploys(anyString(), anyObject(), anyInt())).thenAnswer(
-        new Answer<List<DeployBean>>(){
-          @Override
-          public List<DeployBean> answer(InvocationOnMock invocationOnMock) throws Throwable {
-            return getAcceptedDeploysDelayed((String)invocationOnMock.getArguments()[0],
-                (Interval) invocationOnMock.getArguments()[1]);
-          }
+        String badBuildId = "badbuild1";
+        String goodBuildId = "goodBuild2";
+
+        BuildBean badBuild = new BuildBean();
+        badBuild.setBuild_id(badBuildId);
+        badBuild.setBuild_name(badBuildId);
+        badBuild.setCommit_date(now.minusHours(24).getMillis());
+        badBuild.setPublish_date(now.minusHours(24).getMillis());
+        badBuild.setScm_commit("abcde");
+
+        TagBean tagBean = new TagBean();
+        tagBean.setId(CommonUtils.getBase64UUID());
+        tagBean.setTarget_type(TagTargetType.BUILD);
+        tagBean.setTarget_id(badBuildId);
+        tagBean.setValue(TagValue.BAD_BUILD);
+        tagBean.serializeTagMetaInfo(badBuild);
+
+        predEnvironBean.setDeploy_id("deploy1");
+
+        DeployBean prevDeploy = new DeployBean();
+        prevDeploy.setDeploy_id("deploy1");
+        prevDeploy.setEnv_id(predEnvironBean.getEnv_id());
+        prevDeploy.setStart_date(now.minusHours(23).getMillis());
+        prevDeploy.setBuild_id(badBuildId);
+
+        DeployBean currentDeploy = new DeployBean();
+        currentDeploy.setDeploy_id("deploy2");
+        currentDeploy.setFrom_deploy(prevDeploy.getDeploy_id());
+        currentDeploy.setEnv_id(environBean.getEnv_id());
+        currentDeploy.setStart_date(now.minusHours(22).plusMinutes(40).getMillis());
+        currentDeploy.setBuild_id(goodBuildId);
+
+        allDeployBeans.add(prevDeploy);
+        allDeployBeans.add(currentDeploy);
+
+        when(deployDAO.getById("deploy1")).thenReturn(prevDeploy);
+        when(environDAO.getByStage(environBean.getEnv_name(), "pred")).thenReturn(predEnvironBean);
+        when(deployDAO.getAcceptedDeploys(anyString(), anyObject(), anyInt()))
+            .thenReturn(Arrays.asList(prevDeploy));
+        when(buildDAO.getBuildsFromIds(new HashSet<>(Arrays.asList(badBuildId))))
+            .thenReturn(Arrays.asList(badBuild));
+
+        when(buildTagsManager.getEffectiveTagsWithBuilds(Arrays.asList(badBuild)))
+            .thenReturn(Arrays.asList(BuildTagBean.createFromTagBean(tagBean)));
+
+        when(tagDAO.getLatestByTargetIdAndType(badBuildId, TagTargetType.BUILD,
+            BuildTagsManagerImpl.MAXCHECKTAGS)).thenReturn(Arrays.asList(tagBean));
+
+        AutoPromoter promoter = new AutoPromoter(context);
+        AutoPromoter promoterSpy = Mockito.spy(promoter);
+        promoter.promoteDeploy(environBean, currentDeploy, 1, promoteBean);
+
+        PromoteResult
+            result =
+            promoter.computePromoteDeployResult(environBean, currentDeploy, 1, promoteBean);
+        Assert.assertEquals(PromoteResult.ResultCode.NoCandidateWithinDelayPeriod,
+            result.getResult());
+        // bad build, safe promote never gets called
+        verify(promoterSpy, never())
+            .safePromote(anyObject(), anyString(), anyString(), anyObject(), anyObject());
+    }
+
+    /* Autopromote enabled. Has pred env but it has no deploys*/
+    @Test
+    public void testNoPredEnvironDeployPromote() throws Exception {
+        PromoteBean promoteBean = new PromoteBean();
+        promoteBean.setPred_stage("pred");
+        predEnvironBean.setDeploy_id(null);
+        when(environDAO.getByStage(environBean.getEnv_name(), "pred")).thenReturn(predEnvironBean);
+
+        AutoPromoter promoter = new AutoPromoter(context);
+        //No build. No previous deploy
+        PromoteResult
+            result =
+            promoter.computePromoteDeployResult(environBean, null, 10, promoteBean);
+        Assert.assertEquals(PromoteResult.ResultCode.NoPredEnvironmentDeploy, result.getResult());
+
+        //Ensure same for scheduled build
+        promoteBean.setSchedule(CronTenAMPerDay);
+        result = promoter.computePromoteDeployResult(environBean, null, 10, promoteBean);
+        Assert.assertEquals(PromoteResult.ResultCode.NoPredEnvironmentDeploy, result.getResult());
+
+    }
+
+    /*
+    Autopromote enabled with no delay. Have pred environ and already promote one deploy.
+    No current deploy available
+    */
+    @Test
+    public void testPredDeployAlreadyPromote() throws Exception {
+        DateTime now = DateTime.now();
+        PromoteBean promoteBean = new PromoteBean();
+        promoteBean.setPred_stage("pred");
+        promoteBean.setDelay(0); //minutes
+        predEnvironBean.setDeploy_id("deploy1");
+        DeployBean prevDeploy = new DeployBean();
+        prevDeploy.setDeploy_id("deploy1");
+        prevDeploy.setEnv_id(predEnvironBean.getEnv_id());
+        prevDeploy.setStart_date(now.minusHours(26).getMillis());
+        DeployBean currentDeploy = new DeployBean();
+        currentDeploy.setDeploy_id("deploy2");
+        currentDeploy.setFrom_deploy("deploy1");
+        currentDeploy.setStart_date(now.minusHours(25).getMillis());
+        allDeployBeans.add(prevDeploy);
+        when(environDAO.getByStage(environBean.getEnv_name(), "pred")).thenReturn(predEnvironBean);
+        when(deployDAO.getById("deploy1")).thenReturn(prevDeploy);
+        when(deployDAO.getAcceptedDeploys(anyString(), anyObject(), anyInt())).thenAnswer(
+            new Answer<List<DeployBean>>() {
+                @Override
+                public List<DeployBean> answer(InvocationOnMock invocationOnMock) throws Throwable {
+                    return getAcceptedDeploysDelayed((String) invocationOnMock.getArguments()[0],
+                        (Interval) invocationOnMock.getArguments()[1]);
+                }
+            }
+        );
+
+        AutoPromoter promoter = new AutoPromoter(context);
+        //No build. No previous deploy
+        PromoteResult
+            result =
+            promoter.computePromoteDeployResult(environBean, currentDeploy, 10, promoteBean);
+        Assert.assertEquals(PromoteResult.ResultCode.NoCandidateWithinDelayPeriod,
+            result.getResult());
+
+        promoteBean.setSchedule(CronTenAMPerDay);
+        result = promoter.computePromoteDeployResult(environBean, currentDeploy, 10, promoteBean);
+        Assert.assertEquals(PromoteResult.ResultCode.NoCandidateWithinDelayPeriod,
+            result.getResult());
+    }
+
+    /* Autopromote enabled for any new build. Have previous deploy but from different deploy*/
+    @Test
+    public void testPredDeployDelayPromote() throws Exception {
+        DateTime now = DateTime.now();
+        PromoteBean promoteBean = new PromoteBean();
+        promoteBean.setPred_stage("pred");
+        promoteBean.setDelay(10); //minutes
+        predEnvironBean.setDeploy_id("deploy1");
+        DeployBean prevDeploy = new DeployBean();
+        prevDeploy.setDeploy_id("deploy1");
+        prevDeploy.setEnv_id(predEnvironBean.getEnv_id());
+        prevDeploy.setStart_date(now.minusMinutes(60).getMillis());
+        DeployBean currentDeploy = new DeployBean();
+        currentDeploy.setDeploy_id("deploy2");
+        currentDeploy.setStart_date(now.minusMinutes(25).getMillis());
+        currentDeploy.setFrom_deploy(prevDeploy.getDeploy_id());
+
+        DeployBean newDeploy = new DeployBean();
+        newDeploy.setEnv_id(prevDeploy.getEnv_id());
+        newDeploy.setDeploy_id("deploy3");
+        newDeploy.setBuild_id("build3");
+
+        BuildBean build3 = new BuildBean();
+        build3.setBuild_name("buildname");
+        build3.setBuild_id("build3");
+
+        allDeployBeans.add(prevDeploy);
+        allDeployBeans.add(newDeploy);
+        when(environDAO.getByStage(environBean.getEnv_name(), "pred")).thenReturn(predEnvironBean);
+        when(deployDAO.getById(prevDeploy.getDeploy_id())).thenReturn(prevDeploy);
+        when(deployDAO.getById(newDeploy.getDeploy_id())).thenReturn(newDeploy);
+        when(deployDAO.getAcceptedDeploys(anyString(), anyObject(), anyInt())).thenAnswer(
+            new Answer<List<DeployBean>>() {
+                @Override
+                public List<DeployBean> answer(InvocationOnMock invocationOnMock) throws Throwable {
+                    return getAcceptedDeploysDelayed((String) invocationOnMock.getArguments()[0],
+                        (Interval) invocationOnMock.getArguments()[1]);
+                }
+            }
+        );
+        AutoPromoter promoter = new AutoPromoter(context);
+        //Pre deploy is 6 minutes ago, delay is 10 minutes
+        newDeploy.setStart_date(now.minusMinutes(6).getMillis());
+        PromoteResult
+            result =
+            promoter.computePromoteDeployResult(environBean, currentDeploy, 1, promoteBean);
+        Assert.assertEquals(PromoteResult.ResultCode.NoCandidateWithinDelayPeriod,
+            result.getResult());
+
+        when(buildDAO.getBuildsFromIds(new HashSet<>(Arrays.asList("build3"))))
+            .thenReturn(Arrays.asList(build3));
+
+        //Set predeploy to 11 minutes, delay is 10 minutes
+        newDeploy.setStart_date(now.minusMinutes(11).getMillis());
+        result = promoter.computePromoteDeployResult(environBean, currentDeploy, 1, promoteBean);
+        Assert.assertEquals(PromoteResult.ResultCode.PromoteDeploy, result.getResult());
+
+    }
+
+
+    /* Autopromote enabled for any new build. Have previous deploy but from different deploy*/
+    @Test
+    public void testPredDeployWithDelayPromote() throws Exception {
+        DateTime now = DateTime.now();
+        PromoteBean promoteBean = new PromoteBean();
+        promoteBean.setPred_stage("pred");
+        promoteBean.setDelay(10); //minutes
+        predEnvironBean.setDeploy_id("deploy1");
+
+        DeployBean newDeploy = new DeployBean();
+        newDeploy.setDeploy_id("deploy1");
+        newDeploy.setBuild_id("build1");
+        newDeploy.setEnv_id(predEnvironBean.getEnv_id());
+        DeployBean currentDeploy = new DeployBean();
+        currentDeploy.setDeploy_id("deploy2");
+
+        BuildBean build1 = new BuildBean();
+        build1.setBuild_name("buildname");
+        build1.setBuild_id("build1");
+
+        currentDeploy.setStart_date(now.minusMinutes(25).getMillis());
+        allDeployBeans.add(newDeploy);
+        when(environDAO.getByStage(environBean.getEnv_name(), "pred")).thenReturn(predEnvironBean);
+        when(deployDAO.getById("deploy1")).thenReturn(newDeploy);
+        when(deployDAO.getAcceptedDeploys(anyString(), anyObject(), anyInt())).thenAnswer(
+            new Answer<List<DeployBean>>() {
+                @Override
+                public List<DeployBean> answer(InvocationOnMock invocationOnMock) throws Throwable {
+                    return getAcceptedDeploysDelayed((String) invocationOnMock.getArguments()[0],
+                        (Interval) invocationOnMock.getArguments()[1]);
+                }
+            }
+        );
+        AutoPromoter promoter = new AutoPromoter(context);
+        //Pre deploy is 6 minutes ago, delay is 10 minutes
+        newDeploy.setStart_date(now.minusMinutes(6).getMillis());
+        PromoteResult
+            result =
+            promoter.computePromoteDeployResult(environBean, currentDeploy, 1, promoteBean);
+        Assert.assertEquals(PromoteResult.ResultCode.NoCandidateWithinDelayPeriod,
+            result.getResult());
+
+        when(buildDAO.getBuildsFromIds(new HashSet<>(Arrays.asList("build1"))))
+            .thenReturn(Arrays.asList(build1));
+
+        //Set predeploy to 11 minutes, delay is 10 minutes
+        newDeploy.setStart_date(now.minusMinutes(11).getMillis());
+        result = promoter.computePromoteDeployResult(environBean, currentDeploy, 1, promoteBean);
+        Assert.assertEquals(PromoteResult.ResultCode.PromoteDeploy, result.getResult());
+
+    }
+
+    @Test
+    public void testScheduledPromote() throws Exception {
+        DateTime now = DateTime.now();
+        PromoteBean promoteBean = new PromoteBean();
+        promoteBean.setSchedule(CronTenAMPerDay);
+        promoteBean.setPred_stage("pred");
+        promoteBean.setDelay(0); //minutes
+
+        predEnvironBean.setDeploy_id("deploy1");
+        DeployBean prevDeploy = new DeployBean();
+        prevDeploy.setDeploy_id("deploy1");
+        prevDeploy.setEnv_id(predEnvironBean.getEnv_id());
+
+        BuildBean newBuild = new BuildBean();
+        newBuild.setBuild_name("buildName");
+        newBuild.setBuild_id("newBuild");
+        when(buildDAO.getBuildsFromIds(new HashSet<>(Arrays.asList("newBuild"))))
+            .thenReturn(Arrays.asList(newBuild));
+
+        DeployBean newDeploy = new DeployBean();
+        newDeploy.setDeploy_id("newDeploy");
+        newDeploy.setBuild_id("newBuild");
+        newDeploy.setEnv_id(predEnvironBean.getEnv_id());
+
+        DeployBean currentDeploy = new DeployBean();
+        currentDeploy.setDeploy_id("deploy2");
+        currentDeploy.setFrom_deploy("deploy1");
+
+        allDeployBeans.addAll(Arrays.asList(prevDeploy, newDeploy));
+
+        when(environDAO.getByStage(environBean.getEnv_name(), "pred")).thenReturn(predEnvironBean);
+        when(deployDAO.getById(prevDeploy.getDeploy_id())).thenReturn(prevDeploy);
+        when(deployDAO.getById(newDeploy.getDeploy_id())).thenReturn(newDeploy);
+        when(deployDAO.getAcceptedDeploys(anyString(), anyObject(), anyInt())).thenAnswer(
+            new Answer<List<DeployBean>>() {
+                @Override
+                public List<DeployBean> answer(InvocationOnMock invocationOnMock) throws Throwable {
+                    return getAcceptedDeploysDelayed((String) invocationOnMock.getArguments()[0],
+                        (Interval) invocationOnMock.getArguments()[1]);
+                }
+            }
+        );
+
+        if (now.getHourOfDay() >= 10) {
+            DateTime
+                cuttingPoint =
+                new DateTime(now.getYear(), now.getMonthOfYear(), now.getDayOfMonth(), 10, 0, 0);
+
+            prevDeploy.setStart_date(cuttingPoint.minusHours(3).getMillis());
+            currentDeploy.setStart_date(cuttingPoint.minusHours(2).getMillis());
+            newDeploy.setStart_date(cuttingPoint.minusHours(1).getMillis());
+            AutoPromoter promoter = new AutoPromoter(context);
+            PromoteResult
+                result =
+                promoter.computePromoteDeployResult(environBean, currentDeploy, 1, promoteBean);
+            Assert.assertEquals(PromoteResult.ResultCode.PromoteDeploy, result.getResult());
+            promoteBean.setDelay(1 + (int) (now.getMillis() - newDeploy.getStart_date()) / 60000);
+            result =
+                promoter.computePromoteDeployResult(environBean, currentDeploy, 1, promoteBean);
+            Assert.assertEquals(PromoteResult.ResultCode.NoCandidateWithinDelayPeriod,
+                result.getResult());
+
+        } else {
+            //Before 10 am. Need newdeploy to be >25 hours
+            prevDeploy.setStart_date(now.minusHours(27).getMillis());
+            currentDeploy.setStart_date(now.minusHours(26).getMillis());
+            newDeploy.setStart_date(now.minusHours(25).getMillis());
+            AutoPromoter promoter = new AutoPromoter(context);
+            PromoteResult
+                result =
+                promoter.computePromoteDeployResult(environBean, currentDeploy, 1, promoteBean);
+            Assert.assertEquals(PromoteResult.ResultCode.PromoteDeploy, result.getResult());
+            promoteBean.setDelay(1 + (int) (now.getMillis() - newDeploy.getStart_date()) / 60000);
+            result =
+                promoter.computePromoteDeployResult(environBean, currentDeploy, 10, promoteBean);
+            Assert.assertEquals(PromoteResult.ResultCode.NoCandidateWithinDelayPeriod,
+                result.getResult());
         }
-    );
-
-    if (now.getHourOfDay()>=9 && now.getHourOfDay()<=17) {
-      prevDeploy.setStart_date(now.minusHours(25).getMillis());
-      currentDeploy.setStart_date(now.minusHours(24).getMillis());
-      newDeploy.setStart_date(now.minusHours(now.getHourOfDay()).getMillis());
-      AutoPromoter promoter = new AutoPromoter(context);
-      PromoteResult result = promoter.computePromoteDeployResult(environBean, currentDeploy, 1, promoteBean);
-      Assert.assertEquals(PromoteResult.ResultCode.PromoteDeploy, result.getResult());
-
-      promoteBean.setDelay(1+(int)(now.getMillis() - newDeploy.getStart_date())/60000);
-      result = promoter.computePromoteDeployResult(environBean, currentDeploy, 1, promoteBean);
-      Assert.assertEquals(PromoteResult.ResultCode.NoCandidateWithinDelayPeriod, result.getResult());
 
     }
-    else{
-      prevDeploy.setStart_date(now.minusHours(27).getMillis());
-      currentDeploy.setStart_date(now.minusHours(26).getMillis());
-      newDeploy.setStart_date(now.minusHours(25).getMillis());
-      AutoPromoter promoter = new AutoPromoter(context);
-      PromoteResult result = promoter.computePromoteDeployResult(environBean, currentDeploy, 1, promoteBean);
-      Assert.assertEquals(PromoteResult.ResultCode.PromoteDeploy, result.getResult());
-      promoteBean.setDelay(1+(int)(now.getMillis() - newDeploy.getStart_date())/60000);
-      result = promoter.computePromoteDeployResult(environBean, currentDeploy, 10, promoteBean);
-      Assert.assertEquals(PromoteResult.ResultCode.NoCandidateWithinDelayPeriod, result.getResult());
-    }
 
-  }
+    @Test
+    public void testScheduledPromote2() throws Exception {
+        DateTime now = DateTime.now();
+        PromoteBean promoteBean = new PromoteBean();
+        promoteBean.setSchedule(CronWorkTimePerDay);
+        promoteBean.setPred_stage("pred");
+        promoteBean.setDelay(10); //minutes
+
+        predEnvironBean.setDeploy_id("deploy1");
+        DeployBean prevDeploy = new DeployBean();
+        prevDeploy.setDeploy_id("deploy1");
+        prevDeploy.setEnv_id(predEnvironBean.getEnv_id());
+
+        BuildBean newBuild = new BuildBean();
+        newBuild.setBuild_name("buildname");
+        newBuild.setBuild_id("newBuild");
+        when(buildDAO.getBuildsFromIds(new HashSet<>(Arrays.asList("newBuild"))))
+            .thenReturn(Arrays.asList(newBuild));
+
+        DeployBean newDeploy = new DeployBean();
+        newDeploy.setDeploy_id("newDeploy");
+        newDeploy.setBuild_id("newBuild");
+        newDeploy.setEnv_id(predEnvironBean.getEnv_id());
+
+        DeployBean currentDeploy = new DeployBean();
+        currentDeploy.setDeploy_id("deploy2");
+        currentDeploy.setFrom_deploy("deploy1");
+
+        allDeployBeans.addAll(Arrays.asList(prevDeploy, newDeploy));
+
+        when(environDAO.getByStage(environBean.getEnv_name(), "pred")).thenReturn(predEnvironBean);
+        when(deployDAO.getById(prevDeploy.getDeploy_id())).thenReturn(prevDeploy);
+        when(deployDAO.getById(newDeploy.getDeploy_id())).thenReturn(newDeploy);
+        when(deployDAO.getAcceptedDeploys(anyString(), anyObject(), anyInt())).thenAnswer(
+            new Answer<List<DeployBean>>() {
+                @Override
+                public List<DeployBean> answer(InvocationOnMock invocationOnMock) throws Throwable {
+                    return getAcceptedDeploysDelayed((String) invocationOnMock.getArguments()[0],
+                        (Interval) invocationOnMock.getArguments()[1]);
+                }
+            }
+        );
+
+        if (now.getHourOfDay() >= 9 && now.getHourOfDay() <= 17) {
+            prevDeploy.setStart_date(now.minusHours(25).getMillis());
+            currentDeploy.setStart_date(now.minusHours(24).getMillis());
+            newDeploy.setStart_date(now.minusHours(now.getHourOfDay()).getMillis());
+            AutoPromoter promoter = new AutoPromoter(context);
+            PromoteResult
+                result =
+                promoter.computePromoteDeployResult(environBean, currentDeploy, 1, promoteBean);
+            Assert.assertEquals(PromoteResult.ResultCode.PromoteDeploy, result.getResult());
+
+            promoteBean.setDelay(1 + (int) (now.getMillis() - newDeploy.getStart_date()) / 60000);
+            result =
+                promoter.computePromoteDeployResult(environBean, currentDeploy, 1, promoteBean);
+            Assert.assertEquals(PromoteResult.ResultCode.NoCandidateWithinDelayPeriod,
+                result.getResult());
+
+        } else {
+            prevDeploy.setStart_date(now.minusHours(27).getMillis());
+            currentDeploy.setStart_date(now.minusHours(26).getMillis());
+            newDeploy.setStart_date(now.minusHours(25).getMillis());
+            AutoPromoter promoter = new AutoPromoter(context);
+            PromoteResult
+                result =
+                promoter.computePromoteDeployResult(environBean, currentDeploy, 1, promoteBean);
+            Assert.assertEquals(PromoteResult.ResultCode.PromoteDeploy, result.getResult());
+            promoteBean.setDelay(1 + (int) (now.getMillis() - newDeploy.getStart_date()) / 60000);
+            result =
+                promoter.computePromoteDeployResult(environBean, currentDeploy, 10, promoteBean);
+            Assert.assertEquals(PromoteResult.ResultCode.NoCandidateWithinDelayPeriod,
+                result.getResult());
+        }
+
+    }
 
 }


### PR DESCRIPTION
In some scenario, we have users apply good tags on every build and it may add bad tag to the same build later. The change tries to make this handling be more sane.
1. When computing a build is good or bad, only look at the most recent 1000 tags
2. If one commit have multiple tags, use the latest created one