### PR TITLE
Updated the broken metric links

### DIFF
--- a/deploy-board/deploy_board/settings.py
+++ b/deploy-board/deploy_board/settings.py
@@ -274,7 +274,7 @@ if IS_PINTEREST:
                    {"min": 300, "max": 600, "color": "Green"}]}
     ]
 
-    DEFAULT_START_TIME = "-1d"
+    DEFAULT_START_TIME = "-1w"
 
     #Pinterest Default Cloud Provider
     DEFAULT_PROVIDER = 'AWS'

--- a/deploy-board/deploy_board/settings.py
+++ b/deploy-board/deploy_board/settings.py
@@ -292,13 +292,6 @@ if IS_PINTEREST:
     DEFAULT_CMP_PINFO_ENVIRON = os.getenv('DEFAULT_CMP_PINFO_ENVIRON')
     DEFAULT_CMP_ACCESS_ROLE = os.getenv('DEFAULT_CMP_ACCESS_ROLE')
 
-    #CSP Config
-    CSP_SCRIPT_SRC = ("'self'", "https://www.google.com/ 'unsafe-inline' 'unsafe-eval'")
-    CSP_DEFAULT_SRC = ("'self'")
-    CSP_CONNECT_SRC = ("'self'")
-    CSP_EXCLUDE_URL_PREFIXES = ('/api-docs',)
-    CSP_STYLE_SRC = ("'self'", "'unsafe-inline'")
-
     # Nimbus service url
     NIMBUS_SERVICE_URL = os.getenv("NIMBUS_SERVICE_URL", None)
     NIMBUS_EGRESS_URL = os.getenv("NIMBUS_EGRESS_URL", None)
@@ -306,3 +299,12 @@ if IS_PINTEREST:
     NIMBUS_SERVICE_VERSION = os.getenv("NIMBUS_SERVICE_VERSION", None)
 
     DEFAULT_CLUSTER_TYPE = "PRODUCTION"
+
+# CSP Config
+CSP_DEFAULT_SRC = ("'self'", "*.google.com", "'unsafe-inline'", "'unsafe-eval'")
+CSP_CONNECT_SRC = ("'self'", "*.google.com", "'unsafe-inline'", "'unsafe-eval'")
+CSP_SCRIPT_SRC = ("'self'", "*.google.com", "'unsafe-inline'", "'unsafe-eval'")
+CSP_STYLE_SRC = ("'self'", "*.google.com", "'unsafe-inline'", "'unsafe-eval'")
+CSP_IMG_SRC = ("'self'", "*.google.com", "'unsafe-inline'", "'unsafe-eval'")
+
+CSP_EXCLUDE_URL_PREFIXES = ('/api-docs',)

--- a/deploy-board/deploy_board/settings.py
+++ b/deploy-board/deploy_board/settings.py
@@ -306,5 +306,6 @@ CSP_CONNECT_SRC = ("'self'", "*.google.com", "'unsafe-inline'", "'unsafe-eval'")
 CSP_SCRIPT_SRC = ("'self'", "*.google.com", "'unsafe-inline'", "'unsafe-eval'")
 CSP_STYLE_SRC = ("'self'", "*.google.com", "'unsafe-inline'", "'unsafe-eval'")
 CSP_IMG_SRC = ("'self'", "*.google.com", "'unsafe-inline'", "'unsafe-eval'")
+CSP_REPORT_URI = ("'self'", "*.google.com", "'unsafe-inline'", "'unsafe-eval'")
 
 CSP_EXCLUDE_URL_PREFIXES = ('/api-docs',)

--- a/deploy-board/deploy_board/settings.py
+++ b/deploy-board/deploy_board/settings.py
@@ -301,11 +301,11 @@ if IS_PINTEREST:
     DEFAULT_CLUSTER_TYPE = "PRODUCTION"
 
 # CSP Config
-CSP_DEFAULT_SRC = ("'self'", "*.google.com", "'unsafe-inline'", "'unsafe-eval'")
-CSP_CONNECT_SRC = ("'self'", "*.google.com", "'unsafe-inline'", "'unsafe-eval'")
-CSP_SCRIPT_SRC = ("'self'", "*.google.com", "'unsafe-inline'", "'unsafe-eval'")
-CSP_STYLE_SRC = ("'self'", "*.google.com", "'unsafe-inline'", "'unsafe-eval'")
-CSP_IMG_SRC = ("'self'", "*.google.com", "'unsafe-inline'", "'unsafe-eval'")
-CSP_REPORT_URI = ("'self'", "*.google.com", "'unsafe-inline'", "'unsafe-eval'")
+CSP_DEFAULT_SRC = ("'self'", "*.google.com", "*.gstatic.com", "'unsafe-inline'", "'unsafe-eval'")
+CSP_CONNECT_SRC = ("'self'", "*.google.com", "*.gstatic.com", "'unsafe-inline'", "'unsafe-eval'")
+CSP_SCRIPT_SRC = ("'self'", "*.google.com", "*.gstatic.com", "'unsafe-inline'", "'unsafe-eval'")
+CSP_SCRIPT_SRC_ELEM = ("'self'", "*.google.com", "*.gstatic.com", "'unsafe-inline'", "'unsafe-eval'")
+CSP_STYLE_SRC = ("'self'", "*.google.com", "*.gstatic.com", "'unsafe-inline'", "'unsafe-eval'")
+CSP_IMG_SRC = ("'self'", "*.google.com", "*.gstatic.com", "'unsafe-inline'", "'unsafe-eval'")
 
 CSP_EXCLUDE_URL_PREFIXES = ('/api-docs',)

--- a/deploy-board/deploy_board/templates/base.html
+++ b/deploy-board/deploy_board/templates/base.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="">
     <meta name="author" content="jiehou">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self' *.google.com 'unsafe-eval' 'unsafe-inline'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' *.gstatic.com *.google.com 'unsafe-eval' 'unsafe-inline'; script-src 'self' *.gstatic.com *.google.com 'unsafe-eval' 'unsafe-inline';">
 
     <title>{% block title %}Teletraan{% endblock %}</title>
 

--- a/deploy-board/deploy_board/templates/base.html
+++ b/deploy-board/deploy_board/templates/base.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="">
     <meta name="author" content="jiehou">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' *.google.com 'unsafe-eval' 'unsafe-inline'">
 
     <title>{% block title %}Teletraan{% endblock %}</title>
 

--- a/deploy-board/deploy_board/templates/environs/site_health.tmpl
+++ b/deploy-board/deploy_board/templates/environs/site_health.tmpl
@@ -12,10 +12,10 @@
         <div class="btn-group pull-right">
             {% for config in metrics %}
             {% if config.title == "dashboard" %}
