### PR TITLE
Modify python import and templates for meet new Django version. (1.11.18)

### DIFF
--- a/deploy-board/deploy_board/settings.py
+++ b/deploy-board/deploy_board/settings.py
@@ -16,10 +16,10 @@
 Django settings for deploy_board project.
 
 For more information on this file, see
-https://docs.djangoproject.com/en/1.6/topics/settings/
+https://docs.djangoproject.com/en/1.11/topics/settings/
 
 For the full list of settings and their values, see
-https://docs.djangoproject.com/en/1.6/ref/settings/
+https://docs.djangoproject.com/en/1.11/ref/settings/
 """
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -32,9 +32,18 @@ BASE_DIR = os.path.dirname(__file__)
 
 PROJECT_PATH = BASE_DIR
 
-TEMPLATE_DIRS = (
-    os.path.join(BASE_DIR, 'templates'),
-)
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS' : [os.path.join(BASE_DIR, 'templates')],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+            ],
+        },
+    },
+]
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = os.getenv("SECRET_KEY", None)
@@ -195,7 +204,7 @@ USE_TZ = True
 OLD_BUILD_WARNING_THRESHOLD_DAYS = 10
 
 # Static files (CSS, JavaScript, Images)
-# https://docs.djangoproject.com/en/1.6/howto/static-files/
+# https://docs.djangoproject.com/en/1.11/howto/static-files/
 STATIC_URL = '/static/'
 STATICFILES_DIRS = (
     os.path.join(PROJECT_PATH, "static"),

--- a/deploy-board/deploy_board/urls.py
+++ b/deploy-board/deploy_board/urls.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 
 from django.contrib import admin
 from django.conf.urls.static import static
@@ -23,16 +23,14 @@ admin.autodiscover()
 from settings import IS_PINTEREST
 
 if IS_PINTEREST:
-    urlpatterns = patterns(
-        '',
+    urlpatterns = [
         url(r'^', include('deploy_board.webapp.urls')),
         url(r'^', include('deploy_board.webapp.mix_urls')),
         url(r'^', include('deploy_board.webapp.arcee_urls')),
         url(r'^', include('deploy_board.webapp.ngapp2_urls')),
         url(r'^', include('deploy_board.webapp.cluster_urls')),
-    ) + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+     ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 else:
-    urlpatterns = patterns(
-        '',
+    urlpatterns = [
         url(r'^', include('deploy_board.webapp.urls')),
-    )
+    ]

--- a/deploy-board/deploy_board/wsgi.py
+++ b/deploy-board/deploy_board/wsgi.py
@@ -18,7 +18,7 @@ WSGI config for deploy_board project.
 It exposes the WSGI callable as a module-level variable named ``application``.
 
 For more information on this file, see
-https://docs.djangoproject.com/en/1.6/howto/deployment/wsgi/
+https://docs.djangoproject.com/en/1.11/howto/deployment/wsgi/
 """
 
 import os

--- a/deploy-sentinel/mysite/mysite/settings.py
+++ b/deploy-sentinel/mysite/mysite/settings.py
@@ -16,10 +16,10 @@
 Django settings for mysite project.
 
 For more information on this file, see
-https://docs.djangoproject.com/en/1.6/topics/settings/
+https://docs.djangoproject.com/en/1.11/topics/settings/
 
 For the full list of settings and their values, see
-https://docs.djangoproject.com/en/1.6/ref/settings/
+https://docs.djangoproject.com/en/1.11/ref/settings/
 """
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -28,7 +28,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
 
 # Quick-start development settings - unsuitable for production
-# See https://docs.djangoproject.com/en/1.6/howto/deployment/checklist/
+# See https://docs.djangoproject.com/en/1.11/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = '5_y&4p=teg@cc8dn==sxvj$!ol&b9gmp=$k#(!i%zg%feu%95g'
@@ -67,7 +67,7 @@ WSGI_APPLICATION = 'mysite.wsgi.application'
 
 
 # Database
-# https://docs.djangoproject.com/en/1.6/ref/settings/#databases
+# https://docs.djangoproject.com/en/1.11/ref/settings/#databases
 
 DATABASES = {
     'default': {
@@ -77,7 +77,7 @@ DATABASES = {
 }
 
 # Internationalization
-# https://docs.djangoproject.com/en/1.6/topics/i18n/
+# https://docs.djangoproject.com/en/1.11/topics/i18n/
 
 LANGUAGE_CODE = 'en-us'
 
@@ -91,6 +91,6 @@ USE_TZ = True
 
 
 # Static files (CSS, JavaScript, Images)
-# https://docs.djangoproject.com/en/1.6/howto/static-files/
+# https://docs.djangoproject.com/en/1.11/howto/static-files/
 
 STATIC_URL = '/static/'

--- a/deploy-sentinel/mysite/mysite/urls.py
+++ b/deploy-sentinel/mysite/mysite/urls.py
@@ -12,15 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 
 from django.contrib import admin
 admin.autodiscover()
 
-urlpatterns = patterns('',
+urlpatterns = [
     # Examples:
     # url(r'^$', 'mysite.views.home', name='home'),
     # url(r'^blog/', include('blog.urls')),
 
     url(r'^admin/', include(admin.site.urls)),
-)
+]

--- a/deploy-sentinel/mysite/mysite/wsgi.py
+++ b/deploy-sentinel/mysite/mysite/wsgi.py
@@ -18,7 +18,7 @@ WSGI config for mysite project.
 It exposes the WSGI callable as a module-level variable named ``application``.
 
 For more information on this file, see
-https://docs.djangoproject.com/en/1.6/howto/deployment/wsgi/
+https://docs.djangoproject.com/en/1.11/howto/deployment/wsgi/
 """
 
 import os


### PR DESCRIPTION
We need upgrade Django from 1.6 to 1.11 for security vulnerability.
This PR's changes are needed to meet new Django version. 