### PR TITLE
security patch for jackson-databind

### DIFF
--- a/deploy-service/common/pom.xml
+++ b/deploy-service/common/pom.xml
@@ -181,7 +181,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.1</version>
+            <version>2.9.10.4</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>


### PR DESCRIPTION
Release: https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind/2.9.10.4