### PR TITLE
This fix CSP Chartlist loading on cluster configuration files

### DIFF
--- a/deploy-board/deploy_board/settings.py
+++ b/deploy-board/deploy_board/settings.py
@@ -293,11 +293,11 @@ if IS_PINTEREST:
     DEFAULT_CMP_ACCESS_ROLE = os.getenv('DEFAULT_CMP_ACCESS_ROLE')
 
     #CSP Config
-    CSP_SCRIPT_SRC = ("'self'", "https://*.gstatic.com/ https://www.google.com/ 'unsafe-inline' 'unsafe-eval'")
+    CSP_SCRIPT_SRC = ("'self'", "https://*.gstatic.com/ https://cdn.jsdelivr.net/ https://www.google.com/ 'unsafe-inline' 'unsafe-eval'")
     CSP_DEFAULT_SRC = ("'self'")
     CSP_CONNECT_SRC = ("'self'")
     CSP_EXCLUDE_URL_PREFIXES = ('/api-docs',)
-    CSP_STYLE_SRC = ("'self'", "https://*.gstatic.com/ 'unsafe-inline'")
+    CSP_STYLE_SRC = ("'self'", "https://*.gstatic.com/ https://cdn.jsdelivr.net/ 'unsafe-inline'")
 
     # Nimbus service url
     NIMBUS_SERVICE_URL = os.getenv("NIMBUS_SERVICE_URL", None)


### PR DESCRIPTION
Summary
The scripts are failing to load because of CSP rule and the browser are refusing to load them, this doesn't prevent user to continue but can frustrate its experience.

Test
Open deploy-board-ui-url/env/someenv/somestage/config/cluster/config/
Check if chart tables are being loaded