### PR TITLE
Added the necessary option to allow Django Messages framework

### DIFF
--- a/deploy-board/deploy_board/settings.py
+++ b/deploy-board/deploy_board/settings.py
@@ -40,6 +40,7 @@ TEMPLATES = [
         'OPTIONS': {
             'context_processors': [
                 'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
             ],
         },
     },


### PR DESCRIPTION
PR #634 omitted this setting and thus Messages stopped working.
Per [Django documentation](https://docs.djangoproject.com/en/4.0/ref/contrib/messages/), the following is required to enable the Messages framework
> The 'context_processors' option of the DjangoTemplates backend defined in your [TEMPLATES](https://docs.djangoproject.com/en/4.0/ref/settings/#std-setting-TEMPLATES) setting contains 'django.contrib.messages.context_processors.messages'.

