### PR TITLE
fixed the getCommits return too many when use path parameter

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/scm/BaseManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/scm/BaseManager.java
@@ -91,8 +91,8 @@ public abstract class BaseManager implements SourceControlManager {
             CommitBean commit = commits.peek();
             CommitBean referenceCommit = referenceCommits.peek();
 
-            // We find the endSha, let us return
-            if (commit.getSha().equals(referenceCommit.getSha())) {
+            // We find the endSha, or reach the endSha Date, let us return
+            if (commit.getSha().equals(referenceCommit.getSha()) || commit.getDate() <= referenceCommit.getDate()) {
                 return fullCommits;
             }
 


### PR DESCRIPTION
when get commits with a path parameter, the endSHA might not be in the path thus merely checking the equal to endSHA is not correct, need to check the commitDate as well. 

this issue was introduced by a recent feature https://github.com/pinterest/teletraan/commit/3b467452e9fcb15d546b0b161909d13224601b4d