### PR TITLE
Add gpg support to deploy-agent

### DIFF
--- a/deploy-agent/deployd/download/downloader.py
+++ b/deploy-agent/deployd/download/downloader.py
@@ -82,7 +82,7 @@ class Downloader(object):
                 dest_full_fn = local_full_fn[:(len(extension) * -1)] + innerExtension
 
                 # decrypt gpg archive
-                gpgHelper.decryptFile(local_full_fn, dest_full_fn)
+                status = gpgHelper.decryptFile(local_full_fn, dest_full_fn)
                 
                 if status != Status.SUCCEEDED:
                     # die if we hit a decryption or signing error

--- a/deploy-agent/deployd/download/downloader.py
+++ b/deploy-agent/deployd/download/downloader.py
@@ -83,6 +83,10 @@ class Downloader(object):
 
                 # decrypt gpg archive
                 gpgHelper.decryptFile(local_full_fn, dest_full_fn)
+                
+                if status != Status.SUCCEEDED:
+                    # die if we hit a decryption or signing error
+                    return status
 
                 # remove encrypted gpg archive since it is no longer needed
                 os.remove(local_full_fn)

--- a/deploy-agent/deployd/download/gpg_helper.py
+++ b/deploy-agent/deployd/download/gpg_helper.py
@@ -1,0 +1,39 @@
+# Copyright 2016 Pinterest, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#  
+#     http://www.apache.org/licenses/LICENSE-2.0
+#    
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import logging
+from deployd.common.config import Config
+from deployd.common.status_code import Status
+from deployd.common.caller import Caller
+
+log = logging.getLogger(__name__)
+
+class gpgHelper(object):
+
+    @staticmethod
+    def decryptFile(source, destination):
+        download_cmd = ['gpg', '--batch', '--yes', '--output', destination, '--decrypt', source]
+        log.info('Running command: {}'.format(' '.join(download_cmd)))
+        error_code = Status.SUCCEEDED
+        output, error, status = Caller.call_and_log(download_cmd, cwd=os.getcwd())
+        if output:
+            log.info(output)
+        if error:
+            log.error(error)
+        if status:
+            error_code = Status.FAILED
+        log.info('Finish decrypting: {} to {}'.format(source, destination))
+        return error_code
+        

--- a/deploy-agent/deployd/download/gpg_helper.py
+++ b/deploy-agent/deployd/download/gpg_helper.py
@@ -32,6 +32,7 @@ class gpgHelper(object):
             log.info(output)
         if error:
             log.error(error)
+            error_code = Status.FAILED
         if status:
             error_code = Status.FAILED
         log.info('Finish decrypting: {} to {}'.format(source, destination))


### PR DESCRIPTION
Currently, build artifacts are stored raw and do not have any signing methods. This means that if a nefarious third party or evil employee gained access to our S3 bucket, they would have the following: 

1. They could view all source code in one place, bypassing any source control ACL groupings that exist. We don't store secrets in our codebase, but it would still be a very bad day/week/month if our source code was leaked. 
2. More importantly, if the third party gained write access, they would be able to modify the artifact. This would be a direct injection point to add code to grab session identities, credit card details, or inject any code (client/serverside) into our stack. This would be a maximum severity exploit and theoretically could take down any service. 

The solution to this issue is to encrypt and sign our code artifacts. One industry standard method is via GPG. 

This PR adds the ability to detect if the archive is contained within a GPG container, and decrypt it before decompressing the archive. This would ensure that:

1. If a user gained access to our archive storage location, they would not be able to view the code unless they had the "deploy-agent side" GPG private key. 
2. If a user gained write access to our archive storage location, there would be no way for them to modify the archives unless they are able to gain a copy of the "build service" GPG private key. 

Overall, this PR ensures that code cannot be tampered with after the build process and is encrypted end to end from build container to end destination.

The PR does not interact with GPG beyond the decrypting process - to maximize portability, it is up to the surrounding orchestration and secret handlers to set up the GPG keychains correctly. 

