### PR TITLE
Hosts load UI

### DIFF
--- a/deploy-board/deploy_board/templates/environs/env_landing.html
+++ b/deploy-board/deploy_board/templates/environs/env_landing.html
@@ -166,12 +166,12 @@
       </div>
       <div class="modal-body">
         <p>Are you sure to pause the current deploy? <br>
-           Deployment will be paused on existing instances of a cluster but will continue on any new hosts added to a cluster. 
+           Deployment will be paused on existing instances of a cluster but will continue on any new hosts added to a cluster.
         </p>
         <div class="alert alert-danger" role="alert">
             <strong>WARNING</strong>:
             Please don't leave deployment in the PAUSED state permanently. <br>
-            Cluster will be running two different builds(old on existing instances and new on new instances) as long as deployment is paused.  
+            Cluster will be running two different builds(old on existing instances and new on new instances) as long as deployment is paused.
         </div>
       </div>
       <div class="modal-footer">
@@ -439,7 +439,20 @@ $('#privateBldUploadBtnId button').click(function () {
         </script>
         <div class="collapse in panel-body">
             <div id="activeDeployId">
-                {% include "deploys/deploy_progress.tmpl" %}
+                {% with deploy=report.currentDeployStat.deploy build=report.currentDeployStat.build tag=report.currentDeployStat.buildTag %}
+                {% include "deploys/deploy_progress_summary.tmpl" %}
+                {% endwith %}
+
+                <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"
+                   href="/env/{{ report.envName }}/{{ report.stageName }}/hosts/failed/"
+                   title="Click to see the details of all failed hosts">
+                   <strong>Failed Hosts</strong>
+                </a>
+                <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"
+                   href="/env/{{ report.envName }}/{{ report.stageName }}/hosts/"
+                   title="Click to see the details of all the hosts">
+                   <strong>All Details</strong>
+                </a>
             </div>
             <div class="row" id="serviceAddOnsId">
                 {% include "deploys/deploy_add_ons.tmpl" %}
@@ -452,13 +465,6 @@ $('#privateBldUploadBtnId button').click(function () {
     $(function () {
         var startTime = new Date().getTime();
         $('#serviceAddOnsId').load('/env/{{ env.envName }}/{{ env.stageName }}/update_service_add_ons/');
-
-        var interval = setInterval(function() {
-            if(new Date().getTime() - startTime > 3600000) {
-                clearInterval(interval);
-            }
-            $('#activeDeployId').load('/env/{{ env.envName }}/{{ env.stageName }}/update_deploy_progress/?showMode={{ report.showMode }}&sortByStatus={{ report.sortByStatus }}&sortByTag={{ report.sortByTag }}');
-        }, 30000);
 
         $(".dropdown-menu li").click(function() {
             query_string = $("#updateModeFormId").serialize();

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/AgentDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/AgentDAO.java
@@ -43,6 +43,8 @@ public interface AgentDAO {
 
     List<AgentBean> getAllByEnv(String envId) throws Exception;
 
+    List<AgentBean> getAllByEnvPaginated(String envId, Integer page, Integer size) throws Exception;
+
     List<AgentBean> getByEnvAndFirstDeployTime(String envId, long time) throws Exception;
 
     AgentBean getByHostEnvIds(String hostId, String envId) throws Exception;

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBAgentDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBAgentDAOImpl.java
@@ -51,6 +51,8 @@ public class DBAgentDAOImpl implements AgentDAO {
         "SELECT * FROM agents WHERE host_id=?";
     private static final String GET_ALL_AGENT_BY_ENV =
         "SELECT * FROM agents WHERE env_id=?";
+    private static final String GET_ALL_AGENT_BY_ENV_PAGINATED =
+            "SELECT * FROM agents WHERE env_id=? LIMIT ?,?";
     private static final String GET_AGENT_BY_ENV_AND_FIRST_DEPLOY_TIME =
         "SELECT * FROM agents WHERE env_id=? AND first_deploy_time>?";
     private static final String GET_BY_IDS =
@@ -162,6 +164,12 @@ public class DBAgentDAOImpl implements AgentDAO {
     public List<AgentBean> getAllByEnv(String envId) throws Exception {
         ResultSetHandler<List<AgentBean>> h = new BeanListHandler<>(AgentBean.class);
         return new QueryRunner(dataSource).query(GET_ALL_AGENT_BY_ENV, h, envId);
+    }
+
+    @Override
+    public List<AgentBean> getAllByEnvPaginated(String envId, Integer page, Integer size) throws Exception {
+        ResultSetHandler<List<AgentBean>> h = new BeanListHandler<>(AgentBean.class);
+        return new QueryRunner(dataSource).query(GET_ALL_AGENT_BY_ENV_PAGINATED, h, envId,page*size, (page+1)*size);
     }
 
     @Override

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvAgents.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvAgents.java
@@ -73,6 +73,19 @@ public class EnvAgents {
     }
 
     @GET
+    @ApiOperation(
+            value = "Get deploy agents paginated",
+            notes = "Returns a list of all the deploy agent objects for a given environment name and stage by page",
+            response = AgentBean.class, responseContainer = "List")
+    public List<AgentBean> getAllAgentsPaginated(
+            @ApiParam(value = "Environment name", required = true)@PathParam("envName") String envName,
+            @ApiParam(value = "Stage name", required = true)@PathParam("stageName") String stageName,
+            @ApiParam(value = "Page") Integer page, @ApiParam(value = "Size") Integer size) throws Exception {
+        EnvironBean envBean = Utils.getEnvStage(environDAO, envName, stageName);
+        return agentDAO.getAllByEnvPaginated(envBean.getEnv_id(), page, size);
+    }
+
+    @GET
     @Path("/errors/{hostName : [a-zA-Z0-9\\-_]+}")
     @ApiOperation(
             value = "Get deploy agent error",


### PR DESCRIPTION
Summary:
The env landing page shows all the hosts and some stages are very heavy loaded and this can lead to 500 status code when Teletraan is too busy.

This PR will act in both frontend and backand, changing env landing to not load up thousand of hosts.

Also  the hosts page will now be used to get the details on the hosts instead of the env landing, but also we want to paginate this and reorder in a way that this page lists the most wanted hosts first so users can inspect as easily as before but without overloading the system.

[This PR is not fully completed, please do not merge it]
