### PR TITLE
address security: upgrade django and jackson-databind version

### DIFF
--- a/deploy-board/requirements.txt
+++ b/deploy-board/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.11.20
+Django==1.11.23
 python-dateutil==2.3
 pytz==2014.10
 requests==2.20.0

--- a/deploy-service/common/pom.xml
+++ b/deploy-service/common/pom.xml
@@ -181,7 +181,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.9</version>
+            <version>2.9.9.3</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>


### PR DESCRIPTION
address security: upgrade django and jackson-databind version:

3 com.fasterxml.jackson.core:jackson-databind vulnerabilities found in …/common/pom.xml 
Upgrade com.fasterxml.jackson.core:jackson-databind to version 2.9.9.2 or later.

6 django vulnerabilities found in deploy-board/requirements.txt
Upgrade django to version 1.11.23 or later.