### PR TITLE
upgrade jackson-databind for security vulnerability CVE-2019-12086

### DIFF
--- a/deploy-service/common/pom.xml
+++ b/deploy-service/common/pom.xml
@@ -176,12 +176,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-afterburner</artifactId>
-            <version>2.8.10</version>
+            <version>2.9.9</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.8.11.3</version>
+            <version>2.9.9</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>


### PR DESCRIPTION
this is to address https://github.com/pinterest/teletraan/network/alert/deploy-service/common/pom.xml/com.fasterxml.jackson.core:jackson-databind/open
upgrade to jackson-databind to 2.9.9, and because of this, the jackson-module-afterburner module also need to be upgrade.