### PR TITLE
address security vulnerabilities: CVE-2018-11771 CVE-2018-18074

### DIFF
--- a/deploy-agent/setup.py
+++ b/deploy-agent/setup.py
@@ -25,7 +25,7 @@ console_scripts = ['deploy-agent = deployd.agent:main',
                    'deploy-stager = deployd.staging.stager:main']
 
 install_requires = [
-    "requests==2.9.1",
+    "requests==2.20.0",
     "gevent==1.0.2",
     "lockfile==0.10.2",
     "boto>=2.39.0",

--- a/deploy-board/requirements.txt
+++ b/deploy-board/requirements.txt
@@ -1,7 +1,7 @@
 Django==1.6.3
 python-dateutil==2.3
 pytz==2014.10
-requests==2.8.1
+requests==2.20.0
 diff-match-patch==20110725.1
 oauthlib==1.0.3
 flake8==2.4.1

--- a/deploy-service/common/pom.xml
+++ b/deploy-service/common/pom.xml
@@ -151,7 +151,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.8</version>
+            <version>1.18</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>


### PR DESCRIPTION
CVE-2018-11771
moderate severity
Vulnerable versions: < 1.18
Patched version: 1.18
When reading a specially crafted ZIP archive, the read method of Apache Commons Compress 1.7 to 1.17's ZipArchiveInputStream can fail to return the correct EOF indication after the end of the stream has been reached. When combined with a java.io.InputStreamReader this can lead to an infinite stream, which can be used to mount a denial of service attack against services that use Compress' zip package.

CVE-2018-18074 
moderate severity
Vulnerable versions: <= 2.19.1
Patched version: 2.20.0
The Requests package through 2.19.1 before 2018-09-14 for Python sends an HTTP Authorization header to an http URI upon receiving a same-hostname https-to-http redirect, which makes it easier for remote attackers to discover credentials by sniffing the network.