### PR TITLE
Added trailing slash to avoid redirect

### DIFF
--- a/deploy-board/deploy_board/webapp/cluster_view.py
+++ b/deploy-board/deploy_board/webapp/cluster_view.py
@@ -290,7 +290,7 @@ def create_base_image(request):
     else:
         base_image_info['basic'] = False
     baseimages_helper.create_base_image(request, base_image_info)
-    return redirect('/clouds/baseimages')
+    return redirect('/clouds/baseimages/')
 
 
 def get_base_images(request):
@@ -416,7 +416,7 @@ def create_host_type(request):
     else:
         host_type_info['basic'] = False
     hosttypes_helper.create_host_type(request, host_type_info)
-    return redirect('/clouds/hosttypes')
+    return redirect('/clouds/hosttypes/')
 
 
 def get_host_types(request):
@@ -477,7 +477,7 @@ def create_security_zone(request):
     else:
         security_zone_info['basic'] = False
     securityzones_helper.create_security_zone(request, security_zone_info)
-    return redirect('/clouds/securityzones')
+    return redirect('/clouds/securityzones/')
 
 
 def get_security_zones(request):
@@ -534,7 +534,7 @@ def create_placement(request):
     else:
         placement_info['basic'] = False
     placements_helper.create_placement(request, placement_info)
-    return redirect('/clouds/placements')
+    return redirect('/clouds/placements/')
 
 
 def get_placements(request):
@@ -765,7 +765,7 @@ def terminate_hosts(request, name, stage):
         hosts_str = post_params['hostIds']
         host_ids = [x.strip() for x in hosts_str.split(',')]
     environ_hosts_helper.stop_service_on_host(request, name, stage, host_ids)
-    return redirect('/env/{}/{}'.format(name, stage))
+    return redirect('/env/{}/{}/'.format(name, stage))
 
 
 def force_terminate_hosts(request, name, stage):
@@ -792,7 +792,7 @@ def force_terminate_hosts(request, name, stage):
             cluster_name = group_name
     clusters_helper.force_terminate_hosts(
         request, cluster_name, host_ids, replace_host)
-    return redirect('/env/{}/{}'.format(name, stage))
+    return redirect('/env/{}/{}/'.format(name, stage))
 
 
 def enable_cluster_replacement(request, name, stage):

--- a/deploy-board/deploy_board/webapp/env_views.py
+++ b/deploy-board/deploy_board/webapp/env_views.py
@@ -816,7 +816,7 @@ class EnvNewDeployView(View):
 
     def post(self, request, name, stage):
         common.deploy(request, name, stage)
-        return redirect('/env/%s/%s/deploy' % (name, stage))
+        return redirect('/env/%s/%s/deploy/' % (name, stage))
 
 def post_add_stage(request, name):
     """handler for creating a new stage depending on configuration (IS_PINTEREST, from_stage i.e. clone stage). """
@@ -977,17 +977,17 @@ def promote_to(request, name, stage, deploy_id):
     for toStage in toStages.split(','):
         deploys_helper.promote(request, name, toStage, deploy_id, description)
 
-    return redirect('/env/%s/%s/deploy' % (name, toStage))
+    return redirect('/env/%s/%s/deploy/' % (name, toStage))
 
 
 def restart(request, name, stage):
     common.restart(request, name, stage)
-    return redirect('/env/%s/%s/deploy' % (name, stage))
+    return redirect('/env/%s/%s/deploy/' % (name, stage))
 
 
 def rollback_to(request, name, stage, deploy_id):
     common.rollback_to(request, name, stage, deploy_id)
-    return redirect('/env/%s/%s/deploy' % (name, stage))
+    return redirect('/env/%s/%s/deploy/' % (name, stage))
 
 
 def rollback(request, name, stage):
@@ -1085,26 +1085,26 @@ def promote(request, name, stage, deploy_id):
 
 def pause(request, name, stage):
     deploys_helper.pause(request, name, stage)
-    return redirect('/env/%s/%s/deploy' % (name, stage))
+    return redirect('/env/%s/%s/deploy/' % (name, stage))
 
 
 def resume(request, name, stage):
     deploys_helper.resume(request, name, stage)
-    return redirect('/env/%s/%s/deploy' % (name, stage))
+    return redirect('/env/%s/%s/deploy/' % (name, stage))
 
 
 def enable_env_change(request, name, stage):
     params = request.POST
     description = params.get('description')
     environs_helper.enable_env_changes(request, name, stage, description)
-    return redirect('/env/%s/%s/deploy' % (name, stage))
+    return redirect('/env/%s/%s/deploy/' % (name, stage))
 
 
 def disable_env_change(request, name, stage):
     params = request.POST
     description = params.get('description')
     environs_helper.disable_env_changes(request, name, stage, description)
-    return redirect('/env/%s/%s/deploy' % (name, stage))
+    return redirect('/env/%s/%s/deploy/' % (name, stage))
 
 
 def enable_all_env_change(request):
@@ -1219,7 +1219,7 @@ def reset_hosts(request, name, stage):
         hosts_str = post_params['hostIds']
         host_ids = [x.strip() for x in hosts_str.split(',')]
     environs_helper.reset_hosts(request, name, stage, host_ids)
