### PR TITLE
fix spiffe_id when clone cluster

### DIFF
--- a/deploy-board/deploy_board/webapp/cluster_view.py
+++ b/deploy-board/deploy_board/webapp/cluster_view.py
@@ -650,7 +650,7 @@ def clone_cluster(request, src_name, src_stage):
         src_cluster_info['clusterName'] = dest_cluster_name
         src_cluster_info['capacity'] = 0
         log.info('clone_cluster, request clone cluster info %s' % src_cluster_info)
-        dest_cluster_info = clusters_helper.create_cluster(request, dest_cluster_name, src_cluster_info)
+        dest_cluster_info = clusters_helper.create_cluster_with_env(request, dest_cluster_name, dest_name, dest_stage, src_cluster_info)
         log.info('clone_cluster, cloned cluster info %s' % dest_cluster_info)
 
         ##4. teletraan service update_env_basic_config


### PR DESCRIPTION
when clone a cluster, the spiffe_id from the source cluster was cloned over which is not the expected behavior. the spiffe_id should be regenerated from the dest_env_name and dest_stage_name.
using the create_cluster_with_env function instead of create_cluster function will regenerate the correct spiffe_id for the dest cluster.