### PR TITLE
Remove "update cluster form" call to vue function for update cluster name.  Remove inline references to base image.

### DIFF
--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -59,7 +59,7 @@
                     </baseimage-select>
                     <base-image-help v-show="showBaseImageHelp" v-bind:data="baseImageHelpData"></base-image-help>
                     <label-select label="Host Type" title="Compute Capability of the host" v-model="selectedHostTypeValue" v-bind:selectoptions="hostTypeOptions"
-                        v-on:input="updateImageNameForEbsHost" showhelp="true" v-on:helpclick="hostTypeHelpClick"></label-select>
+                        showhelp="true" v-on:helpclick="hostTypeHelpClick"></label-select>
                     <hostype-help v-show="showHostTypeHelp" v-bind:data="hostTypeHelpData"></hostype-help>
                     <label-select label="Security Zone" title="Security zone to control inbound/outboud traffic" v-model="selectedSecurityZoneValue" v-bind:selectoptions="securityZones"
                     showhelp="true" v-on:helpclick="securityZoneHelpClick"></label-select>

--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -59,7 +59,7 @@
                     </baseimage-select>
                     <base-image-help v-show="showBaseImageHelp" v-bind:data="baseImageHelpData"></base-image-help>
                     <label-select label="Host Type" title="Compute Capability of the host" v-model="selectedHostTypeValue" v-bind:selectoptions="hostTypeOptions"
-                         showhelp="true" v-on:helpclick="hostTypeHelpClick"></label-select>
+                        v-on:input="updateImageNameForEbsHost" showhelp="true" v-on:helpclick="hostTypeHelpClick"></label-select>
                     <hostype-help v-show="showHostTypeHelp" v-bind:data="hostTypeHelpData"></hostype-help>
                     <label-select label="Security Zone" title="Security zone to control inbound/outboud traffic" v-model="selectedSecurityZoneValue" v-bind:selectoptions="securityZones"
                     showhelp="true" v-on:helpclick="securityZoneHelpClick"></label-select>
@@ -717,7 +717,7 @@
                     var cell = capacitySetting.currentCell;
                     var scope = this;
                     var provider = capacitySetting.currentProvider;