-    return redirect('/env/{}/{}/hosts'.format(name, stage))
+    return redirect('/env/{}/{}/hosts/'.format(name, stage))
 
 
 # get total unknown(unreachable) hosts
@@ -1659,7 +1659,7 @@ def add_instance(request, name, stage):
     except:
         log.error(traceback.format_exc())
         raise
-    return redirect('/env/{}/{}/deploy'.format(name, stage))
+    return redirect('/env/{}/{}/deploy/'.format(name, stage))
 
 
 def get_tag_message(request):

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -278,12 +278,12 @@ def gen_asg_setting(request, group_name):
 
 def disable_asg(request, group_name):
     autoscaling_groups_helper.disable_autoscaling(request, group_name)
-    return redirect('/groups/{}'.format(group_name))
+    return redirect('/groups/{}/'.format(group_name))
 
 
 def resume_asg(request, group_name):
     autoscaling_groups_helper.enable_autoscaling(request, group_name)
-    return redirect('/groups/{}'.format(group_name))
+    return redirect('/groups/{}/'.format(group_name))
 
 
 def create_asg(request, group_name):
@@ -1089,7 +1089,7 @@ def add_instance(request, group_name):
         log.error(traceback.format_exc())
         raise
 
-    return redirect('/groups/{}'.format(group_name))
+    return redirect('/groups/{}/'.format(group_name))
 
 
 # Terminate all instances
@@ -1127,7 +1127,7 @@ def terminate_all_hosts(request, group_name):
         log.error(traceback.format_exc())
         raise
 
-    return redirect('/groups/{}'.format(group_name))
+    return redirect('/groups/{}/'.format(group_name))
 
 
 def instance_action_in_asg(request, group_name):
@@ -1140,7 +1140,7 @@ def instance_action_in_asg(request, group_name):
     except:
         log.error(traceback.format_exc())
         raise
-    return redirect('/groups/{}'.format(group_name))
+    return redirect('/groups/{}/'.format(group_name))
 
 
 def attach_instances(request, group_name):
@@ -1215,17 +1215,17 @@ def create_manually_health_check(request, group_name):
     health_check_info["group_name"] = group_name
     health_check_info["type"] = "MANUALLY_TRIGGERED"
     autoscaling_groups_helper.create_health_check(request, group_name, health_check_info)
-    return redirect('/groups/{}/health_check_activities'.format(group_name))
+    return redirect('/groups/{}/health_check_activities/'.format(group_name))
 
 
 def enable_scaling_down_event(request, group_name):
     autoscaling_groups_helper.enable_autoscaling(request, group_name)
-    return redirect('/groups/{}'.format(group_name))
+    return redirect('/groups/{}/'.format(group_name))
 
 
 def disable_scaling_down_event(request, group_name):
     autoscaling_groups_helper.disable_scaling_down_event(request, group_name)
-    return redirect('/groups/{}'.format(group_name))
+    return redirect('/groups/{}/'.format(group_name))
 
 
 def add_scheduled_actions(request, group_name):

--- a/deploy-board/deploy_board/webapp/host_tags_views.py
+++ b/deploy-board/deploy_board/webapp/host_tags_views.py
@@ -56,10 +56,10 @@ def add_constraint(request, name, stage):
             'maxParallel': max_parallel,
             'constraintType': constraint_type
         })
-        return redirect('/env/{}/{}/constraint'.format(name, stage))
+        return redirect('/env/{}/{}/constraint/'.format(name, stage))
     except Exception as e:
         log.error("add constraint failed with {}", e)
-        return redirect('/env/{}/{}/constraint'.format(name, stage))
+        return redirect('/env/{}/{}/constraint/'.format(name, stage))
 
 
 def edit_constraint(request, name, stage):
@@ -74,7 +74,7 @@ def edit_constraint(request, name, stage):
             'maxParallel': max_parallel,
             'constraintType': constraint_type
         })
-        return redirect('/env/{}/{}/constraint'.format(name, stage))
+        return redirect('/env/{}/{}/constraint/'.format(name, stage))
     except Exception as e:
         log.error("get constraint failed with {}", e)
         return HttpResponse(json.dumps({'html': 'Failed to get deploy constraint.'}), status=500,
@@ -87,10 +87,10 @@ def remove_constraint(request, name, stage):
         tag_name = deploy_constraint.get('constraintKey')
         environ_hosts_helper.remove_deploy_constraint(request, name, stage)
         environ_hosts_helper.remove_host_tags(request, name, stage, tag_name)
-        return redirect('/env/{}/{}/constraint'.format(name, stage))
+        return redirect('/env/{}/{}/constraint/'.format(name, stage))
     except Exception as e:
         log.error("remove constraint failed with {}", e)
-        return redirect('/env/{}/{}/constraint'.format(name, stage))
+        return redirect('/env/{}/{}/constraint/'.format(name, stage))
 
 
 def get_constraint(request, name, stage):


### PR DESCRIPTION
Teletraan defines URLs with trailing slash (i.e. `url(r'^clouds/get_base_images/$', cluster_view.get_base_images_by_name),
`). When the URL doesn't contain the trailing slash, it's automatically redirected to the one with the trailing slash. Adding them avoids unnecessary redirects. 