### PR TITLE
Add API for setting external_id on stages

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/EnvironDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/EnvironDAO.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *    
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,6 +32,8 @@ public interface EnvironDAO {
     void update(String envName, String envStage, EnvironBean bean) throws Exception;
 
     void updateAll(EnvironBean bean) throws Exception;
+
+    void setExternalId(EnvironBean bean, String externalId) throws Exception;
 
     UpdateStatement genUpdateStatement(String envId, EnvironBean bean);
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBEnvironDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBEnvironDAOImpl.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *    
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -39,6 +39,8 @@ public class DBEnvironDAOImpl implements EnvironDAO {
         "UPDATE environs SET %s WHERE env_name=? AND stage_name=?";
     private static final String UPDATE_ALL =
         "UPDATE environs SET %s";
+    private static final String SET_EXTERNAL_ID =
+        "UPDATE environs SET external_id=? WHERE env_name=? AND stage_name=?";
     private static final String GET_ENV_BY_ID =
         "SELECT * FROM environs WHERE env_id=?";
     private static final String GET_ENV_BY_NAME =
@@ -133,6 +135,16 @@ public class DBEnvironDAOImpl implements EnvironDAO {
         SetClause setClause = bean.genSetClause();
         String clause = String.format(UPDATE_ALL, setClause.getClause());
         new QueryRunner(dataSource).update(clause, setClause.getValueArray());
+    }
+
+    @Override
+    public void setExternalId(EnvironBean bean, String externalId) throws Exception {
+        ResultSetHandler<EnvironBean> h = new BeanHandler<EnvironBean>(EnvironBean.class);
+        SetClause setClause = bean.genSetClause();
+        String clause = String.format(SET_EXTERNAL_ID, setClause.getClause());
+        String envName = bean.getEnv_name();
+        String stageName = bean.getStage_name();
+        new QueryRunner(dataSource).update(clause, externalId, envName, stageName);
     }
 
     @Override

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanService.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanService.java
@@ -187,6 +187,7 @@ public class TeletraanService extends Application<TeletraanServiceConfiguration>
 
     }
 
+
     public static void main(String[] args) throws Exception {
         new TeletraanService().run(args);
     }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *    
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -112,6 +112,32 @@ public class EnvStages {
         String operator = sc.getUserPrincipal().getName();
         environHandler.deleteEnvStage(envName, stageName, operator);
         LOG.info("Successfully deleted env {}/{} by {}.", envName, stageName, operator);
+    }
+
+    @POST
+    @ApiOperation(
+          value = "Sets the external_id on a stage",
+          notes = "Sets the external_id column on a stage given the environment and stage names",
+          response = EnvironBean.class
+    )
+    @Path("/external_id")
+    public EnvironBean setExternalId(
+            @ApiParam(value = "Environment name", required = true)@PathParam("envName") String envName,
+            @ApiParam(value = "Stage name", required = true)@PathParam("stageName") String stageName,
+            @ApiParam(value="External id", required = true) String externalId)
+            throws Exception {
+
+       EnvironBean originalBean = environDAO.getByStage(envName, stageName);
+       if(originalBean == null) {
+         throw new TeletaanInternalException(Response.Status.NOT_FOUND,
+             String.format("Environment %s/%s does not exist.", envName, stageName));
+       }
+       environDAO.setExternalId(originalBean, externalId);
+       EnvironBean updatedBean = environDAO.getByStage(envName, stageName);
+       String newExternalId = updatedBean.getExternal_id();
+
+       LOG.info("Successfully updated Env/stage - {}/{} with externalid = {}", envName, stageName, newExternalId);
+       return updatedBean;
     }
 
     @POST

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Environs.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Environs.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *    
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.


### PR DESCRIPTION
Summary:
This change allows us to update stages created on Teletraan with a value for external_id. This value will refer to the Nimbus UUID - a canonical identifier across Pinterest resources.

API route is -  `POST /v1/envs/{envName}/{stageName}/external_id`

Reviewers: lidali

Reviewed By: lidali

Differential Revision: https://phabricator.pinadmin.com/D283408