### PR TITLE
Removed from Deploy-Agent setup, pinterest specific packages

### DIFF
--- a/deploy-agent/deployd/__init__.py
+++ b/deploy-agent/deployd/__init__.py
@@ -17,4 +17,4 @@ import os
 # Pinterest specific settings
 IS_PINTEREST = True if os.getenv("IS_PINTEREST", "false") == "true" else False
 
-__version__ = '1.2.25'
+__version__ = '1.2.26'

--- a/deploy-agent/setup.py
+++ b/deploy-agent/setup.py
@@ -33,14 +33,6 @@ install_requires = [
     "future==0.18.2"
 ]
 
-# Pinterest specific settings
-if os.getenv("IS_PINTEREST", "false") == "true":
-    extra_requires = [
-        "pinlogger>=0.11.0",
-        "pinstatsd==1.0.55",
-    ]
-    install_requires += extra_requires
-
 setup(
     name='deploy-agent',
     version=__version__,


### PR DESCRIPTION
Summary:
In order to prevent a dependency confusion in deploy-agent environment exploring non existing dependencies on a non Pinterest environment.
Removed pinlogger and pinstatd packages from setup. 
Test Plan:
1) deploy-agent install happens safely even in Pinterest environment