### PR TITLE
Allow SOX tagging and enforce SOX environments can deploy builds artifacts from sox repo only

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/allowlists/Allowlist.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/allowlists/Allowlist.java
@@ -3,4 +3,5 @@ package com.pinterest.deployservice.allowlists;
 public interface Allowlist {
     Boolean approved(String attempt);
     Boolean trusted(String attempt);
+    Boolean sox_compliant(String attempt);
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/allowlists/BuildAllowlistImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/allowlists/BuildAllowlistImpl.java
@@ -10,10 +10,12 @@ public class BuildAllowlistImpl implements Allowlist {
 
     private List<String> validBuildURLs;
     private List<String> trustedBuildURLs;
+    private List<String> soxBuildURLs;
 
-    public BuildAllowlistImpl(List<String> allowlist, List<String> trustedlist) {
+    public BuildAllowlistImpl(List<String> allowlist, List<String> trustedlist, List<String> soxlist) {
         this.validBuildURLs = allowlist;
         this.trustedBuildURLs = trustedlist;
+        this.soxBuildURLs = soxlist;
     }
 
     // approved checks if build matches approved URL allow list
@@ -29,6 +31,16 @@ public class BuildAllowlistImpl implements Allowlist {
     // trusted checks if build matches trusted URL allow list
     public Boolean trusted(String buildName) {
         for (String pattern : trustedBuildURLs) {
+            if (buildName.matches(pattern)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // sox_compliant checks if build matches trusted URL allow list
+    public Boolean sox_compliant(String buildName) {
+        for (String pattern : soxBuildURLs) {
             if (buildName.matches(pattern)) {
                 return true;
             }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironBean.java
@@ -197,7 +197,7 @@ public class EnvironBean implements Updatable, Serializable {
     private EnvType stage_type;
 
     @JsonProperty("isSOX")
-    private Boolean is_sox;
+    private boolean is_sox;
 
     public void validate() throws Exception {
         // A bunch of these fields will always be alphanumeric (with _ and -)

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironBean.java
@@ -544,11 +544,11 @@ public class EnvironBean implements Updatable, Serializable {
         this.stage_type = stage_type;
     }
 
-    public Boolean getSOX() {
+    public Boolean getIs_sox() {
         return is_sox;
     }
 
-    public void setSOX(Boolean is_sox) {
+    public void setIs_sox(Boolean is_sox) {
         this.is_sox = is_sox;
     }
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironBean.java
@@ -67,6 +67,7 @@ import javax.validation.constraints.Pattern;
  * allow_private_build TINYINT(1)    DEFAULT 0,
  * ensure_trusted_build TINYINT(1)    DEFAULT 0,
  * stage_type VARCHAR(32) NOT NULL DEFAULT PRODUCTION,
+ * is_sox TINYINT(1)    DEFAULT 0,
  * <p>
  * PRIMARY KEY   (env_id)
  * );
@@ -194,6 +195,9 @@ public class EnvironBean implements Updatable, Serializable {
 
     @JsonProperty("stageType")
     private EnvType stage_type;
+
+    @JsonProperty("isSOX")
+    private Boolean is_sox;
 
     public void validate() throws Exception {
         // A bunch of these fields will always be alphanumeric (with _ and -)
@@ -540,6 +544,14 @@ public class EnvironBean implements Updatable, Serializable {
         this.stage_type = stage_type;
     }
 
+    public Boolean getSOX() {
+        return is_sox;
+    }
+
+    public void setSOX(Boolean is_sox) {
+        this.is_sox = is_sox;
+    }
+
     @Override
     public SetClause genSetClause() {
         SetClause clause = new SetClause();
@@ -583,6 +595,7 @@ public class EnvironBean implements Updatable, Serializable {
         clause.addColumn("allow_private_build", allow_private_build);
         clause.addColumn("ensure_trusted_build", ensure_trusted_build);
         clause.addColumn("stage_type", stage_type);
+        clause.addColumn("is_sox", is_sox);
         return clause;
     }
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironBean.java
@@ -67,7 +67,7 @@ import javax.validation.constraints.Pattern;
  * allow_private_build TINYINT(1)    DEFAULT 0,
  * ensure_trusted_build TINYINT(1)    DEFAULT 0,
  * stage_type VARCHAR(32) NOT NULL DEFAULT PRODUCTION,
- * is_sox TINYINT(1)    DEFAULT 0,
+ * is_sox TINYINT(1) NOT NULL DEFAULT 0,
  * <p>
  * PRIMARY KEY   (env_id)
  * );
@@ -197,7 +197,7 @@ public class EnvironBean implements Updatable, Serializable {
     private EnvType stage_type;
 
     @JsonProperty("isSOX")
-    private boolean is_sox;
+    private Boolean is_sox;
 
     public void validate() throws Exception {
         // A bunch of these fields will always be alphanumeric (with _ and -)

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/Role.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/Role.java
@@ -30,16 +30,13 @@ package com.pinterest.deployservice.bean;
  *      plus the ability specify new OPERATORS and ADMINs for said environment.
  *      When a new environment is created the creating user is the designated the
  *      first ADMIN.
- * SYSTEMADMIN:
- *      System level administrator. This role is for system-wide use.
  */
 public enum Role {
     READER(0),
     PINGER(1),
     PUBLISHER(1),
     OPERATOR(10),
-    ADMIN(20),
-    SYSTEMADMIN(100);
+    ADMIN(20);
 
     private int value;
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/Role.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/Role.java
@@ -30,13 +30,16 @@ package com.pinterest.deployservice.bean;
  *      plus the ability specify new OPERATORS and ADMINs for said environment.
  *      When a new environment is created the creating user is the designated the
  *      first ADMIN.
+ * SYSTEMADMIN:
+ *      System level administrator. This role is for system-wide use.
  */
 public enum Role {
     READER(0),
     PINGER(1),
     PUBLISHER(1),
     OPERATOR(10),
-    ADMIN(20);
+    ADMIN(20),
+    SYSTEMADMIN(100);
 
     private int value;
 

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/ConfigHelper.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/ConfigHelper.java
@@ -149,9 +149,9 @@ public class ConfigHelper {
 
         BuildAllowlistFactory buildAllowlistFactory = configuration.getBuildAllowlistFactory();
         if (buildAllowlistFactory != null) {
-            context.setBuildAllowlist(new BuildAllowlistImpl(buildAllowlistFactory.getValidBuildURLs(), buildAllowlistFactory.getTrustedBuildURLs()));
+            context.setBuildAllowlist(new BuildAllowlistImpl(buildAllowlistFactory.getValidBuildURLs(), buildAllowlistFactory.getTrustedBuildURLs(), buildAllowlistFactory.getsoxBuildURLs()));
         } else {
-            context.setBuildAllowlist(new BuildAllowlistImpl(new ArrayList<String>(), new ArrayList<String>()));
+            context.setBuildAllowlist(new BuildAllowlistImpl(new ArrayList<String>(), new ArrayList<String>(), new ArrayList<String>()));
         }
 
         JenkinsFactory jenkinsFactory = configuration.getJenkinsFactory();

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/BuildAllowlistFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/BuildAllowlistFactory.java
@@ -24,6 +24,8 @@ public class BuildAllowlistFactory {
     private List<String> validBuildURLs;
     @JsonProperty
     private List<String> trustedBuildURLs;
+    @JsonProperty
+    private List<String> soxBuildURLs;
 
     public List<String> getValidBuildURLs() {
         return this.validBuildURLs;
@@ -40,4 +42,8 @@ public class BuildAllowlistFactory {
     public void setTrustedBuildURLs(List<String> urls) {
         this.trustedBuildURLs = urls;
     }
+
+    public List<String> getsoxBuildURLs() { return this.soxBuildURLs; }
+
+    public void setsoxBuildURLs(List<String> urls) { this.soxBuildURLs = urls; }
 }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvDeploys.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvDeploys.java
@@ -242,8 +242,7 @@ public class EnvDeploys {
         // disallow sox deploy if the build artifact is not from a sox source url
         if(envBean.getIs_sox() && !buildAllowlist.sox_compliant(buildBean.getArtifact_url())) {
             throw new TeletaanInternalException(Response.Status.BAD_REQUEST,
-                String.format("This stage requires SOX builds. The build must must be from a sox-compliant location (%s). Please Contact #teletraan to ensure the build artifact is published to a sox-compliant url",
-                buildBean.getArtifact_url()));
+                String.format("This stage requires SOX builds. The build must be from a sox-compliant source. Contact your sox administrators."));
         }
 
         String deployId = deployHandler.deploy(envBean, buildId, description, operator);

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvDeploys.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvDeploys.java
@@ -227,12 +227,20 @@ public class EnvDeploys {
                     buildBean.getArtifact_url()));
         }
         // if the stage is not allowed (allow_private_build)
+        // TODO: remove this code once is_sox db column fully populated (before merging this)
         if(! envBean.getAllow_private_build()) { 
             // only allow deploy if it is not private build
             if (buildBean.getScm_branch().equals("private")) {
                 throw new TeletaanInternalException(Response.Status.BAD_REQUEST, 
                     "This stage does not allow deploying a private build. Please Contact #teletraan to allow your stage for deploying private build");
             }
+        }
+
+        // only allow deploy of sox if not private and from sox_compliant source
+        // TODO: fix not not control flow (unravel conditions given !)
+        if(envBean.getIs_SOX() && (buildBean.getScm_branch().equals("private") || buildAllowlist == null || !buildAllowlist.sox_compliant(buildBean.getArtifact_url()))) {
+            throw new TeletaanInternalException(Response.Status.BAD_REQUEST,
+                "This stage requires SOX builds. The build must not be a private build and must be from a SOX location.");
         }
 
         String deployId = deployHandler.deploy(envBean, buildId, description, operator);

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvDeploys.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvDeploys.java
@@ -242,8 +242,8 @@ public class EnvDeploys {
         // disallow sox deploy if the build artifact is not from a sox source url
         if(envBean.getIs_sox() && !buildAllowlist.sox_compliant(buildBean.getArtifact_url())) {
             throw new TeletaanInternalException(Response.Status.BAD_REQUEST,
-                "This stage requires SOX builds. The build must must be from a sox-compliant location (%s). Please Contact #teletraan to ensure the build artifact is published to a sox-compliant url",
-                buildBean.getArtifact_url());
+                String.format("This stage requires SOX builds. The build must must be from a sox-compliant location (%s). Please Contact #teletraan to ensure the build artifact is published to a sox-compliant url",
+                buildBean.getArtifact_url()));
         }
 
         String deployId = deployHandler.deploy(envBean, buildId, description, operator);

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
@@ -94,8 +94,8 @@ public class EnvStages {
                            EnvironBean environBean) throws Exception {
         EnvironBean origBean = Utils.getEnvStage(environDAO, envName, stageName);
         authorizer.authorize(sc, new Resource(origBean.getEnv_name(), Resource.Type.ENV), Role.OPERATOR);
-        if (environBean.getIs_sox() && origBean.getIs_sox() != environBean.getIs_sox()) {
-            //authorizer.authorize(sc, new Resource(Resource.ALL, Resource.Type.SYSTEM), Role.ADMIN);
+        if (origBean.getIs_sox() != environBean.getIs_sox()) {
+            authorizer.authorize(sc, new Resource(Resource.ALL, Resource.Type.SYSTEM), Role.ADMIN);
         }
         String operator = sc.getUserPrincipal().getName();
         try {

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
@@ -103,6 +103,17 @@ public class EnvStages {
         if (origBean.getStage_type() != EnvType.DEFAULT && origBean.getStage_type() != environBean.getStage_type()) {
             throw new TeletaanInternalException(Response.Status.BAD_REQUEST, "Modification of stage type is not allowed!");
         }
+        // TODO: isUserInRole takes a string and does not seem implemented... it should take the value from Role enum
+        if(environBean.getSOX() && !sc.isUserInRole("SYSTEMADMIN")) {  // TODO: see note above
+        //if(environBean.getSOX() && !sc.isUserInRole(Role.SYSTEMADMIN)) {
+            // raise 403
+
+            // we really just want to check the user's role against SYSTEMADMIN, we already identified our "resource"... how?
+            // can we get user role, and can we just use a comparer isAuthorized in Role.java
+            // but we also want to throw just like authorizer.authorize, would rather not reimplement it
+            // we can work with more granular permissions at the DAO level or something in the future.
+            //authorizer.authorize(sc, new Resource(origBean.getEnv_name(), Resource.Type.ENV), Role.SYSTEMADMIN);
+        }
         environBean.setEnv_name(origBean.getEnv_name());
         environBean.setStage_name(origBean.getStage_name());
         environHandler.updateStage(environBean, operator);

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
@@ -94,6 +94,9 @@ public class EnvStages {
                            EnvironBean environBean) throws Exception {
         EnvironBean origBean = Utils.getEnvStage(environDAO, envName, stageName);
         authorizer.authorize(sc, new Resource(origBean.getEnv_name(), Resource.Type.ENV), Role.OPERATOR);
+        if (environBean.getIs_sox() && origBean.getIs_sox() != environBean.getIs_sox()) {
+            //authorizer.authorize(sc, new Resource(Resource.ALL, Resource.Type.SYSTEM), Role.ADMIN);
+        }
         String operator = sc.getUserPrincipal().getName();
         try {
             environBean.validate();
@@ -102,9 +105,6 @@ public class EnvStages {
         }
         if (origBean.getStage_type() != EnvType.DEFAULT && origBean.getStage_type() != environBean.getStage_type()) {
             throw new TeletaanInternalException(Response.Status.BAD_REQUEST, "Modification of stage type is not allowed!");
-        }
-        if(environBean.getIs_sox() && origBean.getIs_sox() != environBean.getIs_sox()) {
-            authorizer.authorize(sc, new Resource(environBean.getEnv_name(), Resource.Type.ENV), Role.SYSTEMADMIN);
         }
         environBean.setEnv_name(origBean.getEnv_name());
         environBean.setStage_name(origBean.getStage_name());

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
@@ -94,8 +94,13 @@ public class EnvStages {
                            EnvironBean environBean) throws Exception {
         EnvironBean origBean = Utils.getEnvStage(environDAO, envName, stageName);
         authorizer.authorize(sc, new Resource(origBean.getEnv_name(), Resource.Type.ENV), Role.OPERATOR);
-        if (origBean.getIs_sox() != environBean.getIs_sox()) {
+        // We must use default null Boolean to know that the user did not change from true->false
+        if (environBean.getIs_sox() != null && origBean.getIs_sox() != environBean.getIs_sox()) {
             authorizer.authorize(sc, new Resource(Resource.ALL, Resource.Type.SYSTEM), Role.ADMIN);
+        }
+        // TODO: If is_sox is not provided, set it, this support existing PATCH style usages of the endpoint
+        if (environBean.getIs_sox() == null) {
+          environBean.setIs_sox(origBean.getIs_sox());
         }
         String operator = sc.getUserPrincipal().getName();
         try {

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
@@ -103,8 +103,7 @@ public class EnvStages {
         if (origBean.getStage_type() != EnvType.DEFAULT && origBean.getStage_type() != environBean.getStage_type()) {
             throw new TeletaanInternalException(Response.Status.BAD_REQUEST, "Modification of stage type is not allowed!");
         }
-        if(environBean.getSOX()) {
-            // TODO: future - should a more granular resource be authorized on?
+        if(environBean.getIs_sox() && origBean.getIs_sox() != environBean.getIs_sox()) {
             authorizer.authorize(sc, new Resource(environBean.getEnv_name(), Resource.Type.ENV), Role.SYSTEMADMIN);
         }
         environBean.setEnv_name(origBean.getEnv_name());

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
@@ -103,16 +103,9 @@ public class EnvStages {
         if (origBean.getStage_type() != EnvType.DEFAULT && origBean.getStage_type() != environBean.getStage_type()) {
             throw new TeletaanInternalException(Response.Status.BAD_REQUEST, "Modification of stage type is not allowed!");
         }
-        // TODO: isUserInRole takes a string and does not seem implemented... it should take the value from Role enum
-        if(environBean.getSOX() && !sc.isUserInRole("SYSTEMADMIN")) {  // TODO: see note above
-        //if(environBean.getSOX() && !sc.isUserInRole(Role.SYSTEMADMIN)) {
-            // raise 403
-
-            // we really just want to check the user's role against SYSTEMADMIN, we already identified our "resource"... how?
-            // can we get user role, and can we just use a comparer isAuthorized in Role.java
-            // but we also want to throw just like authorizer.authorize, would rather not reimplement it
-            // we can work with more granular permissions at the DAO level or something in the future.
-            //authorizer.authorize(sc, new Resource(origBean.getEnv_name(), Resource.Type.ENV), Role.SYSTEMADMIN);
+        if(environBean.getSOX()) {
+            // TODO: future - should a more granular resource be authorized on?
+            authorizer.authorize(sc, new Resource(environBean.getEnv_name(), Resource.Type.ENV), Role.SYSTEMADMIN);
         }
         environBean.setEnv_name(origBean.getEnv_name());
         environBean.setStage_name(origBean.getStage_name());


### PR DESCRIPTION
Summary:
- Allow stages to be tagged is_sox
- Implement sox repo list from configuration
- If stage is tagged is_sox, enforce builds must come from sox repo
- If stage is tagged is_sox, enforce builds cannot be private
- Enforce environs API cannot change is_sox unless user has SYSTEM/ADMIN resource/role.
- Temporarily support `PATCH` type usage of `PUT` endpoint for Rodimus & Deploy-Board

Solves CDP-3779 and CDP-3781.