### PR TITLE
remove launch config button for ASG groups

### DIFF
--- a/deploy-board/deploy_board/templates/groups/group_details.html
+++ b/deploy-board/deploy_board/templates/groups/group_details.html
@@ -37,12 +37,14 @@
         </a>
     </div>
     {% endif %}
+    {% if group_info == None %}
     <div class="row">
         <button id="launchInstance" class="deployToolTip btn btn-default btn-block"
             data-toggle="modal" title="Launch Instances">
             <span class="glyphicon glyphicon-plus-sign"></span> Launch Instance
         </button>
     </div>
+    {% endif %}
     <div class="row">
         <button id="terminateAllHosts" class="deployToolTip btn btn-default btn-block"
             data-toggle="modal" title="Terminate All Hosts">


### PR DESCRIPTION
Only display launch config button for non-ASG groups:
in the following screenshots:
deploy-sentinel-docker is ASG group
deploy-sentinel is non-ASG group
![Screen Shot 2019-04-12 at 12 20 44 PM](https://user-images.githubusercontent.com/7441350/56061157-83e88800-5d1d-11e9-9180-de2481ab8be8.png)
![Screen Shot 2019-04-12 at 12 21 01 PM](https://user-images.githubusercontent.com/7441350/56061166-8945d280-5d1d-11e9-8ecf-61ea06dcd705.png)
