### PR TITLE
Reallow stopping to fall through instead of pausing deploy.

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java
@@ -240,6 +240,7 @@ public class GoalAnalyst {
         if (agent != null && agent.getState() == AgentState.STOP) {
             // agent has been explicitly STOP, do not override
             if (agent.getDeploy_stage() == DeployStage.STOPPING && FATAL_AGENT_STATUSES.contains(status)) {
+                AgentBean updateBean = null;
                 updateBean = genUpdateBeanByReport(report, agent);
                 updateBean.setDeploy_stage(DeployStage.STOPPED);
                 LOG.debug("Agent DeployStage is STOPPING, but report status is {}. Change DeployStage to STOPPED so host can gracefully terminate.", status);

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java
@@ -240,9 +240,9 @@ public class GoalAnalyst {
         if (agent != null && agent.getState() == AgentState.STOP) {
             // agent has been explicitly STOP, do not override
             if (agent.getDeploy_stage() == DeployStage.STOPPING && FATAL_AGENT_STATUSES.contains(status)) {
-                // Note: Retain this logging to determine if commit a2dba4515a71aa7b862afb5ba4bdcfae2b7d3e2b is solving an important bug.
-                // TODO: Determine if this is now being logged and if there is a better way to handle any subsequent issue.
-                LOG.debug("Agent DeployStage is STOPPING, but report status is {}.", status);
+                updateBean = genUpdateBeanByReport(report, agent);
+                updateBean.setDeploy_stage(DeployStage.STOPPED);
+                LOG.debug("Agent DeployStage is STOPPING, but report status is {}. Change DeployStage to STOPPED so host can gracefully terminate.", status);
             }
             return AgentState.STOP;
         }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java
@@ -240,8 +240,9 @@ public class GoalAnalyst {
         if (agent != null && agent.getState() == AgentState.STOP) {
             // agent has been explicitly STOP, do not override
             if (agent.getDeploy_stage() == DeployStage.STOPPING && FATAL_AGENT_STATUSES.contains(status)) {
-                LOG.debug("Agent DeployStage is STOPPING, but report status is {}, propose new agent state as {} ", status, AgentState.PAUSED_BY_SYSTEM);
-                return AgentState.PAUSED_BY_SYSTEM;
+                // Note: Retain this logging to determine if commit a2dba4515a71aa7b862afb5ba4bdcfae2b7d3e2b is solving an important bug.
+                // TODO: Determine if this is now being logged and if there is a better way to handle any subsequent issue.
+                LOG.debug("Agent DeployStage is STOPPING, but report status is {}.", status);
             }
             return AgentState.STOP;
         }


### PR DESCRIPTION
This is an alternative to https://github.com/pinterest/teletraan/pull/872.

This PR reenables STOPPING hosts to continue stopping and preserves the logging.  Logging does not yield any results today and may have been kept defensively, we may see some new logs if this is merged.

Research (complete):
- We still need to continue to the next step when STOPPING fails 3 times, we cannot try STOPPING forever.   The stopping tries timeout is handled in `deploy-agent`.  AI: Determine how STOPPING progresses to the next stage after 3 retries. This is probably already handled.  DONE: once we get into AgentState.STOP then [this is checked very early](https://github.com/pinterest/teletraan/blame/master/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java#L537) and no further action is taken.
- How does STOPPING work when it succeeds? (AI: We also want to bypass STOPPING in the timeout case.) DONE: See the agent stop state success [here](https://github.com/pinterest/teletraan/blame/master/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java#L542).
- Research side effects and purpose of [original change a2dba4515a71aa7b862afb5ba4bdcfae2b7d3e2b](https://github.com/pinterest/teletraan/commit/a2dba4515a71aa7b862afb5ba4bdcfae2b7d3e2b#diff-56f092bb2166dba5fb49d9c5eab4fe5dd6d3d2fb6063f42ff1bca00d3f3e099dR224) which is explicitly against the preserved comment `// agent has been explicitly STOP, do not override`. PART DONE: Looks like this commit is to finish some incomplete work in the original code, you can see the original TODO comment [here](https://github.com/pinterest/teletraan/commit/a2dba4515a71aa7b862afb5ba4bdcfae2b7d3e2b#diff-56f092bb2166dba5fb49d9c5eab4fe5dd6d3d2fb6063f42ff1bca00d3f3e099dL219).

Test Plan:

- Manually test STOPPING host termination behavior on integ in both `exit 0`, `exit non-zero`, and `timeout` (stopping sleep 60 min) cases:
1. for autoscaling case
2. for manually terminated hosts
3. for cluster count reduction (should be same as autoscaling)