### PR TITLE
host can be chose to another stage, exclude such host for current stage deployment

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostDAO.java
@@ -72,4 +72,6 @@ public interface HostDAO {
     Collection<String> getNewHostIdsByGroup(String groupName) throws Exception;
 
     Collection<String> getFailedHostIdsByGroup(String groupName) throws Exception;
+
+    Collection<String> getExcludedHostsFromEnvByEnvId(String envId) throws Exception;
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostDAOImpl.java
@@ -69,6 +69,9 @@ public class DBHostDAOImpl implements HostDAO {
             "GROUP BY x.host_id HAVING count(*) = (SELECT count(*) FROM agents y WHERE y.host_id = x.host_id)";
     private static final String GET_NEW_HOSTIDS_BY_GROUP = "SELECT DISTINCT host_id FROM hosts WHERE can_retire=0 AND group_name=? AND state not in (?,?)";
 
+    private static final String GET_HOSTS_EXCLUDED_FROM_ENV_BY_ENVID = "SELECT host_name FROM hosts_and_envs WHERE host_name IN " +
+        "(SELECT host_name FROM hosts h INNER JOIN groups_and_envs ge ON ge.group_name = h.group_name WHERE ge.env_id=?) and env_id != ? ";
+
     private BasicDataSource dataSource;
 
     public DBHostDAOImpl(BasicDataSource dataSource) {
@@ -269,5 +272,11 @@ public class DBHostDAOImpl implements HostDAO {
                 SingleResultSetHandlerFactory.<String>newListObjectHandler(), groupName,
                 HostState.PENDING_TERMINATE.toString(), HostState.TERMINATING.toString(),
                 AgentStatus.UNKNOWN.toString(), AgentStatus.SUCCEEDED.toString());
+    }
+
+    @Override
+    public Collection<String> getExcludedHostsFromEnvByEnvId(String envId) throws Exception {
+        return new QueryRunner(dataSource).query(GET_HOSTS_EXCLUDED_FROM_ENV_BY_ENVID,
+            SingleResultSetHandlerFactory.<String>newListObjectHandler(), envId, envId);
     }
 }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/DeployTagWorker.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/DeployTagWorker.java
@@ -42,6 +42,19 @@ public class DeployTagWorker implements Runnable {
         String tagName = bean.getConstraint_key();
         String envId = environBean.getEnv_id();
         Collection<HostBean> hostBeans = hostDAO.getHostsByEnvId(envId);
+        Collection<String> excludedHostNames = hostDAO.getExcludedHostsFromEnvByEnvId(envId);
+        if(excludedHostNames != null && excludedHostNames.size() > 0) {
+            Set<String> excludedHostNameSet = new HashSet<>(excludedHostNames);
+            Collection<HostBean> filteredHostBeans = new ArrayList<>();
+            for(HostBean hostBean: hostBeans) {
+                String hostName = hostBean.getHost_name();
+                if(hostName != null && !excludedHostNameSet.contains(hostName)) {
+                    filteredHostBeans.add(hostBean);
+                }
+            }
+            hostBeans = filteredHostBeans;
+        }
+
         Collection<HostTagBean> hostTagBeans = hostTagDAO.getAllByEnvIdAndTagName(envId, tagName);
 
 


### PR DESCRIPTION
we found a bug in AZ aware deploy that prod stage deployment waits for the host that belong to canary stage. (waiting forever for a host that doesnt belong to current deployment stage)

this fix excludes such hosts, and sync host tags with the filtered result