### PR TITLE
Basic metrics

### DIFF
--- a/deploy-agent/deployd/agent.py
+++ b/deploy-agent/deployd/agent.py
@@ -108,9 +108,9 @@ class DeployAgent(object):
                 return
 
         while self._response and self._response.opCode and self._response.opCode != OpCode.NOOP:
-            # ensure stat_time_elapsed_internal is always running
-            self.stat_time_elapsed_internal.resume()
             try:
+                # ensure stat_time_elapsed_internal is always running
+                self.stat_time_elapsed_internal.resume()
                 # update the current deploy goal
                 if self._response.deployGoal:
                     deploy_report = self.process_deploy(self._response)

--- a/deploy-agent/deployd/client/client.py
+++ b/deploy-agent/deployd/client/client.py
@@ -191,7 +191,6 @@ class Client(BaseClient):
                                         stageType=self._stage_type)
 
                 with create_stats_timer('deploy.agent.request.latency',
-                                        sample_rate=1.0,
                                         tags={'host': self._hostname}):
                     ping_response = self.send_reports_internal(ping_request)
 
@@ -200,12 +199,10 @@ class Client(BaseClient):
             else:
                 log.error("Fail to read host info")
                 create_sc_increment(stats='deploy.failed.agent.hostinfocollection',
-                                sample_rate=1.0,
-                                tags={'host': self._hostname})
+                                    tags={'host': self._hostname})
         except Exception:
             log.error(traceback.format_exc())
             create_sc_increment(stats='deploy.failed.agent.requests',
-                                sample_rate=1.0,
                                 tags={'host': self._hostname})
             return None
 

--- a/deploy-agent/deployd/common/stats.py
+++ b/deploy-agent/deployd/common/stats.py
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from deployd import IS_PINTEREST
 import timeit
+
+log = logging.getLogger(__name__)
 
 
 class DefaultStatsdTimer(object):
@@ -26,32 +29,48 @@ class DefaultStatsdTimer(object):
 
 def create_stats_timer(stats, sample_rate=1.0, tags=None):
     if IS_PINTEREST:
-        from pinstatsd.statsd import statsd_context_timer
-        return statsd_context_timer(entry_name=stats, sample_rate=sample_rate, tags=tags)
+        try:
+            from pinstatsd.statsd import statsd_context_timer
+            return statsd_context_timer(entry_name=stats, sample_rate=sample_rate, tags=tags)
+        except Exception as e:
+            error_msg = str(e)
+            log.error('unable to send metric: {}'.format(error_msg))
     else:
         return DefaultStatsdTimer()
 
 
 def create_sc_timing(stat, value, sample_rate=1.0, tags=None):
     if IS_PINTEREST:
-        from pinstatsd.statsd import sc
-        return sc.timing(stat, value, sample_rate=sample_rate, tags=tags)
+        try:
+            from pinstatsd.statsd import sc
+            return sc.timing(stat, value, sample_rate=sample_rate, tags=tags)
+        except Exception as e:
+            error_msg = str(e)
+            log.error('unable to send metric: {}'.format(error_msg))
     else:
         return
 
 
 def create_sc_increment(stats, sample_rate=1.0, tags=None):
     if IS_PINTEREST:
-        from pinstatsd.statsd import sc
-        sc.increment(stats, sample_rate, tags)
+        try:
+            from pinstatsd.statsd import sc
+            sc.increment(stats, sample_rate, tags)
+        except Exception as e:
+            error_msg = str(e)
+            log.error('unable to send metric: {}'.format(error_msg))
     else:
         return
 
 
 def create_sc_gauge(stat, value, sample_rate=1.0, tags=None):
     if IS_PINTEREST:
-        from pinstatsd.statsd import sc
-        sc.gauge(stat, value, sample_rate=sample_rate, tags=tags)
+        try:
+            from pinstatsd.statsd import sc
+            sc.gauge(stat, value, sample_rate=sample_rate, tags=tags)
+        except Exception as e:
+            error_msg = str(e)
+            log.error('unable to send metric: {}'.format(error_msg))
     else:
         return
 

