### PR TITLE
Update trusted builds validation order

### DIFF
--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvDeploys.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvDeploys.java
@@ -219,6 +219,13 @@ public class EnvDeploys {
                 String.format("Build name (%s) does not match stage config (%s).", 
                     buildBean.getBuild_name(), envBean.getBuild_name()));
         }
+        // only allow a non-private deploy if the build is from a trusted artifact url
+        if(envBean.getEnsure_trusted_build() && !buildBean.getScm_branch().equals("private") &&
+            buildWhitelist != null && !buildWhitelist.trusted(buildBean.getArtifact_url())) {
+            throw new TeletaanInternalException(Response.Status.BAD_REQUEST,
+                String.format("Non-private build url points to an untrusted location (%s). Please Contact #teletraan to ensure the build artifact is published to a trusted url",
+                    buildBean.getArtifact_url()));
+        }
         // if the stage is not whitelisted (allow_private_build)
         if(! envBean.getAllow_private_build()) { 
             // only allow deploy if it is not private build
@@ -226,13 +233,6 @@ public class EnvDeploys {
                 throw new TeletaanInternalException(Response.Status.BAD_REQUEST, 
                     "This stage does not allow deploying a private build. Please Contact #teletraan to whitelist your stage for deploying private build");
             }
-        
-            // only allow deploy if the build is from a trusted artifact url
-            if(envBean.getEnsure_trusted_build() && buildWhitelist != null && !buildWhitelist.trusted(buildBean.getArtifact_url())) {
-                throw new TeletaanInternalException(Response.Status.BAD_REQUEST,
-                    String.format("Build url points to an untrusted location (%s). Please Contact #teletraan to ensure the build artifact is published to a trusted url",
-                        buildBean.getArtifact_url()));
-            }            
         }
 
         String deployId = deployHandler.deploy(envBean, buildId, description, operator);


### PR DESCRIPTION
https://github.com/pinterest/teletraan/pull/761/files added the concept of "trusted build URLs", essentially an additional allowlist. The function here is such that we can have a broad allow list for all environments (private builds / development environments AND production builds / environments).

However, in that code we only validate that a build is stored in a "trusted" (production) location if the environment is not marked as one supporting private builds. If an environment opted in to development / private build support, they would then be able to skip the check for their production builds. 

This PR moves the check outside the condition requiring the environment to not have private builds enabled, and only performs the trusted URL check if the build is not marked as private.