### PR TITLE
add UI support for target groups ARNs

### DIFF
--- a/deploy-board/deploy_board/templates/groups/group_config.tmpl
+++ b/deploy-board/deploy_board/templates/groups/group_config.tmpl
@@ -185,7 +185,7 @@
                     <label for="load_balancers" class="deployToolTip control-label col-xs-2"
                         data-toggle="tooltip"
                         title="Enter the name of load balancers to attach to this autoscaling group">
-                        Load Balancers
+                        Classic Load Balancers
                     </label>
                     <div class="col-xs-4">
                         <div class="input-group">
@@ -201,11 +201,38 @@
                         </div>
                     </div>
                 </div>
-                 <div class="form-group collapse" id="loadbalancersExpressionDetailsId">
+                <div class="form-group collapse" id="loadbalancersExpressionDetailsId">
                         <div class="col-xs-2">
                         </div>
                         <div class="col-xs-10">
                         Please enter the load balancers you would like to attach to this group seperated by commas.
+                        </div>
+                </div>
+                <div class="form-group">
+                    <label for="target_groups" class="deployToolTip control-label col-xs-2"
+                        data-toggle="tooltip"
+                        title="Enter the name of target group arns to attach to this autoscaling group">
+                        Target Group ARNs
+                    </label>
+                    <div class="col-xs-10">
+                        <div class="input-group">
+                            <input class="form-control" id="target_groups" name="target_groups" required="false"
+                                   type="text" value="{{ config.targetGroups |default_if_none:'' }}"/>
+                            <span class="input-group-btn">
+                                <button id="targetgroupsExpressionId" class="deployToolTip btn btn-default"
+                                        type="button" data-toggle="tooltip"
+                                        title="click for more information on target groups">
+                                    <span class="glyphicon glyphicon-question-sign"></span>
+                                </button>
+                            </span>
+                        </div>
+                    </div>
+                </div>
+                <div class="form-group collapse" id="targetgroupsExpressionDetailsId">
+                        <div class="col-xs-2">
+                        </div>
+                        <div class="col-xs-10">
+                        Please enter the target group ARNs you would like to attach to this autoscaling group seperated by commas.
                         </div>
                 </div>
             </fieldset>
@@ -308,6 +335,9 @@
         });
         $("#loadbalancersExpressionId").click(function() {
             $("#loadbalancersExpressionDetailsId").collapse('toggle');
+        });
+        $("#targetgroupsExpressionId").click(function() {
+            $("#targetgroupsExpressionDetailsId").collapse('toggle');
         });
     });
 </script>

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -219,6 +219,7 @@ def update_group_config(request, group_name):
         groupRequest["pagerRecipients"] = params.get("pager_recipients")
         groupRequest["launchLatencyTh"] = int(params["launch_latency_th"]) * 60
         groupRequest["loadBalancers"] = params.get("load_balancers")
+        groupRequest["targetGroups"] = params.get("target_groups")
 
         if "healthcheck_state" in params:
             groupRequest["healthcheckState"] = True


### PR DESCRIPTION
Todo:
Need manually add one target group to test ASG and verify the name in UI.
FYI:
I tried pass in a target group from UI for test ASG, it did not update ASG from AWS.
<img width="1652" alt="Screen Shot 2019-04-18 at 9 55 14 PM" src="https://user-images.githubusercontent.com/7441350/56406132-bd8d2780-6224-11e9-9d59-a029de8cf05c.png">
Verified by asking SRE to add a test target group arns to test ASG, teletraan UI will display like this:
<img width="1353" alt="Screen Shot 2019-04-19 at 2 36 11 PM" src="https://user-images.githubusercontent.com/7441350/56445176-be6b9b00-62b0-11e9-8b8f-b11a8670a530.png">