--- a/deploy-agent/deployd/common/stats.py
+++ b/deploy-agent/deployd/common/stats.py
@@ -20,11 +20,11 @@ class DefaultStatsdTimer(object):
     def __enter__(self):
         pass
 
-    def __exit__(self, stats, sample_rate, tags):
+    def __exit__(self, stats, sample_rate=1.0, tags=None):
         pass
 
 
-def create_stats_timer(stats, sample_rate, tags):
+def create_stats_timer(stats, sample_rate=1.0, tags=None):
     if IS_PINTEREST:
         from pinstatsd.statsd import statsd_context_timer
         return statsd_context_timer(entry_name=stats, sample_rate=sample_rate, tags=tags)
@@ -32,7 +32,7 @@ def create_stats_timer(stats, sample_rate, tags):
         return DefaultStatsdTimer()
 
 
-def create_sc_timing(stat, value, sample_rate, tags):
+def create_sc_timing(stat, value, sample_rate=1.0, tags=None):
     if IS_PINTEREST:
         from pinstatsd.statsd import sc
         return sc.timing(stat, value, sample_rate=sample_rate, tags=tags)
@@ -40,7 +40,7 @@ def create_sc_timing(stat, value, sample_rate, tags):
         return
 
 
-def create_sc_increment(stats, sample_rate, tags):
+def create_sc_increment(stats, sample_rate=1.0, tags=None):
     if IS_PINTEREST:
         from pinstatsd.statsd import sc
         sc.increment(stats, sample_rate, tags)
@@ -48,7 +48,7 @@ def create_sc_increment(stats, sample_rate, tags):
         return
 
 
-def create_sc_gauge(stat, value, sample_rate, tags):
+def create_sc_gauge(stat, value, sample_rate=1.0, tags=None):
     if IS_PINTEREST:
         from pinstatsd.statsd import sc
         sc.gauge(stat, value, sample_rate=sample_rate, tags=tags)
@@ -56,7 +56,7 @@ def create_sc_gauge(stat, value, sample_rate, tags):
         return
 
 
-class TimeElapsed():
+class TimeElapsed:
     """ keep track of elapsed time in seconds """
 
     def __init__(self):
@@ -66,13 +66,13 @@ class TimeElapsed():
         self._time_pause = None
 
     def get(self):
-        """ total elapsed running time in seconds """
+        """ total elapsed running time, accuracy in seconds """
         if self._is_paused():
             return self._time_elapsed
         self._time_now = self._timer()
         self._time_elapsed += float(self._time_now - self._time_start)
         self._time_start = self._time_now
-        return self._time_elapsed
+        return int(self._time_elapsed)
 
     def _is_paused(self):
         """ timer pause state """

--- a/deploy-agent/deployd/common/stats.py
+++ b/deploy-agent/deployd/common/stats.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -35,5 +35,13 @@ def create_sc_increment(stats, sample_rate, tags):
     if IS_PINTEREST:
         from pinstatsd.statsd import sc
         sc.increment(stats, sample_rate, tags)
+    else:
+        return
+
+
+def create_sc_gauge(stats, value, sample_rate, tags):
+    if IS_PINTEREST:
+        from pinstatsd.statsd import sc
+        sc.gauge(stats, value, sample_rate=sample_rate, tags=tags)
     else:
         return

--- a/deploy-agent/deployd/common/utils.py
+++ b/deploy-agent/deployd/common/utils.py
@@ -91,6 +91,14 @@ def mkdir_p(path):
         else:
             raise
 
+def uptime():
+    """ return int: seconds of uptime in int, default 0 """
+    sec = 0
+    if sys.platform.startswith('linux'):
+        with open('/proc/uptime') as proc:
+            line = proc.readline().split()
+            sec = int(float(line[0]))
+    return sec
 
 def ensure_dirs(config):
     # make sure deployd directories exist

--- a/deploy-agent/tests/unit/deploy/common/test_stats.py
+++ b/deploy-agent/tests/unit/deploy/common/test_stats.py
@@ -27,7 +27,7 @@ class TestTimeElapsed(tests.TestCase):
         elapsed = TimeElapsed()
         then = elapsed.get()
         self.assertFalse(elapsed._is_paused())