-            <a id="dashboard" type="button" class="deployToolTip btn btn-default btn-sm" 
-                data-toggle="tooltip" 
-                href="{{ config.url }}" 
-                target="_blank" title="" 
+            <a id="dashboard" type="button" class="deployToolTip btn btn-default btn-sm"
+                data-toggle="tooltip"
+                href="{{ config.url }}"
+                target="_blank" title=""
                 data-original-title="Click to see the metrics dashboard for this service.">
                 <large>Dashboard</large>
             </a>
@@ -54,7 +54,7 @@
                 <div class="col-md-3 col-centered">
                     <div id="chart_{{ config.title }}" align="center"></div>
                 </div>
-              {% endif %}  
+              {% endif %}
             {% endfor %}
         </div>
     </div>
@@ -62,8 +62,7 @@
 
 <script type="text/javascript" src="https://www.google.com/jsapi"></script>
 <script>
-    google.load("visualization", "1", {packages: ["corechart", "gauge", "line"]});
-    google.setOnLoadCallback(initialize);
+    google.load("visualization", "1", {packages: ["corechart", "gauge", "line"], "callback": initialize});
 
     var select_cookie_name = 'site-health-graph-selection';
     var toggle_cookie_name = 'site-health-panel-toggle';

--- a/deploy-board/deploy_board/templates/groups/group_details.html
+++ b/deploy-board/deploy_board/templates/groups/group_details.html
@@ -109,23 +109,27 @@
             <div id="loadGroupInfo"></div>
         </div>
         <div align="left" id="tsdLinksId">
+            <!-- https://statsboard.pinadmin.com/build?{"from":"1w","metrics":[{"metric":"avg:autoscaling.{{ group_name }}.size"}]} -->
             <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"
-                href="https://statsboard.pinadmin.com/build?{'from':'1w','metrics':[{'metric':'avg:autoscaling.{{ group_name }}.size'}]}"
+                href="https://statsboard.pinadmin.com/build?%7B%22from%22%3A%221w%22%2C%22until%22%3A%22%22%2C%22metrics%22%3A%5B%7B%22metric%22%3A%22avg%3Aautoscaling.{{ group_name }}.size%22%7D%5D%2C%22renderer%22%3A%22line%22%7D"
                 title="" data-original-title="Click to see more group size information in StatsBoard">
                 <strong>Group Size</strong>
             </a>
             {% for env in envs %}
+                <!-- https://statsboard.pinadmin.com/build?{"from":"1w","metrics":[{"metric":"avg:autoscaling.{{ env.envName }}.{{ env.stageName }}.launchlatency"}]} -->
                 <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"
-                    href="https://statsboard.pinadmin.com/build?{'from':'1w','metrics':[{'metric':'avg:autoscaling.{{ env.envName }}.{{ env.stageName }}.launchlatency'}]}"
+                    href="https://statsboard.pinadmin.com/build?%7B%22from%22%3A%221w%22%2C%22until%22%3A%22%22%2C%22metrics%22%3A%5B%7B%22metric%22%3A%22avg%3Aautoscaling.{{ env.envName }}.{{ env.stageName }}.launchlatency%22%7D%5D%2C%22renderer%22%3A%22line%22%7D"
                     title="" data-original-title="Click to see more launch latency information in StatsBoard">
                     <strong>Launch Latency for {{ env.envName }}</strong>
                 </a>
+                <!-- https://statsboard.pinadmin.com/build?{"from":"1w","metrics":[{"metric":"avg:autoscaling.{{ env.envName }}.{{ env.stageName }}.deploylatency"}]} -->
                 <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"
-                    href="https://statsboard.pinadmin.com/build?{'from':'1w','metrics':[{'metric':'avg:autoscaling.{{ env.envName }}.{{ env.stageName }}.deploylatency'}]}"
+                    href="https://statsboard.pinadmin.com/build?%7B%22from%22%3A%221w%22%2C%22until%22%3A%22%22%2C%22metrics%22%3A%5B%7B%22metric%22%3A%22avg%3autoscaling.{{ env.envName }}.{{ env.stageName }}.deploylatency%22%7D%5D%2C%22renderer%22%3A%22line%22%7D"
                     title="" data-original-title="Click to see more deploy latency information in StatsBoard">
                 <strong>Deploy Latency for {{ env.envName }}</strong>
+                <!-- https://statsboard.pinadmin.com/build?{"from":"1w","metrics":[{"metric":"minmax:autoscaling.{{ env.envName }}.{{ env.stageName }}.first_deploy.failed"}]} -->
                 <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"
-                   href="https://statsboard.pinadmin.com/build?{'from':'1w','metrics':[{'metric':'minmax:autoscaling.{{ env.envName }}.{{ env.stageName }}.first_deploy.failed'}]}"
+                   href="https://statsboard.pinadmin.com/build?%7B%22from%22%3A%221w%22%2C%22until%22%3A%22%22%2C%22metrics%22%3A%5B%7B%22metric%22%3A%22minmax%3autoscaling.{{ env.envName }}.{{ env.stageName }}.first_deploy.failed%22%7D%5D%2C%22renderer%22%3A%22line%22%7D"
                     title="" data-original-title="Click to see more launch failed count information in StatsBoard">
                 <strong>Launch failed count for {{ env.envName }}</strong>
             </a>

--- a/deploy-board/deploy_board/templates/groups/group_details.html
+++ b/deploy-board/deploy_board/templates/groups/group_details.html
@@ -82,7 +82,7 @@
     </div>
     <script type="text/javascript" src="https://www.google.com/jsapi"></script>
     <script type="text/javascript">
-      google.load("visualization", "1", {packages:["corechart"]});
+      google.load("visualization", "1.1", {packages:["corechart"]});
     </script>
 
     <div id="metricStatId" class="collapse in panel-body">
@@ -111,25 +111,25 @@
         <div align="left" id="tsdLinksId">
             <!-- https://statsboard.pinadmin.com/build?{"from":"1w","metrics":[{"metric":"avg:autoscaling.{{ group_name }}.size"}]} -->
             <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"
