### PR TITLE
upgrade jackson-databind to address security vulnerability

### DIFF
--- a/deploy-service/common/pom.xml
+++ b/deploy-service/common/pom.xml
@@ -181,7 +181,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.8.11.1</version>
+            <version>2.8.11.3</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>


### PR DESCRIPTION

Details
CVE-2018-19360 More information
high severity
Vulnerable versions: >= 2.8.0, < 2.8.11.3
Patched version: 2.8.11.3
FasterXML jackson-databind 2.x before 2.9.8 might allow attackers to have unspecified impact by leveraging failure to block the axis2-transport-jms class from polymorphic deserialization.

CVE-2018-14720 More information
high severity
Vulnerable versions: >= 2.8.0, < 2.8.11.3
Patched version: 2.8.11.3
FasterXML jackson-databind 2.x before 2.9.7 might allow attackers to conduct external XML entity (XXE) attacks by leveraging failure to block unspecified JDK classes from polymorphic deserialization.

CVE-2018-14719 More information
high severity
Vulnerable versions: >= 2.8.0, < 2.8.11.3
Patched version: 2.8.11.3
FasterXML jackson-databind 2.x before 2.9.7 might allow remote attackers to execute arbitrary code by leveraging failure to block the blaze-ds-opt and blaze-ds-core classes from polymorphic deserialization.

CVE-2018-14718 More information
high severity
Vulnerable versions: >= 2.8.0, < 2.8.11.3
Patched version: 2.8.11.3
FasterXML jackson-databind 2.x before 2.9.7 might allow remote attackers to execute arbitrary code by leveraging failure to block the slf4j-ext class from polymorphic deserialization.

CVE-2018-19362 More information
high severity
Vulnerable versions: >= 2.8.0, < 2.8.11.3
Patched version: 2.8.11.3
FasterXML jackson-databind 2.x before 2.9.8 might allow attackers to have unspecified impact by leveraging failure to block the jboss-common-core class from polymorphic deserialization.

CVE-2018-14721 More information
high severity
Vulnerable versions: >= 2.8.0, < 2.8.11.3
Patched version: 2.8.11.3
FasterXML jackson-databind 2.x before 2.9.7 might allow remote attackers to conduct server-side request forgery (SSRF) attacks by leveraging failure to block the axis2-jaxws class from polymorphic deserialization.

CVE-2018-19361 More information
high severity
Vulnerable versions: >= 2.8.0, < 2.8.11.3
Patched version: 2.8.11.3
FasterXML jackson-databind 2.x before 2.9.8 might allow attackers to have unspecified impact by leveraging failure to block the openjpa class from polymorphic deserialization.