### PR TITLE
[DRAFT] Restrict modifications of `is_sox` to SYSTEM Role

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironBean.java
@@ -544,11 +544,11 @@ public class EnvironBean implements Updatable, Serializable {
         this.stage_type = stage_type;
     }
 
-    public Boolean getSOX() {
+    public Boolean getIs_sox() {
         return is_sox;
     }
 
-    public void setSOX(Boolean is_sox) {
+    public void setIs_sox(Boolean is_sox) {
         this.is_sox = is_sox;
     }
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironBean.java
@@ -67,6 +67,7 @@ import javax.validation.constraints.Pattern;
  * allow_private_build TINYINT(1)    DEFAULT 0,
  * ensure_trusted_build TINYINT(1)    DEFAULT 0,
  * stage_type VARCHAR(32) NOT NULL DEFAULT PRODUCTION,
+ * is_sox TINYINT(1)    DEFAULT 0,
  * <p>
  * PRIMARY KEY   (env_id)
  * );
@@ -194,6 +195,9 @@ public class EnvironBean implements Updatable, Serializable {
 
     @JsonProperty("stageType")
     private EnvType stage_type;
+
+    @JsonProperty("isSOX")
+    private Boolean is_sox;
 
     public void validate() throws Exception {
         // A bunch of these fields will always be alphanumeric (with _ and -)
@@ -540,6 +544,14 @@ public class EnvironBean implements Updatable, Serializable {
         this.stage_type = stage_type;
     }
 
+    public Boolean getSOX() {
+        return is_sox;
+    }
+
+    public void setSOX(Boolean is_sox) {
+        this.is_sox = is_sox;
+    }
+
     @Override
     public SetClause genSetClause() {
         SetClause clause = new SetClause();
@@ -583,6 +595,7 @@ public class EnvironBean implements Updatable, Serializable {
         clause.addColumn("allow_private_build", allow_private_build);
         clause.addColumn("ensure_trusted_build", ensure_trusted_build);
         clause.addColumn("stage_type", stage_type);
+        clause.addColumn("is_sox", is_sox);
         return clause;
     }
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/Role.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/Role.java
@@ -30,13 +30,16 @@ package com.pinterest.deployservice.bean;
  *      plus the ability specify new OPERATORS and ADMINs for said environment.
  *      When a new environment is created the creating user is the designated the
  *      first ADMIN.
+ * SYSTEMADMIN:
+ *      System level administrator. This role is for system-wide use.
  */
 public enum Role {
     READER(0),
     PINGER(1),
     PUBLISHER(1),
     OPERATOR(10),
-    ADMIN(20);
+    ADMIN(20),
+    SYSTEMADMIN(100);
 
     private int value;
 

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
@@ -103,6 +103,17 @@ public class EnvStages {
         if (origBean.getStage_type() != EnvType.DEFAULT && origBean.getStage_type() != environBean.getStage_type()) {
             throw new TeletaanInternalException(Response.Status.BAD_REQUEST, "Modification of stage type is not allowed!");
         }
+        // TODO: isUserInRole takes a string and does not seem implemented... it should take the value from Role enum
+        if(environBean.getSOX() && !sc.isUserInRole("SYSTEMADMIN")) {  // TODO: see note above
+        //if(environBean.getSOX() && !sc.isUserInRole(Role.SYSTEMADMIN)) {
+            // raise 403
+
+            // we really just want to check the user's role against SYSTEMADMIN, we already identified our "resource"... how?
+            // can we get user role, and can we just use a comparer isAuthorized in Role.java
+            // but we also want to throw just like authorizer.authorize, would rather not reimplement it
+            // we can work with more granular permissions at the DAO level or something in the future.
+            //authorizer.authorize(sc, new Resource(origBean.getEnv_name(), Resource.Type.ENV), Role.SYSTEMADMIN);
+        }
         environBean.setEnv_name(origBean.getEnv_name());
         environBean.setStage_name(origBean.getStage_name());
         environHandler.updateStage(environBean, operator);

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
@@ -103,7 +103,7 @@ public class EnvStages {
         if (origBean.getStage_type() != EnvType.DEFAULT && origBean.getStage_type() != environBean.getStage_type()) {
             throw new TeletaanInternalException(Response.Status.BAD_REQUEST, "Modification of stage type is not allowed!");
         }
-        if(environBean.getIS_sox() && origBean.getIs_sox() != environBean.getIs_sox()) {
+        if(environBean.getIs_sox() && origBean.getIs_sox() != environBean.getIs_sox()) {
             authorizer.authorize(sc, new Resource(environBean.getEnv_name(), Resource.Type.ENV), Role.SYSTEMADMIN);
         }
         environBean.setEnv_name(origBean.getEnv_name());

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
@@ -103,16 +103,9 @@ public class EnvStages {
         if (origBean.getStage_type() != EnvType.DEFAULT && origBean.getStage_type() != environBean.getStage_type()) {
             throw new TeletaanInternalException(Response.Status.BAD_REQUEST, "Modification of stage type is not allowed!");
         }
-        // TODO: isUserInRole takes a string and does not seem implemented... it should take the value from Role enum
-        if(environBean.getSOX() && !sc.isUserInRole("SYSTEMADMIN")) {  // TODO: see note above
-        //if(environBean.getSOX() && !sc.isUserInRole(Role.SYSTEMADMIN)) {
-            // raise 403
-
-            // we really just want to check the user's role against SYSTEMADMIN, we already identified our "resource"... how?
-            // can we get user role, and can we just use a comparer isAuthorized in Role.java
-            // but we also want to throw just like authorizer.authorize, would rather not reimplement it
-            // we can work with more granular permissions at the DAO level or something in the future.
-            //authorizer.authorize(sc, new Resource(origBean.getEnv_name(), Resource.Type.ENV), Role.SYSTEMADMIN);
+        if(environBean.getSOX()) {
+            // TODO: future - should a more granular resource be authorized on than the environBean?
+            authorizer.authorize(sc, environBean, Role.SYSTEMADMIN);
         }
         environBean.setEnv_name(origBean.getEnv_name());
         environBean.setStage_name(origBean.getStage_name());

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
@@ -103,8 +103,7 @@ public class EnvStages {
         if (origBean.getStage_type() != EnvType.DEFAULT && origBean.getStage_type() != environBean.getStage_type()) {
             throw new TeletaanInternalException(Response.Status.BAD_REQUEST, "Modification of stage type is not allowed!");
         }
-        if(environBean.getSOX()) {
-            // TODO: future - should a more granular resource be authorized on?
+        if(environBean.getIS_sox() && origBean.getIs_sox() != environBean.getIs_sox()) {
             authorizer.authorize(sc, new Resource(environBean.getEnv_name(), Resource.Type.ENV), Role.SYSTEMADMIN);
         }
         environBean.setEnv_name(origBean.getEnv_name());

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
@@ -104,8 +104,8 @@ public class EnvStages {
             throw new TeletaanInternalException(Response.Status.BAD_REQUEST, "Modification of stage type is not allowed!");
         }
         if(environBean.getSOX()) {
-            // TODO: future - should a more granular resource be authorized on than the environBean?
-            authorizer.authorize(sc, environBean, Role.SYSTEMADMIN);
+            // TODO: future - should a more granular resource be authorized on?
+            authorizer.authorize(sc, new Resource(environBean.getEnv_name(), Resource.Type.ENV), Role.SYSTEMADMIN);
         }
         environBean.setEnv_name(origBean.getEnv_name());
         environBean.setStage_name(origBean.getStage_name());


### PR DESCRIPTION
The new `is_sox` column will be used to enforce SOX builds cannot have private builds. However, we need to prevent environment users from changing this status with the normal PUT endpoint.

We should restrict the ability to change `is_sox` to authorized users. For now, we can restrict it to SYSTEM users.