### PR TITLE
use NotNull to allow empty list

### DIFF
--- a/deploy-service/teletraanservice/pom.xml
+++ b/deploy-service/teletraanservice/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>5.4.1.Final</version>
+            <version>6.0.23.Final</version>
         </dependency>
         <dependency>
             <groupId>com.pinterest.teletraan</groupId>

--- a/deploy-service/teletraanservice/pom.xml
+++ b/deploy-service/teletraanservice/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>6.0.23.Final</version>
+            <version>5.4.1.Final</version>
         </dependency>
         <dependency>
             <groupId>com.pinterest.teletraan</groupId>

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvCapacities.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvCapacities.java
@@ -31,6 +31,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -95,7 +96,7 @@ public class EnvCapacities {
   public void update(@PathParam("envName") String envName,
                      @PathParam("stageName") String stageName,
                      @QueryParam("capacityType") Optional<CapacityType> capacityType,
-                     @NotEmpty List<String> names, @Context SecurityContext sc) throws Exception {
+                     @NotNull List<String> names, @Context SecurityContext sc) throws Exception {
     EnvironBean envBean = Utils.getEnvStage(environDAO, envName, stageName);
     authorizer.authorize(sc, new Resource(envBean.getEnv_name(), Resource.Type.ENV), Role.OPERATOR);
     String operator = sc.getUserPrincipal().getName();

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvDeploys.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvDeploys.java
@@ -161,7 +161,7 @@ public class EnvDeploys {
             @ApiParam(value = "Environment name", required = true)@PathParam("envName") String envName, 
             @ApiParam(value = "Stage name", required = true)@PathParam("stageName") String stageName,
             @ApiParam(value = "Agent object to update with", required = true)@NotNull @QueryParam("actionType") HostActions actionType,
-            @NotEmpty List<String> hostIds) throws Exception {
+            @NotNull List<String> hostIds) throws Exception {
         EnvironBean envBean = Utils.getEnvStage(environDAO, envName, stageName);
         authorizer.authorize(sc, new Resource(envBean.getEnv_name(), Resource.Type.ENV), Role.OPERATOR);
         AgentBean agentBean = new AgentBean();


### PR DESCRIPTION
We found a bug when removing the last remaining host/group. Fixed it via using NotNull instead of NotEmpty.