### PR TITLE
Metrics phase 2

### DIFF
--- a/deploy-agent/deployd/__init__.py
+++ b/deploy-agent/deployd/__init__.py
@@ -17,4 +17,4 @@ import os
 # Pinterest specific settings
 IS_PINTEREST = True if os.getenv("IS_PINTEREST", "false") == "true" else False
 
-__version__ = '1.2.31'
+__version__ = '1.2.32'

--- a/deploy-agent/deployd/agent.py
+++ b/deploy-agent/deployd/agent.py
@@ -427,6 +427,8 @@ def main():
                             format='%(asctime)s %(name)s:%(lineno)d %(levelname)s %(message)s')
 
     log.info("Start to run deploy-agent.")
+    create_sc_timing('deployd.stats.internal.time_start_sec',
+                     int(time.time()))
     client = Client(config=config, hostname=args.hostname, hostgroup=args.hostgroup,
                     use_facter=args.use_facter, use_host_info=args.use_host_info)
     if is_serverless_mode:
@@ -453,6 +455,8 @@ def main():
     create_sc_timing('deployd.stats.internal.time_elapsed_proc_sec',
                     agent.stat_time_elapsed_internal.get(),
                     tags={'first_run': agent.first_run()})
+    create_sc_timing('deployd.stats.internal.time_end_sec',
+                     int(time.time()))
 
 if __name__ == '__main__':
     main()

--- a/deploy-agent/deployd/agent.py
+++ b/deploy-agent/deployd/agent.py
@@ -332,7 +332,7 @@ class DeployAgent(object):
                 tags['deploy_stage'] = self.deploy_goal_prev.deployStage
             if self.deploy_goal_prev.envName:
                 tags['env_name'] = self.deploy_goal_prev.envName
