### PR TITLE
support github app auth for githubManager, and add SourceControlManagerProxy to support both github and phab in an env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,13 @@ deploy-service/teletraanservice/teletraan/
 
 # VSCode
 .vscode/
+deploy-service/common/.settings/
+deploy-service/.settings/
+deploy-service/common/.*
+deploy-service/teletraanservice/.settings/
+deploy-service/teletraanservice/.*
+docs/docs_generator/.settings/
+
 
 # C extensions
 *.so

--- a/deploy-board/deploy_board/templates/builds/commits.tmpl
+++ b/deploy-board/deploy_board/templates/builds/commits.tmpl
@@ -13,6 +13,7 @@
         <input id="hiddenStartShaId" name="start_sha" type="hidden" value="{{ start_sha }}"/>
         <input id="hiddenEndShaId" name="end_sha" type="hidden" value="{{ end_sha }}"/>
         <input id="hiddenRepoId" name="repo" type="hidden" value="{{ repo }}"/>
+        <input id="hiddenScmId" name="scm" type="hidden" value="{{ scm }}"/>
         <input name="show_checkbox" type="hidden" value="{{ show_checkbox }}"/>
     </form>
 </div>

--- a/deploy-board/deploy_board/templates/builds/pick_a_build.tmpl
+++ b/deploy-board/deploy_board/templates/builds/pick_a_build.tmpl
@@ -30,6 +30,8 @@
             <input class="hiddenCommit" type="hidden" value="{{ buildInfo.build.commit }}"/>
             <input class="hiddenCommit7" type="hidden" value="{{ buildInfo.build.commitShort }}"/>
             <input class="hiddenBranch" type="hidden" value="{{ buildInfo.build.branch }}"/>
+            <input class="hiddenType" type="hidden" value="{{ buildInfo.build.type }}"/>
+            <input class="hiddenRepo" type="hidden" value="{{ buildInfo.build.repo }}"/>
         </td>
         <td>
             {% if buildInfo.build.branch == "private" %}
@@ -85,7 +87,7 @@
                             title="Show commits between two adjacent builds">
                         <span class="glyphicon glyphicon-zoom-in"></span> Show Commits Between Builds
                     </button>
-                    {% if current_build.type == "Github" %}
+                    {% if buildInfo.build.type == "Github" %}
                     <button class="githuber deployToolTip btn btn-default" data-toggle="tooltip"
                             title="Show all the new commits in Gitbhub">
                         <i class="fa fa-github"></i> Show New Commits in Github
@@ -169,9 +171,12 @@
             $(btn).tooltip('hide');
             trid = $(this).closest('tr');
             startSha = trid.prev().find(".hiddenCommit").val();
+            scmType = trid.prev().find(".hiddenType").val();
+            scmRepo = trid.prev().find(".hiddenRepo").val();
             contentId = trid.find('.showContent');
             url = '/commits/compare_commits/?start_sha=' + startSha +
-                '&end_sha={{ current_build.commit }}&repo={{ current_build.repo }}';
+                '&end_sha={{ current_build.commit }}&repo=' + scmRepo +
+                '&scm=' + scmType;
             contentId.load(url, function () {
                 $(btn).button('reset');
             });
@@ -184,9 +189,12 @@
             trid = $(this).closest('tr');
             prevSha = trid.prev().find(".hiddenCommit").val();
             currentSha = trid.next().find(".hiddenCommit").val();
+            scmType = trid.prev().find(".hiddenType").val();
+            scmRepo = trid.prev().find(".hiddenRepo").val();
             contentId = trid.find('.showContent');
             url = '/commits/compare_commits/?start_sha=' + prevSha +
-                '&end_sha=' + currentSha + '&repo={{ current_build.repo }}';
+                '&end_sha=' + currentSha + '&repo=' + scmRepo +
+                '&scm=' + scmType;
             contentId.load(url, function () {
                 $(btn).button('reset');
             });

