### PR TITLE
Metrics caching

### DIFF
--- a/deploy-agent/deployd/__init__.py
+++ b/deploy-agent/deployd/__init__.py
@@ -16,5 +16,7 @@ import os
 
 # Pinterest specific settings
 IS_PINTEREST = True if os.getenv("IS_PINTEREST", "false") == "true" else False
+METRIC_PORT_HEALTH = int(os.getenv('METRIC_PORT_HEALTH')) if os.getenv('METRIC_PORT_HEALTH', False) else None
+METRIC_CACHE_PATH = os.getenv('METRIC_CACHE_PATH', None)
 
-__version__ = '1.2.32'
+__version__ = '1.2.33'

--- a/deploy-agent/deployd/agent.py
+++ b/deploy-agent/deployd/agent.py
@@ -180,7 +180,6 @@ class DeployAgent(object):
                 time.sleep(self._config.get_daemon_sleep_time())
                 self.load_status_file()
 
-
     def serve_once(self):
         log.info("Running deploy agent in non daemon mode")
         try:
@@ -206,7 +205,6 @@ class DeployAgent(object):
             if envId == value.report.envId:
                 return name
         return None
-
 
     def process_deploy(self, response):
         self.stat_time_elapsed_internal.resume()
@@ -427,6 +425,7 @@ class DeployAgent(object):
 
         return False
 
+
 # make sure only one instance is running
 instance = SingleInstance()
 
@@ -518,6 +517,7 @@ def main():
     # timing stats - agent exit time
     create_sc_timing('deployd.stats.internal.time_end_sec',
                      int(time.time()))
+
 
 if __name__ == '__main__':
     main()

--- a/deploy-agent/deployd/agent.py
+++ b/deploy-agent/deployd/agent.py
@@ -180,6 +180,7 @@ class DeployAgent(object):
                 time.sleep(self._config.get_daemon_sleep_time())
                 self.load_status_file()
 
+
     def serve_once(self):
         log.info("Running deploy agent in non daemon mode")
         try:
@@ -205,6 +206,7 @@ class DeployAgent(object):
             if envId == value.report.envId:
                 return name
         return None
+
 
     def process_deploy(self, response):
         self.stat_time_elapsed_internal.resume()
@@ -425,7 +427,6 @@ class DeployAgent(object):
 
         return False
 
-
 # make sure only one instance is running
 instance = SingleInstance()
 
@@ -517,7 +518,6 @@ def main():
     # timing stats - agent exit time
     create_sc_timing('deployd.stats.internal.time_end_sec',
                      int(time.time()))
-
 
 if __name__ == '__main__':
     main()

--- a/deploy-agent/deployd/client/client.py
+++ b/deploy-agent/deployd/client/client.py
@@ -26,7 +26,6 @@ from deployd.common import utils
 from deployd.types.ping_request import PingRequest
 from deployd import IS_PINTEREST
 
-
 log = logging.getLogger(__name__)
 
 
@@ -198,11 +197,11 @@ class Client(BaseClient):
                 return ping_response
             else:
                 log.error("Fail to read host info")
