### PR TITLE
update phobos link using host name instead of host ip for security re…

### DIFF
--- a/deploy-board/deploy_board/webapp/host_views.py
+++ b/deploy-board/deploy_board/webapp/host_views.py
@@ -112,8 +112,9 @@ def get_host_details(host_id):
     }
     if IS_PINTEREST and PHOBOS_URL:
         host_ip = instance['config']['internal_address']
+        host_name = instance['config']['name']
         if host_ip is not None:
-            phobos_link = PHOBOS_URL + host_ip
+            phobos_link = PHOBOS_URL + host_name
             host_details['Phobos Link'] = phobos_link
     return host_details
 


### PR DESCRIPTION
…quirement
This PR is for displaying phobos log link in teletraan UI:
https://phobos.pinadmin.com/phobos/helloworlddummyservice-server-beta-0a0112be/log/deploylog?file=singer.log
I have to adjust link using host name instead of host ip because new secure requirement from Roberto.