### PR TITLE
fix the logger for manage_local

### DIFF
--- a/deploy-board/deploy_board/settings.py
+++ b/deploy-board/deploy_board/settings.py
@@ -104,7 +104,7 @@ else:
 
 LOGGING = {
     'version': 1,
-    'disable_existing_loggers': True,
+    'disable_existing_loggers': False,
     'formatters': {
         'standard': {
             'format': '%(asctime)s [%(levelname)s] %(name)s: %(message)s'


### PR DESCRIPTION
django logging disable_existing_loggers should be set to False to manage_local.py to show the logs.
https://docs.djangoproject.com/en/2.2/topics/logging/#configuring-logging