### PR TITLE
Mark DeployConstraint as ERROR only if SQLException

### DIFF
--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/DeployTagWorker.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/DeployTagWorker.java
@@ -130,9 +130,7 @@ public class DeployTagWorker implements Runnable {
                         processEachEnvironConstraint(latestJob);
                     } catch (Exception e) {
                         LOG.error("failed to process job: {} Error {} stack {}", latestJob.toString(), ExceptionUtils.getRootCauseMessage(e), ExceptionUtils.getStackTrace(e));
-                        if (e instanceof SQLException) {
-                            // Don't do anything
-                        } else {
+                        if (!SQLException.class.isInstance(e)) {
                             latestJob.setState(TagSyncState.ERROR);
                             deployConstraintDAO.updateById(job.getConstraint_id(), latestJob);
                             LOG.error("updated job state to {}", TagSyncState.ERROR);

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/DeployTagWorker.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/DeployTagWorker.java
@@ -122,8 +122,8 @@ public class DeployTagWorker implements Runnable {
             for (DeployConstraintBean job : jobs) {
                 LOG.info("process job: {}", job);
                 String lockName = String.format("DeployTagWorker-%s", job.getConstraint_id());
-                DeployConstraintBean latestJob = deployConstraintDAO.getById(job.getConstraint_id());
                 Connection connection = utilDAO.getLock(lockName);
+                DeployConstraintBean latestJob = deployConstraintDAO.getById(job.getConstraint_id());
                 if (connection != null) {
                     try {
                         processEachEnvironConstraint(latestJob);
@@ -131,11 +131,11 @@ public class DeployTagWorker implements Runnable {
                         LOG.error("failed to process job: {} Error {} stack {}", latestJob.toString(),
                                 ExceptionUtils.getRootCauseMessage(e), ExceptionUtils.getFullStackTrace(e));
                         if (e instanceof SQLException) {
+                            // Don't do anything
+                        } else {
                             latestJob.setState(TagSyncState.ERROR);
                             deployConstraintDAO.updateById(job.getConstraint_id(), latestJob);
                             LOG.error("updated job state to {}", TagSyncState.ERROR);
-                        } else {
-                            // SOME other ERROR
                         }
                     } finally {
                         utilDAO.releaseLock(lockName, connection);

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/DeployTagWorker.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/DeployTagWorker.java
@@ -8,6 +8,7 @@ import com.pinterest.deployservice.rodimus.RodimusManager;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.TransformerUtils;
 import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/DeployTagWorker.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/DeployTagWorker.java
@@ -129,8 +129,7 @@ public class DeployTagWorker implements Runnable {
                     try {
                         processEachEnvironConstraint(latestJob);
                     } catch (Exception e) {
-                        LOG.error("failed to process job: {} Error {} stack {}", latestJob.toString(),
-                                ExceptionUtils.getRootCauseMessage(e), ExceptionUtils.getFullStackTrace(e));
+                        LOG.error("failed to process job: {} Error {} stack {}", latestJob.toString(), ExceptionUtils.getRootCauseMessage(e), ExceptionUtils.getStackTrace(e));
                         if (e instanceof SQLException) {
                             // Don't do anything
                         } else {


### PR DESCRIPTION
After discussion w/ Suli -- incorporated her suggestion to 
1. Query DeployTag once lock is acquired.
2. Add a check in exception to ensure STATE=ERROR only when it is NOT a SQL Exception --> this will ensure retry if there is any connection pool issues
3. Export error with stacktrace