### PR TITLE
redirects the 2nd Create Env button to Console

### DIFF
--- a/deploy-board/deploy_board/templates/environs/envs_landing.html
+++ b/deploy-board/deploy_board/templates/environs/envs_landing.html
@@ -15,10 +15,9 @@
         <h4 class="panel-title pull-left">Environments</h4>
     </div>
     <div class="row">
-        <button id="newEnvBtnId" type="button" class="deployToolTip btn btn-default btn-block"
-            data-toggle="tooltip" title="Create a new deploy environment">
-            <span class="glyphicon glyphicon-file"></span> Create Environment
-        </button>
+        <a href='{{ redirect_create_env_page_url }}' target='_blank' class="deployToolTip btn btn-default btn-block">
+            <span class="glyphicon glyphicon-file"></span>Create Environment
+        </a>
     </div>
     <div class="row">
         <a href="/envs/deploys" type="button" class="deployToolTip btn btn-default btn-block"


### PR DESCRIPTION
It turns out that there are two 'Create environment' buttons on Teletraan. The main one on the home page redirects users to Console whereas the second one on the env page does not. This change updates the second button.