--- a/deploy-board/deploy_board/templates/deploys/deploy_commits.html
+++ b/deploy-board/deploy_board/templates/deploys/deploy_commits.html
@@ -66,7 +66,7 @@
 <script>
     $(function () {
         $('#newCommitsDivId').load('/commits/compare_commits_datatables/?start_sha={{ startSha }}' +
-                '&end_sha={{ endSha }}&repo={{ repo }}'
+                '&end_sha={{ endSha }}&repo={{ repo }}&scm={{ repo|commitRepoType }}'
         );
 
         $('#githuber').click(function () {

--- a/deploy-board/deploy_board/webapp/build_views.py
+++ b/deploy-board/deploy_board/webapp/build_views.py
@@ -76,19 +76,22 @@ def get_all_builds(request):
     size = int(request.GET.get('page_size', common.DEFAULT_BUILD_SIZE))
     builds = builds_helper.get_builds_and_tags(request, name=name, branch=branch, pageIndex=index,
                                       pageSize=size)
-    scm_url = systems_helper.get_scm_url(request)
     deploy_state = None
     current_build_id = request.GET.get('current_build_id', None)
     override_policy = request.GET.get('override_policy')
     deploy_id = request.GET.get('deploy_id')
     current_build = None
+    scmType = ""
     if current_build_id:
         current_build = builds_helper.get_build_and_tag(request, current_build_id)
         current_build = current_build.get('build')
+        scmType = current_build.get('type')
     if deploy_id:
         deploy_config = deploys_helper.get(request, deploy_id)
         if deploy_config:
             deploy_state = deploy_config.get('state', None)
+
+    scm_url = systems_helper.get_scm_url(request, scmType)
 
     html = render_to_string('builds/pick_a_build.tmpl', {
         "builds": builds,
@@ -124,8 +127,9 @@ def get_more_commits(request):
     startSha = request.GET.get('start_sha')
     endSha = request.GET.get('end_sha')
     repo = request.GET.get('repo')
+    scm = request.GET.get('scm')
 
-    commits, truncated, new_start_sha = common.get_commits_batch(request, repo,
+    commits, truncated, new_start_sha = common.get_commits_batch(request, scm, repo,
                                                                  startSha, endSha,
                                                                  keep_first=False)
 
@@ -146,14 +150,16 @@ def compare_commits(request):
     startSha = request.GET.get('start_sha')
     endSha = request.GET.get('end_sha')
     repo = request.GET.get('repo')
-    commits, truncated, new_start_sha = common.get_commits_batch(request, repo,
-                                                                 startSha, endSha,
+    scm = request.GET.get('scm')
+    commits, truncated, new_start_sha = common.get_commits_batch(request, scm, repo,
+                                                                 startSha, endSha, 
                                                                  keep_first=True)
     html = render_to_string('builds/commits.tmpl', {
         "commits": commits,
         "start_sha": new_start_sha,
         "end_sha": endSha,
         "repo": repo,
+        "scm": scm,
         "truncated": truncated,
         "show_checkbox": False,
     })
@@ -164,7 +170,8 @@ def compare_commits_datatables(request):
     startSha = request.GET.get('start_sha')
     endSha = request.GET.get('end_sha')
     repo = request.GET.get('repo')
-    commits, truncated, new_start_sha = common.get_commits_batch(request, repo,
+    scm = request.GET.get('scm')    
+    commits, truncated, new_start_sha = common.get_commits_batch(request, scm, repo,
                                                                  startSha, endSha,
                                                                  size=2000,
                                                                  keep_first=True)
@@ -173,6 +180,7 @@ def compare_commits_datatables(request):
         "start_sha": new_start_sha,
         "end_sha": endSha,
         "repo": repo,
+        "scm": scm,
         "truncated": truncated,
         "show_checkbox": False,
     })

--- a/deploy-board/deploy_board/webapp/common.py
+++ b/deploy-board/deploy_board/webapp/common.py
@@ -83,9 +83,9 @@ def get_previous_deploy(request, env, deploy):
 # Return all the commits, up to allowed size, also a
 # boolean indicated if the result was truncated
 # Notice it will never return endSha itself
-def get_commits_batch(request, repo, startSha, endSha, size=DEFAULT_COMMITS_SIZE,
+def get_commits_batch(request, scm, repo, startSha, endSha, size=DEFAULT_COMMITS_SIZE,
                       keep_first=False):
-    commits = builds_helper.get_commits(request=request, repo=repo, startSha=startSha,
+    commits = builds_helper.get_commits(request=request, scm=scm, repo=repo, startSha=startSha,
                                         endSha=endSha, size=size)
     truncated = False
     new_start_sha = None
@@ -100,7 +100,7 @@ def get_commits_batch(request, repo, startSha, endSha, size=DEFAULT_COMMITS_SIZE
 
 
 # it will return all the commits, or max
-def get_commits_between(request, repo, startSha, endSha, max=500):
+def get_commits_between(request, scm, repo, startSha, endSha, max=500):
     total_commits = []
     keep_first = True
     new_start_sha = startSha
@@ -111,7 +111,7 @@ def get_commits_between(request, repo, startSha, endSha, max=500):
                 repo, startSha, endSha))
             break
 
-        commits, truncated, new_start_sha = get_commits_batch(request, repo,
+        commits, truncated, new_start_sha = get_commits_batch(request, scm, repo,
                                                               new_start_sha, endSha,
                                                               keep_first=keep_first)
         keep_first = False

--- a/deploy-board/deploy_board/webapp/env_views.py
+++ b/deploy-board/deploy_board/webapp/env_views.py
@@ -977,13 +977,15 @@ def deploy_build(request, name, stage, build_id):
     env = environs_helper.get_env_by_stage(request, name, stage)
     current_build = None
     deploy_state = None
+    scmType = ""
     if env.get('deployId'):
         current_deploy = deploys_helper.get(request, env['deployId'])
         current_build = builds_helper.get_build(request, current_deploy['buildId'])
         deploy_state = deploys_helper.get(request, env['deployId'])['state']
+        scmType = current_build['type']
     build = builds_helper.get_build_and_tag(request, build_id)
     builds = [build]
-    scm_url = systems_helper.get_scm_url(request)
+    scm_url = systems_helper.get_scm_url(request, scmType)
 
     html = render_to_string('deploys/deploy_build.html', {
         "env": env,
@@ -1003,10 +1005,12 @@ def deploy_commit(request, name, stage, commit):
     env = environs_helper.get_env_by_stage(request, name, stage)
     builds = builds_helper.get_builds_and_tags(request, name=env.get('buildName', ''), commit=commit)
     current_build = None
+    scmType = ""
     if env.get('deployId'):
         deploy = deploys_helper.get(request, env['deployId'])
         current_build = builds_helper.get_build(request, deploy['buildId'])
-    scm_url = systems_helper.get_scm_url(request)
+        scmType = current_build['type']
+    scm_url = systems_helper.get_scm_url(request, scmType)
 
     html = render_to_string('deploys/deploy_build.html', {
         "env": env,
@@ -1585,7 +1589,7 @@ def get_new_commits(request, name, stage):
     current_build = builds_helper.get_build(request, current_deploy['buildId'])
     startSha = current_build['commit']
     repo = current_build['repo']
-    scm_url = systems_helper.get_scm_url(request)
+    scm_url = systems_helper.get_scm_url(request, current_build['type'])
     diffUrl = "%s/%s/compare/%s...%s" % (scm_url, repo, startSha, startSha)
     last_deploy = common.get_last_completed_deploy(request, env)
     if not last_deploy:
@@ -1630,6 +1634,7 @@ def compare_deploys(request, name, stage):
     start_build = builds_helper.get_build(request, start_deploy['buildId'])
     startSha = start_build['commit']
     repo = start_build['repo']
+    scm = start_build['type']
 
     end_deploy_id = request.GET.get('end_deploy', None)
     if end_deploy_id:
@@ -1642,7 +1647,7 @@ def compare_deploys(request, name, stage):
     end_build = builds_helper.get_build(request, end_deploy['buildId'])
     endSha = _get_endSha(end_build)
 
-    commits, truncated, new_start_sha = common.get_commits_batch(request, repo, startSha,
+    commits, truncated, new_start_sha = common.get_commits_batch(request, scm, repo, startSha,
                                                                  endSha, keep_first=True)
 
     html = render_to_string('builds/commits.tmpl', {
@@ -1650,6 +1655,7 @@ def compare_deploys(request, name, stage):
         "start_sha": new_start_sha,
         "end_sha": endSha,
         "repo": repo,
+        "scm": scm,
         "truncated": truncated,
         "show_checkbox": False,
     })
@@ -1677,7 +1683,7 @@ def compare_deploys_2(request, name, stage):
     end_build = builds_helper.get_build(request, end_build_id)
     endSha = _get_endSha(end_build)
 
-    scm_url = systems_helper.get_scm_url(request)
+    scm_url = systems_helper.get_scm_url(request, start_build['type'])
     diffUrl = "%s/%s/compare/%s...%s" % (scm_url, repo, endSha, startSha)
     return render(request, 'deploys/deploy_commits.html', {
         "env": env,

--- a/deploy-board/deploy_board/webapp/helpers/systems_helper.py
+++ b/deploy-board/deploy_board/webapp/helpers/systems_helper.py
@@ -21,12 +21,12 @@ DEFAULT_NAME_SIZE = 30
 deployclient = DeployClient()
 
 
-def get_url_pattern(request):
-    return deployclient.get("/system/scm_link_template", request.teletraan_user_id.token)
+def get_url_pattern(request, type=""):
+    return deployclient.get("/system/scm_link_template/?scm=" + type, request.teletraan_user_id.token)
 
 
-def get_scm_url(request):
-    return deployclient.get("/system/scm_url", request.teletraan_user_id.token)['url']
+def get_scm_url(request, type=""):
+    return deployclient.get("/system/scm_url/?scm=" + type, request.teletraan_user_id.token)['url']
 
 
 def send_chat_message(request, from_name, to_name, message):

--- a/deploy-board/deploy_board/webapp/hotfix_views.py
+++ b/deploy-board/deploy_board/webapp/hotfix_views.py
@@ -44,7 +44,7 @@ def get_hotfix(request, name, stage, id):
     hotfix = hotfixs_helper.get(request, id)
     deploy = deploys_helper.get(request, hotfix['baseDeployId'])
     build = builds_helper.get_build(request, deploy['buildId'])
-    urlPattern = systems_helper.get_url_pattern(request)
+    urlPattern = systems_helper.get_url_pattern(request, build.get('type'))
     commits = []
     _create_commits(commits, urlPattern['template'], hotfix)
     jenkins_url = "%s/%s/%s" % (BUILD_URL, hotfix['jobName'],
@@ -63,7 +63,7 @@ def get_hotfix_detail(request, id):
     hotfix = hotfixs_helper.get(request, id)
     deploy = deploys_helper.get(request, hotfix['baseDeployId'])
     build = builds_helper.get_build(request, deploy['buildId'])
-    urlPattern = systems_helper.get_url_pattern(request)
+    urlPattern = systems_helper.get_url_pattern(request, build.get('type'))
     commits = []
     _create_commits(commits, urlPattern['template'], hotfix)
     jenkins_url = "%s/%s/%s" % (BUILD_URL, hotfix['jobName'],
@@ -85,7 +85,8 @@ def patch(request, name, stage):
         deploy_id = env['deployId']
     deploy = deploys_helper.get(request, deploy_id)
     build = builds_helper.get_build(request, deploy['buildId'])
-    commits, truncated, new_start_sha = common.get_commits_batch(request, build['repo'],
+    commits, truncated, new_start_sha = common.get_commits_batch(request, build['type'], 
+                                                                 build['repo'],
                                                                  env['branch'],
                                                                  build['commit'],
                                                                  keep_first=True)
@@ -107,7 +108,7 @@ class HotfixesView(View):
         index = int(request.GET.get('page_index', '1'))
         size = int(request.GET.get('page_size', DEFAULT_PAGE_SIZE))
         hotfixes = hotfixs_helper.get_all(request, name, index, size)
-        urlPattern = systems_helper.get_url_pattern(request)
+        urlPattern = systems_helper.get_url_pattern(request, "")
         for hotfix in hotfixes:
             commits = []
             _create_commits(commits, urlPattern['template'], hotfix)

--- a/deploy-board/integ_test/build_tests.py
+++ b/deploy-board/integ_test/build_tests.py
@@ -26,9 +26,12 @@ class TestBuilds(unittest.TestCase):
         request1 = self._generate_request("build1", "commit-1")
         request2 = self._generate_request("build2", "commit-1")
         request3 = self._generate_request("build2", "commit-2", "branch-1")
+        request4 = self._generate_request("build3", "commit-3", "branch-2", "Github")
+
         id1 = builds_helper.publish_build(commons.REQUEST, request1)['id']
         id2 = builds_helper.publish_build(commons.REQUEST, request2)['id']
         id3 = builds_helper.publish_build(commons.REQUEST, request3)['id']
+        id4 = builds_helper.publish_build(commons.REQUEST, request4)['id']
 
         build1 = builds_helper.get_build(commons.REQUEST, id1)
         builds = builds_helper.get_builds(commons.REQUEST, name="build1", branch="master",
@@ -55,14 +58,18 @@ class TestBuilds(unittest.TestCase):
         build_names = builds_helper.get_branches(commons.REQUEST, "build2")
         self.assertTrue(len(build_names) >= 2)
 
+        builds = builds_helper.get_builds(commons.REQUEST, name="build3", pageIndex=1, pageSize=1)
+        self.assertTrue(len(builds) == 1)
+
         builds_helper.delete_build(commons.REQUEST, id1)
         builds_helper.delete_build(commons.REQUEST, id2)
         builds_helper.delete_build(commons.REQUEST, id3)
+        builds_helper.delete_build(commons.REQUEST, id4)
 
-    def _generate_request(self, buildName, commit, branch="master"):
+    def _generate_request(self, buildName, commit, branch="master", type="Phabricator"):
         request = {}
         request['name'] = buildName
-        request['type'] = "Github"
+        request['type'] = type
         request['repo'] = "repo-1"
         request['branch'] = branch
         request['commit'] = commit

--- a/deploy-board/integ_test/build_tests.py
+++ b/deploy-board/integ_test/build_tests.py
@@ -62,12 +62,12 @@ class TestBuilds(unittest.TestCase):
     def _generate_request(self, buildName, commit, branch="master"):
         request = {}
         request['name'] = buildName
-        request['type'] = "phabricator"
+        request['type'] = "Github"
         request['repo'] = "repo-1"
         request['branch'] = branch
         request['commit'] = commit
         request['commitDate'] = int(round(time.time() * 1000))
-        request['artifactUrl'] = "https://whatever.com"
+        request['artifactUrl'] = "https://sample.com"
         request['publishInfo'] = "jenkins12345"
         return request
 

--- a/deploy-service/common/pom.xml
+++ b/deploy-service/common/pom.xml
@@ -227,5 +227,27 @@
             <version>2.1.7.597</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.kohsuke</groupId>
+            <artifactId>github-api</artifactId>
+            <version>1.133</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.10.5</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.10.5</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.10.5</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/ServiceContext.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/ServiceContext.java
@@ -45,8 +45,7 @@ import com.pinterest.deployservice.events.EventSender;
 import com.pinterest.deployservice.group.HostGroupManager;
 import com.pinterest.deployservice.pingrequests.PingRequestValidator;
 import com.pinterest.deployservice.rodimus.RodimusManager;
-import com.pinterest.deployservice.scm.SourceControlManager;
-import com.pinterest.deployservice.allowlists.BuildAllowlistImpl;
+import com.pinterest.deployservice.scm.SourceControlManagerProxy;
 import com.pinterest.deployservice.allowlists.Allowlist;
 
 import org.apache.commons.dbcp.BasicDataSource;
@@ -85,7 +84,7 @@ public class ServiceContext {
 
     private String serviceStage;
     private MailManager mailManager;
-    private SourceControlManager sourceControlManager;
+    private SourceControlManagerProxy sourceControlManagerProxy;
     private ChatManager chatManager;
     private ExecutorService jobPool;
     private RodimusManager rodimusManager;
@@ -287,12 +286,12 @@ public class ServiceContext {
         return this.serviceStage;
     }
 
-    public SourceControlManager getSourceControlManager() {
-        return sourceControlManager;
+    public SourceControlManagerProxy getSourceControlManagerProxy() {
+        return sourceControlManagerProxy;
     }
 
-    public void setSourceControlManager(SourceControlManager sourceControlManager) {
-        this.sourceControlManager = sourceControlManager;
+    public void setSourceControlManagerProxy(SourceControlManagerProxy sourceControlManagerProxy) {
+        this.sourceControlManagerProxy = sourceControlManagerProxy;
     }
 
     public ChatManager getChatManager() {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/EncryptionUtils.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/EncryptionUtils.java
@@ -1,0 +1,118 @@
+package com.pinterest.deployservice.common;
+
+import java.io.IOException;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+
+import java.util.Base64;
+import java.security.GeneralSecurityException;
+import java.security.Key;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.util.Date;
+
+import io.jsonwebtoken.JwtBuilder;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+
+/**
+ * Utility class for loading certificates and keys.
+ * based on: https://github.com/Mastercard/client-encryption-java/blob/main/src/main/java/com/mastercard/developer/utils/EncryptionUtils.java
+ */
+public final class EncryptionUtils {
+
+    private static final String PKCS_1_PEM_HEADER = "-----BEGIN RSA PRIVATE KEY-----";
+    private static final String PKCS_1_PEM_FOOTER = "-----END RSA PRIVATE KEY-----";
+    private static final String PKCS_8_PEM_HEADER = "-----BEGIN PRIVATE KEY-----";
+    private static final String PKCS_8_PEM_FOOTER = "-----END PRIVATE KEY-----";
+
+    private EncryptionUtils() {
+    }
+
+    public static String createGithubJWT(String githubAppId, String privateKeyPEMString, long ttlMillis) throws Exception {
+        // The JWT signature algorithm we will be using to sign the token
+        SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.RS256;
+
+        // We will sign our JWT with our private key
+        Key signingKey = EncryptionUtils.loadDecryptionKey(privateKeyPEMString);
+
+        long nowMillis = System.currentTimeMillis();
+        Date now = new Date(nowMillis);
+
+        // Let's set the JWT Claims
+        JwtBuilder builder = Jwts.builder().setIssuedAt(now).setIssuer(githubAppId).signWith(signingKey,
+            signatureAlgorithm);
+
+        // if it has been specified, let's add the expiration
+        if (ttlMillis > 0) {
+            long expMillis = nowMillis + ttlMillis;
+            Date exp = new Date(expMillis);
+            builder.setExpiration(exp);
+        }
+
+        // Builds the JWT and serializes it to a compact, URL-safe string
+        return builder.compact();
+    }
+
+    /**
+     * Load a RSA decryption key from a file (PEM or DER).
+     */
+    public static PrivateKey loadDecryptionKey(String keyString) throws GeneralSecurityException, IOException {
+        if (keyString.contains(PKCS_1_PEM_HEADER)) {
+            // OpenSSL / PKCS#1 Base64 PEM encoded file
+            keyString = keyString.replace(PKCS_1_PEM_HEADER, "");
+            keyString = keyString.replace(PKCS_1_PEM_FOOTER, "");
+            keyString = keyString.replace("\n", "");
+            keyString = keyString.replace("\r\n", "");
+            return readPkcs1PrivateKey(Base64.getDecoder().decode(keyString));
+        }
+        else if (keyString.contains(PKCS_8_PEM_HEADER)) {
+            // PKCS#8 Base64 PEM encoded file
+            keyString = keyString.replace(PKCS_8_PEM_HEADER, "");
+            keyString = keyString.replace(PKCS_8_PEM_FOOTER, "");
+            keyString = keyString.replace("\n", "");
+            keyString = keyString.replace("\r\n", "");
+            return readPkcs8PrivateKey(Base64.getDecoder().decode(keyString));
+        }
+        else {
+            throw new IllegalArgumentException("Unexpected key format!");
+        }
+    }
+
+    /**
+     * Create a PrivateKey instance from raw PKCS#8 bytes.
+     */
+    private static PrivateKey readPkcs8PrivateKey(byte[] pkcs8Bytes) throws GeneralSecurityException {
+        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+        PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(pkcs8Bytes);
+        try {
+            return keyFactory.generatePrivate(keySpec);
+        } catch (InvalidKeySpecException e) {
+            throw new IllegalArgumentException("Unexpected key format!", e);
+        }
+    }
+
+    /**
+     * Create a PrivateKey instance from raw PKCS#1 bytes.
+     */
+    private static PrivateKey readPkcs1PrivateKey(byte[] pkcs1Bytes) throws GeneralSecurityException {
+        // We can't use Java internal APIs to parse ASN.1 structures, so we build a PKCS#8 key Java can understand
+        int pkcs1Length = pkcs1Bytes.length;
+        int totalLength = pkcs1Length + 22;
+        byte[] pkcs8Header = new byte[] {
+                0x30, (byte) 0x82, (byte) ((totalLength >> 8) & 0xff), (byte) (totalLength & 0xff), // Sequence + total length
+                0x2, 0x1, 0x0, // Integer (0)
+                0x30, 0xD, 0x6, 0x9, 0x2A, (byte) 0x86, 0x48, (byte) 0x86, (byte) 0xF7, 0xD, 0x1, 0x1, 0x1, 0x5, 0x0, // Sequence: 1.2.840.113549.1.1.1, NULL
+                0x4, (byte) 0x82, (byte) ((pkcs1Length >> 8) & 0xff), (byte) (pkcs1Length & 0xff) // Octet string + length
+        };
+        byte[] pkcs8bytes = join(pkcs8Header, pkcs1Bytes);
+        return readPkcs8PrivateKey(pkcs8bytes);
+    }
+
+    private static byte[] join(byte[] byteArray1, byte[] byteArray2){
+        byte[] bytes = new byte[byteArray1.length + byteArray2.length];
+        System.arraycopy(byteArray1, 0, bytes, 0, byteArray1.length);
+        System.arraycopy(byteArray2, 0, bytes, byteArray1.length, byteArray2.length);
+        return bytes;
+    }
+}

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/scm/GithubManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/scm/GithubManager.java
@@ -78,7 +78,7 @@ public class GithubManager extends BaseManager {
 
                 // generate jwt token by signing with github app id and private key
                 String jwtToken = EncryptionUtils.createGithubJWT(this.githubAppId, githubAppPrivateKey, TOKEN_TTL_MILLIS);
-                System.out.println("jtwtoken: " + jwtToken);
+                // System.out.println("jtwtoken: " + jwtToken);
 
                 // get installation token using the jwt token
                 GitHub gitHubApp = new GitHubBuilder().withJwtToken(jwtToken).build();

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/scm/GithubManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/scm/GithubManager.java
@@ -38,9 +38,11 @@ import java.util.Map;
 import java.util.Queue;
 
 import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class GithubManager extends BaseManager {
-
+    private static final Logger LOG = LoggerFactory.getLogger(GithubManager.class);
     public final static String TYPE = "Github";
     private final static String UNKNOWN_LOGIN = "UNKNOWN";
     private final static long TOKEN_TTL_MILLIS = 600000;  //token expires after 10 mins
@@ -71,23 +73,22 @@ public class GithubManager extends BaseManager {
                 KnoxKeyReader knoxKey = new KnoxKeyReader();
                 knoxKey.init(this.githubAppPrivateKeyKnox);
                 String githubAppPrivateKey = knoxKey.getKey();
-                // System.out.println("pemKey: " + githubAppPrivateKey);
                 if (StringUtils.isEmpty(githubAppPrivateKey)) {
-                    throw new IllegalArgumentException("failed to get knox key");
+                    LOG.error("Failed to get Github Knox key");
+                    throw new IllegalArgumentException("Failed to get Github Knox key");
                 }
 
                 // generate jwt token by signing with github app id and private key
                 String jwtToken = EncryptionUtils.createGithubJWT(this.githubAppId, githubAppPrivateKey, TOKEN_TTL_MILLIS);
-                // System.out.println("jtwtoken: " + jwtToken);
 
                 // get installation token using the jwt token
                 GitHub gitHubApp = new GitHubBuilder().withJwtToken(jwtToken).build();
                 GHAppInstallation appInstallation = gitHubApp.getApp().getInstallationByOrganization(this.githubAppOrganization);
                 GHAppInstallationToken appInstallationToken = appInstallation.createToken().create();    
                 this.token = appInstallationToken.getToken();
-                // System.out.println("token: " + token);
             } catch (Exception e) {
                 // e.printStackTrace();
+                LOG.error("Exception when getting Github token: ", e);
                 throw e;
             }
         }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/scm/SourceControlManagerProxy.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/scm/SourceControlManagerProxy.java
@@ -1,0 +1,57 @@
+package com.pinterest.deployservice.scm;
+
+import java.util.HashMap;
+import java.util.List;
+
+import com.pinterest.deployservice.bean.CommitBean;
+
+import org.apache.commons.lang.StringUtils;
+
+public class SourceControlManagerProxy {
+    private final static String DEFAULT_TYPE = PhabricatorManager.TYPE;
+
+    HashMap<String, SourceControlManager> managers;
+
+    public SourceControlManagerProxy(HashMap<String, SourceControlManager> managers) {
+        this.managers = managers;
+    }
+
+    private SourceControlManager getSourceControlManager(String scmType) throws Exception {
+        if(StringUtils.isEmpty(scmType)) {
+            scmType = DEFAULT_TYPE;
+        }
+        SourceControlManager manager = this.managers.get(scmType);
+        if (manager == null) {
+            throw new Exception("unsupported SCM type");
+        }
+        return manager;
+    }
+
+    public String getType() {
+        return DEFAULT_TYPE;
+    }
+
+    public String getCommitLinkTemplate(String scmType) throws Exception {
+        return getSourceControlManager(scmType).getCommitLinkTemplate();
+    }
+
+    public String getUrlPrefix(String scmType) throws Exception {
+        return getSourceControlManager(scmType).getUrlPrefix();
+    }
+
+    public String generateCommitLink(String scmType, String repo, String sha) throws Exception {
+        return getSourceControlManager(scmType).generateCommitLink(repo, sha);
+    }
+
+    public CommitBean getCommit(String scmType, String repo, String sha) throws Exception {
+        return getSourceControlManager(scmType).getCommit(repo, sha);
+    }
+
+    public List<CommitBean> getCommits(String scmType, String repo, String startSha, String endSha, int size) throws Exception {
+        return getSourceControlManager(scmType).getCommits(repo, startSha, endSha, size);
+    }
+
+    public List<CommitBean> getCommits(String scmType, String repo, String startSha, String endSha, int size, String path) throws Exception {
+        return getSourceControlManager(scmType).getCommits(repo, startSha, endSha, size, path);
+    }
+}

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/scm/SourceControlManagerProxy.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/scm/SourceControlManagerProxy.java
@@ -6,8 +6,11 @@ import java.util.List;
 import com.pinterest.deployservice.bean.CommitBean;
 
 import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SourceControlManagerProxy {
+    private static final Logger LOG = LoggerFactory.getLogger(SourceControlManagerProxy.class);
     private final static String DEFAULT_TYPE = PhabricatorManager.TYPE;
 
     HashMap<String, SourceControlManager> managers;
@@ -22,7 +25,8 @@ public class SourceControlManagerProxy {
         }
         SourceControlManager manager = this.managers.get(scmType);
         if (manager == null) {
-            throw new Exception("unsupported SCM type");
+            LOG.error("Unsupported SCM type: " + scmType);
+            throw new Exception("Unsupported SCM type: " + scmType);
         }
         return manager;
     }

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/scm/GithubManagerTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/scm/GithubManagerTest.java
@@ -1,0 +1,38 @@
+package com.pinterest.deployservice.scm;
+
+import com.pinterest.deployservice.bean.CommitBean;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/* To run this test only: 
+ *  update the github configuration in setUp() before running. 
+ *  $ mvn -Dtest=GithubManagerTest -DfailIfNoTests=false test
+ */
+public class GithubManagerTest {
+    GithubManager manager;
+
+    @Before
+    public void setUp() throws Exception {
+        String apiPrefix = "https://api.github.com";
+        String urlPrefix = "https://github.com";
+        String appId = "yourAppId";
+        String appPrivateKeyKnox = "";
+        String appOrgnization = "yourOrg";
+        String token = "";   // github personal token
+
+        this.manager = new GithubManager(token, appId, appPrivateKeyKnox, appOrgnization, apiPrefix, urlPrefix);
+        Assert.assertEquals(this.manager.getUrlPrefix(), urlPrefix);
+        System.out.println(this.manager.headers);
+    }
+
+    @Test
+    @Ignore
+    public void testGetCommit() throws Exception {
+        CommitBean commit = this.manager.getCommit("pinterest/teletraan", "0caa0c0dc877920811e0eb695f1ed0dfd498f586");
+        System.out.println(commit);
+        Assert.assertEquals("https://github.com/pinterest/teletraan/commit/0caa0c0dc877920811e0eb695f1ed0dfd498f586", commit.getInfo());
+    }
+}

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/scm/GithubManagerTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/scm/GithubManagerTest.java
@@ -1,5 +1,7 @@
 package com.pinterest.deployservice.scm;
 
+import java.util.List;
+
 import com.pinterest.deployservice.bean.CommitBean;
 
 import org.junit.Assert;
@@ -8,7 +10,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 /* To run this test only: 
- *  update the github configuration in setUp() before running. 
+ *  update the github configuration in setUp() before running. uncomment the ignore
  *  $ mvn -Dtest=GithubManagerTest -DfailIfNoTests=false test
  */
 public class GithubManagerTest {
@@ -22,7 +24,7 @@ public class GithubManagerTest {
         String appPrivateKeyKnox = "";
         String appOrgnization = "yourOrg";
         String token = "";   // github personal token
-
+        
         this.manager = new GithubManager(token, appId, appPrivateKeyKnox, appOrgnization, apiPrefix, urlPrefix);
         Assert.assertEquals(this.manager.getUrlPrefix(), urlPrefix);
         System.out.println(this.manager.headers);
@@ -34,5 +36,9 @@ public class GithubManagerTest {
         CommitBean commit = this.manager.getCommit("pinterest/teletraan", "0caa0c0dc877920811e0eb695f1ed0dfd498f586");
         System.out.println(commit);
         Assert.assertEquals("https://github.com/pinterest/teletraan/commit/0caa0c0dc877920811e0eb695f1ed0dfd498f586", commit.getInfo());
+
+        List <CommitBean> commits = this.manager.getCommits("pinterest/teletraan", "a220f1808b38f27314b4f5b89270216de7fb84bc", "7fa731d99b9c98c29ce500dfef64ea32c3641786", 100);
+        System.out.println(commits);
+        System.out.println("size = " + commits.size());
     }
 }

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/scm/GithubManagerTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/scm/GithubManagerTest.java
@@ -27,7 +27,6 @@ public class GithubManagerTest {
         
         this.manager = new GithubManager(token, appId, appPrivateKeyKnox, appOrgnization, apiPrefix, urlPrefix);
         Assert.assertEquals(this.manager.getUrlPrefix(), urlPrefix);
-        System.out.println(this.manager.headers);
     }
 
     @Test

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanServiceConfiguration.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanServiceConfiguration.java
@@ -60,7 +60,7 @@ public class TeletraanServiceConfiguration extends Configuration {
 
     @Valid
     @JsonProperty("scm")
-    private SourceControlFactory sourceControlFactory;
+    private List<SourceControlFactory> sourceControlConfigs;
 
     @Valid
     @JsonProperty("chat")
@@ -129,15 +129,15 @@ public class TeletraanServiceConfiguration extends Configuration {
         this.authenticationFactory = authenticationFactory;
     }
 
-    public SourceControlFactory getSourceControlFactory() {
-        if (sourceControlFactory == null) {
-            return new DefaultSourceControlFactory();
+    public List<SourceControlFactory> getSourceControlConfigs() {
+        if (sourceControlConfigs == null) {
+            return Collections.emptyList();
         }
-        return sourceControlFactory;
+        return sourceControlConfigs;
     }
 
-    public void setSourceControlFactory(SourceControlFactory sourceControlFactory) {
-        this.sourceControlFactory = sourceControlFactory;
+    public void setSourceControlConfigs(List<SourceControlFactory> sourceControlConfigs) {
+        this.sourceControlConfigs = sourceControlConfigs;
     }
 
     public AuthorizationFactory getAuthorizationFactory() {

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/GithubFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/GithubFactory.java
@@ -25,9 +25,17 @@ import javax.validation.constraints.NotNull;
 
 @JsonTypeName("github")
 public class GithubFactory implements SourceControlFactory {
-    @NotNull
     @JsonProperty
     private String token;
+
+    @JsonProperty
+    private String appId;
+
+    @JsonProperty
+    private String appPrivateKeyKnox;
+
+    @JsonProperty
+    private String appOrganization;
 
     @NotNull
     @JsonProperty
@@ -43,6 +51,29 @@ public class GithubFactory implements SourceControlFactory {
 
     public void setToken(String token) {
         this.token = token;
+    }
+
+    public String getAppId() {
+        return appId;
+    }
+    public void setAppId(String appId) {
+        this.appId = appId;
+    }
+
+    public String getAppPrivateKeyKnox() {
+        return appPrivateKeyKnox;
+    }
+
+    public void setAppPrivateKeyKnox(String appPrivateKeyKnox) {
+        this.appPrivateKeyKnox = appPrivateKeyKnox;
+    }
+
+    public String getAppOrganization() {
+        return appOrganization;
+    }
+
+    public void setAppOrganization(String appOrganization) {
+        this.appOrganization = appOrganization;
     }
 
     public String getApiPrefix() {
@@ -63,6 +94,6 @@ public class GithubFactory implements SourceControlFactory {
 
     @Override
     public SourceControlManager create() throws Exception {
-        return new GithubManager(token, apiPrefix, urlPrefix);
+        return new GithubManager(token, appId, appPrivateKeyKnox, appOrganization, apiPrefix, urlPrefix);
     }
 }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Builds.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Builds.java
@@ -22,7 +22,7 @@ import com.pinterest.deployservice.buildtags.BuildTagsManagerImpl;
 import com.pinterest.deployservice.common.CommonUtils;
 import com.pinterest.deployservice.dao.BuildDAO;
 import com.pinterest.deployservice.dao.TagDAO;
-import com.pinterest.deployservice.scm.SourceControlManager;
+import com.pinterest.deployservice.scm.SourceControlManagerProxy;
 import com.pinterest.deployservice.allowlists.Allowlist;
 import com.pinterest.teletraan.TeletraanServiceContext;
 import com.pinterest.teletraan.exception.TeletaanInternalException;
@@ -53,7 +53,7 @@ public class Builds {
     private BuildDAO buildDAO;
     private TagDAO tagDAO;
     private Allowlist buildAllowlist;
-    private SourceControlManager sourceControlManager;
+    private SourceControlManagerProxy sourceControlManagerProxy;
     private final Authorizer authorizer;
 
     @Context
@@ -62,7 +62,7 @@ public class Builds {
     public Builds(TeletraanServiceContext context) throws Exception {
         buildDAO = context.getBuildDAO();
         tagDAO = context.getTagDAO();
-        sourceControlManager = context.getSourceControlManager();
+        sourceControlManagerProxy = context.getSourceControlManagerProxy();
         authorizer = context.getAuthorizer();
         buildAllowlist = context.getBuildAllowlist();
     }
@@ -178,7 +178,7 @@ public class Builds {
             @Context SecurityContext sc,
             @ApiParam(value = "BUILD object", required = true)@Valid BuildBean buildBean) throws Exception {
         if (StringUtils.isEmpty(buildBean.getScm())) {
-            buildBean.setScm(sourceControlManager.getType());
+            buildBean.setScm(sourceControlManagerProxy.getType());
         }
 
         if (StringUtils.isEmpty(buildBean.getScm_commit_7())) {
@@ -186,7 +186,7 @@ public class Builds {
         }
 
         if (StringUtils.isEmpty(buildBean.getScm_info())) {
-            buildBean.setScm_info(sourceControlManager.generateCommitLink(buildBean.getScm_repo(), buildBean.getScm_commit()));
+            buildBean.setScm_info(sourceControlManagerProxy.generateCommitLink(buildBean.getScm(), buildBean.getScm_repo(), buildBean.getScm_commit()));
         }
 
         if (StringUtils.isEmpty(buildBean.getPublish_info())) {

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Hotfixs.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Hotfixs.java
@@ -21,8 +21,6 @@ import com.pinterest.deployservice.common.CommonUtils;
 import com.pinterest.deployservice.dao.BuildDAO;
 import com.pinterest.deployservice.dao.DeployDAO;
 import com.pinterest.deployservice.dao.HotfixDAO;
-import com.pinterest.deployservice.scm.GithubManager;
-import com.pinterest.deployservice.scm.SourceControlManager;
 import com.pinterest.teletraan.TeletraanServiceContext;
 import com.pinterest.teletraan.exception.TeletaanInternalException;
 import com.pinterest.teletraan.security.Authorizer;
@@ -45,7 +43,6 @@ public class Hotfixs {
     private DeployDAO deployDAO;
     private BuildDAO buildDAO;
     private HotfixDAO hotfixDAO;
-    private SourceControlManager sourceControlManager;
     private final Authorizer authorizer;
 
     @Context
@@ -55,7 +52,6 @@ public class Hotfixs {
         deployDAO = context.getDeployDAO();
         buildDAO = context.getBuildDAO();
         hotfixDAO = context.getHotfixDAO();
-        sourceControlManager = context.getSourceControlManager();
         authorizer = context.getAuthorizer();
     }
 
@@ -90,9 +86,10 @@ public class Hotfixs {
     }
 
     private String generateJobName(String repo) {
-        if (sourceControlManager.getType().equals(GithubManager.TYPE)) {
-            // Special case for Github to extract repo
-            repo = repo.split("/")[1];
+        String[] repoSplit = repo.split("/");
+        if (repoSplit.length > 1) {
+            // Special case for Github repo to extract repo name from org
+            repo = repoSplit[1];
         }
         return String.format("%s-hotfix-job", repo);
     }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Systems.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Systems.java
@@ -20,7 +20,7 @@ import com.pinterest.deployservice.bean.ChatMessageBean;
 import com.pinterest.deployservice.bean.HostBean;
 import com.pinterest.deployservice.chat.ChatManager;
 import com.pinterest.deployservice.dao.HostDAO;
-import com.pinterest.deployservice.scm.SourceControlManager;
+import com.pinterest.deployservice.scm.SourceControlManagerProxy;
 import com.pinterest.teletraan.TeletraanServiceContext;
 
 import org.slf4j.Logger;
@@ -38,6 +38,9 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
+import javax.ws.rs.QueryParam;
+import com.google.common.base.Optional;
+
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -49,12 +52,12 @@ import io.swagger.annotations.ApiParam;
 public class Systems {
 
     private static final Logger LOG = LoggerFactory.getLogger(Systems.class);
-    private SourceControlManager sourceControlManager;
+    private SourceControlManagerProxy sourceControlManagerProxy;
     private HostDAO hostDAO;
     private ChatManager chatManager;
 
     public Systems(TeletraanServiceContext context) {
-        sourceControlManager = context.getSourceControlManager();
+        sourceControlManagerProxy = context.getSourceControlManagerProxy();
         chatManager = context.getChatManager();
         hostDAO = context.getHostDAO();
     }
@@ -65,9 +68,9 @@ public class Systems {
         value = "Get SCM commit link template",
         notes = "Returns a Source Control Manager specific commit link template.",
         response = String.class)
-    public String getSCMLinkTemplate() throws Exception {
+    public String getSCMLinkTemplate(@QueryParam("scm") Optional<String> scm) throws Exception {
         return String
-            .format("{\"template\": \"%s\"}", sourceControlManager.getCommitLinkTemplate());
+            .format("{\"template\": \"%s\"}", sourceControlManagerProxy.getCommitLinkTemplate(scm.or("")));
     }
 
     @GET
@@ -76,8 +79,8 @@ public class Systems {
         value = "Get SCM url",
         notes = "Returns a Source Control Manager Url.",
         response = String.class)
-    public String getSCMUrl() throws Exception {
-        return String.format("{\"url\": \"%s\"}", sourceControlManager.getUrlPrefix());
+    public String getSCMUrl(@QueryParam("scm") Optional<String> scm) throws Exception {
+        return String.format("{\"url\": \"%s\"}", sourceControlManagerProxy.getUrlPrefix(scm.or("")));
     }
 
     @GET


### PR DESCRIPTION
1. extend GithubManager to support github app authentication, which involves using github app id and privatekey to get the installation token. 
2. extend the server.yaml "scm" config to specify both phabricator and github type SCM config.
3. add a sourceControlManagerProxy to encapsulate the PhabricatorManager and GithubManager, and use the correct manager type to interface with SCM APIs.
4. change all the usage of SourceControlManager API to pass in the "scmType" based on the build info. 
The config (server.yaml) will need to be changed to the following format:
scm:
  - type: phabricator
    urlPrefix: <your-phab-server-url>
    arc: <arc-installation-path>
    arcrc: <arcrc-path>

  - type: github
    appId: <appId>
    appPrivateKeyKnox: <knox-key-for-app-private-key>
    appOrganization: <organization the app install on>
    apiPrefix: https://api.github.com
    urlPrefix: https://github.com