### PR TITLE
fix the jackson library conflict

### DIFF
--- a/deploy-service/common/pom.xml
+++ b/deploy-service/common/pom.xml
@@ -174,13 +174,8 @@
             <version>5.1.3.Final</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-            <version>2.8.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-afterburner</artifactId>
             <version>2.8.10</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
this will fix the jackson library conflict after the upgrade to jackson-databind:2.8.11.1 from https://github.com/pinterest/teletraan/pull/620.

in particular, will fix this exception when ping from the deploy-agent:
deploy-service-pinterest_1   | WARN  [2018-11-10 06:10:44,154] org.eclipse.jetty.servlet.ServletHandler:
deploy-service-pinterest_1   | ! java.lang.NoSuchFieldError: _nullProvider
deploy-service-pinterest_1   | ! at com.fasterxml.jackson.module.afterburner.deser.OptimizedSettableBeanProperty._deserializeString(OptimizedSettableBeanProperty.java:161) ~[jackson-module-afterburner-2.5.1.jar:2.5.1]
deploy-service-pinterest_1   | ! at com.fasterxml.jackson.module.afterburner.deser.SettableStringMethodProperty.deserializeAndSet(SettableStringMethodProperty.java:54) ~[jackson-module-afterburner-2.5.1.jar:2.5.1]
deploy-service-pinterest_1   | ! at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:240) ~[jackson-databind-2.8.11.1.jar:2.8.11.1]
deploy-service-pinterest_1   | ! at com.fasterxml.jackson.module.afterburner.deser.SuperSonicBeanDeserializer.deserializeFromObject(SuperSonicBeanDeserializer.java:218) ~[jackson-module-afterburner-2.5.1.jar:2.5.1]
deploy-service-pinterest_1   | ! at com.fasterxml.jackson.module.afterburner.deser.SuperSonicBeanDeserializer.deserialize(SuperSonicBeanDeserializer.java:122) ~[jackson-module-afterburner-2.5.1.jar:2.5.1]
deploy-service-pinterest_1   | ! at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:287) ~[jackson-databind-2.8.11.1.jar:2.8.11.1]
deploy-service-pinterest_1   | ! at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:259) ~[jackson-databind-2.8.11.1.jar:2.8.11.1]
deploy-service-pinterest_1   | ! at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:26) ~[jackson-databind-2.8.11.1.jar:2.8.11.1]
deploy-service-pinterest_1   | ! at com.fasterxml.jackson.databind.deser.SettableBeanProperty.deserialize(SettableBeanProperty.java:504) ~[jackson-databind-2.8.11.1.jar:2.8.11.1]
deploy-service-pinterest_1   | ! at com.fasterxml.jackson.module.afterburner.deser.SettableObjectMethodProperty.deserializeAndSet(SettableObjectMethodProperty.java:52) ~[jackson-module-afterburner-2.5.1.jar:2.5.1]
deploy-service-pinterest_1   | ! at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:240) ~[jackson-databind-2.8.11.1.jar:2.8.11.1]
deploy-service-pinterest_1   | ! at com.fasterxml.jackson.module.afterburner.deser.SuperSonicBeanDeserializer.deserializeFromObject(SuperSonicBeanDeserializer.java:218) ~[jackson-module-afterburner-2.5.1.jar:2.5.1]
deploy-service-pinterest_1   | ! at com.fasterxml.jackson.module.afterburner.deser.SuperSonicBeanDeserializer.deserialize(SuperSonicBeanDeserializer.java:122) ~[jackson-module-afterburner-2.5.1.jar:2.5.1]
deploy-service-pinterest_1   | ! at com.fasterxml.jackson.databind.ObjectReader._bind(ObjectReader.java:1583) ~[jackson-databind-2.8.11.1.jar:2.8.11.1]
deploy-service-pinterest_1   | ! at com.fasterxml.jackson.databind.ObjectReader.readValue(ObjectReader.java:964) ~[jackson-databind-2.8.11.1.jar:2.8.11.1]
deploy-service-pinterest_1   | ! at com.fasterxml.jackson.jaxrs.base.ProviderBase.readFrom(ProviderBase.java:808) ~[jackson-jaxrs-base-2.5.1.jar:2.5.1]
deploy-service-pinterest_1   | ! at io.dropwizard.jersey.jackson.JacksonMessageBodyProvider.readFrom(JacksonMessageBodyProvider.java:60) ~[dropwizard-jersey-0.8.1.jar:0.8.1]