### PR TITLE
[DRAFT] Remove "terminate all hosts" button and capability.

### DIFF
--- a/deploy-board/deploy_board/templates/groups/group_details.html
+++ b/deploy-board/deploy_board/templates/groups/group_details.html
@@ -43,12 +43,6 @@
             <span class="glyphicon glyphicon-plus-sign"></span> Launch Instance
         </button>
     </div>
-    <div class="row">
-        <button id="terminateAllHosts" class="deployToolTip btn btn-default btn-block"
-            data-toggle="modal" title="Terminate All Hosts">
-            <span class="glyphicon glyphicon-remove"></span> Terminate All Hosts
-        </button>
-    </div>
 	<div class="row">
         <a type="button" href="/groups/{{ group_name }}/config/"
                 class="deployToolTip btn btn-default btn-block"
@@ -271,32 +265,6 @@
     </div><!-- /.modal-dialog -->
 </div><!-- /.modal -->
 
-<!--- terminate hosts modal-->
-<div class="modal fade" id="terminateAllHostsModalId" tabindex="-1" role="dialog" aria-labelledby="terminateAllHostsModalLabel" aria-hidden="true">
-    <div class="modal-dialog modal-md">
-        <div class="modal-content">
-            <form id="terminateAllHostsFormId" class="form-horizontal" role="form" method="delete" action="/groups/{{ group_name }}/terminate/all">
-                <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
-                    <h4 class="modal-title">Terminate All Hosts</h4>
-                </div>
-                <div class="modal-body" id="newMetricModal">
-                    <h4 style="color: darkred;"> <span class="glyphicon glyphicon-warning-sign"></span> Do you wish to terminate all hosts in this group ?</h4>
-                    <br>
-                    <h4> Warning</h4>
-                    <p> This will only delete the hosts. Not the group.</p>
-                    <p> If auto scaling is set up, this will re launch the hosts to manage capacity</p>
-                </div>
-                <div class="modal-footer">
-                    <button id="addMetricBtnId" type="submit" class="btn btn-primary">Terminate</button>
-                    <button id="modalCloseBtnId" type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-                </div>
-                {% csrf_token %}
-            </form>
-        </div><!-- /.modal-content -->
-    </div><!-- /.modal-dialog -->
-</div><!-- /.modal -->
-
 <!--- Enable Scaling Down event button dialog-->
 <div class="modal fade" id="enableScalingDownModelId" tabindex="-1" role="dialog"
      aria-labelledby="enableScalingDownModalLabel" aria-hidden="true">
@@ -424,10 +392,6 @@
         {% else %}
         $("#launchWarningModalId").modal();
         {% endif %}
-    });
-
-    $('#terminateAllHosts').click(function () {
-        $('#terminateAllHostsModalId').modal();
     });
 
     $(document).ready(function() {

--- a/deploy-board/deploy_board/webapp/arcee_urls.py
+++ b/deploy-board/deploy_board/webapp/arcee_urls.py
@@ -105,5 +105,4 @@ urlpatterns = [
         group_view.add_scheduled_actions),
     url(r'^groups/(?P<group_name>[a-zA-Z0-9\-_]+)/autoscaling/update_scheduled_actions/$',
         group_view.update_scheduled_actions),
-    url(r'^groups/(?P<group_name>[a-zA-Z0-9\-_]+)/terminate/all/$', group_view.terminate_all_hosts),
 ]

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -1093,44 +1093,6 @@ def add_instance(request, group_name):
     return redirect('/groups/{}'.format(group_name))
 
 
-# Terminate all instances
-def terminate_all_hosts(request, group_name):
-
-    try:
-        response = autoscaling_groups_helper.terminate_all_hosts(request, group_name)
-        if response is not None and type(response) is dict:
-
-            success_count = 0
-            failed_count = 0
-            failed_instance_ids = []
-
-            content = "{} hosts were marked for termination \n".format(len(response))
-
-            for id, status in response.iteritems():
-                if status == "UNKNOWN" or status == "FAILED":
-                    failed_count += 1
-                    failed_instance_ids.append(id)
-                else:
-                    success_count += 1
-
-            content += "{} hosts successfully terminating...\n".format(success_count)
-            content += "{} hosts failed to terminate \n".format(failed_count)
-            content += ",".join(failed_instance_ids)
-
-            messages.add_message(request, messages.SUCCESS, content)
-
-        else:
-            content = "Unexpected response from rodimus backend"
-            messages.add_message(request, messages.ERROR, content)
-
-    except Exception as e:
-        messages.add_message(request, messages.ERROR, str(e))
-        log.error(traceback.format_exc())
-        raise
-
-    return redirect('/groups/{}'.format(group_name))
-
-
 def instance_action_in_asg(request, group_name):
     host_id = request.GET.get("hostId", "")
     action = request.GET.get("action", "")

--- a/deploy-board/deploy_board/webapp/helpers/autoscaling_groups_helper.py
+++ b/deploy-board/deploy_board/webapp/helpers/autoscaling_groups_helper.py
@@ -63,10 +63,6 @@ def launch_hosts_with_placement_group(request, group_name, host_count, subnet, p
     return rodimus_client.post("/groups/%s/hosts" % group_name, request.teletraan_user_id.token, data=data)
 
 
-def terminate_all_hosts(request, group_name):
-    return rodimus_client.delete("/groups/%s/terminate/all" % group_name, request.teletraan_user_id.token)
-
-
 # Health Checks
 def create_health_check(request, group_name, health_check_info):
     return rodimus_client.post("/groups/%s/healthcheck" % group_name, request.teletraan_user_id.token,


### PR DESCRIPTION
Cluster termination button is too dangerous.  Host cleanup can happen by scaling down the group instead.

Not yet tested.

Todo:
- review api calls again for any more dead code

Test plan:
- TODO