### PR TITLE
Use radio buttons to separate list filter and cluster configuration 

### DIFF
--- a/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
+++ b/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
@@ -326,10 +326,10 @@ Vue.component("placements-select", {
     </span></div>\
     </div>\
     <div class="col-xs-2" v-if="showsubnettype">\
-        <input type="radio" id="public" value="public" v-model="subnettype" v-on:click="filterclick($event.target.value)">\
+        <input type="radio" id="public-subnet" value="public" v-model="subnettype" v-on:click="filterclick($event.target.value)">\
         <label for="public">Public subnets</label>\
         <br>\
-        <input type="radio" id="private" value="private" v-model="subnettype" v-on:click="filterclick($event.target.value)">\
+        <input type="radio" id="private-subnet" value="private" v-model="subnettype" v-on:click="filterclick($event.target.value)">\
         <label for="private">Private subnets</label>\
         <br>\
     </div>\

--- a/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
+++ b/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
@@ -323,9 +323,9 @@ Vue.component("placements-select", {
     <button class="deployToolTip btn btn-default" type="button" data-toggle="tooltip" v-on:click="helpClick" title="click to see more information">\
         <span class="glyphicon glyphicon-question-sign"></span>\
     </button>\
-   </span></div>\
+    </span></div>\
     </div>\
-    <div class="col-xs-2">\
+    <div class="col-xs-2" v-if="showsubnettype">\
         <input type="radio" id="public" value="public" v-model="subnettype" v-on:click="filterclick($event.target.value)">\
         <label for="public">Public subnets</label>\
         <br>\
@@ -337,7 +337,7 @@ Vue.component("placements-select", {
         <input type="checkbox" id="checkbox" v-bind:checked="assignpublicip" v-on:click="assignipchange($event.target.checked)">\
         <label for="checkbox">Assign Public IP</label>\
     </div></div>',
-    props: ['label', 'title', 'selectoptions', 'showhelp', 'assignpublicip', 'subnettype'],
+    props: ['label', 'title', 'selectoptions', 'showhelp', 'assignpublicip', 'subnettype', 'showsubnettype'],
     data: function () {
         return {
             groupStyle: this.showhelp ? 'input-group' : ''

--- a/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
+++ b/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
@@ -315,7 +315,7 @@ Vue.component("placements-select", {
     <label class="deployToolTip control-label col-xs-2" data-toggle="tooltip" v-bind:title="title">\
       {{label}}\
     </label>\
-    <div class="col-xs-7"><div v-bind:class="groupStyle">\
+    <div class="col-xs-6"><div v-bind:class="groupStyle">\
           <select class="form-control chosen-select"  v-on:change="updateValue($event.target.value)" multiple>\
             <option v-for="option in selectoptions" v-bind:value="option.value" v-bind:selected="option.isSelected">{{option.text}}</option>\
           </select>\
@@ -325,11 +325,19 @@ Vue.component("placements-select", {
     </button>\
    </span></div>\
     </div>\
-    <div class="col-xs-3">\
-      <input type="checkbox" id="checkbox" v-bind:checked="assignpublicip" v-on:click="assignipchange($event.target.checked)">\
-      <label for="checkbox">Assign Public IP</label>\
-    <div></div>',
-    props: ['label', 'title', 'selectoptions', 'showhelp', 'assignpublicip'],
+    <div class="col-xs-2">\
+        <input type="radio" id="public" value="public" v-model="subnettype" v-on:click="filterclick($event.target.value)">\
+        <label for="public">Public subnets</label>\
+        <br>\
+        <input type="radio" id="private" value="private" v-model="subnettype" v-on:click="filterclick($event.target.value)">\
+        <label for="private">Private subnets</label>\
+        <br>\
+    </div>\
+    <div class="col-xs-2">\
+        <input type="checkbox" id="checkbox" v-bind:checked="assignpublicip" v-on:click="assignipchange($event.target.checked)">\
+        <label for="checkbox">Assign Public IP</label>\
+    </div></div>',
+    props: ['label', 'title', 'selectoptions', 'showhelp', 'assignpublicip', 'subnettype'],
     data: function () {
         return {
             groupStyle: this.showhelp ? 'input-group' : ''
@@ -344,8 +352,9 @@ Vue.component("placements-select", {
         },
         assignipchange: function (value) {
             this.$emit('assignpublicipclick', value)
+        },
+        filterclick: function(value) {
+            this.$emit('subnetfilterclick', value)
         }
     }
 });
-
-

--- a/deploy-board/deploy_board/static/js/components/sharedcomponents.js
+++ b/deploy-board/deploy_board/static/js/components/sharedcomponents.js
@@ -1,6 +1,6 @@
 /**
- * Common Components 
- *  
+ * Common Components
+ *
  */
 
 
@@ -251,8 +251,6 @@ Vue.component("panel-heading", {
   }
 });
 
-
-
 /**
  * A form table
  */
@@ -264,3 +262,16 @@ Vue.component("help-table", {
     </tr></tbody></table></div></div>',
   props: ['headers', 'data', 'keys']
 })
+
+/**
+ * A form inline warning
+ */
+ Vue.component("form-warning", {
+    template:'<div class="form-group"><div class="col-xs-2"></div>\
+    <div class="col-xs-10">\
+        <div class="alert alert-warning">\
+            <button v-if="dismissible" type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>\
+            <strong>Warning!</strong> {{ warningtext }}</div>\
+    </div></div>',
+    props: ['dismissible', 'warningtext']
+  })

--- a/deploy-board/deploy_board/static/js/deploy-board.js
+++ b/deploy-board/deploy_board/static/js/deploy-board.js
@@ -152,17 +152,17 @@ function getDefaultPlacement(capacityCreationInfo) {
             }
             return foundIdx >= 0 && foundIdx < 3
         },
-        getSimpleList: function (assignPublicIp, existingItems) {
+        getSimpleList: function (showPublicOnly, existingItems) {
             //Return a simple list fo selection.
             //Simple list is grouped by the abstract_name,
             //for each abstract_name, we have one candidate.
             //If existingItems is null or empty, the abstract_name
             //will be the existing one
-            if (typeof assignPublicIp !== "boolean") {
+            if (typeof showPublicOnly !== "boolean") {
                 console.error("getSimpleList expects parameter showPublicOnly to be of boolean type.")
             }
-            var arr = assignPublicIp ? this.cmpPublic : this.cmpPrivate
-            var fullArr = assignPublicIp ? this.allPublic : this.allPrivate
+            var arr = showPublicOnly ? this.cmpPublic : this.cmpPrivate
+            var fullArr = showPublicOnly ? this.allPublic : this.allPrivate
             if (existingItems != null && existingItems.length > 0) {
 
                 existingItems = existingItems.map(function (item) {

--- a/deploy-board/deploy_board/static/js/deploy-board.js
+++ b/deploy-board/deploy_board/static/js/deploy-board.js
@@ -206,8 +206,11 @@ function getDefaultPlacement(capacityCreationInfo) {
             return arr;
 
         },
-        getFullList: function (assignPublicIp, existingItems) {
-            var arr = assignPublicIp == 'true' ? this.allPublic : this.allPrivate
+        getFullList: function (showPublicOnly, existingItems) {
+            if (typeof showPublicOnly !== "boolean") {
+                console.error("getFullList expects parameter assignPublicIp to be of boolean type.")
+            }
+            var arr = showPublicOnly ? this.allPublic : this.allPrivate
             if (existingItems != null && existingItems.length > 0) {
                 existingItems = existingItems.map(function (item) {
                     var fullInfo = arr.find(

--- a/deploy-board/deploy_board/static/js/deploy-board.js
+++ b/deploy-board/deploy_board/static/js/deploy-board.js
@@ -158,7 +158,10 @@ function getDefaultPlacement(capacityCreationInfo) {
             //for each abstract_name, we have one candidate.
             //If existingItems is null or empty, the abstract_name
             //will be the existing one
-            var arr = assignPublicIp == 'true' ? this.cmpPublic : this.cmpPrivate
+            if (typeof assignPublicIp !== "boolean") {
+                console.error("getSimpleList expects parameter showPublicOnly to be of boolean type.")
+            }
+            var arr = assignPublicIp ? this.cmpPublic : this.cmpPrivate
             var fullArr = assignPublicIp ? this.allPublic : this.allPrivate
             if (existingItems != null && existingItems.length > 0) {
 
@@ -208,7 +211,7 @@ function getDefaultPlacement(capacityCreationInfo) {
         },
         getFullList: function (showPublicOnly, existingItems) {
             if (typeof showPublicOnly !== "boolean") {
-                console.error("getFullList expects parameter assignPublicIp to be of boolean type.")
+                console.error("getFullList expects parameter showPublicOnly to be of boolean type.")
             }
             var arr = showPublicOnly ? this.allPublic : this.allPrivate
             if (existingItems != null && existingItems.length > 0) {

--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -64,7 +64,7 @@
                     <label-select label="Security Zone" title="Security zone to control inbound/outboud traffic" v-model="selectedSecurityZoneValue" v-bind:selectoptions="securityZones"
                     showhelp="true" v-on:helpclick="securityZoneHelpClick"></label-select>
                     <securityzone-help v-show="showSecurityZoneHelp" v-bind:data="securityZoneHelpData"></securityzone-help>
-                    <placements-select label="Placements" title="Placements" v-bind:selectoptions="placements" v-bind:assignpublicip="assignPublicIP" v-bind:subnettype="subnetType"
+                    <placements-select label="Placements" title="Placements" showsubnettype="true" v-bind:selectoptions="placements" v-bind:assignpublicip="assignPublicIP" v-bind:subnettype="subnetType"
                     showhelp="true" v-on:helpclick="placementsHelpClick" v-on:assignpublicipclick="selectpublicip" v-on:subnetfilterclick="changeSubnetType"></placements-select>
                     <placements-help v-show="showPlacementsHelp" v-bind:data="placementsHelpData"></placements-help>
                     <div v-if="inAdvanced">

--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -66,6 +66,7 @@
                     <securityzone-help v-show="showSecurityZoneHelp" v-bind:data="securityZoneHelpData"></securityzone-help>
                     <placements-select label="Placements" title="Placements" showsubnettype="true" v-bind:selectoptions="placements" v-bind:assignpublicip="assignPublicIP" v-bind:subnettype="subnetType"
                     showhelp="true" v-on:helpclick="placementsHelpClick" v-on:assignpublicipclick="selectpublicip" v-on:subnetfilterclick="changeSubnetType"></placements-select>
+                    <form-warning v-show="showSubnetReplacementAlert" v-bind:warningtext="subnetReplacementWarning"></form-warning>
                     <placements-help v-show="showPlacementsHelp" v-bind:data="placementsHelpData"></placements-help>
                     <div v-if="inAdvanced">
                         <div class="form-group"></div>
@@ -417,7 +418,7 @@
         var currentPlacements = currentCluster.placement.split(',');
         var placements = getDefaultPlacement(info);
         var showReplaceAlert = currentCluster != null && currentCluster.state != "NORMAL";
-        var assignPublicIP = currentCluster.configs.assign_public_ip === "true" ;
+        var initialAssignPublicIP = currentCluster.configs.assign_public_ip === "true" ;
         var alert = new Vue({
             el: "#clusterAlert",
             data: {
@@ -445,7 +446,7 @@
                                 readonly: info.readonlyFields.indexOf(key) >= 0
                             }
                         }).filter(function(item){return item.name!='assign_public_ip'}),
-                assignPublicIP: assignPublicIP,
+                assignPublicIP: initialAssignPublicIP,
                 awsRole: currentCluster.configs.aws_role,
                 baseimages: info.baseImages.map(function(o) {
                     var acceptance = o.acceptance ? ' [' + o.acceptance + ']' : '';
@@ -477,8 +478,8 @@
                 }),
                 inAdvanced: false,
                 placements: this.inAdvanced ?
-                    placements.getFullList(assignPublicIP, currentPlacements) :
-                    placements.getSimpleList(assignPublicIP, currentPlacements),
+                    placements.getFullList(initialAssignPublicIP, currentPlacements) :
+                    placements.getSimpleList(initialAssignPublicIP, currentPlacements),
                 providers: info.providerList.map(function(o) {
                     return {
                         value: o,
@@ -513,7 +514,9 @@
                 placementsHelpData: [],
                 canSaveCapacity: !showReplaceAlert,
                 showCmpGroup: Boolean(getUrlParameter("showcmpgroup")),
-                subnetType: assignPublicIP ? "public" : "private",
+                subnetType: initialAssignPublicIP ? "public" : "private",
+                showSubnetReplacementAlert: false,
+                subnetReplacementWarning: "Cluster can't have a mix of public and private subnets. Saving this config will remove existing subnets.",
             }),
             methods: {
                 addConfig: function(config) {
@@ -856,6 +859,7 @@
                     this.subnetType = value
                     var showPublicSubnets = value == 'public' ? true : false
                     this.assignPublicIP = showPublicSubnets
+                    this.showSubnetReplacementAlert = initialAssignPublicIP != showPublicSubnets
                     if (this.inAdvanced){
                         this.placements = placements.getFullList(showPublicSubnets, this.selectedPlacements)
                     }

--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -21,7 +21,7 @@
 <script type="text/javascript" src="//cdn.jsdelivr.net/chartist.js/latest/chartist.min.js"></script>
 <script type="text/javascript" src="{% static "js/components/sharedcomponents.js"%}?changedate=2016.12.19.150000"></script>
 <script type="text/javascript" src="{% static "js/components/capacitycomponents.js"%}?changedate=2017.07.05.180000"></script>
-<script type="text/javascript" src="{% static "js/components/clusterconfigcomponents.js"%}?changedate=2022.03.17.153000"></script>
+<script type="text/javascript" src="{% static "js/components/clusterconfigcomponents.js"%}?changedate=2018.05.17.153000"></script>
 
 <div class="panel panel-default" id="side-panel">
     <div class="panel-heading clearfix">
@@ -846,7 +846,7 @@
                         !this.assignPublicIP && this.subnetType == 'public') {
                         globalNotificationBanner.error =
                             `Warning: You ${this.assignPublicIP ? 'selected' :'unselected'} 'Assign Public IP' for ${this.subnetType} subnet type. ` +
-                            `Please double check if this is desiered. If you DO require this configuration, please report your scenario to the CDP team.`
+                            `Please double check if this is desired. If you DO require this configuration, please report your scenario to #teletraan on Slack.`
                     }
                 },
                 changeSubnetType: function(value) {

--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -512,7 +512,7 @@
                 placementsHelpData: [],
                 canSaveCapacity: !showReplaceAlert,
                 showCmpGroup: Boolean(getUrlParameter("showcmpgroup")),
-                subnetType: assignPublicIP,
+                subnetType: assignPublicIP ? "public" : "private",
             }),
             methods: {
                 addConfig: function(config) {

--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -857,10 +857,10 @@
                     var showPublicSubnets = value == 'public' ? true : false
                     this.assignPublicIP = showPublicSubnets
                     if (this.inAdvanced){
-                        this.placements = placements.getFullList(showPublicSubnets, currentPlacements)
+                        this.placements = placements.getFullList(showPublicSubnets, this.selectedPlacements)
                     }
                     else{
-                        this.placements = placements.getSimpleList(showPublicSubnets, currentPlacements)
+                        this.placements = placements.getSimpleList(showPublicSubnets, this.selectedPlacements)
                     }
                 },
                 updateAwsRole:function(value){

--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -846,7 +846,7 @@
                         !this.assignPublicIP && this.subnetType == 'public') {
                         globalNotificationBanner.error =
                             `Warning: You ${this.assignPublicIP ? 'selected' :'unselected'} 'Assign Public IP' for ${this.subnetType} subnet type. ` +
-                            `Please double check if this is desired. If you DO require this configuration, please report your scenario to #teletraan on Slack.`
+                            `Please double check if this is desired. If you DO require this configuration, please report your scenario to the Teletraan team.`
                     }
                 },
                 changeSubnetType: function(value) {

--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -417,6 +417,7 @@
         var currentPlacements = currentCluster.placement.split(',');
         var placements = getDefaultPlacement(info);
         var showReplaceAlert = currentCluster != null && currentCluster.state != "NORMAL";
+        var assignPublicIP = currentCluster.configs.assign_public_ip === "true" ;
         var alert = new Vue({
             el: "#clusterAlert",
             data: {
@@ -444,7 +445,7 @@
                                 readonly: info.readonlyFields.indexOf(key) >= 0
                             }
                         }).filter(function(item){return item.name!='assign_public_ip'}),
-                assignPublicIP: currentCluster.configs.assign_public_ip == "true" ? true : false,
+                assignPublicIP: assignPublicIP,
                 awsRole: currentCluster.configs.aws_role,
                 baseimages: info.baseImages.map(function(o) {
                     var acceptance = o.acceptance ? ' [' + o.acceptance + ']' : '';
@@ -476,8 +477,8 @@
                 }),
                 inAdvanced: false,
                 placements: this.inAdvanced ?
-                    placements.getFullList(currentCluster.configs.assign_public_ip, currentPlacements) :
-                    placements.getSimpleList(currentCluster.configs.assign_public_ip, currentPlacements),
+                    placements.getFullList(assignPublicIP, currentPlacements) :
+                    placements.getSimpleList(assignPublicIP, currentPlacements),
                 providers: info.providerList.map(function(o) {
                     return {
                         value: o,

--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -21,7 +21,7 @@
 <script type="text/javascript" src="//cdn.jsdelivr.net/chartist.js/latest/chartist.min.js"></script>
 <script type="text/javascript" src="{% static "js/components/sharedcomponents.js"%}?changedate=2016.12.19.150000"></script>
 <script type="text/javascript" src="{% static "js/components/capacitycomponents.js"%}?changedate=2017.07.05.180000"></script>
-<script type="text/javascript" src="{% static "js/components/clusterconfigcomponents.js"%}?changedate=2018.05.17.153000"></script>
+<script type="text/javascript" src="{% static "js/components/clusterconfigcomponents.js"%}?changedate=2022.03.17.153000"></script>
 
 <div class="panel panel-default" id="side-panel">
     <div class="panel-heading clearfix">
@@ -64,8 +64,8 @@
                     <label-select label="Security Zone" title="Security zone to control inbound/outboud traffic" v-model="selectedSecurityZoneValue" v-bind:selectoptions="securityZones"
                     showhelp="true" v-on:helpclick="securityZoneHelpClick"></label-select>
                     <securityzone-help v-show="showSecurityZoneHelp" v-bind:data="securityZoneHelpData"></securityzone-help>
-                    <placements-select label="Placements" title="Placements" v-bind:selectoptions="placements" v-bind:assignpublicip="assignPublicIP"
-                    showhelp="true" v-on:helpclick="placementsHelpClick" v-on:assignpublicipclick="selectpublicip"></placements-select>
+                    <placements-select label="Placements" title="Placements" v-bind:selectoptions="placements" v-bind:assignpublicip="assignPublicIP" v-bind:subnettype="subnetType"
+                    showhelp="true" v-on:helpclick="placementsHelpClick" v-on:assignpublicipclick="selectpublicip" v-on:subnetfilterclick="changeSubnetType"></placements-select>
                     <placements-help v-show="showPlacementsHelp" v-bind:data="placementsHelpData"></placements-help>
                     <div v-if="inAdvanced">
                         <div class="form-group"></div>
@@ -511,7 +511,8 @@
                 showPlacementsHelp: false,
                 placementsHelpData: [],
                 canSaveCapacity: !showReplaceAlert,
-                showCmpGroup: Boolean(getUrlParameter("showcmpgroup"))
+                showCmpGroup: Boolean(getUrlParameter("showcmpgroup")),
+                subnetType: assignPublicIP,
             }),
             methods: {
                 addConfig: function(config) {
@@ -840,13 +841,23 @@
                 },
                 selectpublicip: function(value){
                     this.assignPublicIP = value
+                    if (this.assignPublicIP && this.subnetType == 'private' ||
+                        !this.assignPublicIP && this.subnetType == 'public') {
+                        globalNotificationBanner.error =
+                            `Warning: You ${this.assignPublicIP ? 'selected' :'unselected'} 'Assign Public IP' for ${this.subnetType} subnet type. ` +
+                            `Please double check if this is desiered. If you DO require this configuration, please report your scenario to the CDP team.`
+                    }
+                },
+                changeSubnetType: function(value) {
+                    this.subnetType = value
+                    var showPublicSubnets = value == 'public' ? true : false
+                    this.assignPublicIP = showPublicSubnets
                     if (this.inAdvanced){
-                        this.placements = placements.getFullList(this.assignPublicIP, currentPlacements)
+                        this.placements = placements.getFullList(showPublicSubnets, currentPlacements)
                     }
                     else{
-                        this.placements = placements.getSimpleList(this.assignPublicIP, currentPlacements)
+                        this.placements = placements.getSimpleList(showPublicSubnets, currentPlacements)
                     }
-
                 },
                 updateAwsRole:function(value){
                     this.awsRole = value

--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -848,6 +848,9 @@
                             `Warning: You ${this.assignPublicIP ? 'selected' :'unselected'} 'Assign Public IP' for ${this.subnetType} subnet type. ` +
                             `Please double check if this is desired. If you DO require this configuration, please report your scenario to the Teletraan team.`
                     }
+                    else {
+                        globalNotificationBanner.error = ""
+                    }
                 },
                 changeSubnetType: function(value) {
                     this.subnetType = value


### PR DESCRIPTION
Previously in the UI, 'Assign Public IP' checkbox also determined what type of subnets (public or private) to show in the drop down list. In other words, if 'Assign Public IP' is checked, users are only supposed to choose from a list of public subnets. This guarantee however was broken by a bug `var arr = assignPublicIp == 'true' ? this.allPublic : this.allPrivate`. `assignPublicIp` can be a boolean and thus the expression is always evaluated to false and only private subnets are listed. As a consequence, people are allowed to choose private subnet with public IP and public subnet without public IP. Although we don't think these 2 possible combinations are practical for user scenarios, we still keep them available to minimize the impacts of this change.

Here is a description of existing and changed behaviors:
1. [Existing] During cluster creation, `Assign Public IP` checkbox is bond to the display of private or public subnets. <img width="1275" alt="new_adv" src="https://user-images.githubusercontent.com/8442875/159097877-d116dfd0-3a7a-49db-8c30-e2bb71e35494.png">
2. [Changed] When users try to modify an existing cluster, there are 2 separate controls: (1) A radio button that controls the display of public or private subnets. (2) `Assign Public IP` checkbox remains.
    1. When the page is first loaded, the ratio button's state is determined by the cluster subnet configuration. <img width="1319" alt="config_simple_init" src="https://user-images.githubusercontent.com/8442875/159097965-053eca0b-c917-4167-b52b-a6a764dab99a.png">
    2. When user selects public subnet, only public subnets show up in the drop down menu and `Assign Public IP` is checked. <img width="1319" alt="config_adv_public_drop" src="https://user-images.githubusercontent.com/8442875/159098379-64f14b62-5cf3-41d8-86c5-0068522471f0.png">
    3. When user selects private subnet, only private subnets show up in the drop down menu and `Assign Public IP` is unchecked. <img width="1319" alt="config_adv_private_drop" src="https://user-images.githubusercontent.com/8442875/159098429-4ff60173-cabe-42a4-8ee7-aeef6e6948c0.png">
    4. When user changes existing subnet type, an inline warning shows. <img width="1241" alt="warning_change_type" src="https://user-images.githubusercontent.com/8442875/159558853-7f5190d7-8f14-46b2-b72b-d48462d02168.png">
    5. When user checks `Assign Public IP` with private subnets or unchecks with public subnets, a banner shows on top of the screen to warn user to double check and ask the user to report their scenario to #teletraan. Note that users are still able to proceed with the warning. <img width="1319" alt="config_adv_warning" src="https://user-images.githubusercontent.com/8442875/159098319-6689a33f-a0cd-4e84-9778-275af266de5b.png">
 