### PR TITLE
Fix failing docker build

### DIFF
--- a/deploy-service/teletraanservice/Dockerfile
+++ b/deploy-service/teletraanservice/Dockerfile
@@ -1,6 +1,4 @@
-From java:8
-
-RUN apt-get update && apt-get install -y php5 php5-curl
+FROM openjdk:8
 
 ENV PROJECT_DIR=/opt/deploy-service
 


### PR DESCRIPTION
This pull request address two issues:
- Uses the updated java base docker
- Remove php dependency (which throws error) - I navigated the code and didn't found any usage for PHP, let me know if I'm missing something

PHP installation error
```
root@858ae10bb87c:/# apt-get update && apt-get install -y php5 php5-curl
Ign http://deb.debian.org jessie InRelease
Get:1 http://deb.debian.org jessie-updates InRelease [16.3 kB]
Get:2 http://security.debian.org jessie/updates InRelease [44.9 kB]
Ign http://deb.debian.org jessie-backports InRelease
Get:3 http://deb.debian.org jessie Release.gpg [1652 B]
Ign http://deb.debian.org jessie-backports Release.gpg
Get:4 http://deb.debian.org jessie Release [77.3 kB]
Ign http://deb.debian.org jessie-backports Release
Err http://deb.debian.org jessie-backports/main amd64 Packages

Get:5 http://deb.debian.org jessie-updates/main amd64 Packages [20 B]
Get:6 http://deb.debian.org jessie/main amd64 Packages [9098 kB]
Get:7 http://security.debian.org jessie/updates/main amd64 Packages [892 kB]
Err http://deb.debian.org jessie-backports/main amd64 Packages

Err http://deb.debian.org jessie-backports/main amd64 Packages
  404  Not Found
Fetched 10.1 MB in 21s (472 kB/s)
W: There is no public key available for the following key IDs:
AA8E81B4331F7F50
W: Failed to fetch http://deb.debian.org/debian/dists/jessie-backports/main/binary-amd64/Packages  404  Not Found

E: Some index files failed to download. They have been ignored, or old ones used instead.
```