### PR TITLE
use spotMin/Max instead of spotRatio

### DIFF
--- a/deploy-board/deploy_board/templates/groups/asg_config.tmpl
+++ b/deploy-board/deploy_board/templates/groups/asg_config.tmpl
@@ -31,7 +31,7 @@
                 <label for="minSize" class="deployToolTip control-label col-xs-2"
                     data-toggle="tooltip"
                     title="minimum number of hosts in one autoscaling group">
-                    Min Size (current group size {{ group_size }})
+                    Min Size (current size {{ group_size }})
                 </label>
                 <div class="col-xs-4">
                     <input class="form-control" name="minSize" required="true" id="minSizeInput"
@@ -113,69 +113,54 @@
 
             <div id="spotInstanceConfigDiv" class="hidden">
                 <div class="form-group">
-                    <label for="spotInstanceRatio" class="deployToolTip control-label col-xs-2"
+                    <label for="spotInstanceMinSize" class="deployToolTip control-label col-xs-2"
                         data-toggle="tooltip"
-                        title="percentage of the spot instance in the fleet">
-                            Spot Instances Ratio
+                        title="minimum number of hosts in Spot instance autoscaling group">
+                            Spot Instance Min Size
                     </label>
                     <div class="col-xs-4">
-                        <div class="input-group">
-                            <input class="form-control" name="spotRatio" required="true" id="spotRatio"
-                               type="text" value="{{ asg.spotRatio|default_if_none:'' }}"/>
-                            <span class="input-group-addon">%</span>
-                        </div>
+                        <input class="form-control" name="spotMinSize" required="true" id="spotMinSizeInput"
+                           type="text" value="{{ asg.spotMinSize|default_if_none:'' }}"/>
                     </div>
 
-                    <label for="spotsensitivityRatio" class="deployToolTip control-label col-xs-2"
-                        data-toggle="tooltip" title="">
-                        Sensitivity Ratio
+                    <label for="spotMaxSize" class="deployToolTip control-label col-xs-2"
+                        data-toggle="tooltip"
+                        title="maximum number of hosts in Spot instance autoscaling group">
+                            Spot Instance Max Size
                     </label>
                     <div class="col-xs-4">
-                        <div class="input-group">
-                            <input class="form-control" name="sensitivityRatio" required="true"
-                                type="text" value="{{ asg.sensitivityRatio|default_if_none:'' }}"/>
-                        <span class="input-group-addon">%</span>
-                        </div>
-                    </div>
-               </div>
-            </div>
-
-            <div class="form-group">
-                <label for="bidPrice" class="deployToolTip control-label col-xs-2"
-                    data-toggle="tooltip"
-                    title="bidPrice">
-                    Maximum Bid Price
-                </label>
-                <div class="col-xs-4">
-                    <div class="input-group">
-                        <span class="input-group-addon">$</span>
-                        <input class="form-control" name="bidPrice" required="true" type="text" id="bidPrice"
-                            value="{{asg.bidPrice| default_if_none:'' }}" />
+                        <input class="form-control" name="spotMaxSize" required="true" id="spotMaxSizeInput"
+                           type="text" value="{{ asg.spotMaxSize|default_if_none:'' }}"/>
                     </div>
                 </div>
 
-                <label for="bidPrice" class="deployToolTip control-label col-xs-2"
-                    data-toggle="tooltip"
-                    title="bidPrice">
-                    ({{instanceType}} Pricing: $1.68/Hour)
-                </label>
-            </div>
-            <div class="form-group">
-                  <label for="enableResourceLending" class="deployToolTip control-label col-xs-2"
-                     data-toggle="tooltip"
-                     title="Whether we allow free RI lending">
-                     Allow Free Instances Lending
-                  </label>
-                  <div class="col-xs-3">
-                     <div class="input-group">
-                        {% if asg.enableResourceLending %}
-                          <input class="" id="enableResourceLending" name="enableResourceLending" type="checkbox" value="" checked>
-                        {% else %}
-                          <input class="" id="enableResourceLending" name="enableResourceLending" type="checkbox" value="">
-                        {% endif %}
-                     </div>
-                  </div>
-            </div>
+                <div class="form-group">
+                    <label for="bidPrice" class="deployToolTip control-label col-xs-2"
+                        data-toggle="tooltip"
+                        title="bidPrice">
+                        Maximum Bid Price ({{instanceType}} Pricing: $1.68/Hour)
+                    </label>
+                    <div class="col-xs-4">
+                        <div class="input-group">
+                            <span class="input-group-addon">$</span>
+                            <input class="form-control" name="bidPrice" required="true" type="text" id="bidPrice"
+                                value="{{asg.bidPrice| default_if_none:'' }}" />
+                        </div>
+                    </div>
+
+                   <label for="spotsensitivityRatio" class="deployToolTip control-label col-xs-2 hidden"
+                        data-toggle="tooltip" title="">
+                        Sensitivity Ratio
+                    </label>
+
+                    <div class="col-xs-4">
+                        <div class="input-group hidden">
+                            <input class="form-control" name="sensitivityRatio" required="true"
+                                type="text" value="{{ asg.sensitivityRatio|default_if_none:'0' }}"/>
+                            <span class="input-group-addon">%</span>
+                        </div>
+                    </div>
+                </div>
         </fieldset>
       {% csrf_token %}
        </form>
@@ -265,13 +250,6 @@ $(function () {
     $('#autoscalingGroupConfigFormId input').keyup(function() {
         $('#saveEnvConfigBtnId').removeAttr('disabled');
         $('#resetEnvConfigBtnId').removeAttr('disabled');
-        val = parseInt($("#minSizeInput").val())
-        group_size = parseInt({{group_size}})
-        if ( val < group_size / 2) {
-            $('#minSizeWarningDivId').removeClass("hidden");
-        } else {
-            $('#minSizeWarningDivId').addClass("hidden");
-        }
     });
 
     $('#autoscalingGroupConfigFormId select').change(function() {

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -285,8 +285,6 @@ def get_asg_config(request, group_name):
     launch_config = group_info.get("launchInfo")
     group_size = len(instances)
     policies = autoscaling_groups_helper.TerminationPolicy
-    if asg_summary.get("spotRatio", None):
-        asg_summary["spotRatio"] *= 100
     if asg_summary.get("sensitivityRatio", None):
         asg_summary["sensitivityRatio"] *= 100
     scheduled_actions = autoscaling_groups_helper.get_scheduled_actions(request, group_name)
@@ -347,7 +345,8 @@ def update_asg_config(request, group_name):
         asg_request["terminationPolicy"] = params["terminationPolicy"]
         if "enableSpot" in params:
             asg_request["enableSpot"] = True
-            asg_request["spotRatio"] = float(params["spotRatio"]) / 100
+            asg_request["spotMinSize"] = int(params["spotMinSize"])
+            asg_request["spotMaxSize"] = int(params["spotMaxSize"])
             asg_request["sensitivityRatio"] = float(params["sensitivityRatio"]) / 100
             asg_request["spotPrice"] = params["bidPrice"]
             if "enableResourceLending" in params:


### PR DESCRIPTION
this is to support spotInstance. Originally spotInstance use spotRatio to set the size of spotInstance ASG which is not flexible. by using min/max to allow user define what they need independent of the base ASG. We also remove the Free Instances Lending setting as it is not currently implemented and not used.
![image](https://user-images.githubusercontent.com/495715/59560924-411d8780-8fce-11e9-987f-208b817c9b1c.png)
