### PR TITLE
add constraints to commit search results.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,11 +6,14 @@ deploy-service/teletraanservice/teletraan/
 .idea/
 *.iml
 
-# C extensions
-*.so
-
 # vim
 *.swp
+
+# VSCode
+.vscode/
+
+# C extensions
+*.so
 
 # Ignore dirs
 build_id.properties

--- a/deploy-board/deploy_board/templates/builds/builds.tmpl
+++ b/deploy-board/deploy_board/templates/builds/builds.tmpl
@@ -5,6 +5,7 @@
         <th>Commit</th>
         <th>Branch</th>
         <th>Repo</th>
+        <th>Build Name</th>
         <th>More Info</th>
         <th>Details</th>
         <th>Tag</th>
@@ -19,6 +20,7 @@
         </td>
         <td>{{ buildInfo.build.branch }}</td>
         <td>{{ buildInfo.build.repo }}</td>
+        <td>{{ buildInfo.build.name }}</td>
         <td><a class="deployToolTip" data-toggle="tooltip"
                title="Click to see the details of publish job info"
                href='{{ buildInfo.build.publishInfo }}'><i class="fa fa-wrench"></i></a>

--- a/deploy-board/deploy_board/templates/builds/pick_a_build.tmpl
+++ b/deploy-board/deploy_board/templates/builds/pick_a_build.tmpl
@@ -6,6 +6,7 @@
         <th class="col-lg-3">Commit</th>
         <th class="col-lg-2">Branch</th>
         <th class="col-lg-2">Repo</th>
+        <th class="col-lg-2">Build Name</th>
         <th class="col-lg-1">Details</th>
     </tr>
     {% for buildInfo in builds %}
@@ -55,6 +56,7 @@
         </td>
         <td>{{ buildInfo.build.branch }}</td>
         <td>{{ buildInfo.build.repo }}</td>
+        <td>{{ buildInfo.build.name }}</td>
         <td><a href="/builds/{{ buildInfo.build.id }}">view</a></td>
     </tr>
     {% if builds|length > 1 %}

--- a/deploy-board/deploy_board/webapp/env_views.py
+++ b/deploy-board/deploy_board/webapp/env_views.py
@@ -981,7 +981,7 @@ def deploy_build(request, name, stage, build_id):
 
 def deploy_commit(request, name, stage, commit):
     env = environs_helper.get_env_by_stage(request, name, stage)
-    builds = builds_helper.get_builds_and_tags(request, commit=commit)
+    builds = builds_helper.get_builds_and_tags(request, name=env.get('buildName', ''), commit=commit)
     current_build = None
     if env.get('deployId'):
         deploy = deploys_helper.get(request, env['deployId'])

--- a/deploy-board/deploy_board/webapp/helpers/builds_helper.py
+++ b/deploy-board/deploy_board/webapp/helpers/builds_helper.py
@@ -55,7 +55,7 @@ def get_commit(request, repo, sha):
     return deploy_client.get("/commits/%s/%s" % (repo, sha), request.teletraan_user_id.token)
 
 def get_builds_and_tags(request, **kwargs):
-    params = deploy_client.gen_params(kwargs);
+    params = deploy_client.gen_params(kwargs)
     return deploy_client.get("/builds/tags",request.teletraan_user_id.token, params=params)
 
 def get_build_and_tag(request, id):

--- a/deploy-board/tools/create_deploy.py
+++ b/deploy-board/tools/create_deploy.py
@@ -25,7 +25,8 @@ def pick_build_id(buildName, x):
 
 
 def create(name, stage, x):
-    buildId = pick_build_id("sample-build", x)
+    buildName = "sample-service-{}".format(x)
+    buildId = pick_build_id(buildName, 0)
     id = deploys_helper.deploy(commons.REQUEST, name, stage, buildId)['id']
     print "Successfully created deploy %s" % id
 

--- a/deploy-board/tools/publish_build.py
+++ b/deploy-board/tools/publish_build.py
@@ -20,8 +20,10 @@ import commons
 
 
 def main():
-    for x in xrange(1):
-        commons.publish_build("sample-build", "master")
+    for x in xrange(2):
+        # deploy requires build name to be the same as env stage configuration's build name
+        buildName = "sample-service-{}".format(x)
+        commons.publish_build(buildName, "master")
 #    for x in xrange(1):
 #        commons.publish_build("sample-build", "hotfix")
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/BuildDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/BuildDAO.java
@@ -32,7 +32,7 @@ public interface BuildDAO {
     BuildBean getById(String buildId) throws Exception;
 
     // commit in short version
-    List<BuildBean> getByCommit7(String scmCommit7, int pageIndex, int pageSize) throws Exception;
+    List<BuildBean> getByCommit7(String scmCommit7, String buildName, int pageIndex, int pageSize) throws Exception;
 
     void delete(String buildId) throws Exception;
 

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/db/DBDAOTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/db/DBDAOTest.java
@@ -339,7 +339,9 @@ public class DBDAOTest {
         buildDAO.insert(buildBean3);
 
         assertTrue(EqualsBuilder.reflectionEquals(buildBean1, buildDAO.getById("b-1")));
-        assertEquals(buildDAO.getByCommit7("c-1", 1, 10).size(), 4);
+        assertEquals(buildDAO.getByCommit7("c-1", "", 1, 10).size(), 4);
+        assertEquals(buildDAO.getByCommit7("c-1", "sss-1", 1, 10).size(), 3);
+        assertEquals(buildDAO.getByCommit7("c-1", "sss-2", 1, 10).size(), 1);
         assertEquals(buildDAO.getBuildNames("sss-", 1, 100).size(), 2);
 
         List<BuildBean>


### PR DESCRIPTION
- when searching a commit from UI search box, return commits that match
both SHA and build name.
- change unit tests of BuildDAO to add testing for the added search
constraints.
- change tools script to publish builds with build name matching env
stage configuration, so that deploy can be created for these builds.
- update .gitignore to include vscode temp directory.

**Example:**

Commits 1034481 with multiple different build names exist (sample-service-0, sample-service-1, sample-service-2):

![commit_build_0](https://user-images.githubusercontent.com/815701/57663084-548c9b80-75a7-11e9-836e-e4b1ca784efa.png)
![commit_build_1](https://user-images.githubusercontent.com/815701/57663086-58202280-75a7-11e9-9c58-324a0e805b4b.png)
![commit_build_2](https://user-images.githubusercontent.com/815701/57663089-5a827c80-75a7-11e9-8dc2-c79439f56588.png)

Search commit "1034481" returns only one commit, which has build name "sample-service-0".

![search_result](https://user-images.githubusercontent.com/815701/57663119-81d94980-75a7-11e9-8e01-3bc34e7518a4.png)

Display "build name" in build search result:

![pick_a_build](https://user-images.githubusercontent.com/815701/57741850-76ebeb00-7673-11e9-8c4b-70d5e718fd3e.png)

Search a build from stage:

![build_search_from_stage](https://user-images.githubusercontent.com/815701/57741861-8703ca80-7673-11e9-8435-302909a9e9e0.png)

Search a build from global build search on the top corner:

![build_search_from_top](https://user-images.githubusercontent.com/815701/57741882-95ea7d00-7673-11e9-9760-c29a762fb939.png)
