### PR TITLE
Changing HostType Identifier for backend on Cluster Configurations views

### DIFF
--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -457,7 +457,7 @@
                 currentCell: currentCluster.cellName,
                 hostTypeOptions: info.hostTypes.map(function(item, idx) {
                     return {
-                        value: item.abstract_name,
+                        value: item.id,
                         text: item.abstract_name + " (" + item.core + " cores, " + item.mem + " GB, " + item.storage + ", " + item.provider + ": " + item.provider_name + ")",
                         isSelected: item.abstract_name === currentCluster.hostType
                     }

--- a/deploy-board/deploy_board/templates/configs/new_capacity.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity.html
@@ -117,7 +117,7 @@ var capacitySetting = new Vue({
         instanceCount:"",
         hostTypeOptions: capacityCreationInfo.hostTypes.map(function(item,idx){
             return {
-                value: item.abstract_name,
+                value: item.id,
                 text: item.abstract_name+" ("+item.core+" cores, "+item.mem+" GB, "+item.storage+")",
                 isSelected: item.abstract_name === capacityCreationInfo.defaultHostType
             }}),

--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -135,7 +135,7 @@ var capacitySetting = new Vue({
         hostTypeOptions: info.hostTypes.map(
             function (item, idx) {
                 return {
-                    value: item.abstract_name,
+                    value: item.id,
                     text: item.abstract_name + " (" + item.core + " cores, " + item.mem + " GB, " + item.storage + ", " + item.provider + ": " + item.provider_name + ")",
                     isSelected: item.abstract_name === info.defaultHostType
                 }


### PR DESCRIPTION
Using ID instead of Abstract Name to avoid overwriting HostType in User Experience