### PR TITLE
Add ability to validate TLS certificate chain for Deploy-Service API calls

### DIFF
--- a/deploy-agent/deployd/client/restfulclient.py
+++ b/deploy-agent/deployd/client/restfulclient.py
@@ -29,6 +29,7 @@ class RestfulClient(object):
         self.url_prefix = config.get_restful_service_url()
         self.url_version = config.get_restful_service_version()
         self.token = config.get_restful_service_token()
+        self.verify = (config.get_verify_https_certificate() == 'True')
         self.default_timeout = 30
 
     def __call(self, method):
@@ -39,7 +40,7 @@ class RestfulClient(object):
             else:
                 headers = {'Content-type': 'application/json'}
             response = getattr(requests, method)(url, headers=headers, params=params, json=data,
-                                                 timeout=self.default_timeout, verify=False)
+                                                 timeout=self.default_timeout, verify=self.verify )
 
             if response.status_code > 300:
                 msg = "Teletraan failed to call backend server. Hint: %s, %s" % (response.status_code, response.content)

--- a/deploy-agent/deployd/common/config.py
+++ b/deploy-agent/deployd/common/config.py
@@ -249,5 +249,5 @@ class Config(object):
         return self.get_var('agent_group_key', None)
     
     def get_verify_https_certificate(self):
-        return self.get_var('verify_https_certificate', False)
+        return self.get_var('verify_https_certificate', 'False')
 

--- a/deploy-agent/deployd/common/config.py
+++ b/deploy-agent/deployd/common/config.py
@@ -248,4 +248,6 @@ class Config(object):
     def get_facter_group_key(self):
         return self.get_var('agent_group_key', None)
     
+    def get_verify_https_certificate(self):
+        return self.get_var('verify_https_certificate', False)
 

--- a/deploy-agent/deployd/conf/agent.conf
+++ b/deploy-agent/deployd/conf/agent.conf
@@ -49,3 +49,6 @@ teletraan_service_url = http://localhost:8080
 teletraan_service_version = v1
 teletraan_service_token =
 
+# Verify the API HTTPS certificate chain
+verify_https_certificate = False
+


### PR DESCRIPTION
Currently, HTTPS/TLS validation for API calls to deploy-service is **turned off** via a hardcoded constant. This PR adds the config ability to enable TLS certificate verification within the global config to prevent MITM attacks etc. 

Default config behavior retains the existing policy of not validating the certificate chain.