-            create_sc_timing('deployd.stats.deploy.stage.time_elapsed_sec'.format(self.deploy_goal_prev.deployStage),
+            create_sc_timing('deployd.stats.deploy.stage.time_elapsed_sec',
                              self.stat_stage_time_elapsed.get(),
                              tags=tags)
 
@@ -377,7 +377,7 @@ class DeployAgent(object):
             if deploy_goal.envName:
                 tags['env_name'] = deploy_goal.envName
             self.stat_stage_time_elapsed = TimeElapsed()
-            create_sc_timing('deployd.stats.deploy.stage.time_start_sec'.format(deploy_goal.deployStage),
+            create_sc_timing('deployd.stats.deploy.stage.time_start_sec',
                              self.stat_stage_time_elapsed.get(),
                              tags=tags)
             self.deploy_goal_prev = deploy_goal

--- a/deploy-agent/deployd/agent.py
+++ b/deploy-agent/deployd/agent.py
@@ -333,6 +333,19 @@ class DeployAgent(object):
                 for key, value in deploy_goal.scriptVariables.items():
                     f.write("{}={}\n".format(key, value))
 
+        # timing - deploy stage start
+        deploy_stage = deploy_goal.deployStage
+        if deploy_stage:
+            tags = {'first_run': self.first_run(),
+                    'deploy_stage': deploy_stage}
+            if deploy_goal.envName:
+                tags['env_name'] = deploy_goal.envName
+            if deploy_goal.stageName:
+                tags['stage'] = deploy_goal.stageName
+            create_sc_timing("deployd.stats.deploy.stage.{}.time_start_sec".format(deploy_stage),
+                             int(time.time()),
+                             tags=tags)
+
         # load deploy goal to the config
         self._curr_report = self._envs[env_name]
         self._config.update_variables(self._curr_report)

--- a/deploy-agent/deployd/agent.py
+++ b/deploy-agent/deployd/agent.py
@@ -66,6 +66,7 @@ class DeployAgent(object):
         self._config = conf or Config()
         self._executor = executor
         self.stat_time_elapsed_internal = TimeElapsed()
+        self.stat_time_elapsed_total = TimeElapsed()
         self._helper = helper or Helper(self._config)
         self._STATUS_FILE = self._config.get_env_status_fn()
         self._client = client
@@ -427,6 +428,7 @@ def main():
                             format='%(asctime)s %(name)s:%(lineno)d %(levelname)s %(message)s')
 
     log.info("Start to run deploy-agent.")
+    # time - start
     create_sc_timing('deployd.stats.internal.time_start_sec',
                      int(time.time()))
     client = Client(config=config, hostname=args.hostname, hostgroup=args.hostgroup,
@@ -452,9 +454,15 @@ def main():
     else:
         agent.serve_once()
 
+    # time - total processing time excluding external actions
     create_sc_timing('deployd.stats.internal.time_elapsed_proc_sec',
                     agent.stat_time_elapsed_internal.get(),
                     tags={'first_run': agent.first_run()})
+    # time - total
+    create_sc_timing('deployd.stats.internal.time_elapsed_proc_total_sec',
+                     agent.stat_time_elapsed_total.get(),
+                     tags={'first_run': agent.first_run()})
+    # time - exit
     create_sc_timing('deployd.stats.internal.time_end_sec',
                      int(time.time()))
 

--- a/deploy-agent/deployd/common/stats.py
+++ b/deploy-agent/deployd/common/stats.py
@@ -29,7 +29,9 @@ class DefaultStatsdTimer(object):
 
 
 def _add_default_tags(tags=None):
+    """ add default tags to stats """
     if not __version__:
+        # defensive case, should not be hit
         return tags
     if __version__ and not tags:
         tags = dict()

--- a/deploy-agent/deployd/common/stats.py
+++ b/deploy-agent/deployd/common/stats.py
@@ -14,6 +14,7 @@
 
 import logging
 from deployd import IS_PINTEREST
+from deployd import __version__
 import timeit
 
 log = logging.getLogger(__name__)
@@ -27,10 +28,20 @@ class DefaultStatsdTimer(object):
         pass
 
 
+def _add_default_tags(tags=None):
+    if not __version__:
+        return tags
+    if __version__ and not tags:
+        tags = dict()
+    tags['deploy_agent_version'] = __version__
+    return tags
+
+
 def create_stats_timer(stats, sample_rate=1.0, tags=None):
     if IS_PINTEREST:
         try:
             from pinstatsd.statsd import statsd_context_timer
+            tags = _add_default_tags(tags)
             return statsd_context_timer(entry_name=stats, sample_rate=sample_rate, tags=tags)
         except Exception as e:
             error_msg = str(e)
@@ -43,6 +54,7 @@ def create_sc_timing(stat, value, sample_rate=1.0, tags=None):
     if IS_PINTEREST:
         try:
             from pinstatsd.statsd import sc
+            tags = _add_default_tags(tags)
             return sc.timing(stat, value, sample_rate=sample_rate, tags=tags)
         except Exception as e:
             error_msg = str(e)
@@ -55,6 +67,7 @@ def create_sc_increment(stats, sample_rate=1.0, tags=None):
     if IS_PINTEREST:
         try:
             from pinstatsd.statsd import sc
+            tags = _add_default_tags(tags)
             sc.increment(stats, sample_rate, tags)
         except Exception as e:
             error_msg = str(e)
@@ -67,6 +80,7 @@ def create_sc_gauge(stat, value, sample_rate=1.0, tags=None):
     if IS_PINTEREST:
         try:
             from pinstatsd.statsd import sc
+            tags = _add_default_tags(tags)
             sc.gauge(stat, value, sample_rate=sample_rate, tags=tags)
         except Exception as e:
             error_msg = str(e)

--- a/deploy-agent/deployd/common/utils.py
+++ b/deploy-agent/deployd/common/utils.py
@@ -125,7 +125,7 @@ def run_prereqs(config):
 def get_info_from_facter(keys):
     try:
         time_facter = TimeElapsed()
-        # inc stats - facter calls
+        # increment stats - facter calls
         create_sc_increment('deployd.stats.internal.facter_calls_sum', 1)
         log.info("Fetching {} keys from facter".format(keys))
         cmd = ['facter', '-p', '-j']

--- a/deploy-agent/deployd/common/utils.py
+++ b/deploy-agent/deployd/common/utils.py
@@ -25,7 +25,7 @@ import subprocess
 import yaml
 import json
 from deployd import IS_PINTEREST
-from deployd.common.stats import create_sc_increment
+from deployd.common.stats import TimeElapsed, create_sc_increment, create_sc_timing
 
 log = logging.getLogger(__name__)
 
@@ -124,11 +124,16 @@ def run_prereqs(config):
 
 def get_info_from_facter(keys):
     try:
-        log.info("Fetching {} keys from facter".format(keys))
+        time_facter = TimeElapsed()
+        # inc - facter
         create_sc_increment('deployd.stats.internal.facter_calls_sum', 1)
+        log.info("Fetching {} keys from facter".format(keys))
         cmd = ['facter', '-p', '-j']
         cmd.extend(keys)
         output = subprocess.check_output(cmd)
+        # time - facter
+        create_sc_timing('deployd.stats.internal.time_elapsed_facter_calls_sec',
+                         time_facter.get())
         if output:
             return json.loads(output)
         else:

--- a/deploy-agent/deployd/common/utils.py
+++ b/deploy-agent/deployd/common/utils.py
@@ -25,6 +25,7 @@ import subprocess
 import yaml
 import json
 from deployd import IS_PINTEREST
+from deployd.common.stats import create_sc_increment
 
 log = logging.getLogger(__name__)
 
@@ -124,6 +125,7 @@ def run_prereqs(config):
 def get_info_from_facter(keys):
     try:
         log.info("Fetching {} keys from facter".format(keys))
+        create_sc_increment('deployd.stats.internal.facter_calls_sum', 1)
         cmd = ['facter', '-p', '-j']
         cmd.extend(keys)
         output = subprocess.check_output(cmd)

--- a/deploy-agent/deployd/common/utils.py
+++ b/deploy-agent/deployd/common/utils.py
@@ -125,13 +125,13 @@ def run_prereqs(config):
 def get_info_from_facter(keys):
     try:
         time_facter = TimeElapsed()
-        # inc - facter
+        # inc stats - facter calls
         create_sc_increment('deployd.stats.internal.facter_calls_sum', 1)
         log.info("Fetching {} keys from facter".format(keys))
         cmd = ['facter', '-p', '-j']
         cmd.extend(keys)
         output = subprocess.check_output(cmd)
-        # time - facter
+        # timing stats - facter run time
         create_sc_timing('deployd.stats.internal.time_elapsed_facter_calls_sec',
                          time_facter.get())
         if output:


### PR DESCRIPTION
Second phase to add stats.  

These are the additional stats:
- deployd.stats.deploy.stage.time_elapsed_sec
- deployd.stats.deploy.stage.time_start_sec
- deployd.stats.deploy.status.sum
- deployd.stats.internal.facter_calls_sum
- deployd.stats.internal.time_elapsed_facter_calls_sec
- deployd.stats.internal.time_elapsed_proc_sec
- deployd.stats.internal.time_elapsed_proc_total_sec
- deployd.stats.internal.time_end_sec
- deployd.stats.internal.time_start_sec

Added:
- func _add_default_tags which adds default tags to stats
- func _timing_stats_deploy_stage_time_elapsed which sends a stat for the previous deploy goal if the deploy goal has changed

Bumps version deploy-agent 1.2.31 to 1.2.32

Testing:
- Continuous deploys and checking for presence of stats.  
- Deploy from empty state
- Deploy from partially completed desired state
- Deploy from NOOP state