### PR TITLE
Fixed macos bug on first run of deploy-agent

### DIFF
--- a/deploy-agent/deployd/__init__.py
+++ b/deploy-agent/deployd/__init__.py
@@ -16,3 +16,5 @@ import os
 
 # Pinterest specific settings
 IS_PINTEREST = True if os.getenv("IS_PINTEREST", "false") == "true" else False
+
+__version__ = '1.2.24'

--- a/deploy-agent/deployd/common/config.py
+++ b/deploy-agent/deployd/common/config.py
@@ -16,6 +16,8 @@ import logging
 import os
 from ConfigParser import SafeConfigParser
 
+from deployd import __version__
+
 from deployd.common.exceptions import DeployConfigException
 from deployd.common.types import DeployType
 from deployd.common.utils import exit_abruptly
@@ -252,7 +254,7 @@ class Config(object):
         return self.get_var('verify_https_certificate', 'False')
 
     def get_deploy_agent_version(self):
-        return self.get_var('deploy_agent_version', None)
+        return self.get_var('deploy_agent_version', __version__)
 
     def get_facter_az_key(self):
         return self.get_var('availability_zone_key', None)

--- a/deploy-agent/setup.py
+++ b/deploy-agent/setup.py
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from deployd import __version__
 from setuptools import setup
 import os
-
-__version__ = '1.2.24'
 
 markdown_contents = open(os.path.join(os.path.dirname(__file__),
                                       'README.md')).read()


### PR DESCRIPTION
Summary: 
This change is to avoid some crash when running deploy-agent on MacOS, because no agent_version was found leading to an Exception an breaking up the run.

I moved up the version that was being set up in the setup.py file to the __init__ file, a new ticket has been created to discuss if there is a better way to do that.

Expectation: After a clean install of deploy-agent on MacOS, the first run has to be silent (can't break).

TestPlan:

1) Clean install of deploy-agent.
2) deploy-agent -d