### PR TITLE
Switch executor sleep to subprocess.wait

### DIFF
--- a/deploy-agent/deployd/__init__.py
+++ b/deploy-agent/deployd/__init__.py
@@ -19,4 +19,4 @@ IS_PINTEREST = True if os.getenv("IS_PINTEREST", "false") == "true" else False
 METRIC_PORT_HEALTH = int(os.getenv('METRIC_PORT_HEALTH')) if os.getenv('METRIC_PORT_HEALTH', False) else None
 METRIC_CACHE_PATH = os.getenv('METRIC_CACHE_PATH', None)
 
-__version__ = '1.2.37'
+__version__ = '1.2.38'

--- a/deploy-agent/tests/unit/deploy/utils/test_exec.py
+++ b/deploy-agent/tests/unit/deploy/utils/test_exec.py
@@ -58,7 +58,7 @@ class TestUtilsFunctions(tests.TestCase):
         os.remove(fdout_fn)
 
     def test_run_command(self):
-        cmd = ['echo', 'hello world']
+        cmd = ['/bin/echo', 'hello world']
         self.executor.MAX_RUNNING_TIME = 5
         self.executor.MAX_RETRY = 3
         self.executor.PROCESS_POLL_INTERVAL = 2
@@ -78,7 +78,7 @@ class TestUtilsFunctions(tests.TestCase):
         self.assertIsNotNone(deploy_report.output_msg)
 
     def test_run_command_with_max_retry(self):
-        cmd = ['ls', '-ltr', '/abc']
+        cmd = ['/bin/ls', '-ltr', '/abc']
         ping_server = mock.Mock(return_value=False)
         executor = Executor(callback=ping_server)
         executor.LOG_FILENAME = self.fdout_fn
@@ -97,7 +97,7 @@ class TestUtilsFunctions(tests.TestCase):
         self.assertEqual(deploy_report.retry_times, 3)
 
     def test_run_command_with_timeout(self):
-        cmd = ['ls', '-ltr', '/abc']
+        cmd = ['/bin/ls', '-ltr', '/abc']
         ping_server = mock.Mock(return_value=True)
         executor = Executor(callback=ping_server)
         executor.LOG_FILENAME = self.fdout_fn
@@ -111,7 +111,7 @@ class TestUtilsFunctions(tests.TestCase):
         self.assertEqual(deploy_report.status_code, AgentStatus.ABORTED_BY_SERVER)
 
     def test_run_command_with_timeout_error(self):
-        cmd = ['sleep', '20']
+        cmd = ['/bin/sleep', '20']
         ping_server = mock.Mock(return_value=False)
         executor = Executor(callback=ping_server)
         executor.LOG_FILENAME = self.fdout_fn
@@ -128,7 +128,7 @@ class TestUtilsFunctions(tests.TestCase):
         self.assertEqual(deploy_report.status_code, AgentStatus.SCRIPT_TIMEOUT)
 
     def test_run_command_with_shutdown_timeout(self):
-        cmd = ['sleep', '5m']
+        cmd = ['/bin/sleep', '5']
         ping_server = mock.Mock(return_value=PingStatus.PLAN_CHANGED)
         os.killpg = mock.Mock()
         executor = Executor(callback=ping_server)


### PR DESCRIPTION
When using time.sleep we are forced to wait for the full sleep_time, but
if we use subprocess.Popen.wait we will wait _up_ to sleep_time.
(https://docs.python.org/3/library/subprocess.html#subprocess.Popen.wait)

With PROCESS_POLL_INTERVAL defaulting to 2 seconds, switching to this
logic can save up to 2 seconds for very fast executors, which adds up
with many stages and services on a single box.

Update test cases to use full paths for shell commands as we aren't
using shell=True