### PR TITLE
add and fix logs around worker's db connection logic.

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/CommonHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/CommonHandler.java
@@ -398,10 +398,12 @@ public class CommonHandler {
         String lockName = String.format("STATE_TRANSITION-%s", deployId);
         Connection connection = utilDAO.getLock(lockName);
         if (connection != null) {
+            LOG.debug(String.format("Successfully get lock: %s", lockName));
             try {
                 internalTransition(deployId, envBean);
             } finally {
                 utilDAO.releaseLock(lockName, connection);
+                LOG.debug(String.format("Successfully released lock: %s", lockName));
             }
         } else {
             LOG.warn(String.format("Failed to get lock: %s", lockName));

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/CommonHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/CommonHandler.java
@@ -398,15 +398,15 @@ public class CommonHandler {
         String lockName = String.format("STATE_TRANSITION-%s", deployId);
         Connection connection = utilDAO.getLock(lockName);
         if (connection != null) {
-            LOG.debug(String.format("Successfully get lock: %s", lockName));
+            LOG.info(String.format("DB lock operation is successful: get lock %s", lockName));
             try {
                 internalTransition(deployId, envBean);
             } finally {
                 utilDAO.releaseLock(lockName, connection);
-                LOG.debug(String.format("Successfully released lock: %s", lockName));
+                LOG.info(String.format("DB lock operation is successful: release lock %s", lockName));
             }
         } else {
-            LOG.warn(String.format("Failed to get lock: %s", lockName));
+            LOG.warn(String.format("DB lock operation fails: failed to get lock %s", lockName));
         }
     }
 

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AutoPromoter.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AutoPromoter.java
@@ -578,7 +578,7 @@ public class AutoPromoter implements Runnable {
                 LOG.info("Successfully released lock on {}", promoteLockName);
             }
         } else {
-            LOG.warn("Failed to grab PROMOTE_LOCK for env = {}.", currEnvBean.getEnv_id());
+            LOG.warn("Failed to get lock {} for env = {}.", promoteLockName, currEnvBean.getEnv_id());
         }
     }
 

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AutoPromoter.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AutoPromoter.java
@@ -530,7 +530,7 @@ public class AutoPromoter implements Runnable {
         String promoteLockName = String.format("PROMOTE-%s", currEnvBean.getEnv_id());
         Connection connection = utilDAO.getLock(promoteLockName);
         if (connection != null) {
-            LOG.info("Successfully get lock on {}", promoteLockName);
+            LOG.info("DB lock operation is successful: get lock {}", promoteLockName);
             try {
                 // Read the env again, make sure the current deploy is still the same deploy we
                 // think it is
@@ -575,10 +575,10 @@ public class AutoPromoter implements Runnable {
                 LOG.warn("Failed to promote for env {}.", currEnvBean.getEnv_id(), e);
             } finally {
                 utilDAO.releaseLock(promoteLockName, connection);
-                LOG.info("Successfully released lock on {}", promoteLockName);
+                LOG.info("DB lock operation is successful: release lock {}", promoteLockName);
             }
         } else {
-            LOG.warn("Failed to get lock {} for env = {}.", promoteLockName, currEnvBean.getEnv_id());
+            LOG.warn("DB lock operation fails: failed to get lock {} for env = {}.", promoteLockName, currEnvBean.getEnv_id());
         }
     }
 

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/BuildJanitor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/BuildJanitor.java
@@ -68,7 +68,7 @@ public class BuildJanitor implements Job {
                         LOG.error("Failed to delete builds from tables.", e);
                     } finally {
                         utilDAO.releaseLock(buildLockName, connection);
-                        LOG.debug(String.format("Successfully released log: %s", buildLockName));
+                        LOG.debug(String.format("Successfully released lock: %s", buildLockName));
                     }
                 } else {
                     LOG.warn(String.format("Failed to get lock: %s", buildLockName));

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/BuildJanitor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/BuildJanitor.java
@@ -60,7 +60,7 @@ public class BuildJanitor implements Job {
                 String buildLockName = String.format("BUILDJANITOR-%s", buildName);
                 Connection connection = utilDAO.getLock(buildLockName);
                 if (connection != null) {
-                    LOG.debug(String.format("Successfully get lock: %s", buildLockName));
+                    LOG.info(String.format("DB lock operation is successful: get lock %s", buildLockName));
                     try {
                         buildDAO.deleteUnusedBuilds(buildName, timeThreshold, numToDelete);
                         LOG.info(String.format("Successfully removed builds: %s before %d milliseconds has %d.",                            buildName, timeThreshold, numToDelete));
@@ -68,10 +68,10 @@ public class BuildJanitor implements Job {
                         LOG.error("Failed to delete builds from tables.", e);
                     } finally {
                         utilDAO.releaseLock(buildLockName, connection);
-                        LOG.debug(String.format("Successfully released lock: %s", buildLockName));
+                        LOG.info(String.format("DB lock operation is successful: release lock %s", buildLockName));
                     }
                 } else {
-                    LOG.warn(String.format("Failed to get lock: %s", buildLockName));
+                    LOG.warn(String.format("DB lock operation fails: failed to get lock %s", buildLockName));
                 }
             }
         }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/DeployJanitor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/DeployJanitor.java
@@ -57,7 +57,7 @@ public class DeployJanitor implements Job {
                 Connection connection = utilDAO.getLock(deployLockName);
 
                 if (connection != null) {
-                    LOG.debug("Successfully to get the lock: %s", deployLockName);
+                    LOG.debug(String.format("Successfully get lock: %s", deployLockName));
                     try {
                         deployDAO.deleteUnusedDeploys(envId, timeThreshold, numToDelete);
                         LOG.info(String.format("Successfully removed deploys: %s before %d milliseconds has %d.",
@@ -66,10 +66,10 @@ public class DeployJanitor implements Job {
                         LOG.error("Failed to delete builds from tables.", e);
                     } finally {
                         utilDAO.releaseLock(deployLockName, connection);
-                        LOG.debug(String.format("Successfully released the lock: %s", deployLockName));
+                        LOG.debug(String.format("Successfully released lock: %s", deployLockName));
                     }
                 } else {
-                    LOG.warn("Failed to get the lock: %s", deployLockName);
+                    LOG.warn(String.format("Failed to get lock: %s", deployLockName));
                 }
             }
         }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/DeployJanitor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/DeployJanitor.java
@@ -57,7 +57,7 @@ public class DeployJanitor implements Job {
                 Connection connection = utilDAO.getLock(deployLockName);
 
                 if (connection != null) {
-                    LOG.debug(String.format("Successfully get lock: %s", deployLockName));
+                    LOG.info(String.format("DB lock operation is successful: get lock %s", deployLockName));
                     try {
                         deployDAO.deleteUnusedDeploys(envId, timeThreshold, numToDelete);
                         LOG.info(String.format("Successfully removed deploys: %s before %d milliseconds has %d.",
@@ -66,10 +66,10 @@ public class DeployJanitor implements Job {
                         LOG.error("Failed to delete builds from tables.", e);
                     } finally {
                         utilDAO.releaseLock(deployLockName, connection);
-                        LOG.debug(String.format("Successfully released lock: %s", deployLockName));
+                        LOG.info(String.format("DB lock operation is successful: release lock %s", deployLockName));
                     }
                 } else {
-                    LOG.warn(String.format("Failed to get lock: %s", deployLockName));
+                    LOG.warn(String.format("DB lock operation fails: failed to get lock %s", deployLockName));
                 }
             }
         }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/DeployTagWorker.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/DeployTagWorker.java
@@ -125,6 +125,7 @@ public class DeployTagWorker implements Runnable {
                 String lockName = String.format("DeployTagWorker-%s", job.getConstraint_id());
                 Connection connection = utilDAO.getLock(lockName);
                 if (connection != null) {
+                    LOG.debug("Successfully get lock: {}", lockName);
                     try {
                         processEachEnvironConstraint(job);
                     } catch (SQLException e) {
@@ -136,6 +137,7 @@ public class DeployTagWorker implements Runnable {
                         deployConstraintDAO.updateById(job.getConstraint_id(), job);
                     } finally {
                         utilDAO.releaseLock(lockName, connection);
+                        LOG.debug("Successfully released lock: {}", lockName);
                     }
                 } else {
                     LOG.warn("failed to get lock {}", lockName);

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/DeployTagWorker.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/DeployTagWorker.java
@@ -125,7 +125,7 @@ public class DeployTagWorker implements Runnable {
                 String lockName = String.format("DeployTagWorker-%s", job.getConstraint_id());
                 Connection connection = utilDAO.getLock(lockName);
                 if (connection != null) {
-                    LOG.debug("Successfully get lock: {}", lockName);
+                    LOG.info("DB lock operation is successful: get lock {}", lockName);
                     try {
                         processEachEnvironConstraint(job);
                     } catch (SQLException e) {
@@ -137,10 +137,10 @@ public class DeployTagWorker implements Runnable {
                         deployConstraintDAO.updateById(job.getConstraint_id(), job);
                     } finally {
                         utilDAO.releaseLock(lockName, connection);
-                        LOG.debug("Successfully released lock: {}", lockName);
+                        LOG.info("DB lock operation is successful: release lock {}", lockName);
                     }
                 } else {
-                    LOG.warn("failed to get lock {}", lockName);
+                    LOG.warn("DB lock operation fails: failed to get lock {}", lockName);
                 }
             }
         }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/HostTerminator.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/HostTerminator.java
@@ -90,7 +90,7 @@ public class HostTerminator implements Runnable {
             String lockName = String.format("HOSTTERMINATOR-%s", host.getHost_id());
             Connection connection = utilDAO.getLock(lockName);
             if (connection != null) {
-                LOG.debug(String.format("Successfully get lock: %s", lockName));
+                LOG.info(String.format("DB lock operation is successful: get lock %s", lockName));
                 try {
                     if (host.getState() == HostState.PENDING_TERMINATE) {
                         terminateHost(host);
@@ -101,10 +101,10 @@ public class HostTerminator implements Runnable {
                     LOG.error("Failed to process {} host {}", host.getState().toString(), host.getHost_id(), e);
                 } finally {
                     utilDAO.releaseLock(lockName, connection);
-                    LOG.debug(String.format("Successfully released lock: %s", lockName));
+                    LOG.info(String.format("DB lock operation is successful: release lock %s", lockName));
                 }
             } else {
-                LOG.warn(String.format("Failed to get lock: %s", lockName));
+                LOG.warn(String.format("DB lock operation fails: failed to get lock %s", lockName));
             }
         }
     }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/HostTerminator.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/HostTerminator.java
@@ -90,6 +90,7 @@ public class HostTerminator implements Runnable {
             String lockName = String.format("HOSTTERMINATOR-%s", host.getHost_id());
             Connection connection = utilDAO.getLock(lockName);
             if (connection != null) {
+                LOG.debug(String.format("Successfully get lock: %s", lockName));
                 try {
                     if (host.getState() == HostState.PENDING_TERMINATE) {
                         terminateHost(host);
@@ -100,6 +101,7 @@ public class HostTerminator implements Runnable {
                     LOG.error("Failed to process {} host {}", host.getState().toString(), host.getHost_id(), e);
                 } finally {
                     utilDAO.releaseLock(lockName, connection);
+                    LOG.debug(String.format("Successfully released lock: %s", lockName));
                 }
             } else {
                 LOG.warn(String.format("Failed to get lock: %s", lockName));

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/HotfixStateTransitioner.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/HotfixStateTransitioner.java
@@ -95,7 +95,7 @@ public class HotfixStateTransitioner implements Runnable {
         String hotfixLockName = String.format("HOTFIX-%s", hotBean.getId());
         Connection connection = utilDAO.getLock(hotfixLockName);
         if (connection != null) {
-            LOG.info("Successfully get lock on {}", hotfixLockName);
+            LOG.info("DB lock operation is successful: get lock {}", hotfixLockName);
             try {
                 // Check for Hotfix for timeout
                 if ((System.currentTimeMillis() - hotBean.getLast_worked_on()) > (HOTFIX_JOB_DURATION_TIMEOUT * 60000)) {
@@ -195,10 +195,10 @@ public class HotfixStateTransitioner implements Runnable {
                 }
             } finally {
                 utilDAO.releaseLock(hotfixLockName, connection);
-                LOG.info("Successfully released lock on {}", hotfixLockName);
+                LOG.info("DB lock operation is successful: release lock {}", hotfixLockName);
             }
         } else {
-            LOG.warn("Failed to get lock: {}", hotfixLockName);
+            LOG.warn("DB lock operation fails: failed to get lock {}", hotfixLockName);
         }
     }
 

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/HotfixStateTransitioner.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/HotfixStateTransitioner.java
@@ -197,6 +197,8 @@ public class HotfixStateTransitioner implements Runnable {
                 utilDAO.releaseLock(hotfixLockName, connection);
                 LOG.info("Successfully released lock on {}", hotfixLockName);
             }
+        } else {
+            LOG.warn("Failed to get lock: {}", hotfixLockName);
         }
     }
 


### PR DESCRIPTION
small changes for making sure worker logic has proper logs around getting and releasing db connections. each db connection attempt should have three log messages:
- successfully get lock
- successfully release lock
- failed to get lock