-                create_sc_increment(stats='deploy.failed.agent.hostinfocollection',
+                create_sc_increment(name='deploy.failed.agent.hostinfocollection',
                                     tags={'host': self._hostname})
         except Exception:
             log.error(traceback.format_exc())
-            create_sc_increment(stats='deploy.failed.agent.requests',
+            create_sc_increment(name='deploy.failed.agent.requests',
                                 tags={'host': self._hostname})
             return None
 

--- a/deploy-agent/deployd/client/client.py
+++ b/deploy-agent/deployd/client/client.py
@@ -26,6 +26,7 @@ from deployd.common import utils
 from deployd.types.ping_request import PingRequest
 from deployd import IS_PINTEREST
 
+
 log = logging.getLogger(__name__)
 
 

--- a/deploy-agent/deployd/common/stats.py
+++ b/deploy-agent/deployd/common/stats.py
@@ -109,7 +109,7 @@ class MetricCache:
     """ local cache for metrics
         creates empty cache file
     """
-    def __init__(self, path):
+    def __init__(self, path=METRIC_CACHE_PATH):
         self.path = path
         # maximum cache size in bytes
         self.max_size = (10 * 1024 * 1024)

--- a/deploy-agent/deployd/common/stats.py
+++ b/deploy-agent/deployd/common/stats.py
@@ -31,6 +31,9 @@ else:
         def gauge(name, value, sample_rate=None, tags=None):
             pass
 
+        @staticmethod
+        def timing(name, value, sample_rate=None, tags=None):
+            pass
 
     class sc_v2(sc):
         pass

--- a/deploy-agent/deployd/common/stats.py
+++ b/deploy-agent/deployd/common/stats.py
@@ -105,11 +105,20 @@ def create_sc_gauge(name, value, sample_rate=1.0, tags=None):
         return
 
 
+class MetricCacheConfigurationError(ValueError):
+    """ Raised when MetricCache has missing configuration """
+    def __init__(self, name, value):
+        msg = '{} is {}'.format(name, value)
+        super(MetricCacheConfigurationError, self).__init__(msg)
+
+
 class MetricCache:
     """ local cache for metrics
         creates empty cache file
     """
     def __init__(self, path=METRIC_CACHE_PATH):
+        if not path:
+            raise MetricCacheConfigurationError('path', path)
         self.path = path
         # maximum cache size in bytes
         self.max_size = (10 * 1024 * 1024)
@@ -224,10 +233,19 @@ class Stat:
             return False
 
 
+class MetricClientConfigurationError(ValueError):
+    """ Raised when MetricClient has missing configuration """
+    def __init__(self, name, value):
+        msg = '{} is {}'.format(name, value)
+        super(MetricClientConfigurationError, self).__init__(msg)
+
+
 class MetricClient:
     """ metrics client wrapper, enables disk cache """
 
     def __init__(self, port=METRIC_PORT_HEALTH, cache_path=METRIC_CACHE_PATH):
+        if not port:
+            raise MetricClientConfigurationError('port', port)
         self.port = port
         self.cache = MetricCache(path=cache_path)
         self.stat = None

--- a/deploy-agent/deployd/common/stats.py
+++ b/deploy-agent/deployd/common/stats.py
@@ -283,6 +283,9 @@ class MetricClient:
         elif self.stat.mtype == 'gauge' or self.stat.mtype == 'timing':
             func(self.stat.name, self.stat.value, sample_rate=self.stat.sample_rate, tags=self.stat.tags)
             func_v2(self.stat.name, self.stat.value, sample_rate=self.stat.sample_rate, tags=self.stat.tags)
+        else:
+            msg = 'encountered unsupported mtype:{} while sending name:{}, value:{}, sample_rate:{}, tags:{}'
+            log.error(msg.format(self.stat.name, self.stat.value, self.stat.sample_rate, self.stat.tags))
 
     def _send(self):
         """ send metric to sc """

--- a/deploy-agent/deployd/common/stats.py
+++ b/deploy-agent/deployd/common/stats.py
@@ -105,7 +105,7 @@ def create_sc_gauge(name, value, sample_rate=1.0, tags=None):
         return
 
 
-class Cache:
+class MetricCache:
     """ local cache for metrics
         creates empty cache file
     """
@@ -229,7 +229,7 @@ class MetricClient:
 
     def __init__(self, port=METRIC_PORT_HEALTH, cache_path=METRIC_CACHE_PATH):
         self.port = port
-        self.cache = Cache(path=cache_path)
+        self.cache = MetricCache(path=cache_path)
         self.stat = None
 
     @staticmethod

--- a/deploy-agent/deployd/common/stats.py
+++ b/deploy-agent/deployd/common/stats.py
@@ -191,7 +191,8 @@ class Stat:
             # python2 support
             self.JSONDecodeError = ValueError
 
-    def __repr__(self):
+    def serialize(self):
+        """ serialize for cache writing """
         obj = dict()
         obj['mtype'] = self.mtype
         if self.value is not None:
@@ -200,11 +201,7 @@ class Stat:
         obj['name'] = self.name
         obj['sample_rate'] = self.sample_rate
         obj['tags'] = self.tags
-        return obj
-
-    def serialize(self):
-        """ serialize for cache writing """
-        return json.dumps(self.__repr__())
+        return json.dumps(obj)
 
     def _deserialize(self):
         """ read in json, setting defaults for a stat

--- a/deploy-agent/deployd/common/stats.py
+++ b/deploy-agent/deployd/common/stats.py
@@ -49,17 +49,17 @@ class DefaultStatsdTimer(object):
         pass
 
 
+class TimingOnlyStatClient:
+    """ timing only stat client in order to use caching """
+    @staticmethod
+    def timing(*args, **kwargs):
+        client = MetricClient()
+        return client.send_context_timer(*args, **kwargs)
+
+
 def create_stats_timer(name, sample_rate=1.0, tags=None):
     if IS_PINTEREST:
         from pinstatsd.statsd import statsd_context_timer
-
-        class TimingOnlyStatClient:
-            """ timing only stat client in order to use caching """
-            @staticmethod
-            def timing(*args, **kwargs):
-                client = MetricClient()
-                return client.send_context_timer(*args, **kwargs)
-
         timer = statsd_context_timer(entry_name=name, sample_rate=sample_rate, tags=tags)
         timer._statsd_context_timer__stat_client = TimingOnlyStatClient()
         return timer

--- a/deploy-agent/deployd/types/build.py
+++ b/deploy-agent/deployd/types/build.py
@@ -43,6 +43,26 @@ class Build(object):
             self.publishInfo = jsonValue.get('publishInfo')
             self.publishDate = jsonValue.get('publishDate')
 
+    def __eq__(self, other):
+        """ compare Builds """
+        if (self.buildId == other.buildId) \
+           and (self.buildName == other.buildName) \
+           and (self.buildVersion == other.buildVersion) \
+           and (self.artifactUrl == other.artifactUrl) \
+           and (self.scm == other.scm) \
+           and (self.scmRepo == other.scmRepo) \
+           and (self.scmBranch == other.scmBranch) \
+           and (self.scmCommit == other.scmCommit) \
+           and (self.scmInfo == other.scmInfo) \
+           and (self.commitDate == other.commitDate) \
+           and (self.publishInfo == other.publishInfo) \
+           and (self.publishDate == other.publishDate):
+            return True
+        return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     def __str__(self):
         return "Build(buildId={}, buildName={}, buildVersion={}, artifactUrl={}, scm={}, " \
                "scmRepo={}, scmBranch={}, scmCommit={}, scmInfo={}, commitDate={}, publishInfo={}, " \

--- a/deploy-agent/deployd/types/build.py
+++ b/deploy-agent/deployd/types/build.py
@@ -43,25 +43,31 @@ class Build(object):
             self.publishInfo = jsonValue.get('publishInfo')
             self.publishDate = jsonValue.get('publishDate')
 
+    def __key(self):
+        return (self.buildId,
+                self.buildName,
+                self.buildVersion,
+                self.artifactUrl,
+                self.scm,
+                self.scmRepo,
+                self.scmBranch,
+                self.scmCommit,
+                self.scmInfo,
+                self.commitDate,
+                self.publishInfo,
+                self.publishDate)
+
+    def __hash__(self):
+        return hash(self.__key())
+
     def __eq__(self, other):
         """ compare Builds """
-        if (self.buildId == other.buildId) \
-           and (self.buildName == other.buildName) \
-           and (self.buildVersion == other.buildVersion) \
-           and (self.artifactUrl == other.artifactUrl) \
-           and (self.scm == other.scm) \
-           and (self.scmRepo == other.scmRepo) \
-           and (self.scmBranch == other.scmBranch) \
-           and (self.scmCommit == other.scmCommit) \
-           and (self.scmInfo == other.scmInfo) \
-           and (self.commitDate == other.commitDate) \
-           and (self.publishInfo == other.publishInfo) \
-           and (self.publishDate == other.publishDate):
-            return True
-        return False
+        return isinstance(other, Build) \
+               and self.__key() == other.__key()
 
     def __ne__(self, other):
-        return not self.__eq__(other)
+        """ compare Builds """
+        return not self.__key() == other.__key()
 
     def __str__(self):
         return "Build(buildId={}, buildName={}, buildVersion={}, artifactUrl={}, scm={}, " \

--- a/deploy-agent/deployd/types/build.py
+++ b/deploy-agent/deployd/types/build.py
@@ -63,11 +63,12 @@ class Build(object):
     def __eq__(self, other):
         """ compare Builds """
         return isinstance(other, Build) \
-               and self.__key() == other.__key()
+            and self.__key() == other.__key()
 
     def __ne__(self, other):
         """ compare Builds """
-        return not self.__key() == other.__key()
+        return not (isinstance(other, Build)
+                    and self.__key() == other.__key())
 
     def __str__(self):
         return "Build(buildId={}, buildName={}, buildVersion={}, artifactUrl={}, scm={}, " \

--- a/deploy-agent/deployd/types/deploy_goal.py
+++ b/deploy-agent/deployd/types/deploy_goal.py
@@ -72,7 +72,8 @@ class DeployGoal(object):
 
     def __ne__(self, other):
         """ compare DeployGoals """
-        return not self.__key() == other.__key()
+        return not (isinstance(other, DeployGoal)
+                    and self.__key() == other.__key())
 
     def __str__(self):
         return "DeployGoal(deployId={}, envId={}, envName={}, stageName={}, " \

--- a/deploy-agent/deployd/types/deploy_goal.py
+++ b/deploy-agent/deployd/types/deploy_goal.py
@@ -15,7 +15,6 @@
 from deployd.types.build import Build
 from deployd.types.deploy_stage import DeployStage
 
-
 class DeployGoal(object):
     def __init__(self, jsonValue=None):
         self.deployId = None
@@ -49,6 +48,26 @@ class DeployGoal(object):
             self.scriptVariables = jsonValue.get('scriptVariables')
             self.firstDeploy = jsonValue.get('firstDeploy')
             self.isDocker = jsonValue.get('isDocker')
+
+    def __eq__(self, other):
+        if not other:
+            return False
+        if (self.deployId == other.deployId) \
+           and (self.envId == other.envId) \
+           and (self.envName == other.envName) \
+           and (self.stageName == other.stageName) \
+           and (self.deployStage == other.deployStage) \
+           and (self.build == other.build) \
+           and (self.deployAlias == other.deployAlias) \
+           and (self.config == other.config) \
+           and (self.scriptVariables == other.scriptVariables) \
+           and (self.firstDeploy == other.firstDeploy) \
+           and (self.isDocker == other.isDocker):
+            return True
+        return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
     def __str__(self):
         return "DeployGoal(deployId={}, envId={}, envName={}, stageName={}, " \

--- a/deploy-agent/deployd/types/deploy_goal.py
+++ b/deploy-agent/deployd/types/deploy_goal.py
@@ -49,25 +49,30 @@ class DeployGoal(object):
             self.firstDeploy = jsonValue.get('firstDeploy')
             self.isDocker = jsonValue.get('isDocker')
 
+    def __key(self):
+        return (self.deployId,
+                self.envId,
+                self.envName,
+                self.stageName,
+                self.deployStage,
+                self.build,
+                self.deployAlias,
+                self.config,
+                self.scriptVariables,
+                self.firstDeploy,
+                self.isDocker)
+
+    def __hash__(self):
+        return hash(self.__key())
+
     def __eq__(self, other):
-        if not other:
-            return False
-        if (self.deployId == other.deployId) \
-           and (self.envId == other.envId) \
-           and (self.envName == other.envName) \
-           and (self.stageName == other.stageName) \
-           and (self.deployStage == other.deployStage) \
-           and (self.build == other.build) \
-           and (self.deployAlias == other.deployAlias) \
-           and (self.config == other.config) \
-           and (self.scriptVariables == other.scriptVariables) \
-           and (self.firstDeploy == other.firstDeploy) \
-           and (self.isDocker == other.isDocker):
-            return True
-        return False
+        """ compare DeployGoals """
+        return isinstance(other, DeployGoal) \
+            and self.__key() == other.__key()
 
     def __ne__(self, other):
-        return not self.__eq__(other)
+        """ compare DeployGoals """
+        return not self.__key() == other.__key()
 
     def __str__(self):
         return "DeployGoal(deployId={}, envId={}, envName={}, stageName={}, " \

--- a/deploy-agent/tests/unit/deploy/common/test_stats.py
+++ b/deploy-agent/tests/unit/deploy/common/test_stats.py
@@ -168,9 +168,6 @@ class TestTimeElapsed(unittest.TestCase):
     def setUp(self):
         self.elapsed = TimeElapsed()
 
-    def tearDown(self):
-        self.elapsed = None
-
     def test__is_paused(self):
         self.assertFalse(self.elapsed._is_paused())
 

--- a/deploy-agent/tests/unit/deploy/common/test_stats.py
+++ b/deploy-agent/tests/unit/deploy/common/test_stats.py
@@ -152,47 +152,47 @@ class TestMetricClient(unittest.TestCase):
 
 
 class TestTimeElapsed(unittest.TestCase):
+    def setUp(self):
+        self.elapsed = TimeElapsed()
+
+    def tearDown(self):
+        self.elapsed = None
 
     def test__is_paused(self):
-        elapsed = TimeElapsed()
-        self.assertFalse(elapsed._is_paused())
+        self.assertFalse(self.elapsed._is_paused())
 
     def test_get(self):
-        elapsed = TimeElapsed()
-        then = elapsed.get()
-        self.assertFalse(elapsed._is_paused())
+        then = self.elapsed.get()
+        self.assertFalse(self.elapsed._is_paused())
         sleep(2)
-        now = elapsed.get()
+        now = self.elapsed.get()
         self.assertTrue(now > then)
 
-        elapsed.pause()
-        self.assertTrue(elapsed._is_paused())
-        self.assertEqual(elapsed.get(), elapsed._time_elapsed)
+        self.elapsed.pause()
+        self.assertTrue(self.elapsed._is_paused())
+        self.assertEqual(self.elapsed.get(), self.elapsed._time_elapsed)
 
     def test_since_pause(self):
-        elapsed = TimeElapsed()
-        self.assertFalse(elapsed._is_paused())
-        self.assertEqual(elapsed.since_pause(), float(0))
+        self.assertFalse(self.elapsed._is_paused())
+        self.assertEqual(self.elapsed.since_pause(), float(0))
 
         sleep(2)
-        elapsed.pause()
-        self.assertTrue(elapsed._is_paused())
-        self.assertTrue(elapsed.since_pause() > 0)
+        self.elapsed.pause()
+        self.assertTrue(self.elapsed._is_paused())
+        self.assertTrue(self.elapsed.since_pause() > 0)
 
     def test_pause(self):
-        elapsed = TimeElapsed()
-        self.assertFalse(elapsed._is_paused())
-        elapsed.pause()
+        self.assertFalse(self.elapsed._is_paused())
+        self.elapsed.pause()
         sleep(2)
-        self.assertTrue(elapsed._is_paused())
+        self.assertTrue(self.elapsed._is_paused())
 
     def test_resume(self):
-        elapsed = TimeElapsed()
-        self.assertFalse(elapsed._is_paused())
-        elapsed.resume()
-        self.assertFalse(elapsed._is_paused())
+        self.assertFalse(self.elapsed._is_paused())
+        self.elapsed.resume()
+        self.assertFalse(self.elapsed._is_paused())
 
-        elapsed.pause()
-        self.assertTrue(elapsed._is_paused())
-        elapsed.resume()
-        self.assertFalse(elapsed._is_paused())
+        self.elapsed.pause()
+        self.assertTrue(self.elapsed._is_paused())
+        self.elapsed.resume()
+        self.assertFalse(self.elapsed._is_paused())

--- a/deploy-agent/tests/unit/deploy/common/test_stats.py
+++ b/deploy-agent/tests/unit/deploy/common/test_stats.py
@@ -12,12 +12,146 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tests
+from deployd.common.stats import Cache, Stat, MetricClient, TimeElapsed
+from deployd import __version__
+import unittest
+import os
+import json
+import socket
 from time import sleep
-from deployd.common.stats import TimeElapsed
+try:
+    from unittest import mock
+except ImportError:
+    # python2 support
+    import mock
 
 
-class TestTimeElapsed(tests.TestCase):
+class TestCache(unittest.TestCase):
+    path = 'tests/unit/deploy/common/test_stats.cache'
+    data = 'testdata'
+
+    def test_exists(self):
+        cache = Cache(self.path)
+        self.assertTrue(cache.exists())
+
+    def test_is_empty(self):
+        cache = Cache(self.path)
+        cache.truncate()
+        self.assertTrue(cache.is_empty())
+
+    def test_read(self):
+        cache = Cache(self.path)
+        cache.truncate()
+        with open(self.path, 'w') as fh:
+            fh.write('{}\n'.format(self.data))
+        count = 0
+        for _ in cache.read():
+            count += 1
+        self.assertEqual(count, 1)
+
+    def test_write(self):
+        cache = Cache(self.path)
+        cache.truncate()
+        cache.write(self.data)
+        with open(self.path, 'r') as fh:
+            validate = fh.read()
+        expect = '{}\n'.format(self.data)
+        self.assertEqual(validate, expect)
+
+    def tearDown(self):
+        Cache(self.path)
+        os.remove(self.path)
+
+
+class TestStat(unittest.TestCase):
+    mtype = 'increment'
+    name = 'name'
+    value = 1
+    sample_rate = 1.0
+    tags = {'key': 'value'}
+    data = ('{{"mtype": "{0}", '
+            '"name": "{1}", '
+            '"value": {2}, '
+            '"sample_rate": {3}, '
+            '"tags": {4}}}')
+
+    def test_serialize(self):
+        stat = Stat(mtype=self.mtype,
+                    name=self.name,
+                    value=self.value,
+                    sample_rate=self.sample_rate,
+                    tags=self.tags)
+        self.assertIsInstance(stat.serialize(), str)
+
+    def test__deserialize(self):
+        data = self.data.format(self.mtype,
+                                self.name,
+                                self.value,
+                                self.sample_rate,
+                                json.dumps(self.tags))
+        stat = Stat(mtype=None,
+                    name=None,
+                    value=None,
+                    sample_rate=None,
+                    tags=None,
+                    ins=data)
+        stat._deserialize()
+        self.assertEqual(stat.mtype, self.mtype)
+        self.assertEqual(stat.name, self.name)
+        self.assertEqual(stat.sample_rate, self.sample_rate)
+        self.assertEqual(stat.tags, self.tags)
+
+
+    def test_deserialize(self):
+        stat = Stat(mtype=None,
+                    name=None,
+                    value=None,
+                    sample_rate=None,
+                    tags=None)
+        data = self.data.format(self.mtype,
+                                self.name,
+                                self.value,
+                                self.sample_rate,
+                                json.dumps(self.tags))
+        self.assertTrue(stat.deserialize(ins=data))
+        invalid_str = '{1:'
+        self.assertFalse(stat.deserialize(ins=invalid_str))
+        invalid_type = []
+        self.assertFalse(stat.deserialize(ins=invalid_type))
+
+
+class TestMetricClient(unittest.TestCase):
+    cache_path = 'tests/unit/deploy/common/test_stats.cache'
+    port = 5000
+
+    def setUp(self):
+        self.client = MetricClient(port=self.port, cache_path=self.cache_path)
+
+    def test__add_default_tags(self):
+        tag_version = {'deploy_agent_version': __version__}
+        tags = self.client._add_default_tags()
+        if not __version__:
+            self.assertEqual(tags, None)
+        else:
+            self.assertEqual(tags, tag_version)
+        tag_test = {'test': 'data'}
+        tags = self.client._add_default_tags(tag_test)
+        self.assertEqual(tags, dict(tag_version, **tag_test))
+
+    @mock.patch('socket.socket.connect_ex')
+    def test_is_healthy(self, mock_connect_ex):
+        mock_connect_ex.return_value = 0
+        self.assertTrue(self.client.is_healthy())
+        mock_connect_ex.return_value = 50
+        self.assertFalse(self.client.is_healthy())
+        mock_connect_ex.raiseError.side_effect = Exception(socket.error)
+        self.assertFalse(self.client.is_healthy())
+
+    def tearDown(self):
+        Cache(self.cache_path)
+        os.remove(self.cache_path)
+
+class TestTimeElapsed(unittest.TestCase):
 
     def test__is_paused(self):
         elapsed = TimeElapsed()

--- a/deploy-agent/tests/unit/deploy/common/test_stats.py
+++ b/deploy-agent/tests/unit/deploy/common/test_stats.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from deployd.common.stats import Cache, Stat, MetricClient, TimeElapsed
+from deployd.common.stats import MetricCache, Stat, MetricClient, TimeElapsed
 from deployd import __version__
 import unittest
 import os
@@ -26,21 +26,21 @@ except ImportError:
     import mock
 
 
-class TestCache(unittest.TestCase):
+class TestMetricCache(unittest.TestCase):
     path = 'tests/unit/deploy/common/test_stats.cache'
     data = 'testdata'
 
     def test_exists(self):
-        cache = Cache(self.path)
+        cache = MetricCache(self.path)
         self.assertTrue(cache.exists())
 
     def test_is_empty(self):
-        cache = Cache(self.path)
+        cache = MetricCache(self.path)
         cache.truncate()
         self.assertTrue(cache.is_empty())
 
     def test_read(self):
-        cache = Cache(self.path)
+        cache = MetricCache(self.path)
         cache.truncate()
         with open(self.path, 'w') as fh:
             fh.write('{}\n'.format(self.data))
@@ -50,7 +50,7 @@ class TestCache(unittest.TestCase):
         self.assertEqual(count, 1)
 
     def test_write(self):
-        cache = Cache(self.path)
+        cache = MetricCache(self.path)
         cache.truncate()
         cache.write(self.data)
         with open(self.path, 'r') as fh:
@@ -59,7 +59,7 @@ class TestCache(unittest.TestCase):
         self.assertEqual(validate, expect)
 
     def tearDown(self):
-        Cache(self.path)
+        MetricCache(self.path)
         os.remove(self.path)
 
 
@@ -100,7 +100,6 @@ class TestStat(unittest.TestCase):
         self.assertEqual(stat.name, self.name)
         self.assertEqual(stat.sample_rate, self.sample_rate)
         self.assertEqual(stat.tags, self.tags)
-
 
     def test_deserialize(self):
         stat = Stat(mtype=None,
@@ -148,8 +147,9 @@ class TestMetricClient(unittest.TestCase):
         self.assertFalse(self.client.is_healthy())
 
     def tearDown(self):
-        Cache(self.cache_path)
+        MetricCache(self.cache_path)
         os.remove(self.cache_path)
+
 
 class TestTimeElapsed(unittest.TestCase):
 

--- a/deploy-agent/tests/unit/deploy/types/test_build.py
+++ b/deploy-agent/tests/unit/deploy/types/test_build.py
@@ -1,0 +1,150 @@
+# Copyright 2022 Pinterest, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from deployd.types.build import Build
+import unittest
+
+
+class TestBuild(unittest.TestCase):
+    # buildId
+    j_buildId = 'id'
+    buildId = 'buildId'
+    # buildName
+    j_buildName = 'name'
+    buildName = 'buildName'
+    # buildVersion
+    j_buildVersion = 'commitShort'
+    buildVersion = 'buildVersion'
+    # artifactUrl
+    j_artifactUrl = 'artifactUrl'
+    artifactUrl = 'artifactUrl'
+    # scm
+    j_scm = 'type'
+    scm = 'scm'
+    # scmRepo
+    j_scmRepo = 'repo'
+    scmRepo = 'scmRepo'
+    # scmBranch
+    j_scmBranch = 'branch'
+    scmBranch = 'scmBranch'
+    # scmCommit
+    j_scmCommit = 'commit'
+    scmCommit = 'scmCommit'
+    # scmInfo
+    j_scmInfo = 'commitInfo'
+    scmInfo = 'scmInfo'
+    # commitDate
+    j_commitDate = 'commitDate'
+    commitDate = 'commitDate'
+    # publishInfo
+    j_publishInfo = 'publishInfo'
+    publishInfo = 'publishInfo'
+    # publishDate
+    j_publishDate = 'publishDate'
+    publishDate = 'publishDate'
+
+    def test__no_values(self):
+        build = Build(jsonValue=None)
+        self.assertIsNone(build.buildId)
+        self.assertIsNone(build.buildName)
+        self.assertIsNone(build.buildVersion)
+        self.assertIsNone(build.artifactUrl)
+        self.assertIsNone(build.scm)
+        self.assertIsNone(build.scmRepo)
+        self.assertIsNone(build.scmCommit)
+        self.assertIsNone(build.scmInfo)
+        self.assertIsNone(build.commitDate)
+        self.assertIsNone(build.publishInfo)
+        self.assertIsNone(build.publishDate)
+
+    def test__values(self):
+        data = {self.j_buildId: self.buildId,
+                self.j_buildName: self.buildName,
+                self.j_buildVersion: self.buildVersion,
+                self.j_artifactUrl: self.artifactUrl,
+                self.j_scm: self.scm,
+                self.j_scmRepo: self.scmRepo,
+                self.j_scmBranch: self.scmBranch,
+                self.j_scmCommit: self.scmCommit,
+                self.j_scmInfo: self.scmInfo,
+                self.j_commitDate: self.commitDate,
+                self.j_publishInfo: self.publishInfo,
+                self.j_publishDate: self.publishDate}
+        build = Build(jsonValue=data)
+        self.assertEqual(self.buildId, build.buildId)
+        self.assertEqual(self.buildName, build.buildName)
+        self.assertEqual(self.buildVersion, build.buildVersion)
+        self.assertEqual(self.artifactUrl, build.artifactUrl)
+        self.assertEqual(self.scm, build.scm)
+        self.assertEqual(self.scmBranch, build.scmBranch)
+        self.assertEqual(self.scmCommit, build.scmCommit)
+        self.assertEqual(self.scmInfo, build.scmInfo)
+        self.assertEqual(self.commitDate, build.commitDate)
+
+    def test____eq__(self):
+        data_1 = {self.j_buildId: self.buildId,
+                  self.j_buildName: self.buildName,
+                  self.j_buildVersion: self.buildVersion,
+                  self.j_artifactUrl: self.artifactUrl,
+                  self.j_scm: self.scm,
+                  self.j_scmBranch: self.scmBranch,
+                  self.j_scmCommit: self.scmCommit,
+                  self.j_scmInfo: self.scmInfo,
+                  self.j_commitDate: self.commitDate,
+                  self.j_publishInfo: self.publishInfo,
+                  self.j_publishDate: self.publishDate}
+
+        build_1 = Build(jsonValue=data_1)
+        data_2 = {self.j_buildId: self.buildId,
+                  self.j_buildName: self.buildName,
+                  self.j_buildVersion: self.buildVersion,
+                  self.j_artifactUrl: self.artifactUrl,
+                  self.j_scm: self.scm,
+                  self.j_scmBranch: self.scmBranch,
+                  self.j_scmCommit: self.scmCommit,
+                  self.j_scmInfo: self.scmInfo,
+                  self.j_commitDate: self.commitDate,
+                  self.j_publishInfo: self.publishInfo,
+                  self.j_publishDate: self.publishDate}
+        build_2 = Build(jsonValue=data_2)
+        self.assertEqual(build_1, build_2)
+        self.assertTrue(Build(jsonValue=None) == Build(jsonValue=None))
+
+    def test____ne__(self):
+        data = {self.j_buildId: self.buildId,
+                self.j_buildName: self.buildName,
+                self.j_buildVersion: self.buildVersion,
+                self.j_artifactUrl: self.artifactUrl,
+                self.j_scm: self.scm,
+                self.j_scmBranch: self.scmBranch,
+                self.j_scmCommit: self.scmCommit,
+                self.j_scmInfo: self.scmInfo,
+                self.j_commitDate: self.commitDate,
+                self.j_publishInfo: self.publishInfo,
+                self.j_publishDate: self.publishDate}
+        build = Build(jsonValue=data)
+        other = 'other'
+        self.assertNotEqual(build, Build(jsonValue={self.j_buildId: other}))
+        self.assertNotEqual(build, Build(jsonValue={self.j_buildName: other}))
+        self.assertNotEqual(build, Build(jsonValue={self.j_buildVersion: other}))
+        self.assertNotEqual(build, Build(jsonValue={self.j_artifactUrl: other}))
+        self.assertNotEqual(build, Build(jsonValue={self.j_scm: other}))
+        self.assertNotEqual(build, Build(jsonValue={self.j_scmBranch: other}))
+        self.assertNotEqual(build, Build(jsonValue={self.j_scmCommit: other}))
+        self.assertNotEqual(build, Build(jsonValue={self.j_scmInfo: other}))
+        self.assertNotEqual(build, Build(jsonValue={self.j_commitDate: other}))
+        self.assertNotEqual(build, Build(jsonValue={self.j_publishInfo: other}))
+        self.assertNotEqual(build, Build(jsonValue={self.j_publishDate: other}))
+        self.assertFalse(Build(jsonValue=None) is None)
+        self.assertFalse(Build(jsonValue=None) == "")

--- a/deploy-agent/tests/unit/deploy/types/test_build.py
+++ b/deploy-agent/tests/unit/deploy/types/test_build.py
@@ -120,6 +120,7 @@ class TestBuild(unittest.TestCase):
         build_2 = Build(jsonValue=data_2)
         self.assertEqual(build_1, build_2)
         self.assertTrue(Build(jsonValue=None) == Build(jsonValue=None))
+        self.assertFalse(Build(jsonValue=None) is None)
 
     def test____ne__(self):
         data = {self.j_buildId: self.buildId,
@@ -146,5 +147,5 @@ class TestBuild(unittest.TestCase):
         self.assertNotEqual(build, Build(jsonValue={self.j_commitDate: other}))
         self.assertNotEqual(build, Build(jsonValue={self.j_publishInfo: other}))
         self.assertNotEqual(build, Build(jsonValue={self.j_publishDate: other}))
-        self.assertFalse(Build(jsonValue=None) is None)
+        self.assertTrue(Build(jsonValue=None) is not None)
         self.assertFalse(Build(jsonValue=None) == "")

--- a/deploy-agent/tests/unit/deploy/types/test_deploy_goal.py
+++ b/deploy-agent/tests/unit/deploy/types/test_deploy_goal.py
@@ -1,0 +1,134 @@
+# Copyright 2022 Pinterest, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from deployd.types.deploy_goal import DeployGoal
+from deployd.types.build import Build
+import unittest
+
+
+class TestDeployGoal(unittest.TestCase):
+    deployId = 'deployId'
+    envId = 'envId'
+    envName = 'envName'
+    stageName = 'stageName'
+    deployStage = 'deployStage'
+    build = 'build'
+    deployAlias = 'deployAlias'
+    config = 'agentConfigs'
+    j_agentConfigs = 'agentConfigs'
+    scriptVariables = 'scriptVariables'
+    firstDeploy = 'firstDeploy'
+    isDocker = 'isDocker'
+
+    def test__no_values(self):
+        deploy_goal = DeployGoal(jsonValue=None)
+        self.assertIsNone(deploy_goal.deployId)
+        self.assertIsNone(deploy_goal.envId)
+        self.assertIsNone(deploy_goal.envName)
+        self.assertIsNone(deploy_goal.stageName)
+        self.assertIsNone(deploy_goal.deployStage)
+        self.assertIsNone(deploy_goal.deployAlias)
+        self.assertIsNone(deploy_goal.config)
+        self.assertIsNone(deploy_goal.scriptVariables)
+        self.assertIsNone(deploy_goal.firstDeploy)
+        self.assertIsNone(deploy_goal.isDocker)
+
+    def test__values(self):
+        data = {self.deployId: self.deployId,
+                self.envId: self.envId,
+                self.envName: self.envName,
+                self.stageName: self.stageName,
+                self.deployStage: self.deployStage,
+                self.deployAlias: self.deployAlias,
+                self.j_agentConfigs: self.config,
+                self.scriptVariables: self.scriptVariables,
+                self.firstDeploy: self.firstDeploy,
+                self.isDocker: self.isDocker}
+        deploy_goal = DeployGoal(jsonValue=data)
+        self.assertEqual(self.deployId, deploy_goal.deployId)
+        self.assertEqual(self.envId, deploy_goal.envId)
+        self.assertEqual(self.envName, deploy_goal.envName)
+        self.assertEqual(self.stageName, deploy_goal.stageName)
+        self.assertEqual(self.deployStage, deploy_goal.deployStage)
+        self.assertEqual(self.deployAlias, deploy_goal.deployAlias)
+        self.assertEqual(self.config, deploy_goal.config)
+        self.assertEqual(self.scriptVariables, deploy_goal.scriptVariables)
+        self.assertEqual(self.firstDeploy, deploy_goal.firstDeploy)
+        self.assertEqual(self.isDocker, deploy_goal.isDocker)
+
+    def test__build(self):
+        data = {self.build: {'id': 1}}
+        deploy_goal = DeployGoal(jsonValue=data)
+        self.assertIsInstance(deploy_goal.build, Build)
+
+    def test__deploy_stage(self):
+        data = {self.deployStage: 1}
+        deploy_goal = DeployGoal(jsonValue=data)
+        self.assertIsInstance(deploy_goal.deployStage, str)
+
+        data = {self.deployStage: self.deployStage}
+        deploy_goal = DeployGoal(jsonValue=data)
+        self.assertIsInstance(deploy_goal.deployStage, str)
+
+    def test____eq__(self):
+        data_1 = {self.deployId: self.deployId,
+                  self.envId: self.envId,
+                  self.envName: self.envName,
+                  self.stageName: self.stageName,
+                  self.deployStage: self.deployStage,
+                  self.deployAlias: self.deployAlias,
+                  self.j_agentConfigs: self.config,
+                  self.scriptVariables: self.scriptVariables,
+                  self.firstDeploy: self.firstDeploy,
+                  self.isDocker: self.isDocker}
+        deploy_goal_1 = DeployGoal(jsonValue=data_1)
+        data_2 = {self.deployId: self.deployId,
+                  self.envId: self.envId,
+                  self.envName: self.envName,
+                  self.stageName: self.stageName,
+                  self.deployStage: self.deployStage,
+                  self.deployAlias: self.deployAlias,
+                  self.j_agentConfigs: self.config,
+                  self.scriptVariables: self.scriptVariables,
+                  self.firstDeploy: self.firstDeploy,
+                  self.isDocker: self.isDocker}
+        deploy_goal_2 = DeployGoal(jsonValue=data_2)
+        self.assertEqual(deploy_goal_1, deploy_goal_2)
+        self.assertTrue(DeployGoal(jsonValue=None) == DeployGoal(jsonValue=None))
+
+    def test____ne__(self):
+        data = {self.deployId: self.deployId,
+                self.envId: self.envId,
+                self.envName: self.envName,
+                self.stageName: self.stageName,
+                self.deployStage: self.deployStage,
+                self.deployAlias: self.deployAlias,
+                self.j_agentConfigs: self.config,
+                self.scriptVariables: self.scriptVariables,
+                self.firstDeploy: self.firstDeploy,
+                self.isDocker: self.isDocker}
+        deploy_goal = DeployGoal(jsonValue=data)
+        other = 'other'
+        self.assertNotEqual(deploy_goal, DeployGoal(jsonValue={self.deployId: other}))
+        self.assertNotEqual(deploy_goal, DeployGoal(jsonValue={self.envId: other}))
+        self.assertNotEqual(deploy_goal, DeployGoal(jsonValue={self.envName: other}))
+        self.assertNotEqual(deploy_goal, DeployGoal(jsonValue={self.stageName: other}))
+        self.assertNotEqual(deploy_goal, DeployGoal(jsonValue={self.deployStage: other}))
+        self.assertNotEqual(deploy_goal, DeployGoal(jsonValue={self.deployAlias: other}))
+        self.assertNotEqual(deploy_goal, DeployGoal(jsonValue={self.j_agentConfigs: other}))
+        self.assertNotEqual(deploy_goal, DeployGoal(jsonValue={self.scriptVariables: other}))
+        self.assertNotEqual(deploy_goal, DeployGoal(jsonValue={self.firstDeploy: other}))
+        self.assertNotEqual(deploy_goal, DeployGoal(jsonValue={self.isDocker: other}))
+        self.assertFalse(DeployGoal(jsonValue=None) is None)
+        self.assertFalse(DeployGoal(jsonValue=None) == "")

--- a/deploy-agent/tests/unit/deploy/types/test_deploy_goal.py
+++ b/deploy-agent/tests/unit/deploy/types/test_deploy_goal.py
@@ -106,6 +106,7 @@ class TestDeployGoal(unittest.TestCase):
         deploy_goal_2 = DeployGoal(jsonValue=data_2)
         self.assertEqual(deploy_goal_1, deploy_goal_2)
         self.assertTrue(DeployGoal(jsonValue=None) == DeployGoal(jsonValue=None))
+        self.assertFalse(DeployGoal(jsonValue=None) is None)
 
     def test____ne__(self):
         data = {self.deployId: self.deployId,
@@ -130,5 +131,5 @@ class TestDeployGoal(unittest.TestCase):
         self.assertNotEqual(deploy_goal, DeployGoal(jsonValue={self.scriptVariables: other}))
         self.assertNotEqual(deploy_goal, DeployGoal(jsonValue={self.firstDeploy: other}))
         self.assertNotEqual(deploy_goal, DeployGoal(jsonValue={self.isDocker: other}))
-        self.assertFalse(DeployGoal(jsonValue=None) is None)
+        self.assertTrue(DeployGoal(jsonValue=None) is not None)
         self.assertFalse(DeployGoal(jsonValue=None) == "")


### PR DESCRIPTION
Add caching functionality to metric collection and sending

- Uses simple health checking before sending any metrics
- If health check fails, a cache file is written to 
- When the health check succeeds the cache file is flushed and metrics are sent normally 