### PR TITLE
Add a decode() for py3 compatibility

### DIFF
--- a/deploy-agent/deployd/client/client.py
+++ b/deploy-agent/deployd/client/client.py
@@ -182,7 +182,7 @@ class Client(BaseClient):
                     # the server side:
                     # https://app.asana.com/0/11815463290546/40714916594784
                     if report.errorMessage:
-                        report.errorMessage = report.errorMessage.encode('ascii', 'ignore')
+                        report.errorMessage = report.errorMessage.encode('ascii', 'ignore').decode()
                 ping_request = PingRequest(hostId=self._id, hostName=self._hostname, hostIp=self._ip,
                                         groups=self._hostgroup, reports=reports,
                                         agentVersion=self._agent_version,

--- a/deploy-agent/requirements_test.txt
+++ b/deploy-agent/requirements_test.txt
@@ -3,7 +3,8 @@
 # tests
 tox==1.6.1
 coverage
-pytest==6.2.2
+pytest==6.2.2; python_version >= '3'
+pytest==4.6.11; python_version < '3'
 mock==1.0.1
 flake8==2.5.4
 pep8


### PR DESCRIPTION
Currently on py3, report.errorMessage being bytes can cause a JSONEncodeError due to inability of bytes to be json encoded.

This change will cause report.errorMessage to be re-encoded to str on py3 and unicode on py2, both of which can be handled by the JSON encoder.