### PR TITLE
Add Python 3 support to deployd

### DIFF
--- a/deploy-agent/deployd/agent.py
+++ b/deploy-agent/deployd/agent.py
@@ -78,7 +78,7 @@ class DeployAgent(object):
             self._curr_report = None
             return
 
-        self._curr_report = self._envs.values()[0]
+        self._curr_report = list(self._envs.values())[0]
         self._config.update_variables(self._curr_report)
 
     def serve_build(self):
@@ -168,7 +168,7 @@ class DeployAgent(object):
         # DELETE goal.
         if envName:
             return envName
-        for name, value in self._envs.iteritems():
+        for name, value in self._envs.items():
             if envId == value.report.envId:
                 return name
         return None

--- a/deploy-agent/deployd/client/base_client.py
+++ b/deploy-agent/deployd/client/base_client.py
@@ -13,14 +13,13 @@
 # limitations under the License.
 
 from abc import ABCMeta, abstractmethod
+from future.utils import with_metaclass
 
 
-class BaseClient:
+class BaseClient(with_metaclass(ABCMeta, object)):
     """This class plays a role as an interface defining methods for agent to
     communicate with teletraan service.
     """
-
-    __metaclass__ = ABCMeta
     
     @abstractmethod
     def send_reports(self, env_reports=None):

--- a/deploy-agent/deployd/client/client.py
+++ b/deploy-agent/deployd/client/client.py
@@ -175,8 +175,8 @@ class Client(BaseClient):
             if self._read_host_info():
                 reports = [status.report for status in env_reports.values()]
                 for report in reports:
-                    if isinstance(report.errorMessage, str):
-                        report.errorMessage = unicode(report.errorMessage, "utf-8")
+                    if isinstance(report.errorMessage, bytes):
+                        report.errorMessage = report.errorMessage.decode('utf-8')
 
                     # We ignore non-ascii charater for now, we should further solve this problem on
                     # the server side:

--- a/deploy-agent/deployd/client/serverless_client.py
+++ b/deploy-agent/deployd/client/serverless_client.py
@@ -25,7 +25,7 @@ from deployd.types.ping_response import PingResponse
 
 log = logging.getLogger(__name__)
 
-_DEPLOY_STAGE_TRANSITIONS = dict(map(lambda i: (i, i+1), range(DeployStage.PRE_DOWNLOAD, DeployStage.SERVING_BUILD)))
+_DEPLOY_STAGE_TRANSITIONS = dict([(i, i+1) for i in range(DeployStage.PRE_DOWNLOAD, DeployStage.SERVING_BUILD)])
 
 
 class ServerlessClient(BaseClient):
@@ -45,7 +45,7 @@ class ServerlessClient(BaseClient):
         self._build = json.loads(utils.check_not_none(build, 'build can not be None'))
         self._script_variables = json.loads(utils.check_not_none(script_variables, 'script_variables can not be None'))
         self._deploy_id = uuid.uuid4().hex
-              
+
     def send_reports(self, env_reports=None):
         reports = [status.report for status in env_reports.values()]
         for report in reports:

--- a/deploy-agent/deployd/common/caller.py
+++ b/deploy-agent/deployd/common/caller.py
@@ -17,6 +17,8 @@ import traceback
 import logging
 import time
 
+from future.utils import PY3
+
 log = logging.getLogger(__name__)
 
 
@@ -29,8 +31,12 @@ class Caller(object):
         output = ""
         start = time.time()
         try:
-            process = subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                                       stderr=subprocess.PIPE, **kwargs)
+            if PY3:
+                process = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                                           stderr=subprocess.PIPE, encoding='utf-8', **kwargs)
+            else:
+                process = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                                           stderr=subprocess.PIPE, **kwargs)
             while process.poll() is None:
                 line = process.stdout.readline()
                 if line:

--- a/deploy-agent/deployd/common/caller.py
+++ b/deploy-agent/deployd/common/caller.py
@@ -42,4 +42,4 @@ class Caller(object):
             return output.strip(), error.strip(), process.poll()
         except Exception as e:
             log.error(traceback.format_exc())
-            return None, e.message, 1
+            return None, str(e), 1

