### PR TITLE
display the ongoing sidecar deploys and total running deploy count

### DIFF
--- a/deploy-board/deploy_board/templates/deploys/daily_deploy_count.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/daily_deploy_count.tmpl
@@ -1,3 +1,4 @@
 {% load utils %}
 {% load static %}
-<b>Global Deploys Today:</b> {{daily_deploy_count}}
+<b>Global Deploys Today:</b> {{daily_deploy_count}} <br/>
+<b>Current Running Deploys:</b> {{running_deploy_count}} <br/>

--- a/deploy-board/deploy_board/templates/landing.html
+++ b/deploy-board/deploy_board/templates/landing.html
@@ -18,19 +18,29 @@
     </div>
 </div>
 
-    <div class="panel panel-default">
-    {% include "panel_heading.tmpl" with panel_title="Deployment Statistics" panel_body_id="deployStatsId" direction="down" %}
-        <div id="deployStatsId" class="collapse in panel-body">
-            <div id="dailyDeployCountId"></div>
-        </div>
+<div class="panel panel-default">
+    {% include "panel_heading.tmpl" with panel_title="Ongoing Sidecar Deployments" panel_body_id="onGoingSidecarDeployId" direction="down" %}
+    <div id="onGoingSidecarDeployId" class="collapse in panel-body table-responsive">
     </div>
+</div>
+
+<div class="panel panel-default">
+{% include "panel_heading.tmpl" with panel_title="Deployment Statistics" panel_body_id="deployStatsId" direction="down" %}
+    <div id="deployStatsId" class="collapse in panel-body">
+        <div id="dailyDeployCountId"></div>
+    </div>
+</div>
 <script>
     $(function () {
         $('#onGoingDeployId').load('/deploys/ongoing/');
-
         setInterval(function() {
             $('#onGoingDeployId').load('/deploys/ongoing/');
-        }, 30000);
+        }, 60000);
+
+        $('#onGoingSidecarDeployId').load('/deploys/ongoing_sidecar/');
+        setInterval(function() {
+            $('#onGoingSidecarDeployId').load('/deploys/ongoing_sidecar/');
+        }, 60000);
 
         $('#dailyDeployCountId').load('/deploys/dailycount');
     });

--- a/deploy-board/deploy_board/webapp/helpers/environs_helper.py
+++ b/deploy-board/deploy_board/webapp/helpers/environs_helper.py
@@ -105,6 +105,10 @@ def get_all_envs_by_group(request, group_name):
     return deployclient.get("/envs/", request.teletraan_user_id.token, params=params)
 
 
+def get_all_sidecar_envs(request):
+    return deployclient.get("/envs/sidecars", request.teletraan_user_id.token)
+
+
 def get(request, id):
     return deployclient.get("/envs/%s" % id, request.teletraan_user_id.token)
 

--- a/deploy-board/deploy_board/webapp/urls.py
+++ b/deploy-board/deploy_board/webapp/urls.py
@@ -38,6 +38,7 @@ urlpatterns = [
     url(r'^deploy/inline_update/$', deploy_views.inline_update),
     url(r'^deploy/(?P<deploy_id>[a-zA-Z0-9\-_]+)', deploy_views.DeployView.as_view()),
     url(r'^deploys/ongoing/$', deploy_views.get_ongoing_deploys),
+    url(r'^deploys/ongoing_sidecar/$', deploy_views.get_ongoing_sidecar_deploys),
     url(r'^deploys/dailycount', deploy_views.get_daily_deploy_count),
     url(r'^env/create/$', env_views.post_create_env),
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/EnvironDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/EnvironDAO.java
@@ -65,8 +65,9 @@ public interface EnvironDAO {
 
     // Return all
     List<String> getAllEnvIds() throws Exception;
-
+    
     List<EnvironBean> getAllEnvs() throws Exception;
+    List<EnvironBean> getAllSidecarEnvs() throws Exception;
 
     void deleteSchedule(String envName, String stageName) throws Exception;
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBEnvironDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBEnvironDAOImpl.java
@@ -96,6 +96,8 @@ public class DBEnvironDAOImpl implements EnvironDAO {
         "SELECT env_id FROM environs";
     private static final String GET_ALL_ENVS =
         "SELECT * FROM environs";
+    private static final String GET_ALL_SIDECAR_ENVS =
+        "SELECT * FROM environs where system_priority > 0";
     private static final String DELETE_SCHEDULE =
         "UPDATE environs SET schedule_id=null where env_name=? AND stage_name=?";
     private static final String DELETE_CLUSTER =
@@ -264,6 +266,12 @@ public class DBEnvironDAOImpl implements EnvironDAO {
     public List<EnvironBean> getAllEnvs() throws Exception {
         ResultSetHandler<List<EnvironBean>> h = new BeanListHandler<>(EnvironBean.class);
         return new QueryRunner(dataSource).query(GET_ALL_ENVS, h);
+    }
+
+    @Override
+    public List<EnvironBean> getAllSidecarEnvs() throws Exception {
+        ResultSetHandler<List<EnvironBean>> h = new BeanListHandler<>(EnvironBean.class);
+        return new QueryRunner(dataSource).query(GET_ALL_SIDECAR_ENVS, h);
     }
 
     @Override

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Environs.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Environs.java
@@ -114,6 +114,16 @@ public class Environs {
     }
 
     @GET
+    @Path("/sidecars")
+    @ApiOperation(
+            value = "Get all sidecar environment objects",
+            notes = "Returns a list of sidecar environment objects",
+            response = EnvironBean.class, responseContainer = "List")
+    public List<EnvironBean> getAllSidecars() throws Exception {
+        return environDAO.getAllSidecarEnvs();
+    }
+
+    @GET
     @ApiOperation(
             value = "Get all environment objects",
             notes = "Returns a list of environment objects related to the given environment name",


### PR DESCRIPTION
1. add a new api: /envs/sidecars  to return all sidecar envs that is identified as having system_priority
2. display the ongoing sidecar deploy in the home page in a table
3. display the total running deploy count in the "deploy statistic" section on the homepage
<img width="803" alt="Screen Shot 2021-06-10 at 12 49 25 PM" src="https://user-images.githubusercontent.com/495715/121588659-0860ef00-c9eb-11eb-9627-ab467e9e7bfd.png">