-                href="https://statsboard.pinadmin.com/build?%7B%22from%22%3A%221w%22%2C%22until%22%3A%22%22%2C%22metrics%22%3A%5B%7B%22metric%22%3A%22avg%3Aautoscaling.{{ group_name }}.size%22%7D%5D%2C%22renderer%22%3A%22line%22%7D"
+                href="https://statsboard.pinadmin.com/build?%7B%22from%22%3A%221w%22%2C%22metrics%22%3A%5B%7B%22metric%22%3A%22avg%3Aautoscaling.{{ group_name }}.size%22%7D%5D%2C%22renderer%22%3A%22line%22%7D"
                 title="" data-original-title="Click to see more group size information in StatsBoard">
                 <strong>Group Size</strong>
             </a>
             {% for env in envs %}
                 <!-- https://statsboard.pinadmin.com/build?{"from":"1w","metrics":[{"metric":"avg:autoscaling.{{ env.envName }}.{{ env.stageName }}.launchlatency"}]} -->
                 <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"
-                    href="https://statsboard.pinadmin.com/build?%7B%22from%22%3A%221w%22%2C%22until%22%3A%22%22%2C%22metrics%22%3A%5B%7B%22metric%22%3A%22avg%3Aautoscaling.{{ env.envName }}.{{ env.stageName }}.launchlatency%22%7D%5D%2C%22renderer%22%3A%22line%22%7D"
+                    href="https://statsboard.pinadmin.com/build?%7B%22from%22%3A%221w%22%2C%22metrics%22%3A%5B%7B%22metric%22%3A%22avg%3Aautoscaling.srebot.prod.launchlatency%22%7D%5D%2C%22renderer%22%3A%22line%22%7D"
                     title="" data-original-title="Click to see more launch latency information in StatsBoard">
                     <strong>Launch Latency for {{ env.envName }}</strong>
                 </a>
                 <!-- https://statsboard.pinadmin.com/build?{"from":"1w","metrics":[{"metric":"avg:autoscaling.{{ env.envName }}.{{ env.stageName }}.deploylatency"}]} -->
                 <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"
-                    href="https://statsboard.pinadmin.com/build?%7B%22from%22%3A%221w%22%2C%22until%22%3A%22%22%2C%22metrics%22%3A%5B%7B%22metric%22%3A%22avg%3autoscaling.{{ env.envName }}.{{ env.stageName }}.deploylatency%22%7D%5D%2C%22renderer%22%3A%22line%22%7D"
+                    href="https://statsboard.pinadmin.com/build?%7B%22from%22%3A%221w%22%2C%22metrics%22%3A%5B%7B%22metric%22%3A%22avg%3autoscaling.{{ env.envName }}.{{ env.stageName }}.deploylatency%22%7D%5D%2C%22renderer%22%3A%22line%22%7D"
                     title="" data-original-title="Click to see more deploy latency information in StatsBoard">
                 <strong>Deploy Latency for {{ env.envName }}</strong>
                 <!-- https://statsboard.pinadmin.com/build?{"from":"1w","metrics":[{"metric":"minmax:autoscaling.{{ env.envName }}.{{ env.stageName }}.first_deploy.failed"}]} -->
                 <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"
-                   href="https://statsboard.pinadmin.com/build?%7B%22from%22%3A%221w%22%2C%22until%22%3A%22%22%2C%22metrics%22%3A%5B%7B%22metric%22%3A%22minmax%3autoscaling.{{ env.envName }}.{{ env.stageName }}.first_deploy.failed%22%7D%5D%2C%22renderer%22%3A%22line%22%7D"
+                   href="https://statsboard.pinadmin.com/build?%7B%22from%22%3A%221w%22%2C%22metrics%22%3A%5B%7B%22metric%22%3A%22minmax%3autoscaling.{{ env.envName }}.{{ env.stageName }}.first_deploy.failed%22%7D%5D%2C%22renderer%22%3A%22line%22%7D"
                     title="" data-original-title="Click to see more launch failed count information in StatsBoard">
                 <strong>Launch failed count for {{ env.envName }}</strong>
             </a>

--- a/deploy-board/deploy_board/templates/groups/group_details.html
+++ b/deploy-board/deploy_board/templates/groups/group_details.html
@@ -121,7 +121,7 @@
                     <strong>Launch Latency for {{ env.envName }}</strong>
                 </a>
                 <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"
-                    href="https://statsboard.pinadmin.com/build?{'from':'1w','metrics':[{'metric':'avg:autoscaling.{{ env.envName }}.{{ env.stageName }}.launchlatency'}]}"
+                    href="https://statsboard.pinadmin.com/build?{'from':'1w','metrics':[{'metric':'avg:autoscaling.{{ env.envName }}.{{ env.stageName }}.deploylatency'}]}"
                     title="" data-original-title="Click to see more deploy latency information in StatsBoard">
                 <strong>Deploy Latency for {{ env.envName }}</strong>
                 <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"

--- a/deploy-board/deploy_board/templates/groups/group_details.html
+++ b/deploy-board/deploy_board/templates/groups/group_details.html
@@ -110,22 +110,22 @@
         </div>
         <div align="left" id="tsdLinksId">
             <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"
-                href="https://statsboard.pinadmin.com/build?%7B%22from%22%3A%221w%22%2C%22metrics%22%3A%5B%7B%22metric%22%3A%22avg%3Aavg:autoscaling.{{ group_name }}.size"
+                href="https://statsboard.pinadmin.com/build?{'from':'1w','metrics':[{'metric':'avg:autoscaling.{{ group_name }}.size'}]}"
                 title="" data-original-title="Click to see more group size information in StatsBoard">
                 <strong>Group Size</strong>
             </a>
             {% for env in envs %}
                 <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"
-                    href="https://statsboard.pinadmin.com/build?%7B%22from%22%3A%221w%22%2C%22metrics%22%3A%5B%7B%22metric%22%3A%22avg%3Aavg:autoscaling.{{ env.envName }}.{{ env.stageName }}.launchlatency"
+                    href="https://statsboard.pinadmin.com/build?{'from':'1w','metrics':[{'metric':'avg:autoscaling.{{ env.envName }}.{{ env.stageName }}.launchlatency'}]}"
                     title="" data-original-title="Click to see more launch latency information in StatsBoard">
                     <strong>Launch Latency for {{ env.envName }}</strong>
                 </a>
                 <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"
-                    href="https://statsboard.pinadmin.com/build?%7B%22from%22%3A%221w%22%2C%22metrics%22%3A%5B%7B%22metric%22%3A%22avg%3Aavg:autoscaling.{{ env.envName }}.{{ env.stageName }}.deploylatency"
+                    href="https://statsboard.pinadmin.com/build?{'from':'1w','metrics':[{'metric':'avg:autoscaling.{{ env.envName }}.{{ env.stageName }}.launchlatency'}]}"
                     title="" data-original-title="Click to see more deploy latency information in StatsBoard">
                 <strong>Deploy Latency for {{ env.envName }}</strong>
                 <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"
