### PR TITLE
Use getValue instead of lookup in Django template to avoid exception

### DIFF
--- a/deploy-board/deploy_board/templates/hosts/host_details.html
+++ b/deploy-board/deploy_board/templates/hosts/host_details.html
@@ -45,7 +45,7 @@
     {% include "panel_heading.tmpl" with panel_title="Agent Details" panel_body_id="agentDetailsId" direction="down" copy_host_name_button=True %}
     <div id="agentDetailsId" class="collapse in panel-body">
         {% for agent_wrapper in agent_wrappers %}
-        {% with env=agent_wrapper.env agent=agent_wrapper.agent hostdetailsvalue=host_details.items|lookup:"Phobos Link" %}
+        {% with env=agent_wrapper.env agent=agent_wrapper.agent hostdetailsvalue=host_details|getValue:"Phobos Link" %}
         {% include "hosts/host_details.tmpl" with agent=agent env=env hostdetailsvalue=hostdetailsvalue%}
         {% endwith %}
         {% endfor %}

--- a/deploy-board/deploy_board/webapp/host_views.py
+++ b/deploy-board/deploy_board/webapp/host_views.py
@@ -16,7 +16,6 @@ from django.shortcuts import render
 from django.http import HttpResponse
 from django.views.generic import View
 import logging
-import traceback
 from helpers import environs_helper, agents_helper, autoscaling_groups_helper
 from helpers import environ_hosts_helper, hosts_helper
 from deploy_board.settings import IS_PINTEREST, CMDB_API_HOST, CMDB_INSTANCE_URL, CMDB_UI_HOST, PHOBOS_URL
@@ -148,7 +147,6 @@ class GroupHostDetailView(View):
 
 class HostDetailView(View):
     def get(self, request, name, stage, hostname):
-      try:
         envs = environs_helper.get_all_env_stages(request, name)
         stages, env = common.get_all_stages(envs, stage)
         duplicate_stage = ''
@@ -177,25 +175,6 @@ class HostDetailView(View):
             'hosts': hosts,
             'host_id': host_id,
             'agent_wrappers': agent_wrappers,