-                    value = 'cmp_base-ebs';
+                    value = 'cmp_base-ebs-18.04';
                     const selectedHostTypeObject = capacityCreationInfo.hostTypes.find(hostType => hostType.id === this.selectedHostTypeValue);
                     if (selectedHostTypeObject.abstract_name.startsWith('EbsCompute')) {
                         capacitySetting.imageNameValue = value;

--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -59,7 +59,7 @@
                     </baseimage-select>
                     <base-image-help v-show="showBaseImageHelp" v-bind:data="baseImageHelpData"></base-image-help>
                     <label-select label="Host Type" title="Compute Capability of the host" v-model="selectedHostTypeValue" v-bind:selectoptions="hostTypeOptions"
-                        v-on:input="updateImageNameForEbsHost" showhelp="true" v-on:helpclick="hostTypeHelpClick"></label-select>
+                         showhelp="true" v-on:helpclick="hostTypeHelpClick"></label-select>
                     <hostype-help v-show="showHostTypeHelp" v-bind:data="hostTypeHelpData"></hostype-help>
                     <label-select label="Security Zone" title="Security zone to control inbound/outboud traffic" v-model="selectedSecurityZoneValue" v-bind:selectoptions="securityZones"
                     showhelp="true" v-on:helpclick="securityZoneHelpClick"></label-select>

--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -717,7 +717,7 @@
                     var cell = capacitySetting.currentCell;
                     var scope = this;
                     var provider = capacitySetting.currentProvider;
-                    value = 'cmp_base-ebs-18.04';
+                    value = {{ default_cmp_image }};
                     const selectedHostTypeObject = capacityCreationInfo.hostTypes.find(hostType => hostType.id === this.selectedHostTypeValue);
                     if (selectedHostTypeObject.abstract_name.startsWith('EbsCompute')) {
                         capacitySetting.imageNameValue = value;

--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -717,7 +717,7 @@
                     var cell = capacitySetting.currentCell;
                     var scope = this;
                     var provider = capacitySetting.currentProvider;
-                    value = {{ default_cmp_image }};
+                    value = '{{ default_cmp_image }}';
                     const selectedHostTypeObject = capacityCreationInfo.hostTypes.find(hostType => hostType.id === this.selectedHostTypeValue);
                     if (selectedHostTypeObject.abstract_name.startsWith('EbsCompute')) {
                         capacitySetting.imageNameValue = value;

--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -372,7 +372,7 @@ var capacitySetting = new Vue({
             var cell = capacitySetting.currentCell;
             var scope = this;
             var provider = capacitySetting.currentProvider;
-            value = 'cmp_base-ebs-18.04';
+            value = {{ default_cmp_image }};
             const selectedHostTypeObject = capacityCreationInfo.hostTypes.find(hostType => hostType.id === this.selectedHostTypeValue);
             if (selectedHostTypeObject.abstract_name.startsWith('EbsCompute')) {
                 capacitySetting.imageNameValue = value;

--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -44,7 +44,7 @@
                     </baseimage-select>
                     <base-image-help v-show="showBaseImageHelp" v-bind:data="baseImageHelpData"></base-image-help>
                     <label-select label="Host Type" title="Compute Capability of the host" v-model="selectedHostTypeValue" v-bind:selectoptions="hostTypeOptions"
-                        v-on:input="updateImageNameForEbsHost" showhelp="true" v-on:helpclick="hostTypeHelpClick"></label-select>
+                        showhelp="true" v-on:helpclick="hostTypeHelpClick"></label-select>
                     <hostype-help v-show="showHostTypeHelp" v-bind:data="hostTypeHelpData"></hostype-help>
                     <label-select label="Security Zone" title="Security zone to control inbound/outboud traffic" showhelp="true" v-model="selectedSecurityZoneValue"
                         v-bind:selectoptions="securityZones" v-on:helpclick="securityZoneHelpClick"></label-select>

--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -44,7 +44,7 @@
                     </baseimage-select>
                     <base-image-help v-show="showBaseImageHelp" v-bind:data="baseImageHelpData"></base-image-help>
                     <label-select label="Host Type" title="Compute Capability of the host" v-model="selectedHostTypeValue" v-bind:selectoptions="hostTypeOptions"
-                        showhelp="true" v-on:helpclick="hostTypeHelpClick"></label-select>
+                        v-on:input="updateImageNameForEbsHost" showhelp="true" v-on:helpclick="hostTypeHelpClick"></label-select>
                     <hostype-help v-show="showHostTypeHelp" v-bind:data="hostTypeHelpData"></hostype-help>
                     <label-select label="Security Zone" title="Security zone to control inbound/outboud traffic" showhelp="true" v-model="selectedSecurityZoneValue"
                         v-bind:selectoptions="securityZones" v-on:helpclick="securityZoneHelpClick"></label-select>

--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -372,7 +372,7 @@ var capacitySetting = new Vue({
             var cell = capacitySetting.currentCell;
             var scope = this;
             var provider = capacitySetting.currentProvider;
-            value = {{ default_cmp_image }};
+            value = '{{ default_cmp_image }}';
             const selectedHostTypeObject = capacityCreationInfo.hostTypes.find(hostType => hostType.id === this.selectedHostTypeValue);
             if (selectedHostTypeObject.abstract_name.startsWith('EbsCompute')) {
                 capacitySetting.imageNameValue = value;

--- a/deploy-board/deploy_board/webapp/cluster_view.py
+++ b/deploy-board/deploy_board/webapp/cluster_view.py
@@ -141,6 +141,7 @@ class EnvCapacityAdvCreateView(View):
         return render(request, 'configs/new_capacity_adv.html', {
             'env': env,
             'capacity_creation_info': json.dumps(capacity_creation_info),
+            'default_cmp_image': DEFAULT_CMP_IMAGE,
             'user_data_config_settings_wiki': USER_DATA_CONFIG_SETTINGS_WIKI,
             'is_pinterest': IS_PINTEREST})
 
@@ -217,6 +218,7 @@ class ClusterConfigurationView(View):
         return render(request, 'clusters/cluster_configuration.html', {
             'env': env,
             'capacity_creation_info': json.dumps(capacity_creation_info),
+            'default_cmp_image': DEFAULT_CMP_IMAGE,
             'user_data_config_settings_wiki': USER_DATA_CONFIG_SETTINGS_WIKI,
             'is_pinterest': IS_PINTEREST})
 


### PR DESCRIPTION
1. Remove advanced call to vue function for update cluster name. This feature causes the user's visible fields to be altered and can cause issues.
2. Remove inline references to base image and get from settings.py. In the future this should come from some external source.
3. Fix outdated `cmp_base-ebs` reference in cluster configuration form (#2 on this list covers this fix)