### PR TITLE
Keep cap check

### DIFF
--- a/deploy-board/deploy_board/webapp/env_views.py
+++ b/deploy-board/deploy_board/webapp/env_views.py
@@ -859,7 +859,7 @@ def post_add_stage(request, name):
 
     all_envs_stages = environs_helper.get_all_env_stages(request, name)
     stages, _ = common.get_all_stages(all_envs_stages, None)
-    if from_stage not in stages:
+    if from_stage and from_stage not in stages:
         raise Exception("Can not clone from non-existing stage!")
     
     external_id = None

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/EnvironHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/EnvironHandler.java
@@ -381,6 +381,11 @@ public class EnvironHandler {
             throw new DeployInternalException("Reject the delete of env %s while it still has group capacity", envId);
         }
 
+        List<String> hosts = groupDAO.getCapacityHosts(envBean.getEnv_id());
+        if (hosts != null && !hosts.isEmpty()) {
+            throw new DeployInternalException("Reject the delete of env %s while it still has host capacity", envId);
+        }
+
         long total = agentDAO.countAgentByEnv(envId);
         if (total > 0) {
             throw new DeployInternalException("Reject the delete of env %s while there are still %d hosts active", envId, total);


### PR DESCRIPTION
To be on safe side, continue checking hosts and groups capacity along with existing agent when environment is deleted.