### PR TITLE
Scrub filtered query param values from response logs.

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/HTTPClient.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/HTTPClient.java
@@ -30,9 +30,8 @@ import java.util.Map;
 public class HTTPClient {
     private static final int TIMEOUT = 15*1000;  // http timeout in 15 seconds
     private static final Logger LOG = LoggerFactory.getLogger(HTTPClient.class);
-    private String[] filteredQueryKeySubstrings = {"token"};
 
-    private String generateUrlAndQuery(String url, Map<String, String> params, boolean scrubUrl) throws Exception {
+    public String generateUrlAndQuery(String url, Map<String, String> params, boolean scrubUrl) throws Exception {
         if (params == null || params.isEmpty()) {
             return url;
         }
@@ -44,16 +43,18 @@ public class HTTPClient {
             prefix = "&";
             // note:  scrubUrlQueryValue could be expensive with many filtered values
             //        consider using it only in only a DEBUG logging context in the future
-            String reportedValue = scrubUrl ? scrubUrlQueryValue(entry.getValue()) : entry.getValue();
+            String reportedValue = scrubUrl ? scrubUrlQueryValue(entry.getKey(), entry.getValue()) : entry.getValue();
             sb.append(String.format("%s=%s", entry.getKey(),
                 URLEncoder.encode(reportedValue, "UTF-8")));
         }
         return sb.toString();
     }
 
-    private String scrubUrlQueryValue(String queryParamValue) {
+    public String scrubUrlQueryValue(String queryParamKey, String queryParamValue) {
+        String[] filteredQueryKeySubstrings = {"token"};
+
         for (String filteredQueryKeySubstring : filteredQueryKeySubstrings) {
-            if (StringUtils.containsIgnoreCase(queryParamValue, filteredQueryKeySubstring)) {
+            if (StringUtils.containsIgnoreCase(queryParamKey, filteredQueryKeySubstring)) {
                 return "xxxxxxxxx";
             }
         }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/HTTPClient.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/HTTPClient.java
@@ -31,7 +31,7 @@ public class HTTPClient {
     private static final int TIMEOUT = 15*1000;  // http timeout in 15 seconds
     private static final Logger LOG = LoggerFactory.getLogger(HTTPClient.class);
 
-    public String generateUrlAndQuery(String url, Map<String, String> params, boolean scrubUrl) throws Exception {
+    private String generateUrlAndQuery(String url, Map<String, String> params, boolean scrubUrl) throws Exception {
         if (params == null || params.isEmpty()) {
             return url;
         }
@@ -50,7 +50,7 @@ public class HTTPClient {
         return sb.toString();
     }
 
-    public String scrubUrlQueryValue(String queryParamKey, String queryParamValue) {
+    private String scrubUrlQueryValue(String queryParamKey, String queryParamValue) {
         String[] filteredQueryKeySubstrings = {"token"};
 
         for (String filteredQueryKeySubstring : filteredQueryKeySubstrings) {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/HTTPClient.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/HTTPClient.java
@@ -97,7 +97,8 @@ public class HTTPClient {
                     throw new DeployInternalException("HTTP request failed, status = {}, content = {}",
                         responseCode, ret);
                 }
-                LOG.info("HTTP Request returned with response code {} for URL {}", responseCode, url);
+                String urlNoQueryString = url.substring(0, url.lastIndexOf("?"));
+                LOG.info("HTTP Request returned with response code {} for URL {}", responseCode, urlNoQueryString);
                 return ret;
             } catch (Exception e) {
                 lastException = e;

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/HTTPClient.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/HTTPClient.java
@@ -30,6 +30,7 @@ import java.util.Map;
 public class HTTPClient {
     private static final int TIMEOUT = 15*1000;  // http timeout in 15 seconds
     private static final Logger LOG = LoggerFactory.getLogger(HTTPClient.class);
+    public static String secretMask = "xxxxxxxxx";
 
     private String generateUrlAndQuery(String url, Map<String, String> params, boolean scrubUrl) throws Exception {
         if (params == null || params.isEmpty()) {
@@ -55,7 +56,7 @@ public class HTTPClient {
 
         for (String filteredQueryKeySubstring : filteredQueryKeySubstrings) {
             if (StringUtils.containsIgnoreCase(queryParamKey, filteredQueryKeySubstring)) {
-                return "xxxxxxxxx";
+                return secretMask;
             }
         }
         return queryParamValue;

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/common/HTTPClientTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/common/HTTPClientTest.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2016 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *    
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.deployservice.common;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class HTTPClientTest {
+    @Test
+    public void testScrubUrlQueryValue() throws Exception {
+        HTTPClient httpClient = new HTTPClient();
+
+        assertEquals("xxxxxxxxx", httpClient.scrubUrlQueryValue("access_token", "dangerous_stuff"));
+        assertEquals("xxxxxxxxx", httpClient.scrubUrlQueryValue("token", "dangerous_stuff"));
+        assertEquals("some_stuff", httpClient.scrubUrlQueryValue("s", "some_stuff"));
+    }
+
+    @Test
+    public void testGenerateUrlAndQuery() throws Exception {
+        HTTPClient httpClient = new HTTPClient();
+        String baseUrl = "example.com/example/tests/";
+
+        Map<String, String> filteredParams1 = new HashMap<>();
+        Map<String, String> filteredParams2 = new HashMap<>();
+        filteredParams1.put("access_token", "dangerous_stuff");
+        filteredParams2.put("token", "dangerous_stuff");
+
+        Map<String, String> unfilteredParams1 = new HashMap<>();
+        unfilteredParams1.put("s", "some_stuff");
+
+        // only pass 1 param to avoid flaky tests due to unordered Map
+        // Future: Add some other tests to handle multiple query parameter cases
+        assertEquals("example.com/example/tests/?access_token=xxxxxxxxx", httpClient.generateUrlAndQuery(baseUrl, filteredParams1, true));
+        assertEquals("example.com/example/tests/?token=xxxxxxxxx", httpClient.generateUrlAndQuery(baseUrl, filteredParams2, true));
+        assertEquals("example.com/example/tests/?access_token=dangerous_stuff", httpClient.generateUrlAndQuery(baseUrl, filteredParams1, false));
+        assertEquals("example.com/example/tests/?s=some_stuff", httpClient.generateUrlAndQuery(baseUrl, unfilteredParams1, true));
+    }
+}

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/common/HTTPClientTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/common/HTTPClientTest.java
@@ -32,8 +32,8 @@ public class HTTPClientTest {;
         Method scrubUrlQueryValue = HTTPClient.class.getDeclaredMethod("scrubUrlQueryValue", String.class, String.class);
         scrubUrlQueryValue.setAccessible(true);
 
-        assertEquals("xxxxxxxxx", scrubUrlQueryValue.invoke(httpClient, "access_token", "dangerous_stuff"));
-        assertEquals("xxxxxxxxx", scrubUrlQueryValue.invoke(httpClient, "token", "dangerous_stuff"));
+        assertEquals(HTTPClient.secretMask, scrubUrlQueryValue.invoke(httpClient, "access_token", "dangerous_stuff"));
+        assertEquals(HTTPClient.secretMask, scrubUrlQueryValue.invoke(httpClient, "token", "dangerous_stuff"));
         assertEquals("some_stuff", scrubUrlQueryValue.invoke(httpClient, "s", "some_stuff"));
     }
 
@@ -57,8 +57,8 @@ public class HTTPClientTest {;
 
         // only pass 1 param to avoid flaky tests due to unordered Map
         // Future: Consider how handle multiple query parameter cases when testing HTTPClient
-        assertEquals("example.com/example/tests/?access_token=xxxxxxxxx", generateUrlAndQuery.invoke(httpClient, baseUrl, filteredParams1, true));
-        assertEquals("example.com/example/tests/?token=xxxxxxxxx", generateUrlAndQuery.invoke(httpClient, baseUrl, filteredParams2, true));
+        assertEquals("example.com/example/tests/?access_token="+HTTPClient.secretMask, generateUrlAndQuery.invoke(httpClient, baseUrl, filteredParams1, true));
+        assertEquals("example.com/example/tests/?token="+HTTPClient.secretMask, generateUrlAndQuery.invoke(httpClient, baseUrl, filteredParams2, true));
         assertEquals("example.com/example/tests/?access_token=dangerous_stuff", generateUrlAndQuery.invoke(httpClient, baseUrl, filteredParams1, false));
         assertEquals("example.com/example/tests/?s=some_stuff", generateUrlAndQuery.invoke(httpClient, baseUrl, unfilteredParams1, true));
     }

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/common/HTTPClientTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/common/HTTPClientTest.java
@@ -17,39 +17,49 @@ package com.pinterest.deployservice.common;
 
 import org.junit.Test;
 
+import java.lang.reflect.Method;
+
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
-public class HTTPClientTest {
+public class HTTPClientTest {;
     @Test
     public void testScrubUrlQueryValue() throws Exception {
         HTTPClient httpClient = new HTTPClient();
+        // Future: there should be some better way to test HTTPClient private methods rather than use reflection on private methods
+        Method scrubUrlQueryValue = HTTPClient.class.getDeclaredMethod("scrubUrlQueryValue", String.class, String.class);
+        scrubUrlQueryValue.setAccessible(true);
 
-        assertEquals("xxxxxxxxx", httpClient.scrubUrlQueryValue("access_token", "dangerous_stuff"));
-        assertEquals("xxxxxxxxx", httpClient.scrubUrlQueryValue("token", "dangerous_stuff"));
-        assertEquals("some_stuff", httpClient.scrubUrlQueryValue("s", "some_stuff"));
+        assertEquals("xxxxxxxxx", scrubUrlQueryValue.invoke(httpClient, "access_token", "dangerous_stuff"));
+        assertEquals("xxxxxxxxx", scrubUrlQueryValue.invoke(httpClient, "token", "dangerous_stuff"));
+        assertEquals("some_stuff", scrubUrlQueryValue.invoke(httpClient, "s", "some_stuff"));
     }
 
     @Test
     public void testGenerateUrlAndQuery() throws Exception {
         HTTPClient httpClient = new HTTPClient();
+        // Future: there should be some better way to test HTTPClient private methods rather than use reflection on private methods
+        Method generateUrlAndQuery = HTTPClient.class.getDeclaredMethod("generateUrlAndQuery", String.class, Map.class, boolean.class);
+        generateUrlAndQuery.setAccessible(true);
+
         String baseUrl = "example.com/example/tests/";
 
         Map<String, String> filteredParams1 = new HashMap<>();
-        Map<String, String> filteredParams2 = new HashMap<>();
         filteredParams1.put("access_token", "dangerous_stuff");
+
+        Map<String, String> filteredParams2 = new HashMap<>();
         filteredParams2.put("token", "dangerous_stuff");
 
         Map<String, String> unfilteredParams1 = new HashMap<>();
         unfilteredParams1.put("s", "some_stuff");
 
         // only pass 1 param to avoid flaky tests due to unordered Map
-        // Future: Add some other tests to handle multiple query parameter cases
-        assertEquals("example.com/example/tests/?access_token=xxxxxxxxx", httpClient.generateUrlAndQuery(baseUrl, filteredParams1, true));
-        assertEquals("example.com/example/tests/?token=xxxxxxxxx", httpClient.generateUrlAndQuery(baseUrl, filteredParams2, true));
-        assertEquals("example.com/example/tests/?access_token=dangerous_stuff", httpClient.generateUrlAndQuery(baseUrl, filteredParams1, false));
-        assertEquals("example.com/example/tests/?s=some_stuff", httpClient.generateUrlAndQuery(baseUrl, unfilteredParams1, true));
+        // Future: Consider how handle multiple query parameter cases when testing HTTPClient
+        assertEquals("example.com/example/tests/?access_token=xxxxxxxxx", generateUrlAndQuery.invoke(httpClient, baseUrl, filteredParams1, true));
+        assertEquals("example.com/example/tests/?token=xxxxxxxxx", generateUrlAndQuery.invoke(httpClient, baseUrl, filteredParams2, true));
+        assertEquals("example.com/example/tests/?access_token=dangerous_stuff", generateUrlAndQuery.invoke(httpClient, baseUrl, filteredParams1, false));
+        assertEquals("example.com/example/tests/?s=some_stuff", generateUrlAndQuery.invoke(httpClient, baseUrl, unfilteredParams1, true));
     }
 }


### PR DESCRIPTION
Goal: do not log queryparam values if the queryparam key has a case insensitive substring in the filter list `filteredQueryKeySubstrings`.

Summary:
- normalized internals of public interfaces
- added query parameter value filter function and filter list

Manual testing:
- call with scrubbed queries
- call without scrubbed queries