--- a/deploy-agent/deployd/common/config.py
+++ b/deploy-agent/deployd/common/config.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright 2016 Pinterest, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,13 +15,15 @@
 
 import logging
 import os
-from ConfigParser import SafeConfigParser
 
 from deployd.common.exceptions import DeployConfigException
 from deployd.common.types import DeployType
 from deployd.common.utils import exit_abruptly
 from deployd.types.deploy_stage import DeployStage
 from deployd.types.opcode import OperationCode
+
+from configparser import ConfigParser
+
 
 log = logging.getLogger(__name__)
 
@@ -36,7 +39,7 @@ class Config(object):
             self._config_reader = config_reader
             return
 
-        self._config_reader = SafeConfigParser()
+        self._config_reader = ConfigParser()
         if not filenames:
             return
 

--- a/deploy-agent/deployd/common/env_status.py
+++ b/deploy-agent/deployd/common/env_status.py
@@ -42,7 +42,7 @@ class EnvStatus(object):
             with self._lock, open(self._status_fn, 'r+') as config_fn:
                 data = json.load(config_fn)
                 log.debug('load status file: {}'.format(data))
-                envs = {key: DeployStatus(json_value=d) for key, d in data.iteritems()}
+                envs = {key: DeployStatus(json_value=d) for key, d in data.items()}
         except IOError:
             log.info("Could not find file {}. It happens when run deploy-agent the "
                      "first time, or there is no deploy yet.".format(self._status_fn))
