### PR TITLE
Updated endpoint force_terminate_hosts

### DIFF
--- a/deploy-board/deploy_board/templates/hosts/hosts.tmpl
+++ b/deploy-board/deploy_board/templates/hosts/hosts.tmpl
@@ -273,7 +273,7 @@
 <div class="modal fade" id="forceTerminateSelectedHosts" tabindex="-1" role="dialog" aria-labelledby="newEntryModalLabel" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
-            <form id="forceTerminateSelectedHostForm" class="form-horizontal" method="post" role="form"  action="/env/{{ env.envName }}/{{ env.stageName }}/terminate_hosts/">
+            <form id="forceTerminateSelectedHostForm" class="form-horizontal" method="post" role="form"  action="/env/{{ env.envName }}/{{ env.stageName }}/force_terminate_hosts/">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
                     <h4 class="modal-title">Host(s) Force Termination Confirmation</h4>


### PR DESCRIPTION
The Force terminate button was associated with the wrong API, it should use the corresponding endpoint.