-                   href="https://statsboard.pinadmin.com/build?%7B%22from%22%3A%221w%22%2C%22metrics%22%3A%5B%7B%22metric%22%3A%22minmax%3Amimmax:autoscaling.{{ env.envName }}.{{ env.stageName }}.first_deploy.failed"
+                   href="https://statsboard.pinadmin.com/build?{'from':'1w','metrics':[{'metric':'minmax:autoscaling.{{ env.envName }}.{{ env.stageName }}.first_deploy.failed'}]}"
                     title="" data-original-title="Click to see more launch failed count information in StatsBoard">
                 <strong>Launch failed count for {{ env.envName }}</strong>
             </a>

--- a/deploy-board/deploy_board/templates/groups/group_details.html
+++ b/deploy-board/deploy_board/templates/groups/group_details.html
@@ -110,22 +110,22 @@
         </div>
         <div align="left" id="tsdLinksId">
             <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"
-                href="https://statsboard.pinadmin.com/stats/avg:autoscaling.{{ group_name }}.size"
+                href="https://statsboard.pinadmin.com/build?%7B%22from%22%3A%221w%22%2C%22metrics%22%3A%5B%7B%22metric%22%3A%22avg%3Aavg:autoscaling.{{ group_name }}.size"
                 title="" data-original-title="Click to see more group size information in StatsBoard">
                 <strong>Group Size</strong>
             </a>
             {% for env in envs %}
                 <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"
-                    href="https://statsboard.pqinadmin.com/stats/avg:autoscaling.{{ env.envName }}.{{ env.stageName }}.launchlatency"
+                    href="https://statsboard.pinadmin.com/build?%7B%22from%22%3A%221w%22%2C%22metrics%22%3A%5B%7B%22metric%22%3A%22avg%3Aavg:autoscaling.{{ env.envName }}.{{ env.stageName }}.launchlatency"
                     title="" data-original-title="Click to see more launch latency information in StatsBoard">
                     <strong>Launch Latency for {{ env.envName }}</strong>
                 </a>
                 <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"
-                    href="https://statsboard.pinadmin.com/stats/avg:autoscaling.{{ env.envName }}.{{ env.stageName }}.deploylatency"
+                    href="https://statsboard.pinadmin.com/build?%7B%22from%22%3A%221w%22%2C%22metrics%22%3A%5B%7B%22metric%22%3A%22avg%3Aavg:autoscaling.{{ env.envName }}.{{ env.stageName }}.deploylatency"
                     title="" data-original-title="Click to see more deploy latency information in StatsBoard">
                 <strong>Deploy Latency for {{ env.envName }}</strong>
                 <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"
-                   href="https://statsboard.pinadmin.com/stats/mimmax:autoscaling.{{ env.envName }}.{{ env.stageName }}.first_deploy.failed"
+                   href="https://statsboard.pinadmin.com/build?%7B%22from%22%3A%221w%22%2C%22metrics%22%3A%5B%7B%22metric%22%3A%22minmax%3Amimmax:autoscaling.{{ env.envName }}.{{ env.stageName }}.first_deploy.failed"
                     title="" data-original-title="Click to see more launch failed count information in StatsBoard">
                 <strong>Launch failed count for {{ env.envName }}</strong>
             </a>

--- a/deploy-board/deploy_board/templates/groups/group_details.html
+++ b/deploy-board/deploy_board/templates/groups/group_details.html
@@ -107,23 +107,23 @@
         </div>
         <div align="left" id="tsdLinksId">
             <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"
-                href="https://tsd.pinadmin.com/#start=1w-ago&m=avg:autoscaling.{{ group_name }}.size"
-                title="" data-original-title="Click to see more group size information in TSDB">
+                href="https://statsboard.pinadmin.com/stats/avg:autoscaling.{{ group_name }}.size"
+                title="" data-original-title="Click to see more group size information in StatsBoard">
                 <strong>Group Size</strong>
             </a>
             {% for env in envs %}
                 <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"
-                    href="https://tsd.pinadmin.com/#start=1w-ago&m=avg:autoscaling.{{ env.envName }}.{{ env.stageName }}.launchlatency"
-                    title="" data-original-title="Click to see more launch latency information in TSDB">
+                    href="https://statsboard.pqinadmin.com/stats/avg:autoscaling.{{ env.envName }}.{{ env.stageName }}.launchlatency"
+                    title="" data-original-title="Click to see more launch latency information in StatsBoard">
                     <strong>Launch Latency for {{ env.envName }}</strong>
                 </a>
                 <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"
-                    href="https://tsd.pinadmin.com/#start=1w-ago&m=avg:autoscaling.{{ env.envName }}.{{ env.stageName }}.deploylatency"
-                    title="" data-original-title="Click to see more deploy latency information in TSDB">
+                    href="https://statsboard.pinadmin.com/stats/avg:autoscaling.{{ env.envName }}.{{ env.stageName }}.deploylatency"
+                    title="" data-original-title="Click to see more deploy latency information in StatsBoard">
                 <strong>Deploy Latency for {{ env.envName }}</strong>
                 <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"
-                   href="https://tsd.pinadmin.com/#start=1w-ago&m=mimmax:autoscaling.{{ env.envName }}.{{ env.stageName }}.first_deploy.failed"
-                    title="" data-original-title="Click to see more launch failed count information in TSDB">
+                   href="https://statsboard.pinadmin.com/stats/mimmax:autoscaling.{{ env.envName }}.{{ env.stageName }}.first_deploy.failed"
+                    title="" data-original-title="Click to see more launch failed count information in StatsBoard">
                 <strong>Launch failed count for {{ env.envName }}</strong>
             </a>
             {% endfor %}

--- a/deploy-board/deploy_board/templates/groups/group_details.html
+++ b/deploy-board/deploy_board/templates/groups/group_details.html
@@ -80,11 +80,11 @@
             </a>
         </h4>
     </div>
-    <script src="https://www.gstatic.com/charts/loader.js"></script>
-    <script>
-      google.charts.load('current', {packages: ['corechart']});
-      google.charts.setOnLoadCallback(drawChart);
+    <script type="text/javascript" src="https://www.google.com/jsapi"></script>
+    <script type="text/javascript">
+      google.load("visualization", "1", {packages:["corechart"]});
     </script>
+
     <div id="metricStatId" class="collapse in panel-body">
         <div align="center" id="groupStatsId" class="collapse in panel-body">
             <div id="container" class="chartContainer">

--- a/deploy-board/deploy_board/templates/groups/group_details.html
+++ b/deploy-board/deploy_board/templates/groups/group_details.html
@@ -80,8 +80,11 @@
             </a>
         </h4>
     </div>
