### PR TITLE
Update _read_host_info to call facter less

### DIFF
--- a/deploy-agent/deployd/__init__.py
+++ b/deploy-agent/deployd/__init__.py
@@ -19,4 +19,4 @@ IS_PINTEREST = True if os.getenv("IS_PINTEREST", "false") == "true" else False
 METRIC_PORT_HEALTH = int(os.getenv('METRIC_PORT_HEALTH')) if os.getenv('METRIC_PORT_HEALTH', False) else None
 METRIC_CACHE_PATH = os.getenv('METRIC_CACHE_PATH', None)
 
-__version__ = '1.2.38'
+__version__ = '1.2.39'


### PR DESCRIPTION
After a Client that uses facter is initialized we don't want to keep
calling facter every time send_reports runs. If facter fails for any
reason and a field is missing the next call will try and load the
missing field again (related to #341).

* If keys_to_fetch is empty don't call facter at all
* Since stage_type might not exist, only try fetching it once.