### PR TITLE
Retire .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-before_install: cd deploy-service
-language: java
-jdk:
-  - openjdk11


### PR DESCRIPTION
b05c7ebd3 moved CI to GitHub Actions. We no longer need .travis.yml.