### PR TITLE
use True instead of 1

### DIFF
--- a/deploy-board/deploy_board/templates/deploys/deploy_build.html
+++ b/deploy-board/deploy_board/templates/deploys/deploy_build.html
@@ -39,7 +39,7 @@
         <h4 class="panel-title pull-left">Build Details</h4>
     </div>
     <div class="panel-body table-responsive">
-        {% include "builds/pick_a_build.tmpl" with deployState=deployState overridePolicy=overridePolicy singleBuildPage=1 %}
+        {% include "builds/pick_a_build.tmpl" with deployState=deployState overridePolicy=overridePolicy singleBuildPage=True %}
     </div>
 </div>
 


### PR DESCRIPTION
according to https://stackoverflow.com/questions/11804315/how-to-pass-boolean-keyword-argument-along-with-the-use-of-include-template-ta, seems like we should use True instead of 1 since our python requirements shows Django==1.11.29