-        sleep(0.5)
+        sleep(2)
         now = elapsed.get()
         self.assertTrue(now > then)
 
@@ -40,7 +40,7 @@ class TestTimeElapsed(tests.TestCase):
         self.assertFalse(elapsed._is_paused())
         self.assertEqual(elapsed.since_pause(), float(0))
 
-        sleep(0.5)
+        sleep(2)
         elapsed.pause()
         self.assertTrue(elapsed._is_paused())
         self.assertTrue(elapsed.since_pause() > 0)
@@ -49,7 +49,7 @@ class TestTimeElapsed(tests.TestCase):
         elapsed = TimeElapsed()
         self.assertFalse(elapsed._is_paused())
         elapsed.pause()
-        sleep(1)
+        sleep(2)
         self.assertTrue(elapsed._is_paused())
 
     def test_resume(self):

--- a/deploy-agent/tests/unit/deploy/common/test_stats.py
+++ b/deploy-agent/tests/unit/deploy/common/test_stats.py
@@ -1,0 +1,64 @@
+# Copyright 2021 Pinterest, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tests
+from time import sleep
+from deployd.common.stats import TimeElapsed
+
+
+class TestTimeElapsed(tests.TestCase):
+
+    def test__is_paused(self):
+        elapsed = TimeElapsed()
+        self.assertFalse(elapsed._is_paused())
+
+    def test_get(self):
+        elapsed = TimeElapsed()
+        then = elapsed.get()
+        self.assertFalse(elapsed._is_paused())
+        sleep(0.5)
+        now = elapsed.get()
+        self.assertTrue(now > then)
+
+        elapsed.pause()
+        self.assertTrue(elapsed._is_paused())
+        self.assertEqual(elapsed.get(), elapsed._time_elapsed)
+
+    def test_since_pause(self):
+        elapsed = TimeElapsed()
+        self.assertFalse(elapsed._is_paused())
+        self.assertEqual(elapsed.since_pause(), float(0))
+
+        sleep(0.5)
+        elapsed.pause()
+        self.assertTrue(elapsed._is_paused())
+        self.assertTrue(elapsed.since_pause() > 0)
+
+    def test_pause(self):
+        elapsed = TimeElapsed()
+        self.assertFalse(elapsed._is_paused())
+        elapsed.pause()
+        sleep(1)
+        self.assertTrue(elapsed._is_paused())
+
+    def test_resume(self):
+        elapsed = TimeElapsed()
+        self.assertFalse(elapsed._is_paused())
+        elapsed.resume()
+        self.assertFalse(elapsed._is_paused())
+
+        elapsed.pause()
+        self.assertTrue(elapsed._is_paused())
+        elapsed.resume()
+        self.assertFalse(elapsed._is_paused())

--- a/deploy-agent/tests/unit/deploy/utils/test_agent.py
+++ b/deploy-agent/tests/unit/deploy/utils/test_agent.py
@@ -19,6 +19,7 @@ import time
 import unittest
 
 from deployd.common.helper import Helper
+from deployd.common import utils
 
 
 class TestAgentHelperFunctions(tests.FileTestCase):
@@ -84,6 +85,12 @@ class TestAgentHelperFunctions(tests.FileTestCase):
         self.assertFalse(Helper.get_build_id("whateverfile", "cmp_test")[0])
         self.assertFalse(Helper.get_build_id("whateverfile.tar.gz", "cmp_test")[0])
         self.assertFalse(Helper.get_build_id("cmp_test-tmp", "cmp_test")[0])
+
+    def test_get_uptime(self):
+        """
+        Test utils.uptime()
+        """
+        self.assertTrue(isinstance(utils.uptime(), int))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
add some basic metrics to deploy-agent
* stat for the sum elapsed time spent on internal actions - excludes time spent during external actions
* stat for instance uptime
* add a new class for keeping track of sum elapsed time, supports pausing and resuming timer.