-    <script type="text/javascript" src="https://www.google.com/jsapi?autoload={'modules':[{'name':'visualization','version':'1.1','packages':['corechart']}]}"></script>
-
+    <script src="https://www.gstatic.com/charts/loader.js"></script>
+    <script>
+      google.charts.load('current', {packages: ['corechart']});
+      google.charts.setOnLoadCallback(drawChart);
+    </script>
     <div id="metricStatId" class="collapse in panel-body">
         <div align="center" id="groupStatsId" class="collapse in panel-body">
             <div id="container" class="chartContainer">

--- a/deploy-board/deploy_board/templates/groups/group_details.html
+++ b/deploy-board/deploy_board/templates/groups/group_details.html
@@ -109,16 +109,16 @@
             <div id="loadGroupInfo"></div>
         </div>
         <div align="left" id="tsdLinksId">
-            <!-- https://statsboard.pinadmin.com/build?{"from":"1w","metrics":[{"metric":"avg:autoscaling.{{ group_name }}.size"}]} -->
+            <!-- https://statsboard.pinadmin.com/build?{"renderer":"line","title":"Fleet Size", "yAxisLabel":"Group Size","ymax":"15","ymin":"0","from":"1w","metrics":[{"agg":"avg","cell":"aws-us-east-1","color":"dodgerblue","db":"tsdb","dsAgg":"avg","dsValue":"10m", "metric":"autoscaling.{{group_name}}.size","renderer":"line"}]} -->
             <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"
-                href="https://statsboard.pinadmin.com/build?%7B%22from%22%3A%221w%22%2C%22metrics%22%3A%5B%7B%22metric%22%3A%22avg%3Aautoscaling.{{ group_name }}.size%22%7D%5D%2C%22renderer%22%3A%22line%22%7D"
+                href="https://statsboard.pinadmin.com/build?%7B%22renderer%22%3A%22line%22%2C%22title%22%3A%22Fleet%20Size%22%2C%22yAxisLabel%22%3A%22Group%20Size%22%2C%22ymax%22%3A%2215%22%2C%22ymin%22%3A%220%22%2C%22from%22%3A%221w%22%2C%22metrics%22%3A%5B%7B%22agg%22%3A%22avg%22%2C%22cell%22%3A%22aws-us-east-1%22%2C%22color%22%3A%22dodgerblue%22%2C%22db%22%3A%22tsdb%22%2C%22dsAgg%22%3A%22avg%22%2C%22dsValue%22%3A%2210m%22%2C%22metric%22%3A%22autoscaling.{{ group_name }}.size%22%2C%22renderer%22%3A%22line%22%7D%5D%7D"
                 title="" data-original-title="Click to see more group size information in StatsBoard">
                 <strong>Group Size</strong>
             </a>
             {% for env in envs %}
                 <!-- https://statsboard.pinadmin.com/build?{"from":"1w","metrics":[{"metric":"avg:autoscaling.{{ env.envName }}.{{ env.stageName }}.launchlatency"}]} -->
                 <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"
-                    href="https://statsboard.pinadmin.com/build?%7B%22from%22%3A%221w%22%2C%22metrics%22%3A%5B%7B%22metric%22%3A%22avg%3Aautoscaling.srebot.prod.launchlatency%22%7D%5D%2C%22renderer%22%3A%22line%22%7D"
+                    href="https://statsboard.pinadmin.com/build?%7B%22from%22%3A%221w%22%2C%22metrics%22%3A%5B%7B%22metric%22%3A%22avg%3Aautoscaling.{{ env.envName }}.{{ env.stageName }}.launchlatency%22%7D%5D%2C%22renderer%22%3A%22line%22%7D"
                     title="" data-original-title="Click to see more launch latency information in StatsBoard">
                     <strong>Launch Latency for {{ env.envName }}</strong>
                 </a>
@@ -127,9 +127,9 @@
                     href="https://statsboard.pinadmin.com/build?%7B%22from%22%3A%221w%22%2C%22metrics%22%3A%5B%7B%22metric%22%3A%22avg%3autoscaling.{{ env.envName }}.{{ env.stageName }}.deploylatency%22%7D%5D%2C%22renderer%22%3A%22line%22%7D"
                     title="" data-original-title="Click to see more deploy latency information in StatsBoard">
                 <strong>Deploy Latency for {{ env.envName }}</strong>
-                <!-- https://statsboard.pinadmin.com/build?{"from":"1w","metrics":[{"metric":"minmax:autoscaling.{{ env.envName }}.{{ env.stageName }}.first_deploy.failed"}]} -->
+                <!-- https://statsboard.pinadmin.com/build?{"from":"1w","metrics":[{"metric":"mimmax:autoscaling.{{ env.envName }}.{{ env.stageName }}.first_deploy.failed"}]} -->
                 <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"
-                   href="https://statsboard.pinadmin.com/build?%7B%22from%22%3A%221w%22%2C%22metrics%22%3A%5B%7B%22metric%22%3A%22minmax%3autoscaling.{{ env.envName }}.{{ env.stageName }}.first_deploy.failed%22%7D%5D%2C%22renderer%22%3A%22line%22%7D"
+                   href="https://statsboard.pinadmin.com/build?%7B%22from%22%3A%221w%22%2C%22metrics%22%3A%5B%7B%22metric%22%3A%22mimmax%3autoscaling.{{ env.envName }}.{{ env.stageName }}.first_deploy.failed%22%7D%5D%2C%22renderer%22%3A%22line%22%7D"
                     title="" data-original-title="Click to see more launch failed count information in StatsBoard">
                 <strong>Launch failed count for {{ env.envName }}</strong>
             </a>

--- a/deploy-board/deploy_board/templates/groups/group_stats.tmpl
+++ b/deploy-board/deploy_board/templates/groups/group_stats.tmpl
@@ -1,4 +1,6 @@
 <script type="text/javascript">
+google.load("visualization", "1.1", {packages:["corechart"], "callback" : drawChart0});
+function drawChart0(){
 {% if enable_policy  %}
 
     {% for alarm_info in alarm_infos %}
@@ -228,4 +230,5 @@
             chart.draw(data, options);
 
 {% endif %}
+}
 </script>

--- a/deploy-board/deploy_board/templates/groups/latency_stats.tmpl
+++ b/deploy-board/deploy_board/templates/groups/latency_stats.tmpl
@@ -4,6 +4,48 @@
         var charts2 = {};
     </script>
 
