### PR TITLE
Fix issue in migration script - refers to a table that doesn't exist

### DIFF
--- a/tools/mysql/schema-update-8.sql
+++ b/tools/mysql/schema-update-8.sql
@@ -5,7 +5,7 @@
 # This script upgrade DB schema from version 7 to version 8
 
 ALTER TABLE environs ADD COLUMN stage_type VARCHAR(32) NOT NULL DEFAULT 'PRODUCTION';
-ALTER TABLE groups MODIFY group_name VARCHAR(128) NOT NULL;
+ALTER TABLE groups_and_roles MODIFY group_name VARCHAR(128) NOT NULL;
 ALTER TABLE groups_and_envs MODIFY group_name VARCHAR(128) NOT NULL;
 
 CREATE TABLE IF NOT EXISTS hosts_and_agents (


### PR DESCRIPTION
Hello Pinterest, 
`tools/mysql/schema-update-8.sql` seems to refer to a table that does not exist, `groups`. 

logs from the migration script:
```
Will upgrade schema from version 6 to version 13
upgrading to version 7 with schema-update-7.sql...
upgrading to version 8 with schema-update-8.sql...
ERROR 1146 (42S02) at line 8: Table 'deploy.groups' doesn't exist
```
My assumption is that the table that was meant to be modified is actually `groups_and_roles`. 
If `groups` should exist, it's not being tracked in any of the existing SQL files.