### PR TITLE
availability_zone aware deploy

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/DeployConstraintBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/DeployConstraintBean.java
@@ -9,6 +9,7 @@ import org.apache.commons.lang.builder.ReflectionToStringBuilder;
  * constraint_id     VARCHAR(22)         NOT NULL,
  * constraint_key    VARCHAR(64)         NOT NULL
  * max_parallel      BIGINT              NOT NULL,
+ * inclusive         TINYINT(1)          NOT NULL DEFAULT 0,
  * state             VARCHAR(32)         NOT NULL,
  * start_date        BIGINT              NOT NULL,
  * last_update       BIGINT,
@@ -24,6 +25,9 @@ public class DeployConstraintBean implements Updatable {
 
     @JsonProperty("maxParallel")
     private Long max_parallel;
+
+    @JsonProperty("inclusive")
+    private Boolean inclusive;
 
     @JsonProperty("state")
     private TagSyncState state;
@@ -58,6 +62,14 @@ public class DeployConstraintBean implements Updatable {
         this.max_parallel = max_parallel;
     }
 
+    public Boolean getInclusive() {
+        return inclusive;
+    }
+
+    public void setInclusive(Boolean inclusive) {
+        this.inclusive = inclusive;
+    }
+
     public TagSyncState getState() {
         return state;
     }
@@ -88,6 +100,7 @@ public class DeployConstraintBean implements Updatable {
         clause.addColumn("constraint_id", constraint_id);
         clause.addColumn("constraint_key", constraint_key);
         clause.addColumn("max_parallel", max_parallel);
+        clause.addColumn("inclusive", inclusive);
         clause.addColumn("state", state);
         clause.addColumn("start_date", start_date);
         clause.addColumn("last_update", last_update);

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/HostTagBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/HostTagBean.java
@@ -21,11 +21,12 @@ import org.apache.commons.lang.builder.ReflectionToStringBuilder;
 /**
  * Keep the bean and table in sync
  * CREATE TABLE host_tags (
- * host_id         VARCHAR(64)         NOT NULL,
- * env_id          VARCHAR(22)         NOT NULL,
- * tag_name        VARCHAR(64)         NOT NULL,
- * tag_value       VARCHAR(256),
- * create_date     BIGINT              NOT NULL,
+ * host_id          VARCHAR(64)         NOT NULL,
+ * env_id           VARCHAR(22)         NOT NULL,
+ * tag_name         VARCHAR(64)         NOT NULL,
+ * tag_value        VARCHAR(256),
+ * parent_tag_value VARCHAR(256),
+ * create_date      BIGINT              NOT NULL,
  * PRIMARY KEY    (host_id, tag_name)
  * );
  */
@@ -35,6 +36,7 @@ public class HostTagBean implements Updatable {
             "env_id=VALUES(env_id)," +
             "tag_name=VALUES(tag_name)," +
             "tag_value=VALUES(tag_value)," +
+            "parent_tag_value=VALUES(parent_tag_value)," +
             "create_date=VALUES(create_date)";
     @JsonProperty("hostId")
     private String host_id;
@@ -44,6 +46,8 @@ public class HostTagBean implements Updatable {
     private String tag_name;
     @JsonProperty("tagValue")
     private String tag_value;
+    @JsonProperty("parentTagValue")
+    private String parent_tag_value;
     @JsonProperty("createDate")
     private Long create_date;
 
@@ -71,6 +75,14 @@ public class HostTagBean implements Updatable {
         this.tag_value = tag_value;
     }
 
+    public String getParent_tag_value() {
+        return parent_tag_value;
+    }
+
+    public void setParent_tag_value(String parent_tag_value) {
+        this.parent_tag_value = parent_tag_value;
+    }
+
     public Long getCreate_date() {
         return create_date;
     }
@@ -94,6 +106,7 @@ public class HostTagBean implements Updatable {
         clause.addColumn("env_id", env_id);
         clause.addColumn("tag_name", tag_name);
         clause.addColumn("tag_value", tag_value);
+        clause.addColumn("parent_tag_value", parent_tag_value);
         clause.addColumn("create_date", create_date);
         return clause;
     }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/AgentDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/AgentDAO.java
@@ -80,6 +80,8 @@ public interface AgentDAO {
 
     long countDeployingAgentWithHostTag(String envId, String tagName, String tagValue) throws Exception;
 
+    long countFinishedAgentsByDeployWithHostTag(String envId, String deployId, String tagName, String tagValue) throws Exception;
+
     // return how many hosts that are deployed
     long countDeployedHosts() throws Exception;
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostTagDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostTagDAO.java
@@ -27,6 +27,8 @@ public interface HostTagDAO {
 
     UpdateStatement genInsertOrUpdate(HostTagBean hostTagBean);
 
+    UpdateStatement genUpdateParentTagStatement(String parentTagValue, String envId, String tagName, String tagValue) throws Exception;
+
     HostTagBean get(String hostId, String key) throws Exception;
 
     void deleteAllByEnvId(String envId, String tagName) throws Exception;
@@ -40,4 +42,8 @@ public interface HostTagDAO {
     List<HostTagInfo> getHostsByEnvIdAndTagName(String envId, String tagName) throws Exception;
 
     List<HostTagInfo> getHostsByEnvId(String envId) throws Exception;
+
+    long countHostsByEnvIdAndTag(String envId, String tagName, String tagValue) throws Exception;
+
+    List<String> getUniqueTagValuesByEnvIdAndTagName(String envId, String tagName) throws Exception;
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBAgentDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBAgentDAOImpl.java
@@ -80,6 +80,10 @@ public class DBAgentDAOImpl implements AgentDAO {
     private static final String COUNT_SERVING_AND_NORMAL_TOTAL = "SELECT COUNT(*) FROM agents WHERE env_id=? AND deploy_stage=? AND state=?";
     private static final String COUNT_FINISHED_AGENTS_BY_DEPLOY =
         "SELECT COUNT(*) FROM agents WHERE deploy_id=? AND (deploy_stage='SERVING_BUILD' OR state='PAUSED_BY_USER' OR state='PAUSED_BY_SYSTEM')";
+    private static final String COUNT_FINISHED_AGENTS_BY_DEPLOY_WITH_HOST_TAG =
+        "SELECT COUNT(*) FROM agents INNER JOIN host_tags ON host_tags.host_id = agents.host_id " +
+            "WHERE agents.env_id=? AND host_tags.env_id=? AND agents.deploy_id=? AND (agents.deploy_stage='SERVING_BUILD' OR agents.state='PAUSED_BY_USER' OR agents.state='PAUSED_BY_SYSTEM') " +
+        "AND host_tags.tag_name = ? AND host_tags.tag_value = ?";
     private static final String COUNT_AGENTS_BY_DEPLOY =
         "SELECT COUNT(*) FROM agents WHERE deploy_id=?";
     private static final String COUNT_ALL_DEPLOYED_HOSTS =
@@ -255,6 +259,13 @@ public class DBAgentDAOImpl implements AgentDAO {
     public long countDeployingAgentWithHostTag(String envId, String tagName, String tagValue) throws Exception {
         Long n = new QueryRunner(dataSource).query(GET_DEPLOYING_TOTAL_WITH_HOST_TAG,
             SingleResultSetHandlerFactory.<Long>newObjectHandler(), envId, envId, DeployStage.SERVING_BUILD.toString(), 0, tagName, tagValue);
+        return n == null ? 0 : n;
+    }
+
+    @Override
+    public long countFinishedAgentsByDeployWithHostTag(String envId, String deployId, String tagName, String tagValue) throws Exception {
+        Long n = new QueryRunner(dataSource).query(COUNT_FINISHED_AGENTS_BY_DEPLOY_WITH_HOST_TAG,
+            SingleResultSetHandlerFactory.<Long>newObjectHandler(), envId, envId, deployId, tagName, tagValue);
         return n == null ? 0 : n;
     }
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/DefaultRodimusManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/DefaultRodimusManager.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
 
 public class DefaultRodimusManager implements RodimusManager {
 
@@ -39,6 +40,11 @@ public class DefaultRodimusManager implements RodimusManager {
 
     @Override
     public Map<String, Map<String, String>> getEc2Tags(Collection<String> hostIds) throws Exception {
-        return new HashMap<String, Map<String, String>>();
+        return new HashMap<>();
+    }
+
+    @Override
+    public Map<String, List<String>> getAvailabilityZones(Collection<String> hostIds) throws Exception {
+        return new HashMap<>();
     }
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/RodimusManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/RodimusManager.java
@@ -17,6 +17,7 @@ package com.pinterest.deployservice.rodimus;
 
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 public interface RodimusManager {
@@ -27,4 +28,6 @@ public interface RodimusManager {
     Long getClusterInstanceLaunchGracePeriod(String clusterName) throws Exception;
 
     Map<String, Map<String, String>> getEc2Tags(Collection<String> hostIds) throws Exception;
+
+    Map<String, List<String>> getAvailabilityZones(Collection<String> hostIds) throws Exception;
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/RodimusManagerImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/RodimusManagerImpl.java
@@ -34,6 +34,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
 
 public class RodimusManagerImpl implements RodimusManager {
     private static final Logger LOG = LoggerFactory.getLogger(RodimusManagerImpl.class);
@@ -110,5 +111,12 @@ public class RodimusManagerImpl implements RodimusManager {
         String url = String.format("%s/v1/host_ec2tags", rodimusUrl);
         String res = httpClient.post(url, gson.toJson(hostIds), headers, RETRIES);
         return gson.fromJson(res, new TypeToken<Map<String, Map<String, String>>>(){}.getType());
+    }
+
+    @Override
+    public Map<String, List<String>> getAvailabilityZones(Collection<String> hostIds) throws Exception {
+        String url = String.format("%s/v1/host_availability_zones", rodimusUrl);
+        String res = httpClient.post(url, gson.toJson(hostIds), headers, RETRIES);
+        return gson.fromJson(res, new TypeToken<Map<String, List<String>>>(){}.getType());
     }
 }

--- a/deploy-service/common/src/main/resources/sql/deploy.sql
+++ b/deploy-service/common/src/main/resources/sql/deploy.sql
@@ -131,6 +131,7 @@ CREATE TABLE IF NOT EXISTS host_tags (
     env_id         VARCHAR(22)         NOT NULL,
     tag_name       VARCHAR(64)         NOT NULL,
     tag_value      VARCHAR(256),
+    parent_tag_value VARCHAR(256),
     create_date     BIGINT              NOT NULL,
     PRIMARY KEY    (host_id, env_id, tag_name)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
@@ -141,6 +142,7 @@ CREATE TABLE IF NOT EXISTS deploy_constraints (
   constraint_id     VARCHAR(22)         NOT NULL,
   constraint_key    VARCHAR(64)         NOT NULL,
   max_parallel      BIGINT              NOT NULL,
+  inclusive         TINYINT(1)          NOT NULL DEFAULT 0,
   state             VARCHAR(32)         NOT NULL,
   start_date        BIGINT              NOT NULL,
   last_update       BIGINT,

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanService.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanService.java
@@ -122,6 +122,9 @@ public class TeletraanService extends Application<TeletraanServiceConfiguration>
         DeployConstraints deployConstraints = new DeployConstraints(context);
         environment.jersey().register(deployConstraints);
 
+        EnvHostAZs envHostAZs = new EnvHostAZs(context);
+        environment.jersey().register(envHostAZs);
+
         Hotfixs hotfixes = new Hotfixs(context);
         environment.jersey().register(hotfixes);
 

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/DeployConstraints.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/DeployConstraints.java
@@ -86,6 +86,10 @@ public class DeployConstraints {
         if (tagName != null) {
             updateBean.setConstraint_key(tagName);
         }
+        boolean inclusive = deployConstraintBean.getInclusive();
+        if(inclusive) {
+            updateBean.setInclusive(true);
+        }
 
         List<UpdateStatement> statements = new ArrayList<>();
         if (constraintId == null) {

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvHostAZs.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvHostAZs.java
@@ -1,0 +1,102 @@
+package com.pinterest.teletraan.resource;
+
+import com.google.common.base.Optional;
+import com.pinterest.deployservice.bean.*;
+import com.pinterest.deployservice.dao.EnvironDAO;
+import com.pinterest.deployservice.dao.HostDAO;
+import com.pinterest.deployservice.dao.HostTagDAO;
+import com.pinterest.deployservice.rodimus.RodimusManager;
+import com.pinterest.teletraan.TeletraanServiceContext;
+import com.pinterest.teletraan.security.Authorizer;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.SwaggerDefinition;
+import io.swagger.annotations.Tag;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.SecurityContext;
+import java.util.*;
+
+
+@Path("/v1/envs/{envName : [a-zA-Z0-9\\-_]+}/{stageName : [a-zA-Z0-9\\-_]+}/host_availability_zones")
+@Api(tags = "Hosts Availability Zones")
+@SwaggerDefinition(
+    tags = {
+        @Tag(name = "Host Availability Zones", description = "Host Availability Zones related APIs"),
+    }
+)
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class EnvHostAZs {
+    public static final String AVAILABILITY_ZONE_RESERVED_TAG_NAME = "availability_zone";
+
+    private static final Logger LOG = LoggerFactory.getLogger(EnvHostAZs.class);
+    private HostTagDAO hostTagDAO;
+    private EnvironDAO environDAO;
+    private HostDAO hostDAO;
+    private final RodimusManager rodimusManager;
+    private Authorizer authorizer;
+
+    public EnvHostAZs(TeletraanServiceContext context) {
+        hostDAO = context.getHostDAO();
+        hostTagDAO = context.getHostTagDAO();
+        environDAO = context.getEnvironDAO();
+        authorizer = context.getAuthorizer();
+        rodimusManager = context.getRodimusManager();
+    }
+    @GET
+    @ApiOperation(
+        value = "List all the hosts tags",
+        notes = "Returns a map group by tagValue and hosts tagged with tagName:tagValue in an environment",
+        response = HostTagInfo.class, responseContainer = "Collection")
+    public Collection<HostTagInfo> get(@PathParam("envName") String envName,
+                                       @PathParam("stageName") String stageName,
+                                       @QueryParam("ec2AZs") Optional<Boolean> ec2AZs,
+                                       @Context SecurityContext sc) throws Exception {
+        EnvironBean envBean = Utils.getEnvStage(environDAO, envName, stageName);
+        authorizer.authorize(sc, new Resource(envBean.getEnv_name(), Resource.Type.ENV), Role.OPERATOR);
+
+        Boolean loadEC2AZs = ec2AZs.or(false);
+        if (loadEC2AZs) {
+            // read ec2 tags from CMDB
+            return remoteQueryHostAZs(envBean);
+        }
+        return hostTagDAO.getHostsByEnvId(envBean.getEnv_id());
+    }
+
+
+    private Collection<HostTagInfo> remoteQueryHostAZs(EnvironBean environBean) throws Exception {
+        Collection<HostBean> hostsByEnvId = hostDAO.getHostsByEnvId(environBean.getEnv_id());
+        Map<String, String> hostId2HostName = new HashMap<String, String>();
+        for (HostBean hostBean : hostsByEnvId) {
+            if (hostBean.getHost_id() != null) {
+                hostId2HostName.put(hostBean.getHost_id(), hostBean.getHost_name());
+            }
+        }
+        Set<String> hostIds = hostId2HostName.keySet();
+        LOG.info(String.format("Env %s start get all availability zone tags for host_ids %s", environBean.getEnv_id(), hostIds));
+        Map<String, List<String>> az2HostIdsMap = rodimusManager.getAvailabilityZones(hostIds);
+        LOG.info(String.format("Env %s host availability zone tags results: %s", environBean.getEnv_id(), az2HostIdsMap));
+
+        Collection<HostTagInfo> rs = new ArrayList<>();
+        if (az2HostIdsMap != null) {
+            for (String az : az2HostIdsMap.keySet()) {
+                List<String> sameAZHostIds = az2HostIdsMap.get(az);
+                for(String hostId: sameAZHostIds) {
+                    HostTagInfo hostTagInfo = new HostTagInfo();
+                    hostTagInfo.setHostId(hostId);
+                    hostTagInfo.setHostName(hostId2HostName.get(hostId));
+                    hostTagInfo.setTagValue(az);
+                    hostTagInfo.setTagName(AVAILABILITY_ZONE_RESERVED_TAG_NAME);
+                    rs.add(hostTagInfo);
+                }
+            }
+        }
+        return rs;
+
+    }
+}

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvHostTags.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvHostTags.java
@@ -52,7 +52,7 @@ public class EnvHostTags {
     @GET
     @ApiOperation(
         value = "List all the hosts tags",
-        notes = "Returns a map group by tagValue and hosts tagged with tagName:tagValue in an environment",
+        notes = "Returns a list the host tags in an environment",
         response = HostTagInfo.class)
     public Collection<HostTagInfo> get(@PathParam("envName") String envName,
                                                     @PathParam("stageName") String stageName,

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/DeployTagWorker.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/DeployTagWorker.java
@@ -14,6 +14,8 @@ import org.slf4j.LoggerFactory;
 import java.sql.Connection;
 import java.util.*;
 
+import static com.pinterest.teletraan.resource.EnvHostAZs.AVAILABILITY_ZONE_RESERVED_TAG_NAME;
+
 public class DeployTagWorker implements Runnable {
     private static final Logger LOG = LoggerFactory.getLogger(DeployTagWorker.class);
     private static final int MAX_QUERY_TAGS_SIZE = 200;
@@ -35,6 +37,31 @@ public class DeployTagWorker implements Runnable {
         dataSource = serviceContext.getDataSource();
         utilDAO = serviceContext.getUtilDAO();
     }
+    
+    private void updateParentTagValue(DeployConstraintBean bean, String envId) throws Exception {
+        String tagName = bean.getConstraint_key();
+        // needs to update parent tag
+        List<UpdateStatement> statements = new ArrayList<>();
+        // 1. get all host tags tagged by tagName
+        List<String> uniqueTagValues = hostTagDAO.getUniqueTagValuesByEnvIdAndTagName(envId, tagName);
+        
+        // 2. the 1st tag's parent tag is itself
+        int totalUniqueTagValues = uniqueTagValues.size();
+        String childTagValue = uniqueTagValues.get(0);
+        String parentTagValue = uniqueTagValues.get(0);
+        
+        // 3. from 2nd tag, tag's parent tag is index-1
+        statements.add(hostTagDAO.genUpdateParentTagStatement(parentTagValue, envId, tagName, childTagValue));
+        if(totalUniqueTagValues > 1) {
+            for(int i = 1; i < totalUniqueTagValues; i++) {
+                childTagValue = uniqueTagValues.get(i);
+                parentTagValue = uniqueTagValues.get(i-1);
+                statements.add(hostTagDAO.genUpdateParentTagStatement(parentTagValue, envId, tagName, childTagValue));
+            }
+        }
+        LOG.info(String.format("Env %s host parent tags have been updated with %s", envId, uniqueTagValues));
+        DatabaseUtil.transactionalUpdate(dataSource, statements);
+    }
 
 
     private void processEachEnvironConstraint(DeployConstraintBean bean) throws Exception {
@@ -52,6 +79,11 @@ public class DeployTagWorker implements Runnable {
         List<String> extras = new ArrayList(CollectionUtils.subtract(envHostIdsWithHostTag, envHostIds));
         if (missings.size() == 0 && extras.size() == 0) {
             LOG.info(String.format("Env %s host tag is in sync", envId));
+            if(bean.getInclusive()) {
+                // inclusive deploy constraint, needs to update parent tag
+                updateParentTagValue(bean, envId);
+            }
+            
             if(bean.getState() != TagSyncState.FINISHED) {
                 bean.setLast_update(System.currentTimeMillis());
                 bean.setState(TagSyncState.FINISHED);
@@ -83,28 +115,51 @@ public class DeployTagWorker implements Runnable {
             for(int i = 0; i < missings.size(); i += MAX_QUERY_TAGS_SIZE) {
                 Collection<String> oneBatch = missings.subList(i, Math.min(i + MAX_QUERY_TAGS_SIZE, missings.size()));
                 LOG.info(String.format("Env %s start get ec2 tags %s for host_ids %s", envId, tagName, oneBatch));
-                Map<String, Map<String, String>> hostMissingEc2Tags = rodimusManager.getEc2Tags(oneBatch);
-                LOG.info(String.format("Env %s host ec2 tags %s results: %s", envId, tagName, hostMissingEc2Tags));
-                if (hostMissingEc2Tags == null) {
-                    continue;
-                }
-                for (String hostId : hostMissingEc2Tags.keySet()) {
-                    Map<String, String> ec2Tags = hostMissingEc2Tags.get(hostId);
-                    if (ec2Tags == null) {
+                if(tagName.equals(AVAILABILITY_ZONE_RESERVED_TAG_NAME)) {
+                    Map<String, List<String>> hostMissingAZTags = rodimusManager.getAvailabilityZones(oneBatch);
+                    LOG.info(String.format("Env %s host availability zones %s results: %s", envId, tagName, hostMissingAZTags));
+                    if(hostMissingAZTags == null) {
                         continue;
                     }
-                    if (ec2Tags.containsKey(tagName)) {
-                        String tagValue = ec2Tags.get(tagName);
-                        if (tagValue == null) {
+                    for(String az: hostMissingAZTags.keySet()) {
+                        List<String> sameAZHostIds = hostMissingAZTags.get(az);
+                        if(sameAZHostIds == null) {
                             continue;
                         }
-                        HostTagBean hostTagBean = new HostTagBean();
-                        hostTagBean.setHost_id(hostId);
-                        hostTagBean.setTag_name(tagName);
-                        hostTagBean.setTag_value(tagValue);
-                        hostTagBean.setEnv_id(envId);
-                        hostTagBean.setCreate_date(System.currentTimeMillis());
-                        statements.add(hostTagDAO.genInsertOrUpdate(hostTagBean));
+                        for(String hostId: sameAZHostIds) {
+                            HostTagBean hostTagBean = new HostTagBean();
+                            hostTagBean.setHost_id(hostId);
+                            hostTagBean.setTag_name(tagName);
+                            hostTagBean.setTag_value(az);
+                            hostTagBean.setEnv_id(envId);
+                            hostTagBean.setCreate_date(System.currentTimeMillis());
+                            statements.add(hostTagDAO.genInsertOrUpdate(hostTagBean));
+                        }
+                    }
+                } else {
+                    Map<String, Map<String, String>> hostMissingEc2Tags = rodimusManager.getEc2Tags(oneBatch);
+                    LOG.info(String.format("Env %s host ec2 tags %s results: %s", envId, tagName, hostMissingEc2Tags));
+                    if (hostMissingEc2Tags == null) {
+                        continue;
+                    }
+                    for (String hostId : hostMissingEc2Tags.keySet()) {
+                        Map<String, String> ec2Tags = hostMissingEc2Tags.get(hostId);
+                        if (ec2Tags == null) {
+                            continue;
+                        }
+                        if (ec2Tags.containsKey(tagName)) {
+                            String tagValue = ec2Tags.get(tagName);
+                            if (tagValue == null) {
+                                continue;
+                            }
+                            HostTagBean hostTagBean = new HostTagBean();
+                            hostTagBean.setHost_id(hostId);
+                            hostTagBean.setTag_name(tagName);
+                            hostTagBean.setTag_value(tagValue);
+                            hostTagBean.setEnv_id(envId);
+                            hostTagBean.setCreate_date(System.currentTimeMillis());
+                            statements.add(hostTagDAO.genInsertOrUpdate(hostTagBean));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This commit extends the deploy constraint functionality from tag-aware to availability_zone-aware deploy, though different in:
 tag-aware choose X number of hosts from each tag groups, and deploy in parallel.
 az-aware choose X number of hosts from one group only, and deploy group by group.


![screen shot 2018-02-22 at 4 37 12 pm](https://user-images.githubusercontent.com/24964493/36572215-506cead0-17ef-11e8-878f-4fb18316c447.png)
 
in this example deploy in order of:  us-east-1c -> us-east-1a -> us-east-1d