+    <script>
+        function updateCharts2(response) {
+            if(data_options2['Requests'] && data_options2['Requests'].length > 1){
+                var data = data_options2['Requests'][0];
+                var options = data_options2['Requests'][1];
+                var stage_names = response['stage_names'];
+                var launch_latency_th = response['launch_latency_th'];
+                var launch_tmp = "launch_latency.";
+                var deploy_tmp = "deploy_latency.";
+
+                if (stage_names != null) {
+                    for (var i = 0; i < 1; ++i) {
+                        var metric_name1 = launch_tmp + stage_names[i];
+                        var metric_name2 = deploy_tmp + stage_names[i];
+
+                        data.addColumn("number", metric_name1);
+                        data.addColumn("number", metric_name2);
+
+                        var data_list1 = response[metric_name1];
+                        var data_list2 = response[metric_name2];
+                        var data_len = Math.min(data_list1.length,  data_list2.length);
+                        for (var j = 0; j < data_len; ++j) {
+                            var d = new Date(data_list1[j][0]);
+                            data.addRow([d, launch_latency_th, data_list1[j][1], data_list2[j][1]]);
+                        }
+                    }
+                }
+                var metric_chart = charts2["Requests"];
+                metric_chart.draw(data, options);
+            }
+        }
+
+        function poll_metrics2() {
+            $.get('/group_latency_stats/{{ group_name }}', function(response) {
+                updateCharts2(response);
+            }).fail(function() {
+                console.error('Fail to get group latency stats!');
+            });
+        }
+
+    </script>
+
     <script type="text/javascript">
         google.load("visualization", "1.1", {packages:["corechart"], "callback":drawChart2});
 
@@ -52,50 +94,9 @@
             charts2['Requests'] = chart2;
             chart2.draw(data, options);
             data_options2['Requests'] = [data, options];
-        }
-    </script>
-
-    <script>
-        function updateCharts2(response) {
-            if(data_options2['Requests'] && data_options2['Requests'].length > 1){
-                var data = data_options2['Requests'][0];
-                var options = data_options2['Requests'][1];
-                var stage_names = response['stage_names'];
-                var launch_latency_th = response['launch_latency_th'];
-                var launch_tmp = "launch_latency.";
-                var deploy_tmp = "deploy_latency.";
-
-                if (stage_names != null) {
-                    for (var i = 0; i < 1; ++i) {
-                        var metric_name1 = launch_tmp + stage_names[i];
-                        var metric_name2 = deploy_tmp + stage_names[i];
-
-                        data.addColumn("number", metric_name1);
-                        data.addColumn("number", metric_name2);
-
-                        var data_list1 = response[metric_name1];
-                        var data_list2 = response[metric_name2];
-                        var data_len = Math.min(data_list1.length,  data_list2.length);
-                        for (var j = 0; j < data_len; ++j) {
-                            var d = new Date(data_list1[j][0]);
-                            data.addRow([d, launch_latency_th, data_list1[j][1], data_list2[j][1]]);
-                        }
-                    }
-                }
-                var metric_chart = charts2["Requests"];
-                metric_chart.draw(data, options);
-            }
-        }
-
-        function poll_metrics2() {
-            $.get('/group_latency_stats/{{ group_name }}', function(response) {
-                updateCharts2(response);
-            }).fail(function() {
-            });
-        }
-
-        $(document).ready(function() {
             poll_metrics2();
-        });
+        }
     </script>
+
+
 </html>

--- a/deploy-board/deploy_board/templates/groups/latency_stats.tmpl
+++ b/deploy-board/deploy_board/templates/groups/latency_stats.tmpl
@@ -5,8 +5,7 @@
     </script>
 
     <script type="text/javascript">