@@ -58,7 +58,7 @@ class EnvStatus(object):
         """
         host_type_match = False
         file_path = os.path.join(directory, host_type)
-        for key, value in envs.iteritems():
+        for key, value in envs.items():
             if value.report.stageName == host_type:
                 host_type_match = True
                 break
@@ -78,7 +78,7 @@ class EnvStatus(object):
         try:
             json_data = {}
             if envs:
-                json_data = {key: value.to_json() for key, value in envs.iteritems()}
+                json_data = {key: value.to_json() for key, value in envs.items()}
             with self._lock, open(self._status_fn, 'w') as config_output:
                 json.dump(json_data, config_output, sort_keys=True,
                           indent=2, separators=(',', ': '))

--- a/deploy-agent/deployd/common/env_status.py
+++ b/deploy-agent/deployd/common/env_status.py
@@ -47,8 +47,8 @@ class EnvStatus(object):
             log.info("Could not find file {}. It happens when run deploy-agent the "
                      "first time, or there is no deploy yet.".format(self._status_fn))
             return {}
-        except Exception as e:
-            log.error(e.message)
+        except Exception:
+            log.exception("Something went wrong in load_envs")
         finally:
             return envs
 
@@ -87,7 +87,7 @@ class EnvStatus(object):
                 self._touch_or_rm_host_type_file(envs, "canary")
             return True
         except IOError as e:
-            log.warning("Could not write to {}. Reason: {}".format(self._status_fn, e.message))
+            log.warning("Could not write to {}. Reason: {}".format(self._status_fn, e))
             return False
         except Exception:
             log.error(traceback.format_exc())

--- a/deploy-agent/deployd/common/executor.py
+++ b/deploy-agent/deployd/common/executor.py
@@ -184,7 +184,7 @@ class Executor(object):
         try:
             os.killpg(process.pid, signal.SIGKILL)
         except Exception as e:
-            log.debug('Failed to kill process: {}'.format(e.message))
+            log.debug('Failed to kill process: {}'.format(e))
 
     def execute_command(self, script):
         try:
@@ -222,9 +222,9 @@ class Executor(object):
             os.chmod(script, st.st_mode | stat.S_IXUSR)
             return self.run_cmd(script)
         except Exception as e:
-            error_msg = e.message
+            error_msg = str(e)
             log.error('Failed to execute command: {}. Reason: {}'.format(script, error_msg))
             log.error(traceback.format_exc())
             return DeployReport(status_code=AgentStatus.AGENT_FAILED,
                                 error_code=1,
-                                output_msg=e.message)
+                                output_msg=str(e))

--- a/deploy-agent/deployd/common/single_instance.py
+++ b/deploy-agent/deployd/common/single_instance.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 # Copyright 2016 Pinterest, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +19,7 @@ import os
 import stat
 import tempfile
 import fcntl
-import utils
+from . import utils
 
 log = logging.getLogger(__name__)
 
@@ -43,8 +45,8 @@ class SingleInstance(object):
         try:
             fcntl.lockf(lockfile_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
         except IOError:
-            print ('Error: {0} may already be running. Only one instance of it '
-                   'can run at a time.').format(appname)
+            print(('Error: {0} may already be running. Only one instance of it '
+                   'can run at a time.').format(appname))
             # noinspection PyTypeChecker
             os.close(lockfile_fd)
             utils.exit_abruptly(1)

--- a/deploy-agent/deployd/common/types.py
+++ b/deploy-agent/deployd/common/types.py
@@ -188,9 +188,9 @@ class DeployStatus(object):
 
     def to_json(self):
         json = {}
-        for key, value in self.__dict__.iteritems():
+        for key, value in self.__dict__.items():
             if type(value) is dict:
-                json[key] = {k: v for k, v in value.iteritems()}
+                json[key] = {k: v for k, v in value.items()}
             elif value:
                 if hasattr(value, "__dict__"):
                     json[key] = value.__dict__

--- a/deploy-agent/deployd/common/utils.py
+++ b/deploy-agent/deployd/common/utils.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright 2016 Pinterest, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/deploy-agent/deployd/common/utils.py
+++ b/deploy-agent/deployd/common/utils.py
@@ -46,7 +46,7 @@ def exit_abruptly(status=0):
 
 def touch(fname, times=None):
     try:
-        with file(fname, 'a'):
+        with open(fname, 'a'):
             os.utime(fname, times)
     except IOError:
         log.error('Failed touching host type file {}'.format(fname))

--- a/deploy-agent/deployd/download/download_helper_factory.py
+++ b/deploy-agent/deployd/download/download_helper_factory.py
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+
+from future.moves.urllib.parse import urlparse
 from boto.s3.connection import S3Connection
+
 from deployd.download.s3_download_helper import S3DownloadHelper
 from deployd.download.http_download_helper import HTTPDownloadHelper
 from deployd.download.local_download_helper import LocalDownloadHelper
-from urlparse import urlparse
-import logging
+
 
 log = logging.getLogger(__name__)
 

--- a/deploy-agent/deployd/download/downloader.py
+++ b/deploy-agent/deployd/download/downloader.py
@@ -120,10 +120,10 @@ class Downloader(object):
             log.info("Successfully extracted {} to {}".format(local_full_fn, working_dir))
         except tarfile.TarError as e:
             status = Status.FAILED
-            log.error("Failed to extract files: {}".format(e.message))
+            log.error("Failed to extract files: {}".format(e))
         except OSError as e:
             status = Status.FAILED
-            log.error("Failed: {}".format(e.message))
+            log.error("Failed: {}".format(e))
         except Exception:
             status = Status.FAILED
             log.error(traceback.format_exc())

--- a/deploy-agent/deployd/download/downloader.py
+++ b/deploy-agent/deployd/download/downloader.py
@@ -115,7 +115,7 @@ class Downloader(object):
 
             # change the working directory back
             os.chdir(curr_working_dir)
-            with file(extracted_file, 'w'):
+            with open(extracted_file, 'w'):
                 pass
             log.info("Successfully extracted {} to {}".format(local_full_fn, working_dir))
         except tarfile.TarError as e:

--- a/deploy-agent/deployd/download/http_download_helper.py
+++ b/deploy-agent/deployd/download/http_download_helper.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # Copyright 2016 Pinterest, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +14,7 @@
 # limitations under the License.
 
 from deployd.common.caller import Caller
-from downloader import Status
+from .downloader import Status
 from deployd.download.download_helper import DownloadHelper
 import os
 import requests

--- a/deploy-agent/deployd/staging/stager.py
+++ b/deploy-agent/deployd/staging/stager.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # Copyright 2016 Pinterest, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +24,7 @@ import logging
 from deployd.common.caller import Caller
 from deployd.common.config import Config
 from deployd.common.status_code import Status
-from transformer import Transformer
+from .transformer import Transformer
 
 log = logging.getLogger(__name__)
 

--- a/deploy-agent/requirements.txt
+++ b/deploy-agent/requirements.txt
@@ -6,7 +6,6 @@ coverage
 pytest
 mock==1.0.1
 flake8==2.5.4
-nose-socket-whitelist
 pep8
 PyYAML==5.3.1
 zipp==1.2.0

--- a/deploy-agent/requirements.txt
+++ b/deploy-agent/requirements.txt
@@ -3,7 +3,7 @@
 # tests
 tox==1.6.1
 coverage
-pytest
+pytest==6.2.2
 mock==1.0.1
 flake8==2.5.4
 pep8

--- a/deploy-agent/requirements.txt
+++ b/deploy-agent/requirements.txt
@@ -3,7 +3,7 @@
 # tests
 tox==1.6.1
 coverage
-pytest==2.3.5
+pytest
 mock==1.0.1
 flake8==2.5.4
 nose-socket-whitelist

--- a/deploy-agent/setup.py
+++ b/deploy-agent/setup.py
@@ -26,7 +26,8 @@ console_scripts = ['deploy-agent = deployd.agent:main',
 
 install_requires = [
     "requests==2.20.0",
-    "gevent>=1.0.2,<=1.2.2",
+    "gevent>=1.0.2,<=1.2.2; python_version < '3'",
+    "gevent>=1.0.2,<=1.5.0; python_version >= '3'",
     "lockfile==0.10.2",
     "boto>=2.39.0",
     "python-daemon==2.0.6"

--- a/deploy-agent/setup.py
+++ b/deploy-agent/setup.py
@@ -30,7 +30,8 @@ install_requires = [
     "gevent>=1.0.2,<=1.5.0; python_version >= '3'",
     "lockfile==0.10.2",
     "boto>=2.39.0",
-    "python-daemon==2.0.6"
+    "python-daemon==2.0.6",
+    "future==0.18.2"
 ]
 
 # Pinterest specific settings

--- a/deploy-agent/tests/__init__.py
+++ b/deploy-agent/tests/__init__.py
@@ -19,7 +19,6 @@ import shutil
 import tempfile
 import unittest
 
-from socketwhitelist.plugins import ErroringSocketWhitelistPlugin
 from deployd.common.types import OpCode
 
 
@@ -31,8 +30,6 @@ class TestCase(unittest.TestCase):
         logger = logging.getLogger('deployd.messaging')
         logger.handlers = []
 
-        plugin = ErroringSocketWhitelistPlugin()
-        plugin.begin()
         os.environ['DEPLOY_TESTING'] = '1'
         self.client = mock.Mock()
         self.client.sendRequest = mock.Mock(return_value=(OpCode.NOOP, None))

--- a/deploy-agent/tests/unit/deploy/download/test_local_download_helper.py
+++ b/deploy-agent/tests/unit/deploy/download/test_local_download_helper.py
@@ -38,7 +38,7 @@ class LocalDownloadFunctionsTest(unittest.TestCase):
         cls.target = target
 
     def test_download_local(self):
-        log_capture_string = io.BytesIO()
+        log_capture_string = io.StringIO()
         stream_handler = logging.StreamHandler(log_capture_string)
         logger.addHandler(stream_handler)
         try:

--- a/deploy-agent/tests/unit/deploy/utils/test_exec.py
+++ b/deploy-agent/tests/unit/deploy/utils/test_exec.py
@@ -40,7 +40,7 @@ class TestUtilsFunctions(tests.TestCase):
         fdout_fn = tempfile.mkstemp()[1]
         with open(fdout_fn, 'w') as f:
             f.write('echo hello')
-        os.chmod(fdout_fn, 0755)
+        os.chmod(fdout_fn, 0o755)
 
         ping_server = mock.Mock(return_value=True)
         executor = Executor(callback=ping_server)

--- a/deploy-agent/tox.ini
+++ b/deploy-agent/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist=py27
+envlist=py27,py3
 
 [flake8]
 exclude=.tox
 max-line-length=100
 
-[testenv:py27]
+[testenv]
 deps=-rrequirements.txt
 commands=py.test {posargs}


### PR DESCRIPTION
Add python 3 support in a backwards compatible manor so Python 2 still works by using [futurize](https://python-future.org/).

Make sure all unit tests pass via running 'tox'