### PR TITLE
fix exceptions when failing to create an identifier.

### DIFF
--- a/deploy-board/deploy_board/webapp/env_views.py
+++ b/deploy-board/deploy_board/webapp/env_views.py
@@ -837,16 +837,15 @@ def create_identifier_for_new_stage(request, env_name, stage_name):
     if stage_with_external_id == None:
         return None
 
-    else:
     # retrieve Nimbus identifier for existing_stage
-        existing_stage_identifier = environs_helper.get_nimbus_identifier(request, stage_with_external_id['externalId'])
-        new_stage_identifier = None
-         # create Nimbus Identifier for the new stage
-        if existing_stage_identifier is not None:
-            nimbus_request_data = existing_stage_identifier.copy()
-            nimbus_request_data['stage_name'] = stage_name
-            nimbus_request_data['env_name'] = env_name
-            new_stage_identifier = environs_helper.create_nimbus_identifier(request, nimbus_request_data)
+    new_stage_identifier = None
+    existing_stage_identifier = environs_helper.get_nimbus_identifier(request, stage_with_external_id['externalId'])
+    # create Nimbus Identifier for the new stage
+    if existing_stage_identifier is not None:
+        nimbus_request_data = existing_stage_identifier.copy()
+        nimbus_request_data['stage_name'] = stage_name
+        nimbus_request_data['env_name'] = env_name
+        new_stage_identifier = environs_helper.create_nimbus_identifier(request, nimbus_request_data)
 
     return new_stage_identifier
 

--- a/deploy-board/deploy_board/webapp/helpers/nimbusclient.py
+++ b/deploy-board/deploy_board/webapp/helpers/nimbusclient.py
@@ -41,10 +41,20 @@ class NimbusClient(object):
         return self.handle_response(response)
 
     def create_one_identifier(self, data, token=None):
+        """
+        Create a Nimbus Identifier according to the input request data.
+        If the request data does not have all the information needed for creating a Nimbus identifier, this method will return None.
+        """
         headers = {}
         headers['Client-Authorization'] = 'client Teletraan'
         if token:
             headers['Authorization'] = 'token %s' % token
+
+        requiredParams = ['projectName', 'env_name', 'stage_name']
+        for param in requiredParams:
+            if data.get(param) is None or len(data.get(param)) == 0:
+                log.error("Missing %s in the request data, cannot create a Nimbus identifier" % param)
+                return None
 
         payload = {}
         payload['kind'] = 'Identifier'
@@ -52,9 +62,13 @@ class NimbusClient(object):
         payload['platformName'] = 'teletraan'
         payload['projectName'] = data.get('projectName')
 
+        cellName = None
         for property in data['propertyList']['properties']:
             if property['propertyName'] == 'cellName':
                 cellName = property['propertyValue']
+        if cellName is None:
+            log.error("Missing cellName in the request data, cannot create a Nimbus identifier")
+            return None
 
         payload['spec'] = {
             'kind': 'EnvironmentSpec',

--- a/deploy-board/deploy_board/webapp/helpers/nimbusclient.py
+++ b/deploy-board/deploy_board/webapp/helpers/nimbusclient.py
@@ -59,12 +59,6 @@ class NimbusClient(object):
         if token:
             headers['Authorization'] = 'token %s' % token
 
-        requiredParams = ['projectName', 'env_name', 'stage_name']
-        for param in requiredParams:
-            if data.get(param) is None or len(data.get(param)) == 0:
-                log.error("Missing %s in the request data, cannot create a Nimbus identifier" % param)
-                return None
-
         payload = {}
         payload['kind'] = 'Identifier'
         payload['apiVersion'] = 'v1'

--- a/deploy-board/deploy_board/webapp/helpers/nimbusclient.py
+++ b/deploy-board/deploy_board/webapp/helpers/nimbusclient.py
@@ -43,18 +43,21 @@ class NimbusClient(object):
     def create_one_identifier(self, data, token=None):
         """
         Create a Nimbus Identifier according to the input request data.
-        If the request data does not have all the information needed for creating a Nimbus identifier, this method will return None.
+        If the request data does not have all the information needed for creating a Nimbus identifier, this method will raise a Teletraan Exception.
         """
-        headers = {}
-        headers['Client-Authorization'] = 'client Teletraan'
-        if token:
-            headers['Authorization'] = 'token %s' % token
 
         requiredParams = ['projectName', 'env_name', 'stage_name']
         for param in requiredParams:
             if data.get(param) is None or len(data.get(param)) == 0:
                 log.error("Missing %s in the request data, cannot create a Nimbus identifier" % param)
+                if IS_PINTEREST:
+                    raise TeletraanException("Teletraan cannot create a Nimbus identifier because %s is missing. Contact #teletraan for assistance.") % param
                 return None
+
+        headers = {}
+        headers['Client-Authorization'] = 'client Teletraan'
+        if token:
+            headers['Authorization'] = 'token %s' % token
 
         payload = {}
         payload['kind'] = 'Identifier'
@@ -68,6 +71,8 @@ class NimbusClient(object):
                 cellName = property['propertyValue']
         if cellName is None:
             log.error("Missing cellName in the request data, cannot create a Nimbus identifier")
+            if IS_PINTEREST:
+                raise TeletraanException("Teletraan cannot create a Nimbus identifier because cellName is missing in this env's existing identifier. Contact #teletraan for assistance.") 
             return None
 
         payload['spec'] = {


### PR DESCRIPTION
This change fixes the incorrect error messages shown on Teletraan UI when a user create a new stage while Teletraan can't create a nimbus identifier.

![image](https://user-images.githubusercontent.com/815701/76919291-b7b12380-6885-11ea-90cc-8a4754d63548.png)

