### PR TITLE
add modal to confirm cluster capacity changes

### DIFF
--- a/deploy-board/deploy_board/static/js/components/capacitycomponents.js
+++ b/deploy-board/deploy_board/static/js/components/capacitycomponents.js
@@ -199,7 +199,7 @@ Vue.component("static-capacity-config", {
         Capacity\
     </label>\
     <div class="col-xs-2" >\
-    <input class="form-control" v-bind:value="capacity" v-on:change="updateValue($event.target.value)"></input>\
+    <input class="form-control" v-bind:value="capacity" v-on:change="updateValue($event.target.value)" @keydown.enter.prevent=""></input>\
     </div></div>',
     props: ['capacity'],
     methods: {
@@ -221,13 +221,13 @@ Vue.component("asg-capacity-config", {
             <div class="col-xs-2">\
                 <div class="input-group" >\
                     <span class="input-group-addon">Min Size</span>\
-                    <input class="form-control" v-bind:value="minsize" v-on:change="updateMinSize($event.target.value)"></input>\
+                    <input class="form-control" v-bind:value="minsize" v-on:change="updateMinSize($event.target.value)" @keydown.enter.prevent=""></input>\
                 </div>\
             </div>\
             <div class="col-xs-2">\
                 <div class="input-group" >\
                     <span class="input-group-addon">Max Size</span>\
-                    <input class="form-control" v-bind:value="maxsize" v-on:change="updateMaxSize($event.target.value)"></input>\
+                    <input class="form-control" v-bind:value="maxsize" v-on:change="updateMaxSize($event.target.value)" @keydown.enter.prevent=""></input>\
                 </div>\
             </div>\
     </div>',

--- a/deploy-board/deploy_board/templates/clusters/cluster_capacity.tmpl
+++ b/deploy-board/deploy_board/templates/clusters/cluster_capacity.tmpl
@@ -1,31 +1,33 @@
-
 <div id="clusterPanelId" v-if="hasCluster" class="panel panel-default">
-<panel-heading title="Cluster Capacity" target="#clusterConfigId" initcollapse="false">
-</panel-heading>
-<div id="clusterConfigId" class="collapse in panel-body">
-    <div class="container-fluid">
-        <form id="clusterConfigFormId" class="form-horizontal" role="form">
-            <fieldset id="clusterConfigFieldSetId">
-                <label-info title="Cluster State" name="Cluster State" v-bind:text="clusterstate" v-bind:styleclass="clusterStateStyle"></label-info>
-                <label-info title="Cell" name="Cell" v-bind:text="cell"></label-info>
-                <static-capacity-config v-if="!autoscalingEnabled" v-bind:capacity="desiredCapacity" v-on:change="updateStatic">
-                </static-capacity-config>
-                <asg-capacity-config v-if="autoscalingEnabled" v-bind:minsize="minsize" v-bind:maxsize="maxsize" v-on:minchange="updateMin" v-on:maxchange="updateMax">
-                </asg-capacity-config>
-            </fieldset>
-        </form>
+    <panel-heading title="Cluster Capacity" target="#clusterConfigId" initcollapse="false"></panel-heading>
+    <div id="clusterConfigId" class="collapse in panel-body">
+        <div class="container-fluid">
+            <form id="clusterConfigFormId" class="form-horizontal" role="form">
+                <fieldset id="clusterConfigFieldSetId">
+                    <label-info title="Cluster State" name="Cluster State" v-bind:text="clusterstate" v-bind:styleclass="clusterStateStyle"></label-info>
+                    <label-info title="Cell" name="Cell" v-bind:text="cell"></label-info>
+                    <static-capacity-config v-if="!autoscalingEnabled" v-bind:capacity="desiredCapacity" v-on:change="updateStatic"></static-capacity-config>
+                    <asg-capacity-config v-if="autoscalingEnabled" v-bind:minsize="minsize" v-bind:maxsize="maxsize" v-on:minchange="updateMin" v-on:maxchange="updateMax"></asg-capacity-config>
+                </fieldset>
+            </form>
+        </div>
     </div>
+    <div class="panel-footer clearfix">
+        <div class="pull-right">
+            <button type="button" id="saveClusterConfigBtnId" class="btn btn-primary" v-bind:disabled="!canSaveCapacity"
+                    data-toggle="modal"
+                    :data-target="`#${confirmDialogId}`"
+                    title="Save cluster capacity configuration">
+                <span class="glyphicon glyphicon-floppy-save"></span>
+                Save
+            </button>
+        </div>
+    </div>
+    <modal v-bind:title="confirmDialogTitle" v-bind:id="confirmDialogId" v-on:input="clickDialog">
+        <div slot="body"> Are you sure you want to <strong>change capacity</strong> for this cluster?</div>
+    </modal>
 </div>
 
-<div class="panel-footer clearfix">
-    <div class="pull-right">
-        <button type="button" id="saveClusterConfigBtnId" class="btn btn-primary" v-bind:disabled="!canSaveCapacity"
-                data-loading-text="Saving..." v-on:click="save">
-            <span class="glyphicon glyphicon-floppy-save"></span> Save
-        </button>
-    </div>
-</div>
-</div>
 <script>
     var cluster = info.basic_cluster_info;
     if (cluster!=null){
@@ -46,6 +48,8 @@
                 cell: cluster.cellName,
                 clusterstate: cluster.state,
                 clusterStateStyle: cluster.state === "NORMAL" ? "text-success" : "text-danger",
+                confirmDialogTitle:"Change Cluster Capacity Confirmation",
+                confirmDialogId:"confirmClusterCapacityDialog",
                 desiredCapacity: cluster.capacity,
                 instancetype: cluster.hostType,
                 minsize: asg_launch_info.minSize,
@@ -67,6 +71,11 @@
                     this.maxsize = Number(value)
                     if (this.maxsize<this.minsize){
                         this.minsize = this.maxsize
+                    }
+                },
+                clickDialog: function(value){
+                    if (value){
+                        this.save();
                     }
                 },
                 save:function(){


### PR DESCRIPTION
Add a modal to confirm any cluster capacity changes

Original capacity
![01_capacity](https://user-images.githubusercontent.com/2539362/138772164-57bf06b2-714e-4073-9522-6e31a9152e5d.jpg)

Changed capacity confirmation modal for fixed sizes
![02_capacity_confirmation](https://user-images.githubusercontent.com/2539362/138772299-91f1d083-a8a3-445c-ba40-4dc0ee7b38a1.jpg)


Changed capacity confirmation modal for min/max
![03_capacity_min_max](https://user-images.githubusercontent.com/2539362/138772356-8f896605-3f08-4f9d-a2e6-2016c7f23d49.jpg)

Save behavior for clusters with an invalid sate is unmodified.  Pressing "enter" on these input dialogs is disabled because of unexpected browser behavior.
![04_unexpected_cluster_state](https://user-images.githubusercontent.com/2539362/138772538-e5994503-0eba-4a8e-936e-fab613d5a457.jpg)


