### PR TITLE
When an existing ASG is disabled, still launch is ASG by increasing the capacity.

### DIFF
--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -1046,7 +1046,7 @@ def add_instance(request, group_name):
                 use_placement_group = True
 
         # When a group has an associated ASG, its status is either ENABLED or DISABLED.
-        # We should always launch in ASG when there is an ASG setup regardless its status
+        # We should always launch in ASG when an ASG is set up regardless its status,
         # unless placement group is specified
         if (asg_status == "ENABLED" or asg_status == "DISABLED") and not use_placement_group:
             launch_in_asg = True

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -1032,7 +1032,6 @@ def add_instance(request, group_name):
     subnet = None
     placement_group = None
     asg_status = str(params['asgStatus']).upper()
-    launch_in_asg = False
     use_placement_group = False
 
     try:
@@ -1049,9 +1048,6 @@ def add_instance(request, group_name):
         # We should always launch in ASG when an ASG is set up regardless its status,
         # unless placement group is specified.
         if (asg_status == 'ENABLED' or asg_status == 'DISABLED') and not use_placement_group:
-            launch_in_asg = True
-
-        if launch_in_asg:
             # Launch hosts inside ASG / Bump ASG size by required instances
             autoscaling_groups_helper.launch_hosts(request, group_name, num, None)
             content = 'Capacity increased by {} for Auto Scaling Group {}. Please go to ' \

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -1048,7 +1048,7 @@ def add_instance(request, group_name):
         # When a group has an associated ASG, its status is either ENABLED or DISABLED.
         # We should always launch in ASG when an ASG is set up regardless its status,
         # unless placement group is specified.
-        if (asg_status == "ENABLED" or asg_status == "DISABLED") and not use_placement_group:
+        if (asg_status == 'ENABLED' or asg_status == 'DISABLED') and not use_placement_group:
             launch_in_asg = True
 
         if launch_in_asg:

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -1047,7 +1047,7 @@ def add_instance(request, group_name):
 
         # When a group has an associated ASG, its status is either ENABLED or DISABLED.
         # We should always launch in ASG when an ASG is set up regardless its status,
-        # unless placement group is specified
+        # unless placement group is specified.
         if (asg_status == "ENABLED" or asg_status == "DISABLED") and not use_placement_group:
             launch_in_asg = True
 
@@ -1057,6 +1057,8 @@ def add_instance(request, group_name):
             content = 'Capacity increased by {} for Auto Scaling Group {}. Please go to ' \
                       '<a href="/groups/{}/">group page</a> ' \
                       'to check new hosts information.'.format(num, group_name, group_name)
+            if 'customSubnet' in params:
+                content += '\nNote: the subnet {} you selected was ignored.'.format(subnet)
             messages.add_message(request, messages.SUCCESS, content)
         else:
             # Launch hosts outside ASG / static hosts

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -1046,7 +1046,8 @@ def add_instance(request, group_name):
                 use_placement_group = True
 
         # When a group has an associated ASG, its status is either ENABLED or DISABLED.
-        # We should always launch in ASG unless placement group is specified
+        # We should always launch in ASG when there is an ASG setup regardless its status
+        # unless placement group is specified
         if (asg_status == "ENABLED" or asg_status == "DISABLED") and not use_placement_group:
             launch_in_asg = True
 


### PR DESCRIPTION
After users disabled auto scaling, they still have the need to increase the capacity manually via “Launch Instance”. Therefore Teletraan should increase the ASG size like the ASG is still enabled. 

When clusters have associated ASGs, the only way to launch outside the ASG is to specify a subnet and a placement group. 