-            'show_terminate': show_terminate,
-            'show_warning_message': show_warning_message,
-            'show_force_terminate': IS_PINTEREST,
-            'asg_group': asg,
-            'is_unreachable': is_unreachable,
-            'pinterest': IS_PINTEREST,
-            'host_information_url': CMDB_UI_HOST,
-            'instance_protected': is_protected,
-            'host_details': host_details,
-            'duplicate_stage': duplicate_stage,
-        })
-      except:
-        log.error(traceback.format_exc())
-        return render(request, 'hosts/host_details.html', {
-            'env_name': name,
-            'stage_name': stage,
-            'hostname': hostname,
-            'hosts': hosts,
-            'host_id': host_id,
             'show_terminate': show_terminate,
             'show_warning_message': show_warning_message,
             'show_force_terminate': IS_PINTEREST,

--- a/deploy-board/deploy_board/webapp/host_views.py
+++ b/deploy-board/deploy_board/webapp/host_views.py
@@ -148,7 +148,7 @@ class GroupHostDetailView(View):
 
 class HostDetailView(View):
     def get(self, request, name, stage, hostname):
-      hosts, host_id, agent_wrappers, show_terminate, show_warning_message, asg, is_unreachable, is_protected, host_details, duplicate_stage = [None for _ in range(10)]
+      #hosts, host_id, agent_wrappers, show_terminate, show_warning_message, asg, is_unreachable, is_protected, host_details, duplicate_stage = [None for _ in range(10)]
       try:
         envs = environs_helper.get_all_env_stages(request, name)
         stages, env = common.get_all_stages(envs, stage)
@@ -172,6 +172,9 @@ class HostDetailView(View):
         host_details = get_host_details(host_id)
       except:
         log.error(traceback.format_exc())
+        log.error("yaqin test")
+        return render(request, 'hosts/host_details.html', {
+        })
 
       return render(request, 'hosts/host_details.html', {
         'duplicate_stage': duplicate_stage,

--- a/deploy-board/deploy_board/webapp/host_views.py
+++ b/deploy-board/deploy_board/webapp/host_views.py
@@ -147,11 +147,10 @@ class GroupHostDetailView(View):
 
 class HostDetailView(View):
     def get(self, request, name, stage, hostname):
+      hosts, host_id, agent_wrappers, show_terminate, show_warning_message, asg, is_unreachable, is_protected, host_details, duplicate_stage = [None for _ in range(10)]
       try:
-        hosts, host_id, agent_wrappers, show_terminate, show_warning_message, asg, is_unreachable, is_protected, host_details = [None for _ in range(9)]
         envs = environs_helper.get_all_env_stages(request, name)
         stages, env = common.get_all_stages(envs, stage)
-        duplicate_stage = ''
         for stage_name in stages:
             if stage_name != stage:
                 hosts = environs_helper.get_env_capacity(request, name, stage_name, capacity_type="HOST")

--- a/deploy-board/deploy_board/webapp/host_views.py
+++ b/deploy-board/deploy_board/webapp/host_views.py
@@ -148,11 +148,11 @@ class GroupHostDetailView(View):
 
 class HostDetailView(View):
     def get(self, request, name, stage, hostname):
-      hosts, host_id, agent_wrappers, show_terminate, show_warning_message, asg, is_unreachable, is_protected, host_details = [None for _ in range(9)]
-      duplicate_stage = ''
+      hosts, host_id, agent_wrappers, show_terminate, show_warning_message, asg, is_unreachable, is_protected, host_details, duplicate_stage = [None for _ in range(10)]
       try:
         envs = environs_helper.get_all_env_stages(request, name)
         stages, env = common.get_all_stages(envs, stage)
+        duplicate_stage = ''
         for stage_name in stages:
             if stage_name != stage:
                 hosts = environs_helper.get_env_capacity(request, name, stage_name, capacity_type="HOST")
@@ -172,7 +172,9 @@ class HostDetailView(View):
         host_details = get_host_details(host_id)
       except:
         log.error(traceback.format_exc())
+
       return render(request, 'hosts/host_details.html', {
+        'duplicate_stage': duplicate_stage,
         'env_name': name,
         'stage_name': stage,
         'hostname': hostname,
@@ -188,7 +190,6 @@ class HostDetailView(View):
         'host_information_url': CMDB_UI_HOST,
         'instance_protected': is_protected,
         'host_details': host_details,
-        'duplicate_stage': duplicate_stage,
         })
 
 

--- a/deploy-board/deploy_board/webapp/host_views.py
+++ b/deploy-board/deploy_board/webapp/host_views.py
@@ -148,7 +148,8 @@ class GroupHostDetailView(View):
 
 class HostDetailView(View):
     def get(self, request, name, stage, hostname):
-      hosts, host_id, agent_wrappers, show_terminate, show_warning_message, asg, is_unreachable, is_protected, host_details, duplicate_stage = [None for _ in range(10)]
+      hosts, host_id, agent_wrappers, show_terminate, show_warning_message, asg, is_unreachable, is_protected, host_details = [None for _ in range(9)]
+      duplicate_stage = ''
       try:
         envs = environs_helper.get_all_env_stages(request, name)
         stages, env = common.get_all_stages(envs, stage)

--- a/deploy-board/deploy_board/webapp/host_views.py
+++ b/deploy-board/deploy_board/webapp/host_views.py
@@ -147,6 +147,8 @@ class GroupHostDetailView(View):
 
 class HostDetailView(View):
     def get(self, request, name, stage, hostname):
+      try:
+        hosts, host_id, agent_wrappers, show_terminate, show_warning_message, asg, is_unreachable, is_protected, host_details = [None for _ in range(9)]
         envs = environs_helper.get_all_env_stages(request, name)
         stages, env = common.get_all_stages(envs, stage)
         duplicate_stage = ''
@@ -167,24 +169,25 @@ class HostDetailView(View):
 
         agent_wrappers, is_unreachable = get_agent_wrapper(request, hostname)
         host_details = get_host_details(host_id)
-
-        return render(request, 'hosts/host_details.html', {
-            'env_name': name,
-            'stage_name': stage,
-            'hostname': hostname,
-            'hosts': hosts,
-            'host_id': host_id,
-            'agent_wrappers': agent_wrappers,
-            'show_terminate': show_terminate,
-            'show_warning_message': show_warning_message,
-            'show_force_terminate': IS_PINTEREST,
-            'asg_group': asg,
-            'is_unreachable': is_unreachable,
-            'pinterest': IS_PINTEREST,
-            'host_information_url': CMDB_UI_HOST,
-            'instance_protected': is_protected,
-            'host_details': host_details,
-            'duplicate_stage': duplicate_stage,
+      except:
+        pass
+      return render(request, 'hosts/host_details.html', {
+        'env_name': name,
+        'stage_name': stage,
+        'hostname': hostname,
+        'hosts': hosts,
+        'host_id': host_id,
+        'agent_wrappers': agent_wrappers,
+        'show_terminate': show_terminate,
+        'show_warning_message': show_warning_message,
+        'show_force_terminate': IS_PINTEREST,
+        'asg_group': asg,
+        'is_unreachable': is_unreachable,
+        'pinterest': IS_PINTEREST,
+        'host_information_url': CMDB_UI_HOST,
+        'instance_protected': is_protected,
+        'host_details': host_details,
+        'duplicate_stage': duplicate_stage,
         })
 
 

--- a/deploy-board/deploy_board/webapp/host_views.py
+++ b/deploy-board/deploy_board/webapp/host_views.py
@@ -191,6 +191,21 @@ class HostDetailView(View):
       except:
         log.error(traceback.format_exc())
         return render(request, 'hosts/host_details.html', {
+            'env_name': name,
+            'stage_name': stage,
+            'hostname': hostname,
+            'hosts': hosts,
+            'host_id': host_id,
+            'show_terminate': show_terminate,
+            'show_warning_message': show_warning_message,
+            'show_force_terminate': IS_PINTEREST,
+            'asg_group': asg,
+            'is_unreachable': is_unreachable,
+            'pinterest': IS_PINTEREST,
+            'host_information_url': CMDB_UI_HOST,
+            'instance_protected': is_protected,
+            'host_details': host_details,
+            'duplicate_stage': duplicate_stage,
         })
 
 

--- a/deploy-board/deploy_board/webapp/host_views.py
+++ b/deploy-board/deploy_board/webapp/host_views.py
@@ -16,6 +16,7 @@ from django.shortcuts import render
 from django.http import HttpResponse
 from django.views.generic import View
 import logging
+import traceback
 from helpers import environs_helper, agents_helper, autoscaling_groups_helper
 from helpers import environ_hosts_helper, hosts_helper
 from deploy_board.settings import IS_PINTEREST, CMDB_API_HOST, CMDB_INSTANCE_URL, CMDB_UI_HOST, PHOBOS_URL
@@ -169,7 +170,7 @@ class HostDetailView(View):
         agent_wrappers, is_unreachable = get_agent_wrapper(request, hostname)
         host_details = get_host_details(host_id)
       except:
-        pass
+        log.error(traceback.format_exc())
       return render(request, 'hosts/host_details.html', {
         'env_name': name,
         'stage_name': stage,

--- a/deploy-board/deploy_board/webapp/host_views.py
+++ b/deploy-board/deploy_board/webapp/host_views.py
@@ -148,7 +148,6 @@ class GroupHostDetailView(View):
 
 class HostDetailView(View):
     def get(self, request, name, stage, hostname):
-      #hosts, host_id, agent_wrappers, show_terminate, show_warning_message, asg, is_unreachable, is_protected, host_details, duplicate_stage = [None for _ in range(10)]
       try:
         envs = environs_helper.get_all_env_stages(request, name)
         stages, env = common.get_all_stages(envs, stage)
@@ -170,29 +169,28 @@ class HostDetailView(View):
 
         agent_wrappers, is_unreachable = get_agent_wrapper(request, hostname)
         host_details = get_host_details(host_id)
+
+        return render(request, 'hosts/host_details.html', {
+            'env_name': name,
+            'stage_name': stage,
+            'hostname': hostname,
+            'hosts': hosts,
+            'host_id': host_id,
+            'agent_wrappers': agent_wrappers,
+            'show_terminate': show_terminate,
+            'show_warning_message': show_warning_message,
+            'show_force_terminate': IS_PINTEREST,
+            'asg_group': asg,
+            'is_unreachable': is_unreachable,
+            'pinterest': IS_PINTEREST,
+            'host_information_url': CMDB_UI_HOST,
+            'instance_protected': is_protected,
+            'host_details': host_details,
+            'duplicate_stage': duplicate_stage,
+        })
       except:
         log.error(traceback.format_exc())
-        log.error("yaqin test")
         return render(request, 'hosts/host_details.html', {
-        })
-
-      return render(request, 'hosts/host_details.html', {
-        'duplicate_stage': duplicate_stage,
-        'env_name': name,
-        'stage_name': stage,
-        'hostname': hostname,
-        'hosts': hosts,
-        'host_id': host_id,
-        'agent_wrappers': agent_wrappers,
-        'show_terminate': show_terminate,
-        'show_warning_message': show_warning_message,
-        'show_force_terminate': IS_PINTEREST,
-        'asg_group': asg,
-        'is_unreachable': is_unreachable,
-        'pinterest': IS_PINTEREST,
-        'host_information_url': CMDB_UI_HOST,
-        'instance_protected': is_protected,
-        'host_details': host_details,
         })
 
 


### PR DESCRIPTION
issue:
we didn't catch exception which caused a horrible error showing up on teletraan ui:
![image (7)](https://user-images.githubusercontent.com/42289525/144321570-e1209f0e-7844-4cf2-a0ce-2790de7895dd.png)

related jira ticket: https://jira.pinadmin.com/browse/CDP-4432

fix:
there is a line in host_details.html which tries to get a value from non-existing key:
{% with env=agent_wrapper.env agent=agent_wrapper.agent hostdetailsvalue=host_details.items|lookup:"Phobos Link" %}
this caused an exception and redirected the user to the error page.
in this pr, I used getValue instead of lookup to avoid the exception in Django template.

test:
before:
<img width="1661" alt="Screen Shot 2021-11-30 at 3 36 42 PM" src="https://user-images.githubusercontent.com/42289525/144321598-6d323946-5fc9-40ba-bde5-5d8c1c902f9d.png">

after:
<img width="1663" alt="Screen Shot 2021-12-01 at 2 04 01 PM" src="https://user-images.githubusercontent.com/42289525/144321477-af039ff2-3472-44b8-9188-b0396add0b17.png">
