### PR TITLE
Select machine by id, not abstract name.

### DIFF
--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -459,7 +459,7 @@
                     return {
                         value: item.id,
                         text: item.abstract_name + " (" + item.core + " cores, " + item.mem + " GB, " + item.storage + ", " + item.provider + ": " + item.provider_name + ")",
-                        isSelected: item.abstract_name === currentCluster.hostType
+                        isSelected: item.id === currentCluster.hostType
                     }
                 }),
                 imageNameValue: currentCluster.baseImageName,

--- a/deploy-board/deploy_board/templates/configs/new_capacity.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity.html
@@ -119,7 +119,7 @@ var capacitySetting = new Vue({
             return {
                 value: item.id,
                 text: item.abstract_name+" ("+item.core+" cores, "+item.mem+" GB, "+item.storage+")",
-                isSelected: item.abstract_name === capacityCreationInfo.defaultHostType
+                isSelected: item.id === capacityCreationInfo.defaultHostType
             }}),
         placements: placements.cmpPrivate.map(function(item, index) {
                 return {

--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -137,7 +137,7 @@ var capacitySetting = new Vue({
                 return {
                     value: item.id,
                     text: item.abstract_name + " (" + item.core + " cores, " + item.mem + " GB, " + item.storage + ", " + item.provider + ": " + item.provider_name + ")",
-                    isSelected: item.abstract_name === info.defaultHostType
+                    isSelected: item.id === info.defaultHostType
                 }
             }),
         cellValue: info.defaultCell,


### PR DESCRIPTION
Selected comparison is not correct which can cause invalid data to populate in the UI.

Also fixed 2 comparisons in "new capacity" and "new capacity advanced" although these comparisons should not cause any problem because they are not selecting existing data.  Potentially they will cause these fields to be unselected and require user interaction, but we haven't had a report of any submit issue on new cluster create.

Testing plan:
- reproduce issue DONE
- manual test this fix