### PR TITLE
Remove constraint allowing only one of alarm autoscaling or time based autoscaling

### DIFF
--- a/deploy-board/deploy_board/templates/groups/asg_config.tmpl
+++ b/deploy-board/deploy_board/templates/groups/asg_config.tmpl
@@ -130,7 +130,7 @@ function loadAsgAlarms() {
 }
 
 function getAdvancedSetting() {
-j   loadAsgScheduledActions();
+    loadAsgScheduledActions();
     loadAsgPolicy();
     loadAsgAlarms();
 }

--- a/deploy-board/deploy_board/templates/groups/asg_config.tmpl
+++ b/deploy-board/deploy_board/templates/groups/asg_config.tmpl
@@ -130,8 +130,8 @@ function loadAsgAlarms() {
 }
 
 function getAdvancedSetting() {
-    loadAsgScheduledActions();
     loadAsgPolicy();
+    loadAsgScheduledActions();
     loadAsgAlarms();
 }
 

--- a/deploy-board/deploy_board/templates/groups/asg_config.tmpl
+++ b/deploy-board/deploy_board/templates/groups/asg_config.tmpl
@@ -59,23 +59,6 @@
             </div>
 
             <div class="form-group">
-                <label for="autoScalingType" class="deployToolTip control-label col-xs-2"
-                  data-toggle="tooltip"
-                  title="Auto Scaling Type">
-                  Auto Scaling Type
-                </label>
-                <div class="col-xs-4">
-                <select class="form-control" name="autoScalingType" id="autoScalingType">
-                    {% if time_based_asg %}
-                        <option value="time" selected>Time based</option>
-                        <option value="alarm">Alarm based</option>
-                    {% else %}
-                        <option value="alarm" selected>Alarm based</option>
-                        <option value="time">Time based</option>
-                    {% endif %}
-                </select>
-                </div>
-
                 <label for="terminationPolicy" class="deployToolTip control-label col-xs-2"
                   data-toggle="tooltip"
                   title="termination policy">
@@ -147,19 +130,9 @@ function loadAsgAlarms() {
 }
 
 function getAdvancedSetting() {
-    var auto_scaling_type = $("#autoScalingType option:selected").val();
-    if (auto_scaling_type == "time") {
-        $("#scalingPolicyPid").empty();
-        $("#scalingPolicyPid").removeClass("panel panel-default");
-        $("#alarmMetricPid").empty();
-        $("#alarmMetricPid").removeClass("panel panel-default");
-        loadAsgScheduledActions();
-    } else {
-        $("#scheduledActionsPid").empty();
-        $("#scheduledActionsPid").removeClass("panel panel-default");
-        loadAsgPolicy();
-        loadAsgAlarms();
-    }
+j   loadAsgScheduledActions();
+    loadAsgPolicy();
+    loadAsgAlarms();
 }
 
 $(document).ready(function() {

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -307,8 +307,6 @@ def get_asg_config(request, group_name):
     policies = autoscaling_groups_helper.TerminationPolicy
     if asg_summary.get("sensitivityRatio", None):
         asg_summary["sensitivityRatio"] *= 100
-
-    # handle scheduled actions
     scheduled_actions = autoscaling_groups_helper.get_scheduled_actions(request, group_name)
     content = render_to_string("groups/asg_config.tmpl", {
         "group_name": group_name,
@@ -393,7 +391,6 @@ def update_asg_config(request, group_name):
 
         autoscaling_groups_helper.update_autoscaling(request, group_name, asg_request)
 
-        # TODO: this may not be used anymore, but related to time based autoscaling
         # Save new pas min and max, disable pas
         pas_config = {}
         pas_config['group_name'] = group_name

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -307,17 +307,15 @@ def get_asg_config(request, group_name):
     policies = autoscaling_groups_helper.TerminationPolicy
     if asg_summary.get("sensitivityRatio", None):
         asg_summary["sensitivityRatio"] *= 100
+
+    # handle scheduled actions
     scheduled_actions = autoscaling_groups_helper.get_scheduled_actions(request, group_name)
-    time_based_asg = False
-    if len(scheduled_actions) > 0:
-        time_based_asg = True
     content = render_to_string("groups/asg_config.tmpl", {
         "group_name": group_name,
         "asg": asg_summary,
         "group_size": group_size,
         "terminationPolicies": policies,
         "instanceType": launch_config.get("instanceType"),
-        "time_based_asg": time_based_asg,
         "csrf_token": get_token(request),
         "pas_config": pas_config,
     })
@@ -395,6 +393,7 @@ def update_asg_config(request, group_name):
 
         autoscaling_groups_helper.update_autoscaling(request, group_name, asg_request)
 
+        # TODO: this may not be used anymore, but related to time based autoscaling
         # Save new pas min and max, disable pas
         pas_config = {}
         pas_config['group_name'] = group_name

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -463,6 +463,9 @@ def _parse_metrics_configs(query_data, group_name):
         if key.startswith('TELETRAAN_'):
             alarm_info = {}
             alarm_id = key[len('TELETRAAN_'):]
+            # skip scheduled actions
+            if page_data.get("schedule_{}".format(alarm_id)) or page_data.get("capacity_{}".format(alarm_id)):
+                continue
             alarm_info["alarmId"] = alarm_id
             alarm_info["actionType"] = page_data["actionType_{}".format(alarm_id)][0]
             alarm_info["metricSource"] = page_data["metricsUrl_{}".format(alarm_id)][0]


### PR DESCRIPTION
AWS autoscaling supports scheduled scaling and alarm autoscaling together. Remove the restrictions preventing the concurrent use of these features. Fix any issues.


DONE:
* FIXED - fix alarm "Save" form submit button. it does not allow update of existing alarms. New alarms "Add Alarm" button is not affected.
* CAN NOT REPRO - test that alarms and time based scaling can be put on the ASG together by deploy-board form submit.  (Can not repro: this was possibly, but not definitely, related to custom metric ~25 minute scaling latency at that time.)

Test plan:
* manual testing