### PR TITLE
Fix the deploy board webapp urls regexps to allow builds with dots in their name

### DIFF
--- a/deploy-board/deploy_board/webapp/urls.py
+++ b/deploy-board/deploy_board/webapp/urls.py
@@ -205,8 +205,8 @@ urlpatterns = [
     # builds related
     url(r'^builds/get_all_builds/$', build_views.get_all_builds),
     url(r'^builds/search_commit/(?P<commit>[a-zA-Z0-9\-_]+)/$', build_views.search_commit),
-    url(r'^builds/names/(?P<name>[a-zA-Z0-9\-_]+)/builds/$', build_views.list_builds),
-    url(r'^builds/names/(?P<name>[a-zA-Z0-9\-_]+)/branches/$',
+    url(r'^builds/names/(?P<name>[a-zA-Z0-9\-_.]+)/builds/$', build_views.list_builds),
+    url(r'^builds/names/(?P<name>[a-zA-Z0-9\-_.]+)/branches/$',
         build_views.list_build_branches),
     url(r'^builds/names/$', build_views.get_build_names),
     url(r'^builds/(?P<id>[a-zA-Z0-9\-_]+)/$', build_views.get_build),


### PR DESCRIPTION
Currently, it's impossible to view the details of a build that has a name which contains a dot (for instance `counter-18.04` see https://jira.pinadmin.com/browse/CDP-1664), this simple fix should solve that.
