### PR TITLE
Fix bugfix on hosttype in cluster_configuration with default hosttype

### DIFF
--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -495,7 +495,7 @@
                         isSelected: item.abstract_name === currentCluster.securityZone
                     }
                 }),
-                selectedHostTypeValue: currentCluster.hostType,
+                selectedHostTypeValue: capacityCreationInfo.hostTypes.find(hostType => hostType.abstract_name === currentCluster.hostType).id,
                 selectedSecurityZoneValue: currentCluster.securityZone,
                 selectedPlacements: currentPlacements,
                 showBaseImageHelp: false,
@@ -718,7 +718,8 @@
                     var scope = this;
                     var provider = capacitySetting.currentProvider;
                     value = 'cmp_base-ebs';
-                    if (this.selectedHostTypeValue.startsWith('EbsCompute')) {
+                    const selectedHostTypeObject = capacityCreationInfo.hostTypes.find(hostType => hostType.id === this.selectedHostTypeValue);
+                    if (selectedHostTypeObject.abstract_name.startsWith('EbsCompute')) {
                         capacitySetting.imageNameValue = value;
                         capacitySetting.imagenames = info.baseImageNames.map(
                             function (o) {

--- a/deploy-board/deploy_board/templates/configs/new_capacity.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity.html
@@ -135,7 +135,7 @@ var capacitySetting = new Vue({
                 isSelected: item.abstract_name === capacityCreationInfo.defaultSeurityZone
             }
         }),
-        selectedHostTypeValue: capacityCreationInfo.defaultHostType,
+        selectedHostTypeValue: capacityCreationInfo.hostTypes.find(hostType => hostType.abstract_name === capacityCreationInfo.defaultHostType).id,
         selectedSecurityZoneValue: capacityCreationInfo.defaultSeurityZone,
         selectedPlacements: null
     },

--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -373,7 +373,8 @@ var capacitySetting = new Vue({
             var scope = this;
             var provider = capacitySetting.currentProvider;
             value = 'cmp_base-ebs-18.04';
-            if (this.selectedHostTypeValue.startsWith('EbsCompute')) {
+            const selectedHostTypeObject = capacityCreationInfo.hostTypes.find(hostType => hostType.id === this.selectedHostTypeValue);
+            if (selectedHostTypeObject.abstract_name.startsWith('EbsCompute')) {
                 capacitySetting.imageNameValue = value;
                 capacitySetting.imagenames = info.baseImageNames.map(
                     function (o) {


### PR DESCRIPTION
After changing Cluster API to use ID instead of Abstract Name, this is an adjusment to the UI to send ID instead of Abstract name on cluster configurations