-        google.load("visualization", "1", {packages:["corechart"]});
-        google.setOnLoadCallback(drawChart2);
+        google.load("visualization", "1.1", {packages:["corechart"], "callback":drawChart2});
 
         function drawChart2() {
             var data = new google.visualization.DataTable();
@@ -58,32 +57,34 @@
 
     <script>
         function updateCharts2(response) {
-            var data = data_options2['Requests'][0];
-            var options = data_options2['Requests'][1];
-            var stage_names = response['stage_names'];
-            var launch_latency_th = response['launch_latency_th'];
-            var launch_tmp = "launch_latency.";
-            var deploy_tmp = "deploy_latency.";
+            if(data_options2['Requests'] && data_options2['Requests'].length > 1){
+                var data = data_options2['Requests'][0];
+                var options = data_options2['Requests'][1];
+                var stage_names = response['stage_names'];
+                var launch_latency_th = response['launch_latency_th'];
+                var launch_tmp = "launch_latency.";
+                var deploy_tmp = "deploy_latency.";
 
-            if (stage_names != null) {
-                for (var i = 0; i < 1; ++i) {
-                    var metric_name1 = launch_tmp + stage_names[i];
-                    var metric_name2 = deploy_tmp + stage_names[i];
+                if (stage_names != null) {
+                    for (var i = 0; i < 1; ++i) {
+                        var metric_name1 = launch_tmp + stage_names[i];
+                        var metric_name2 = deploy_tmp + stage_names[i];
 
-                    data.addColumn("number", metric_name1);
-                    data.addColumn("number", metric_name2);
+                        data.addColumn("number", metric_name1);
+                        data.addColumn("number", metric_name2);
 
-                    var data_list1 = response[metric_name1];
-                    var data_list2 = response[metric_name2];
-                    var data_len = Math.min(data_list1.length,  data_list2.length);
-                    for (var j = 0; j < data_len; ++j) {
-                        var d = new Date(data_list1[j][0]);
-                        data.addRow([d, launch_latency_th, data_list1[j][1], data_list2[j][1]]);
+                        var data_list1 = response[metric_name1];
+                        var data_list2 = response[metric_name2];
+                        var data_len = Math.min(data_list1.length,  data_list2.length);
+                        for (var j = 0; j < data_len; ++j) {
+                            var d = new Date(data_list1[j][0]);
+                            data.addRow([d, launch_latency_th, data_list1[j][1], data_list2[j][1]]);
+                        }
                     }
                 }
+                var metric_chart = charts2["Requests"];
+                metric_chart.draw(data, options);
             }
-            var metric_chart = charts2["Requests"];
-            metric_chart.draw(data, options);
         }
 
         function poll_metrics2() {

--- a/deploy-board/deploy_board/templates/groups/launch_rate.tmpl
+++ b/deploy-board/deploy_board/templates/groups/launch_rate.tmpl
@@ -4,12 +4,14 @@
         var charts3 = {};
     </script>
     <script "text/javascript">
-        google.load("visualization", "1", {packages:["corechart"]});
-        google.setOnLoadCallback(drawChart3);
+        google.load("visualization", "1.1", {packages:["corechart"], 'callback': drawChart3});
 
         function drawChart3() {
             var data = new google.visualization.DataTable();
             data.addColumn("datetime", "Date");
+
+            var failure_count_name = "Launch Failure Count";
+            data.addColumn("number", failure_count_name);
 
             var options = {
                 title: 'Launch Failure Count',
@@ -56,22 +58,24 @@
 
     <script>
         function updateLaunchRateCharts(response) {
-            var data = launch_rate_data_options['Requests'][0];
-            var options = launch_rate_data_options['Requests'][1];
-            var metric_names = response['metric_names'];
-            if (metric_names != null) {
-                for (var i = 0; i < 1; ++i) {
-                    var metric_name = metric_names[i];
-                    data.addColumn("number", "Launch Failure Count");
-                    data_list = response[metric_name];
-                    for (j = 0; j < data_list.length; ++j) {
-                        var d = new Date(data_list[j][0]);
-                        data.addRow([d, data_list[j][1]]);
+            if(launch_rate_data_options['Requests'] && launch_rate_data_options['Requests'].length > 1){
+                var data = launch_rate_data_options['Requests'][0];
+                var options = launch_rate_data_options['Requests'][1];
+                var metric_names = response['metric_names'];
+                if (metric_names != null) {
+                    for (var i = 0; i < 1; ++i) {
+                        var metric_name = metric_names[i];
+                        data.addColumn("number", "Launch Failure Count");
+                        data_list = response[metric_name];
+                        for (j = 0; j < data_list.length; ++j) {
+                            var d = new Date(data_list[j][0]);
+                            data.addRow([d, data_list[j][1]]);
+                        }
                     }
                 }
+                var metric_chart = charts3["Requests"];
+                metric_chart.draw(data, options);
             }
-            var metric_chart = charts3["Requests"];
-            metric_chart.draw(data, options);
         }
 
         function pollLaunchRateMetrics() {

--- a/deploy-board/deploy_board/templates/groups/launch_rate.tmpl
+++ b/deploy-board/deploy_board/templates/groups/launch_rate.tmpl
@@ -3,6 +3,36 @@
         var launch_rate_data_options = {};
         var charts3 = {};
     </script>
+    <script>
+        function updateLaunchRateCharts(response) {
+            if(launch_rate_data_options['Requests'] && launch_rate_data_options['Requests'].length > 1){
+                var data = launch_rate_data_options['Requests'][0];
+                var options = launch_rate_data_options['Requests'][1];
+                var metric_names = response['metric_names'];
+                if (metric_names != null) {
+                    for (var i = 0; i < 1; ++i) {
+                        var metric_name = metric_names[i];
+                        data.addColumn("number", "Launch Failure Count");
+                        data_list = response[metric_name];
+                        for (j = 0; j < data_list.length; ++j) {
+                            var d = new Date(data_list[j][0]);
+                            data.addRow([d, data_list[j][1]]);
+                        }
+                    }
+                }
+                var metric_chart = charts3["Requests"];
+                metric_chart.draw(data, options);
+            }
+        }
+
+        function pollLaunchRateMetrics() {
+            $.get('/group_launch_rate/{{ group_name }}/', function(response) {
+                updateLaunchRateCharts(response);
+            }).fail(function() {
+                console.error('Failed to get rate charts');
+            });
+        }
+    </script>
     <script "text/javascript">
         google.load("visualization", "1.1", {packages:["corechart"], 'callback': drawChart3});
 
@@ -52,41 +82,8 @@
             charts3['Requests'] = chart3;
             chart3.draw(data, options);
             launch_rate_data_options['Requests'] = [data, options];
+            pollLaunchRateMetrics();
         }
 
     </script>
-
-    <script>
-        function updateLaunchRateCharts(response) {
-            if(launch_rate_data_options['Requests'] && launch_rate_data_options['Requests'].length > 1){
-                var data = launch_rate_data_options['Requests'][0];
-                var options = launch_rate_data_options['Requests'][1];
-                var metric_names = response['metric_names'];
-                if (metric_names != null) {
-                    for (var i = 0; i < 1; ++i) {
-                        var metric_name = metric_names[i];
-                        data.addColumn("number", "Launch Failure Count");
-                        data_list = response[metric_name];
-                        for (j = 0; j < data_list.length; ++j) {
-                            var d = new Date(data_list[j][0]);
-                            data.addRow([d, data_list[j][1]]);
-                        }
-                    }
-                }
-                var metric_chart = charts3["Requests"];
-                metric_chart.draw(data, options);
-            }
-        }
-
-        function pollLaunchRateMetrics() {
-            $.get('/group_launch_rate/{{ group_name }}/', function(response) {
-                updateLaunchRateCharts(response);
-            }).fail(function() {
-            });
-        }
-
-        $(document).ready(function() {
-            pollLaunchRateMetrics();
-        });
-</script>
 </html>

--- a/deploy-board/deploy_board/templates/groups/pas_stats.tmpl
+++ b/deploy-board/deploy_board/templates/groups/pas_stats.tmpl
@@ -5,8 +5,7 @@
     </script>
 
     <script type="text/javascript">
-        google.load("visualization", "1", {packages:["corechart"]});
-        google.setOnLoadCallback(drawChart4);
+        google.load("visualization", "1.1", {packages:["corechart"]}, "callback": drawChart4);
 
         function drawChart4() {
             var data = new google.visualization.DataTable();
@@ -56,21 +55,23 @@
 
     <script>
         function updateCharts4(response) {
-            var data = data_options4['Requests'][0];
-            var options = data_options4['Requests'][1];
+            if(data_options4['Requests'] && data_options4['Requests'].length > 1){
+                var data = data_options4['Requests'][0];
+                var options = data_options4['Requests'][1];
 
-            var arcee_data = response['arcee'];
-            var data_len = arcee_data.length;
+                var arcee_data = response['arcee'];
+                var data_len = arcee_data.length;
 
-            data.addColumn("number", "Min Size Changes");
+                data.addColumn("number", "Min Size Changes");
 
-            for (var j = 0; j < data_len; ++j) {
-                var d = new Date(arcee_data[data_len - j - 1][0]);
-                data.addRow([d, arcee_data[data_len - j - 1][1]]);
+                for (var j = 0; j < data_len; ++j) {
+                    var d = new Date(arcee_data[data_len - j - 1][0]);
+                    data.addRow([d, arcee_data[data_len - j - 1][1]]);
+                }
+
+                var metric_chart = charts4["Requests"];
+                metric_chart.draw(data, options);
             }
-
-            var metric_chart = charts4["Requests"];
-            metric_chart.draw(data, options);
         }
 
         function poll_metrics4() {

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -640,13 +640,13 @@ def get_group_info(request, group_name):
 def get_group_size(request, group_name):
     try:
 
-        metric_name = "max:autoscaling.{}.first_deploy.failed".format(group_name)
+        metric_name = "max:autoscaling.{}.size".format(group_name)
 
         group_size_datum = \
             autoscaling_metrics_helper.get_raw_metrics(request, metric_name,
                                                            settings.DEFAULT_START_TIME)
 
-        spot_metric_name = "max:autoscaling.{}-spot.first_deploy.failed".format(group_name)
+        spot_metric_name = "max:autoscaling.{}-spot.size".format(group_name)
 
         spot_group_size_datum = \
             autoscaling_metrics_helper.get_raw_metrics(request, spot_metric_name,

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -639,13 +639,18 @@ def get_group_info(request, group_name):
 
 def get_group_size(request, group_name):
     try:
+
+        metric_name = "max:autoscaling.{}.first_deploy.failed".format(group_name)
+
         group_size_datum = \
-            autoscaling_metrics_helper.get_asg_size_metric(request, group_name,
+            autoscaling_metrics_helper.get_raw_metrics(request, metric_name,
                                                            settings.DEFAULT_START_TIME)
 
+        spot_metric_name = "max:autoscaling.{}-spot.first_deploy.failed".format(group_name)
+
         spot_group_size_datum = \
-            autoscaling_metrics_helper.get_asg_size_metric(request, "{}-spot".format(group_name),
-                                                           settings.DEFAULT_START_TIME)
+            autoscaling_metrics_helper.get_raw_metrics(request, spot_metric_name,
+                                                       settings.DEFAULT_START_TIME)
 
         alarm_infos = autoscaling_groups_helper.get_alarms(request, group_name)
         spot_group_name = "{}-spot".format(group_name)
@@ -1229,7 +1234,7 @@ def add_scheduled_actions(request, group_name):
         scheduled_action_capacity = int(params['capacity'])
         if scheduled_action_capacity < asg_minsize or scheduled_action_capacity > asg_maxsize:
             raise TeletraanException("Invalid capacity: {}. Desired capacity must be within the limits of ASG's minimum capacity ({}) and maximum capacity ({}). Please change the value you input for Capacity.".format(params['capacity'], asg_minsize, asg_maxsize))
- 
+
         autoscaling_groups_helper.add_scheduled_actions(request, group_name, [schedule_action])
     except:
         log.error(traceback.format_exc())

--- a/deploy-board/deploy_board/webapp/util_views.py
+++ b/deploy-board/deploy_board/webapp/util_views.py
@@ -61,7 +61,11 @@ def get_service_metrics(request, name, stage):
 def get_site_health_metrics(request):
     data = {}
     for metric in SITE_METRICS_CONFIGS:
-        data[metric['title']] = _get_latest_metrics(metric['url'])
+        try:
+            data[metric['title']] = _get_latest_metrics(metric['url'])
+        except Exception as e:
+            log.error('Failed to get latest metric {} Error {}', metric['title'], e)
+            continue
     return HttpResponse(json.dumps({'html': data}), content_type="application/json")
 
 
@@ -163,7 +167,7 @@ def get_launch_rate(request, group_name):
     try:
         util_data["metric_names"] = []
         for env in envs:
-            metric_name = "mimmax:5m-mimmax:autoscaling.{}.{}.first_deploy.failed".format(
+            metric_name = "mimmax:autoscaling.{}.{}.first_deploy.failed".format(
                 env["envName"], env["stageName"])
             rate_data_points = autoscaling_metrics_helper.get_raw_metrics(request, metric_name,
                                                                           settings.DEFAULT_START_TIME)

--- a/deploy-board/deploy_board/webapp/util_views.py
+++ b/deploy-board/deploy_board/webapp/util_views.py
@@ -127,9 +127,9 @@ def get_latency_metrics(request, group_name):
 
     try:
         for env in envs:
-            name = "{}.{}".format(env["envName"], env["stageName"])
+            name = "autoscaling.{}.{}".format(env["envName"], env["stageName"])
             stage_names.append(name)
-            metric_name1 = "launch_latency.{}".format(name)
+            metric_name1 = "{}.launchlatency".format(name)
             launch_data_points = autoscaling_metrics_helper.get_latency_data(request, env["id"],
                                                                              "LAUNCH", settings.DEFAULT_START_TIME)
             json_data = []
@@ -138,7 +138,7 @@ def get_latency_metrics(request, group_name):
                 json_data.append([timestamp, value])
             util_data[metric_name1] = json_data
 
-            metric_name2 = "deploy_latency.{}".format(name)
+            metric_name2 = "{}.deploylatency".format(name)
             deploy_data_points = autoscaling_metrics_helper.get_latency_data(request, env["id"],
                                                                              "DEPLOY", settings.DEFAULT_START_TIME)
             json_data2 = []

--- a/deploy-board/deploy_board/webapp/util_views.py
+++ b/deploy-board/deploy_board/webapp/util_views.py
@@ -127,9 +127,9 @@ def get_latency_metrics(request, group_name):
 
     try:
         for env in envs:
-            name = "autoscaling.{}.{}".format(env["envName"], env["stageName"])
+            name = "{}.{}".format(env["envName"], env["stageName"])
             stage_names.append(name)
-            metric_name1 = "{}.launchlatency".format(name)
+            metric_name1 = "launch_latency.{}".format(name)
             launch_data_points = autoscaling_metrics_helper.get_latency_data(request, env["id"],
                                                                              "LAUNCH", settings.DEFAULT_START_TIME)
             json_data = []
@@ -138,7 +138,7 @@ def get_latency_metrics(request, group_name):
                 json_data.append([timestamp, value])
             util_data[metric_name1] = json_data
 
-            metric_name2 = "{}.deploylatency".format(name)
+            metric_name2 = "deploy_latency.{}".format(name)
             deploy_data_points = autoscaling_metrics_helper.get_latency_data(request, env["id"],
                                                                              "DEPLOY", settings.DEFAULT_START_TIME)
             json_data2 = []

--- a/deploy-board/requirements.txt
+++ b/deploy-board/requirements.txt
@@ -8,4 +8,4 @@ flake8==2.4.1
 nose==1.3.0
 mock==0.8.0
 simplejson==3.11.1
-django-csp==3.4
+django-csp==3.6


### PR DESCRIPTION
Summary:
The deploy board stats link are broken.
This fix changes the old tsd.pinadmin.com to statsboard.

Test Plan:
Check if the graph match the ones in this list
https://statsboard.pinadmin.com/search?q=autoscaling

Using statsboard stats link instead. 
