### PR TITLE
expose env system priority in config UI

### DIFF
--- a/deploy-board/deploy_board/templates/configs/env_config.tmpl
+++ b/deploy-board/deploy_board/templates/configs/env_config.tmpl
@@ -248,6 +248,19 @@
                     </div>
                 </div>
                 <div class="form-group">
+                    <label for="syspriority" class="deployToolTip control-label col-xs-2"
+                        data-toggle="tooltip"
+                        title="System Priority for Sidecars">
+                        Sidecar System Priority
+                    </label>
+
+                    <div class="col-xs-4">
+                        <input class="form-control" name="syspriority" required="false" readonly="true"
+                               type="text" value="{{ env.systemPriority |default_if_none:'' }}"
+                               maxlength="128"/>
+                    </div>
+                </div>
+                <div class="form-group">
                     <label for="description" class="deployToolTip control-label col-xs-2"
                         data-toggle="tooltip"
                         title="Simple description of this env stage">

--- a/deploy-board/deploy_board/webapp/env_config_views.py
+++ b/deploy-board/deploy_board/webapp/env_config_views.py
@@ -83,6 +83,7 @@ class EnvConfigView(View):
             data["notifyAuthors"] = False
         self._set_parallel(data, query_dict)
         data["priority"] = query_dict["priority"]
+        data["systemPriority"] = query_dict["systemPriority"]
         data["stuckThreshold"] = int(query_dict["stuckThreshold"])
         data["successThreshold"] = float(query_dict["successThreshold"]) * 100
         data["description"] = query_dict.get("description")


### PR DESCRIPTION
the env Config UI will have a new field called "Sidecar System Priority" to expose it for sidecar specifically and readonly. this is an internal priority that service owner should not change by themself.