### PR TITLE
Fix the first run using docker

### DIFF
--- a/tools/mysql/schema-update-11.sql
+++ b/tools/mysql/schema-update-11.sql
@@ -4,7 +4,7 @@
 
 # This script upgrade DB schema from version 10 to version 11
 
-ALTER TABLE environs MODIFY COLUMN stage_type VARCHAR(32) NOT NULL DEFAULT 'DEFAULT';
+ALTER TABLE environs MODIFY COLUMN stage_type VARCHAR(32) NOT NULL DEFAULT 'DEFAULT';
 
 -- make sure to update the schema version to 11
 UPDATE schema_versions SET version=11;

--- a/tools/mysql/schema-update-7.sql
+++ b/tools/mysql/schema-update-7.sql
@@ -4,7 +4,7 @@
 
 # This script upgrade DB schema from version 6 to version 7
 
-ALTER TABLE environs MODIFY chatroom VARCHAR(128) DEFAULT NULL;
+ALTER TABLE environs MODIFY chatroom VARCHAR(128) DEFAULT NULL;
 
 -- make sure to update the schema version to 7
 UPDATE schema_versions SET version=7;

--- a/tools/mysql/schema-update-8.sql
+++ b/tools/mysql/schema-update-8.sql
@@ -4,13 +4,13 @@
 
 # This script upgrade DB schema from version 7 to version 8
 
-ALTER TABLE environs ADD COLUMN stage_type VARCHAR(32) NOT NULL DEFAULT 'PRODUCTION';
-ALTER TABLE groups MODIFY group_name VARCHAR(128) NOT NULL;
-ALTER TABLE groups_and_envs MODIFY group_name VARCHAR(128) NOT NULL;
+ALTER TABLE environs ADD COLUMN stage_type VARCHAR(32) NOT NULL DEFAULT 'PRODUCTION';
+ALTER TABLE groups MODIFY group_name VARCHAR(128) NOT NULL;
+ALTER TABLE groups_and_envs MODIFY group_name VARCHAR(128) NOT NULL;
 
 CREATE TABLE IF NOT EXISTS hosts_and_agents (
     host_id         VARCHAR(64)         NOT NULL,
-    agent_version   VARCHAR(64), DEFAULT 'UNKNOWN',
+    agent_version   VARCHAR(64)  DEFAULT 'UNKNOWN',
 
     PRIMARY KEY    (host_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/tools/mysql/schema-update-9.sql
+++ b/tools/mysql/schema-update-9.sql
@@ -4,7 +4,7 @@
 
 # This script upgrade DB schema from version 8 to version 9
 
-ALTER TABLE hosts MODIFY group_name VARCHAR(128) NOT NULL;
+ALTER TABLE hosts MODIFY group_name VARCHAR(128) NOT NULL;
 
 -- make sure to update the schema version to 9
 UPDATE schema_versions SET version=9;


### PR DESCRIPTION
Fixed bug on schema-updates

Removed the extra comma in the schema-update-8.sql (syntax issue)
Changed the NO-BREAK-SPACE to a Space in schema-update-(11-7-9-8)



Expectations
In the first run of Teletraan, after create database it has to be on version 11

Test Plan
1) docker-compose up --build
2) docker exec teletraan_pinterest_mysql /var/teletraan/tools/deploydb.sh -f /var/tools/check_version.sql
