### PR TITLE
fix exceptions when failing to create an identifier.

### DIFF
--- a/deploy-board/deploy_board/webapp/env_views.py
+++ b/deploy-board/deploy_board/webapp/env_views.py
@@ -837,16 +837,15 @@ def create_identifier_for_new_stage(request, env_name, stage_name):
     if stage_with_external_id == None:
         return None
 
-    else:
     # retrieve Nimbus identifier for existing_stage
-        existing_stage_identifier = environs_helper.get_nimbus_identifier(request, stage_with_external_id['externalId'])
-        new_stage_identifier = None
-         # create Nimbus Identifier for the new stage
-        if existing_stage_identifier is not None:
-            nimbus_request_data = existing_stage_identifier.copy()
-            nimbus_request_data['stage_name'] = stage_name
-            nimbus_request_data['env_name'] = env_name
-            new_stage_identifier = environs_helper.create_nimbus_identifier(request, nimbus_request_data)
+    existing_stage_identifier = environs_helper.get_nimbus_identifier(request, stage_with_external_id['externalId'])
+    # create Nimbus Identifier for the new stage
+    new_stage_identifier = None
+    if existing_stage_identifier is not None:
+        nimbus_request_data = existing_stage_identifier.copy()
+        nimbus_request_data['stage_name'] = stage_name
+        nimbus_request_data['env_name'] = env_name
+        new_stage_identifier = environs_helper.create_nimbus_identifier(request, nimbus_request_data)
 
     return new_stage_identifier
 

--- a/deploy-board/deploy_board/webapp/helpers/nimbusclient.py
+++ b/deploy-board/deploy_board/webapp/helpers/nimbusclient.py
@@ -49,9 +49,10 @@ class NimbusClient(object):
         for param in requiredParams:
             if data.get(param) is None or len(data.get(param)) == 0:
                 log.error("Missing %s in the request data, cannot create a Nimbus identifier" % param)
+                exceptionMessage = "Teletraan cannot create a Nimbus identifier because %s is missing." % param
                 if IS_PINTEREST:
-                    raise TeletraanException("Teletraan cannot create a Nimbus identifier because %s is missing. Contact #teletraan for assistance.") % param
-                return None
+                    exceptionMessage += " Contact #teletraan for assistance."
+                raise TeletraanException(exceptionMessage)
         
         headers = {}
         headers['Client-Authorization'] = 'client Teletraan'
@@ -70,9 +71,10 @@ class NimbusClient(object):
                 cellName = property['propertyValue']
         if cellName is None:
             log.error("Missing cellName in the request data, cannot create a Nimbus identifier")
+            exceptionMessage = "Teletraan cannot create a Nimbus identifier because cellName is missing in this env's existing identifier."
             if IS_PINTEREST:
-                raise TeletraanException("Teletraan cannot create a Nimbus identifier because cellName is missing in this env's existing identifier. Contact #teletraan for assistance.") 
-            return None
+                exceptionMessage += " Contact #teletraan for assistance."
+            raise TeletraanException(exceptionMessage)
 
         payload['spec'] = {
             'kind': 'EnvironmentSpec',


### PR DESCRIPTION
This change fixes the incorrect error messages shown on Teletraan UI when a user create a new stage while Teletraan can't create a nimbus identifier.

![76919291-b7b12380-6885-11ea-90cc-8a4754d63548](https://user-images.githubusercontent.com/815701/77097722-7710f180-69ce-11ea-8229-52948ad6f5e3.png)
