### PR TITLE
Add timestamps to the logs for downloader and stager

### DIFF
--- a/deploy-agent/deployd/common/__init__.py
+++ b/deploy-agent/deployd/common/__init__.py
@@ -12,3 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+LOG_FORMAT = '%(asctime)s:%(levelname)s: %(message)s'

--- a/deploy-agent/deployd/download/downloader.py
+++ b/deploy-agent/deployd/download/downloader.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import argparse
+from deployd.common import LOG_FORMAT
 from deployd.common.config import Config
 from deployd.common.status_code import Status
 from deployd.download.download_helper_factory import DownloadHelperFactory
@@ -146,7 +147,7 @@ def main():
                         help="the environment name currently in deploy.")
     args = parser.parse_args()
     config = Config(args.config_file)
-    logging.basicConfig(level=config.get_log_level())
+    logging.basicConfig(format=LOG_FORMAT, level=config.get_log_level())
 
     log.info("Start to download the package.")
     status = Downloader(config, args.build, args.url, args.env_name).download()

--- a/deploy-agent/deployd/staging/stager.py
+++ b/deploy-agent/deployd/staging/stager.py
@@ -21,6 +21,7 @@ import shutil
 import traceback
 import logging
 
+from deployd.common import LOG_FORMAT
 from deployd.common.caller import Caller
 from deployd.common.config import Config
 from deployd.common.status_code import Status
@@ -133,7 +134,7 @@ def main():
                         help="the environment name currently in deploy.")
     args = parser.parse_args()
     config = Config(args.config_file)
-    logging.basicConfig(level=config.get_log_level())
+    logging.basicConfig(format=LOG_FORMAT, level=config.get_log_level())
 
     log.info("Start to stage the package.")
     result = Stager(config=config, build=args.build,


### PR DESCRIPTION
Make it easier to understand how long things take from the logs, by
updating the default log format to include a timestamp. Note after this
change each env_name log will have more timestamps but many lines still
won't have timestamps if they are coming from the scripts (RESTARTING
etc.)

https://docs.python.org/3/library/logging.html#logrecord-attributes