### PR TITLE
modify Stat parsing to be more defensive with bad data

### DIFF
--- a/deploy-agent/deployd/common/stats.py
+++ b/deploy-agent/deployd/common/stats.py
@@ -205,14 +205,17 @@ class Stat:
 
     def _deserialize(self):
         """ read in json, setting defaults for a stat
-            return: None
+            return: bool
         """
         obj = json.loads(self.ins)
-        self.mtype = obj.get('mtype', None)
-        self.name = obj.get('name', None)
-        self.value = obj.get('value', None)
-        self.sample_rate = obj.get('sample_rate', None)
-        self.tags = obj.get('tags', None)
+        if isinstance(obj, dict):
+            self.mtype = obj.get('mtype', None)
+            self.name = obj.get('name', None)
+            self.value = obj.get('value', None)
+            self.sample_rate = obj.get('sample_rate', None)
+            self.tags = obj.get('tags', None)
+            return True
+        return False
 
     def deserialize(self, ins=None):
         """ attempt to deserialize
@@ -222,12 +225,14 @@ class Stat:
         if ins:
             self.ins = ins
         try:
-            self._deserialize()
-            return True
+            valid = self._deserialize()
+            if valid:
+                return True
         except self.JSONDecodeError:
             return False
         except TypeError:
             return False
+        return False
 
 
 class MetricClientConfigurationError(ValueError):

--- a/deploy-agent/tests/unit/deploy/common/test_stats.py
+++ b/deploy-agent/tests/unit/deploy/common/test_stats.py
@@ -102,11 +102,47 @@ class TestStat(unittest.TestCase):
                     sample_rate=None,
                     tags=None,
                     ins=data)
-        stat._deserialize()
+        self.assertTrue(stat._deserialize())
         self.assertEqual(stat.mtype, self.mtype)
         self.assertEqual(stat.name, self.name)
         self.assertEqual(stat.sample_rate, self.sample_rate)
         self.assertEqual(stat.tags, self.tags)
+        invalid_str = '{1:'
+        stat = Stat(mtype=None,
+                    name=None,
+                    value=None,
+                    sample_rate=None,
+                    tags=None,
+                    ins=invalid_str)
+        with self.assertRaises(stat.JSONDecodeError):
+            stat._deserialize()
+        invalid_prop = b'{\x48:\x69}'
+        stat = Stat(mtype=None,
+                    name=None,
+                    value=None,
+                    sample_rate=None,
+                    tags=None,
+                    ins=invalid_prop)
+        with self.assertRaises(stat.JSONDecodeError):
+            stat._deserialize()
+        invalid_type_1 = list()
+        stat = Stat(mtype=None,
+                    name=None,
+                    value=None,
+                    sample_rate=None,
+                    tags=None,
+                    ins=invalid_type_1)
+        with self.assertRaises(TypeError):
+            stat._deserialize()
+        invalid_type_2 = 1
+        stat = Stat(mtype=None,
+                    name=None,
+                    value=None,
+                    sample_rate=None,
+                    tags=None,
+                    ins=invalid_type_2)
+        with self.assertRaises(TypeError):
+            stat._deserialize()
 
     def test_deserialize(self):
         stat = Stat(mtype=None,


### PR DESCRIPTION
* modify Stat parsing to be more defensive with bad data
* Account for a rare possible case where cache has been modified outside of deploy-agent and includes valid json structure with invalid properties
* Add unit tests for control characters and invalid types