### PR TITLE
Fix more abstract host problems.

### DIFF
--- a/deploy-board/deploy_board/settings.py
+++ b/deploy-board/deploy_board/settings.py
@@ -284,7 +284,8 @@ if IS_PINTEREST:
     DEFAULT_CMP_IMAGE = 'cmp_base-ebs-18.04'
 
     #Pinterest Default Host Type
-    # TODO: This is a description of the host type but is nonunique. It should be replaced by the host type ID.
+    # TODO: This is a description of the host type but is nonunique. However, it cannot be replaced by host_type ID since it is unique per service database.
+    # TODO: The model for host type should be rebuilt based on a unique abstract factor such as ec2 instance type, for now we should keep expected behavior.
     DEFAULT_CMP_HOST_TYPE = 'EbsComputeLo(Recommended)'
 
     DEFAULT_CELL = 'aws-us-east-1'

--- a/deploy-board/deploy_board/settings.py
+++ b/deploy-board/deploy_board/settings.py
@@ -284,6 +284,7 @@ if IS_PINTEREST:
     DEFAULT_CMP_IMAGE = 'cmp_base-ebs-18.04'
 
     #Pinterest Default Host Type
+    # TODO: This is a description of the host type but is nonunique. It should be replaced by the host type ID.
     DEFAULT_CMP_HOST_TYPE = 'EbsComputeLo(Recommended)'
 
     DEFAULT_CELL = 'aws-us-east-1'

--- a/deploy-board/deploy_board/static/js/deploy-board.js
+++ b/deploy-board/deploy_board/static/js/deploy-board.js
@@ -104,6 +104,7 @@ function getDefaultPlacement(capacityCreationInfo) {
     $.each(this.capacityCreationInfo.placements, function (index, item) {
         if (item.assign_public_ip) {
             allPublicIPPlacements.push(item)
+            // TODO this should not be hardcoded around the codebase
             if (capacityCreationInfo.defaultHostType === "EbsComputeLo(Recommended)" ) {
                 if (defaultAssignedGroupForC5Instance.has(item.abstract_name)) {
                     addToMaxGroup(item, cmpPublicIPPlacements)
@@ -114,6 +115,7 @@ function getDefaultPlacement(capacityCreationInfo) {
         }
         else {
             allPrivateIPPlacements.push(item)
+            // TODO this should not be hardcoded around the codebase
             if (capacityCreationInfo.defaultHostType === "EbsComputeLo(Recommended)" ) {
                 if (defaultAssignedGroupForC5Instance.has(item.abstract_name)) {
                     addToMaxGroup(item, cmpPrivateIPPlacements)

--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -499,7 +499,7 @@
                         isSelected: item.abstract_name === currentCluster.securityZone
                     }
                 }),
-                selectedHostTypeValue: capacityCreationInfo.hostTypes.find(hostType => hostType.abstract_name === currentCluster.hostType).id,
+                selectedHostTypeValue: currentCluster.hostType,
                 selectedSecurityZoneValue: currentCluster.securityZone,
                 selectedPlacements: currentPlacements,
                 showBaseImageHelp: false,

--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -463,7 +463,7 @@
                     return {
                         value: item.id,
                         text: item.abstract_name + " (" + item.core + " cores, " + item.mem + " GB, " + item.storage + ", " + item.provider + ": " + item.provider_name + ")",
-                        isSelected: item.abstract_name === currentCluster.hostType
+                        isSelected: item.id === currentCluster.hostType
                     }
                 }),
                 imageNameValue: currentCluster.baseImageName,

--- a/deploy-board/deploy_board/templates/configs/new_capacity.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity.html
@@ -135,7 +135,8 @@ var capacitySetting = new Vue({
                 isSelected: item.abstract_name === capacityCreationInfo.defaultSeurityZone
             }
         }),
-        selectedHostTypeValue: capacityCreationInfo.defaultHostType,
+        // TODO: The default host type comes from settings and should probably not be an abstract_name since they are not guaranteed to be unique.
+        selectedHostTypeValue: capacityCreationInfo.hostTypes.find(hostType => hostType.abstract_name === capacityCreationInfo.defaultHostType).id,
         selectedSecurityZoneValue: capacityCreationInfo.defaultSeurityZone,
         selectedPlacements: null
     },

--- a/deploy-board/deploy_board/templates/configs/new_capacity.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity.html
@@ -135,7 +135,7 @@ var capacitySetting = new Vue({
                 isSelected: item.abstract_name === capacityCreationInfo.defaultSeurityZone
             }
         }),
-        selectedHostTypeValue: capacityCreationInfo.hostTypes.find(hostType => hostType.abstract_name === capacityCreationInfo.defaultHostType).id,
+        selectedHostTypeValue: capacityCreationInfo.defaultHostType,
         selectedSecurityZoneValue: capacityCreationInfo.defaultSeurityZone,
         selectedPlacements: null
     },

--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -183,7 +183,8 @@ var capacitySetting = new Vue({
                     isSelected: item.abstract_name === info.defaultSeurityZone
                 }
             }),
-        selectedHostTypeValue: capacityCreationInfo.hostTypes.find(hostType => hostType.abstract_name === capacityCreationInfo.defaultHostType).id,
+        // need to check on capacityCreationInfo.defaultHostType
+        selectedHostTypeValue: capacityCreationInfo.defaultHostType,
         selectedSecurityZoneValue: info.defaultSeurityZone,
         selectedPlacements: [],
         showBaseImageHelp: false,

--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -183,8 +183,8 @@ var capacitySetting = new Vue({
                     isSelected: item.abstract_name === info.defaultSeurityZone
                 }
             }),
-        // need to check on capacityCreationInfo.defaultHostType
-        selectedHostTypeValue: capacityCreationInfo.defaultHostType,
+        // TODO: The default host type comes from settings and should probably not be an abstract_name since they are not guaranteed to be unique.
+        selectedHostTypeValue: capacityCreationInfo.hostTypes.find(hostType => hostType.abstract_name === capacityCreationInfo.defaultHostType).id,
         selectedSecurityZoneValue: info.defaultSeurityZone,
         selectedPlacements: [],
         showBaseImageHelp: false,


### PR DESCRIPTION
Fix some more problems from abstract_host being treated as unique.

Hardcoded default reference is out of scope as we cannot use the host_type ID there. It is unique per service.   The PR won't address the larger problem with parsing abstract name strings in the deploy-board control flow.

Manual Testing:
- Cluster settings should should no longer fail to render correctly
- Cluster settings form should select the correct host type
- New cluster creation should work normally (no unexpected side effects)