### PR TITLE
Add same fix for default host type to advanced cluster creation view.

### DIFF
--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -183,7 +183,7 @@ var capacitySetting = new Vue({
                     isSelected: item.abstract_name === info.defaultSeurityZone
                 }
             }),
-        selectedHostTypeValue: info.defaultHostType,
+        selectedHostTypeValue: capacityCreationInfo.hostTypes.find(hostType => hostType.abstract_name === capacityCreationInfo.defaultHostType).id,
         selectedSecurityZoneValue: info.defaultSeurityZone,
         selectedPlacements: [],
         showBaseImageHelp: false,

--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -135,8 +135,9 @@ var capacitySetting = new Vue({
         hostTypeOptions: info.hostTypes.map(
             function (item, idx) {
                 return {
-                    value: item.id, text: item.abstract_name + " (" + item.core + " cores, " + item.mem + " GB, " + item.storage + ", " + item.provider + ": " + item.provider_name + ")",
-                    isSelected: item.abstract_name === capacityCreationInfo.hostTypes.find(hostType => hostType.abstract_name === capacityCreationInfo.defaultHostType).id
+                    value: item.id,
+                    text: item.abstract_name + " (" + item.core + " cores, " + item.mem + " GB, " + item.storage + ", " + item.provider + ": " + item.provider_name + ")",
+                    isSelected: item.abstract_name === info.defaultHostType
                 }
             }),
         cellValue: info.defaultCell,

--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -135,9 +135,8 @@ var capacitySetting = new Vue({
         hostTypeOptions: info.hostTypes.map(
             function (item, idx) {
                 return {
-                    value: item.id,
-                    text: item.abstract_name + " (" + item.core + " cores, " + item.mem + " GB, " + item.storage + ", " + item.provider + ": " + item.provider_name + ")",
-                    isSelected: item.abstract_name === info.defaultHostType
+                    value: item.id, text: item.abstract_name + " (" + item.core + " cores, " + item.mem + " GB, " + item.storage + ", " + item.provider + ": " + item.provider_name + ")",
+                    isSelected: item.abstract_name === capacityCreationInfo.hostTypes.find(hostType => hostType.abstract_name === capacityCreationInfo.defaultHostType).id
                 }
             }),
         cellValue: info.defaultCell,


### PR DESCRIPTION
The new default host type value was missed for the advanced form in https://github.com/pinterest/teletraan/pull/833.

This PR adds the same value find method as the basic form in the advanced form.