### PR TITLE
Fix stray space

### DIFF
--- a/deploy-board/deploy_board/templates/configs/config_map.tmpl
+++ b/deploy-board/deploy_board/templates/configs/config_map.tmpl
@@ -10,7 +10,7 @@
                     <div class="col-xs-6">
                         <textarea class="form-control" name="TELETRAAN_{{ key }}"
                         rows="1" style="resize: none;"
-                        >{{ value|default_if_none:'' }} </textarea>
+                        >{{ value|default_if_none:'' }}</textarea>
                     </div>
                     <div class="col-xs-3">
                         <button type="button" class="delete_button btn btn-default">Delete</button>


### PR DESCRIPTION
Whenever the config page is loaded, an extra space gets added to these textareas (and it is hard to notice unless you highlight the text). When you hit "Save", this space then gets sent to the backend and can have bad consequences if it is not trimmed properly by the service using the config.