### PR TITLE
Adding timeout to prevent webhook failures

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/HTTPClient.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/HTTPClient.java
@@ -73,7 +73,7 @@ public class HTTPClient {
                 conn = (HttpURLConnection) urlObj.openConnection();
                 conn.setRequestMethod(method);
                 conn.setRequestProperty("Accept-Charset", "UTF-8");
-                conn.setConnectTimeout(15000)
+                conn.setConnectTimeout(15000);
 
                 if (headers != null) {
                     for (Map.Entry<String, String> entry : headers.entrySet()) {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/HTTPClient.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/HTTPClient.java
@@ -73,6 +73,7 @@ public class HTTPClient {
                 conn = (HttpURLConnection) urlObj.openConnection();
                 conn.setRequestMethod(method);
                 conn.setRequestProperty("Accept-Charset", "UTF-8");
+                conn.setConnectTimeout(15000)
 
                 if (headers != null) {
                     for (Map.Entry<String, String> entry : headers.entrySet()) {


### PR DESCRIPTION
If a webhook never returns, it will hang forever and all subsequent webhooks will not be called.  This resolves the issue.