### PR TITLE
add build name validation before starting a deployment.

### DIFF
--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvDeploys.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvDeploys.java
@@ -22,6 +22,7 @@ import com.pinterest.deployservice.bean.*;
 import com.pinterest.deployservice.common.Constants;
 import com.pinterest.deployservice.dao.DeployDAO;
 import com.pinterest.deployservice.dao.EnvironDAO;
+import com.pinterest.deployservice.dao.BuildDAO;
 import com.pinterest.deployservice.dao.AgentDAO;
 import com.pinterest.deployservice.handler.ConfigHistoryHandler;
 import com.pinterest.deployservice.handler.DeployHandler;
@@ -60,6 +61,7 @@ public class EnvDeploys {
 
     private static final Logger LOG = LoggerFactory.getLogger(EnvDeploys.class);
     private EnvironDAO environDAO;
+    private BuildDAO buildDAO;
     private DeployDAO deployDAO;
     private Authorizer authorizer;
     private AgentDAO agentDAO;
@@ -72,6 +74,7 @@ public class EnvDeploys {
 
     public EnvDeploys(TeletraanServiceContext context) throws Exception {
         environDAO = context.getEnvironDAO();
+        buildDAO = context.getBuildDAO();
         deployDAO = context.getDeployDAO();
         authorizer = context.getAuthorizer();
         agentDAO = context.getAgentDAO();
@@ -203,6 +206,10 @@ public class EnvDeploys {
         String operator = sc.getUserPrincipal().getName();
         if(StringUtils.isEmpty(buildId)) {
             throw new TeletaanInternalException(Response.Status.BAD_REQUEST, "Build id can not be empty.");
+        }
+        BuildBean buildBean = buildDAO.getById(buildId);
+        if(!buildBean.getBuild_name().equals(envBean.getBuild_name())) {
+            throw new TeletaanInternalException(Response.Status.BAD_REQUEST, String.format("Build name (%s) does not match stage config (%s).", buildBean.getBuild_name(), envBean.getBuild_name()));
         }
         String deployId = deployHandler.deploy(envBean, buildId, description, operator);
         LOG.info("Successfully create deploy {} for env {}/{} by {}.", deployId, envName, stageName, operator);


### PR DESCRIPTION
Before a deployment starts, validate if the build name is the same as the build name in stage configuration. Only proceed deployment when the build name validation passes.

This validation is added in Teletraan API.

When build name validation fails, Teletraan reports error messages:
<img width="880" alt="Screen Shot 2019-04-12 at 1 52 50 PM" src="https://user-images.githubusercontent.com/815701/56070703-4ea06200-5d3e-11e9-9db2-6b32f20ba070.png">
