### PR TITLE
set webhook http read timeout

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/HTTPClient.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/HTTPClient.java
@@ -28,6 +28,7 @@ import java.util.Map;
 
 // A simple HttpURLConnection wrapper
 public class HTTPClient {
+    private static final int TIMEOUT = 15*1000;  // http timeout in 15 seconds
     private static final Logger LOG = LoggerFactory.getLogger(HTTPClient.class);
 
     private String generateUrlAndQuery(String url, Map<String, String> params) throws Exception {
@@ -73,7 +74,8 @@ public class HTTPClient {
                 conn = (HttpURLConnection) urlObj.openConnection();
                 conn.setRequestMethod(method);
                 conn.setRequestProperty("Accept-Charset", "UTF-8");
-                conn.setConnectTimeout(15000);
+                conn.setConnectTimeout(TIMEOUT);
+                conn.setReadTimeout(TIMEOUT);
 
                 if (headers != null) {
                     for (Map.Entry<String, String> entry : headers.entrySet()) {


### PR DESCRIPTION
the http webhook still block in conn.getInputStream() when the connection read is blocked. this set the connection readtimeout to prevent webhook block and subsequently block other normal webhook in the threadpool.