### PR TITLE
Normalize env stage req

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironBean.java
@@ -257,7 +257,7 @@ public class EnvironBean implements Updatable, Serializable {
 
     public void setDescription(String description) {
         // Escape user input which could contain injected Javascript
-        this.description = StringEscapeUtils.escapeHtml(this.description);
+        this.description = StringEscapeUtils.escapeHtml(description);
     }
 
     public String getBuild_name() {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/EnvironHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/EnvironHandler.java
@@ -331,24 +331,24 @@ public class EnvironHandler {
     }
 
     public String resume(EnvironBean envBean, String operator) throws Exception {
-        environBean.setEnv_state(EnvState.NORMAL);
+        envBean.setEnv_state(EnvState.NORMAL);
         updateStage(envBean, operator);
         return envBean.getEnv_id();
     }
 
     public String pause(EnvironBean envBean, String operator) throws Exception {
-        environBean.setEnv_state(EnvState.PAUSED);
+        envBean.setEnv_state(EnvState.PAUSED);
         updateStage(envBean, operator);
         return envBean.getEnv_id();
     }
 
     public void enable(EnvironBean envBean, String operator) throws Exception {
-        environBean.setState(EnvironState.NORMAL);
+        envBean.setState(EnvironState.NORMAL);
         updateStage(envBean, operator);
     }
 
     public void disable(EnvironBean envBean, String operator) throws Exception {
-        environBean.setState(EnvironState.DISABLED);
+        envBean.setState(EnvironState.DISABLED);
         updateStage(envBean, operator);
     }
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/EnvironHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/EnvironHandler.java
@@ -204,9 +204,8 @@ public class EnvironHandler {
         String id = environBean.getAlarm_config_id();
         if (StringUtils.isEmpty(id)) {
             id = dataHandler.insertData(alarmBeans, AlarmDataFactory.class, operator);
-            EnvironBean updateBean = new EnvironBean();
-            updateBean.setAlarm_config_id(id);
-            updateStage(environBean, updateBean, operator);
+            environBean.setAlarm_config_id(id);
+            updateStage(environBean, operator);
         } else {
             dataHandler.updateData(id, alarmBeans, AlarmDataFactory.class, operator);
         }
@@ -224,8 +223,7 @@ public class EnvironHandler {
         String id = environBean.getMetrics_config_id();
         if (StringUtils.isEmpty(id)) {
             id = dataHandler.insertData(metricsBeans, MetricsDataFactory.class, operator);
-            EnvironBean updateBean = new EnvironBean();
-            updateBean.setMetrics_config_id(id);
+            environBean.setMetrics_config_id(id);
             updateStage(environBean, updateBean, operator);
         } else {
             dataHandler.updateData(id, metricsBeans, MetricsDataFactory.class, operator);
@@ -244,9 +242,8 @@ public class EnvironHandler {
         String id = environBean.getWebhooks_config_id();
         if (StringUtils.isEmpty(id)) {
             id = dataHandler.insertData(hookBean, WebhookDataFactory.class, operator);
-            EnvironBean updateBean = new EnvironBean();
-            updateBean.setWebhooks_config_id(id);
-            updateStage(environBean, updateBean, operator);
+            environBean.setWebhooks_config_id(id);
+            updateStage(environBean, operator);
         } else {
             dataHandler.updateData(id, hookBean, WebhookDataFactory.class, operator);
         }
@@ -265,9 +262,8 @@ public class EnvironHandler {
         if (dataId == null) {
             // Create data the first time
             dataId = dataHandler.insertMap(configs, operator);
-            EnvironBean updateBean = new EnvironBean();
-            updateBean.setAdv_config_id(dataId);
-            updateStage(environBean, updateBean, operator);
+            environBean.setAdv_config_id(dataId);
+            updateStage(environBean, operator);
         } else {
             dataHandler.updateMap(dataId, configs, operator);
         }
@@ -286,16 +282,15 @@ public class EnvironHandler {
         if (dataId == null) {
             // Create data the first time
             dataId = dataHandler.insertMap(configs, operator);
-            EnvironBean updateBean = new EnvironBean();
-            updateBean.setSc_config_id(dataId);
-            updateStage(environBean, updateBean, operator);
+            environBean.setSc_config_id(dataId);
+            updateStage(environBean, operator);
         } else {
             dataHandler.updateMap(dataId, configs, operator);
         }
     }
 
-    public void updateStage(EnvironBean origBean, EnvironBean updateBean, String operator) throws Exception {
-        normalizeEnvRequest(origBean, updateBean, operator);
+    public void updateStage(EnvironBean updateBean, String operator) throws Exception {
+        normalizeEnvRequest(updateBean, operator);
         environDAO.update(origBean.getEnv_name(), origBean.getStage_name(), updateBean);
     }
 
@@ -336,29 +331,25 @@ public class EnvironHandler {
     }
 
     public String resume(EnvironBean envBean, String operator) throws Exception {
-        EnvironBean updateBean = new EnvironBean();
-        updateBean.setEnv_state(EnvState.NORMAL);
-        updateStage(envBean, updateBean, operator);
+        environBean.setEnv_state(EnvState.NORMAL);
+        updateStage(envBean, operator);
         return envBean.getEnv_id();
     }
 
     public String pause(EnvironBean envBean, String operator) throws Exception {
-        EnvironBean updateBean = new EnvironBean();
-        updateBean.setEnv_state(EnvState.PAUSED);
-        updateStage(envBean, updateBean, operator);
+        environBean.setEnv_state(EnvState.PAUSED);
+        updateStage(envBean, operator);
         return envBean.getEnv_id();
     }
 
     public void enable(EnvironBean envBean, String operator) throws Exception {
-        EnvironBean updateBean = new EnvironBean();
-        updateBean.setState(EnvironState.NORMAL);
-        updateStage(envBean, updateBean, operator);
+        environBean.setState(EnvironState.NORMAL);
+        updateStage(envBean, operator);
     }
 
     public void disable(EnvironBean envBean, String operator) throws Exception {
-        EnvironBean updateBean = new EnvironBean();
-        updateBean.setState(EnvironState.DISABLED);
-        updateStage(envBean, updateBean, operator);
+        environBean.setState(EnvironState.DISABLED);
+        updateStage(envBean, operator);
     }
 
     public void enableAll(String operator) throws Exception {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/EnvironHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/EnvironHandler.java
@@ -56,7 +56,7 @@ public class EnvironHandler {
         dataHandler = new DataHandler(serviceContext);
     }
 
-    void normalizeEnvRequest(EnvironBean envBean, String operator) throws Exception {
+    void normalizeEnvRequest(EnvironBean origBean, EnvironBean envBean, String operator) throws Exception {
         if (envBean.getSuccess_th() != null) {
             Integer successTh = envBean.getSuccess_th();
             if (successTh > 10000 || successTh < 0) {
@@ -184,7 +184,7 @@ public class EnvironHandler {
     }
 
     public String createEnvStage(EnvironBean envBean, String operator) throws Exception {
-        normalizeEnvRequest(envBean, operator);
+        normalizeEnvRequest(envBean, envBean, operator);
         updateEnvBeanDefault(envBean);
         String envId = CommonUtils.getBase64UUID();
         envBean.setEnv_id(envId);
@@ -295,10 +295,7 @@ public class EnvironHandler {
     }
 
     public void updateStage(EnvironBean origBean, EnvironBean updateBean, String operator) throws Exception {
-        normalizeEnvRequest(updateBean, operator);
-        if (origBean.getStage_type() != EnvType.DEFAULT && origBean.getStage_type() != updateBean.getStage_type()) {
-            throw new DeployInternalException("Modification of stage type is not allowed!");
-        }
+        normalizeEnvRequest(origBean, updateBean, operator);
         environDAO.update(origBean.getEnv_name(), origBean.getStage_name(), updateBean);
     }
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/EnvironHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/EnvironHandler.java
@@ -56,7 +56,7 @@ public class EnvironHandler {
         dataHandler = new DataHandler(serviceContext);
     }
 
-    void normalizeEnvRequest(EnvironBean origBean, EnvironBean envBean, String operator) throws Exception {
+    void normalizeEnvRequest(EnvironBean envBean, String operator) throws Exception {
         if (envBean.getSuccess_th() != null) {
             Integer successTh = envBean.getSuccess_th();
             if (successTh > 10000 || successTh < 0) {
@@ -184,7 +184,7 @@ public class EnvironHandler {
     }
 
     public String createEnvStage(EnvironBean envBean, String operator) throws Exception {
-        normalizeEnvRequest(envBean, envBean, operator);
+        normalizeEnvRequest(envBean, operator);
         updateEnvBeanDefault(envBean);
         String envId = CommonUtils.getBase64UUID();
         envBean.setEnv_id(envId);
@@ -224,7 +224,7 @@ public class EnvironHandler {
         if (StringUtils.isEmpty(id)) {
             id = dataHandler.insertData(metricsBeans, MetricsDataFactory.class, operator);
             environBean.setMetrics_config_id(id);
-            updateStage(environBean, updateBean, operator);
+            updateStage(environBean, operator);
         } else {
             dataHandler.updateData(id, metricsBeans, MetricsDataFactory.class, operator);
         }
@@ -291,7 +291,7 @@ public class EnvironHandler {
 
     public void updateStage(EnvironBean updateBean, String operator) throws Exception {
         normalizeEnvRequest(updateBean, operator);
-        environDAO.update(origBean.getEnv_name(), origBean.getStage_name(), updateBean);
+        environDAO.update(updateBean.getEnv_name(), updateBean.getStage_name(), updateBean);
     }
 
     PromoteBean genDefaultEnvPromote(String envId) {

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
@@ -18,6 +18,7 @@ package com.pinterest.teletraan.resource;
 import com.pinterest.deployservice.bean.EnvironBean;
 import com.pinterest.deployservice.bean.Resource;
 import com.pinterest.deployservice.bean.Role;
+import com.pinterest.deployservice.bean.EnvType;
 import com.pinterest.deployservice.bean.TagBean;
 import com.pinterest.deployservice.bean.TagTargetType;
 import com.pinterest.deployservice.bean.TagValue;
@@ -99,9 +100,11 @@ public class EnvStages {
         } catch (Exception e) {
             throw new TeletaanInternalException(Response.Status.BAD_REQUEST, e.toString());
         }
-        if (origBean.getStage_type() != EnvType.DEFAULT && origBean.getStage_type() != updateBean.getStage_type()) {
+        if (origBean.getStage_type() != EnvType.DEFAULT && origBean.getStage_type() != environBean.getStage_type()) {
             throw new TeletaanInternalException(Response.Status.BAD_REQUEST, "Modification of stage type is not allowed!");
         }
+        environBean.setEnv_name(origBean.getEnv_name());
+        environBean.setStage_name(origBean.getStage_name());
         environHandler.updateStage(environBean, operator);
         configHistoryHandler.updateConfigHistory(origBean.getEnv_id(), Constants.TYPE_ENV_GENERAL, environBean, operator);
         configHistoryHandler.updateChangeFeed(Constants.CONFIG_TYPE_ENV, origBean.getEnv_id(), Constants.TYPE_ENV_GENERAL, operator);

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
@@ -99,8 +99,10 @@ public class EnvStages {
         } catch (Exception e) {
             throw new TeletaanInternalException(Response.Status.BAD_REQUEST, e.toString());
         }
-        
-        environHandler.updateStage(origBean, environBean, operator);
+        if (origBean.getStage_type() != EnvType.DEFAULT && origBean.getStage_type() != updateBean.getStage_type()) {
+            throw new TeletaanInternalException(Response.Status.BAD_REQUEST, "Modification of stage type is not allowed!");
+        }
+        environHandler.updateStage(environBean, operator);
         configHistoryHandler.updateConfigHistory(origBean.getEnv_id(), Constants.TYPE_ENV_GENERAL, environBean, operator);
         configHistoryHandler.updateChangeFeed(Constants.CONFIG_TYPE_ENV, origBean.getEnv_id(), Constants.TYPE_ENV_GENERAL, operator);
         LOG.info("Successfully updated env {}/{} with {} by {}.",


### PR DESCRIPTION
Problem:
While trying to create new metric, Error is thrown "Modification of stage type is not allowed!". 

Cause:
Some of the actions on environment/stage, for ex: pause, resume, add metric, script config etc. goes through common helper method "updateStage". updateStage is where check was added to reject modification in stage type. 
It seems for environment actions mentioned above, updateStage is called by initiating new EnvironBean object (without copying existing environ settings from database) which is wrong. Without this check, it would have overwritten stage type setting and possibly other settings of the environment. 
This is a dormant day one issue. 

Fix:
Introduce get followed by put behavior.