### PR TITLE
validate ASG capacity configurations.

### DIFF
--- a/deploy-board/deploy_board/templates/groups/asg_config.tmpl
+++ b/deploy-board/deploy_board/templates/groups/asg_config.tmpl
@@ -31,7 +31,7 @@
                 <label for="minSize" class="deployToolTip control-label col-xs-2"
                     data-toggle="tooltip"
                     title="minimum number of hosts in one autoscaling group">
-                    Min Size (current size {{ group_size }})
+                    Min Size (Current size is {{ group_size }})
                 </label>
                 <div class="col-xs-4">
                     <input class="form-control" name="minSize" required="true" id="minSizeInput"


### PR DESCRIPTION
This change adds validation for ASG's capacity configurations. including:
1) for each scheduled scaling action config, the desired capacity must be within the limits of ASG's min size and max size, i.e. ASG min size <= capacity <= ASG max size. Otherwise throws exception.
2) when updating an ASG's configuration, check the existing scheduled scaling actions and validate the desired capacity.

Related UI:
![Screen Shot 2020-05-20 at 6 40 04 PM](https://user-images.githubusercontent.com/815701/82513995-5d248580-9ac9-11ea-8fb2-430a67b5a0c8.png)
