### PR TITLE
change HostBean can_retire type (db schema is already TINYINT(1)), an…

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/HostBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/HostBean.java
@@ -56,7 +56,7 @@ public class HostBean implements Updatable {
     private HostState state;
 
     @JsonProperty("canRetire")
-    private Boolean can_retire;
+    private Integer can_retire;
 
     public String getHost_name() {
         return host_name;
@@ -114,11 +114,11 @@ public class HostBean implements Updatable {
         this.state = state;
     }
 
-    public Boolean getCan_retire() {
+    public Integer getCan_retire() {
         return can_retire;
     }
 
-    public void setCan_retire(Boolean can_retire) {
+    public void setCan_retire(Integer can_retire) {
         this.can_retire = can_retire;
     }
 

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/db/DBDAOTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/db/DBDAOTest.java
@@ -763,7 +763,7 @@ public class DBDAOTest {
         hostBean6.setCreate_date(currentTime);
         hostBean6.setLast_update(currentTime);
         hostBean6.setState(HostState.ACTIVE);
-        hostBean6.setCan_retire(true);
+        hostBean6.setCan_retire(1);
         hostDAO.insert(hostBean6);
 
         hostBean6.setHost_name("i-12");
@@ -777,7 +777,7 @@ public class DBDAOTest {
         hostBean7.setCreate_date(currentTime);
         hostBean7.setLast_update(currentTime);
         hostBean7.setState(HostState.TERMINATING);
-        hostBean7.setCan_retire(true);
+        hostBean7.setCan_retire(1);
         hostDAO.insert(hostBean7);
 
         Collection<String>


### PR DESCRIPTION
1. change HostBean can_retire type (db schema is already TINYINT(1))
2. the UI can not rely `cluster capacity count` on capacity field of clusterBean, need AWS query for ASG summary.