### PR TITLE
Configurable agent count cache ttl

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/ServiceContext.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/ServiceContext.java
@@ -100,7 +100,7 @@ public class ServiceContext {
     private String jenkinsUrl;
     private String jenkinsRemoteToken;
     private List<PingRequestValidator> pingRequestValidators;
-
+    private Long agentCountCacheTtl;
     public Allowlist getBuildAllowlist() {
         return buildAllowlist;
     }
@@ -439,4 +439,13 @@ public class ServiceContext {
         List<PingRequestValidator> pingRequestValidators) {
         this.pingRequestValidators = pingRequestValidators;
     }
+
+    public Long getAgentCountCacheTtl() {
+        return agentCountCacheTtl;
+    }
+
+    public void setAgentCountCacheTtl(Long agentCountCacheTttl) {
+        this.agentCountCacheTtl = agentCountCacheTttl;
+    }
+
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironBean.java
@@ -257,7 +257,7 @@ public class EnvironBean implements Updatable, Serializable {
 
     public void setDescription(String description) {
         // Escape user input which could contain injected Javascript
-        this.description = StringEscapeUtils.escapeHtml(this.description);
+        this.description = StringEscapeUtils.escapeHtml(description);
     }
 
     public String getBuild_name() {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
@@ -279,6 +279,7 @@ public class PingHandler {
 
                 if (agentCountBean == null) {
                     agentCountBean = new AgentCountBean();
+                    agentCountBean.setEnv_id(envId);
                 }
                 agentCountBean.setExisting_count(totalNonFirstDeployAgents);
                 agentCountBean.setActive_count(totalActiveAgents + 1);

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/ConfigHelper.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/ConfigHelper.java
@@ -194,6 +194,8 @@ public class ConfigHelper {
 
         context.setDeployBoardUrlPrefix(configuration.getSystemFactory().getDashboardUrl());
         context.setChangeFeedUrl(configuration.getSystemFactory().getChangeFeedUrl());
+        // Only applies to Teletraan agent service 
+        context.setAgentCountCacheTtl(configuration.getSystemFactory().getAgentCountCacheTtl());
         return context;
     }
 

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanServiceContext.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanServiceContext.java
@@ -26,7 +26,6 @@ public class TeletraanServiceContext extends ServiceContext {
   private int maxBuildsToKeep;
   private ExternalAlertFactory externalAlertsFactory;
 
-
   public ExternalAlertFactory getExternalAlertsFactory() {
     return externalAlertsFactory;
   }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/SystemFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/SystemFactory.java
@@ -30,6 +30,9 @@ public class SystemFactory {
     @JsonProperty
     private String clientError = Constants.CLIENT_ERROR_SHORT;
 
+    @JsonProperty
+    private long agentCountCacheTtl = 10 * 1000;
+
     public String getDashboardUrl() {
         return dashboardUrl;
     }
@@ -52,5 +55,13 @@ public class SystemFactory {
 
     public void setClientError(String clientError) {
         this.clientError = clientError;
+    }
+
+    public Long getAgentCountCacheTtl() {
+        return agentCountCacheTtl;
+    }
+
+    public void setAgentCountCacheTtl(Long agentCountCacheTtl) {
+        this.agentCountCacheTtl = agentCountCacheTtl;
     }
 }


### PR DESCRIPTION
(Builds on top of https://github.com/pinterest/teletraan/pull/788)
- Makes agent count cache ttl configurable 
- Default cache is on with 10s ttl
- fixes a missed out fix due to incorrect merge

Testing...

Test agent service,
1. without AGENT_COUNT_CACHE_TTL setting in script config.
2. with AGENT_COUNT_CACHE_TTL setting in script config.
3. removed existing AGENT_COUNT_CACHE_TTL setting from script config.


Log: 
----
DEBUG [2020-12-09 20:31:07,530] com.pinterest.deployservice.handler.PingHandler: updating count for envId t4yRkU8WT76py_eJzKBvqw, existing_count 128, active_count 1, last_refresh 1607545867530, ttl 10000 seconds
DEBUG [2020-12-09 20:34:07,866] com.pinterest.deployservice.handler.PingHandler: updating count for envId t4yRkU8WT76py_eJzKBvqw, existing_count 128, active_count 1, last_refresh 1607546047866, ttl 10000 seconds




DEBUG [2020-12-09 20:49:27,761] com.pinterest.deployservice.handler.PingHandler: updating count for envId U-bK8bM7RtqEoBzzsCBdcw, existing_count 10, active_count 2, last_refresh 1607546967761, ttl 5000 seconds
DEBUG [2020-12-09 20:49:32,903] com.pinterest.deployservice.handler.PingHandler: updating count for envId U-bK8bM7RtqEoBzzsCBdcw, existing_count 10, active_count 5, last_refresh 1607546972903, ttl 5000 seconds
