### PR TITLE
Generate new Nimbus id when cloning cluster

### DIFF
--- a/deploy-board/deploy_board/webapp/env_views.py
+++ b/deploy-board/deploy_board/webapp/env_views.py
@@ -818,38 +818,6 @@ class EnvNewDeployView(View):
         common.deploy(request, name, stage)
         return redirect('/env/%s/%s/deploy' % (name, stage))
 
-def create_identifier_for_new_stage(request, env_name, stage_name):
-    """ Create a Nimbus Identifier for the new stage. Assumes that the environment has at least one stage with externalId set.
-        This is needed so that the method knows which project to associate the new stage to.
-
-        If the environment has no stage with externalId set, this method will not attempt to create an Identifier.
-    """
-
-    # get all stages within this environment
-    all_env_stages = environs_helper.get_all_env_stages(request, env_name)
-    stage_with_external_id = None
-
-    # find a stage in this environment that has externalId set
-    for env_stage in all_env_stages:
-        if env_stage['externalId'] is not None:
-            stage_with_external_id = env_stage
-            break
-
-    if stage_with_external_id == None:
-        return None
-
-    # retrieve Nimbus identifier for existing_stage
-    existing_stage_identifier = environs_helper.get_nimbus_identifier(request, stage_with_external_id['externalId'])
-    # create Nimbus Identifier for the new stage
-    new_stage_identifier = None
-    if existing_stage_identifier is not None:
-        nimbus_request_data = existing_stage_identifier.copy()
-        nimbus_request_data['stage_name'] = stage_name
-        nimbus_request_data['env_name'] = env_name
-        new_stage_identifier = environs_helper.create_nimbus_identifier(request, nimbus_request_data)
-
-    return new_stage_identifier
-
 def post_add_stage(request, name):
     """handler for creating a new stage depending on configuration (IS_PINTEREST, from_stage i.e. clone stage). """
     # TODO how to validate stage name
@@ -862,11 +830,8 @@ def post_add_stage(request, name):
     stages, _ = common.get_all_stages(all_envs_stages, None)
     if from_stage and from_stage not in stages:
         raise Exception("Can not clone from non-existing stage!")
-    
-    external_id = None
-    if IS_PINTEREST:
-        identifier = create_identifier_for_new_stage(request, name, stage)
-        external_id = identifier.get('uuid') if not identifier == None else None # if there is no stage in this env with externalId, still create the new stage
+
+    external_id = environs_helper.create_identifier_for_new_stage(request, name, stage)
 
     try:
         if from_stage:
@@ -874,8 +839,7 @@ def post_add_stage(request, name):
         else:
             common.create_simple_stage(request,name, stage, description, external_id)
     except:
-        if IS_PINTEREST:
-            environs_helper.delete_nimbus_identifier(request, external_id)
+        environs_helper.delete_nimbus_identifier(request, external_id)
         raise
 
     return redirect('/env/' + name + '/' + stage + '/config/')


### PR DESCRIPTION
The "Capacity" view in the Teletraan stage has a "clone cluster" button
to clone the stage and cluster.

However, it also clones the nimbus uuid which gets the teletraan stage/nimbus id out of sync.

Instead, generate a new Nimbus uuid for the cloned cluster