### PR TITLE
Added inline form warning when users try to over-resize ASGs

### DIFF
--- a/deploy-board/deploy_board/static/js/components/capacitycomponents.js
+++ b/deploy-board/deploy_board/static/js/components/capacitycomponents.js
@@ -216,8 +216,8 @@ Vue.component("static-capacity-config", {
             Capacity
         </label>
         <div class="col-xs-2" >
-            <input name='"capacity" class="form-control" type="number" min="0" required
-                v-model="capacity" @keydown.enter.prevent="">
+            <input name="capacity" class="form-control" type="number" min="0" required
+                :value="capacity" @input="onCapacityChange($event.target.value)" @keydown.enter.prevent="">
         </div>
     </div>
     <form-error v-show="showSizeError" :alert-text="sizeError"></form-error>
@@ -234,14 +234,12 @@ Vue.component("static-capacity-config", {
             sizeError: '',
         }
     },
-    watch: {
-        capacity: function (value) {
-            this.capacity = Number(capacity);
-            this.validateSize();
-            this.$emit('change', value);
-        },
-    },
     methods: {
+        onCapacityChange: function (value) {
+            this.capacity = Number(value);
+            this.validateSize();
+            this.$emit('change', this.capacity );
+        },
         validateSize: function () {
             const sizeIncrease = this.capacity - this.originalCapacity;
             if (sizeIncrease >= this.remainingCapacity) {
@@ -268,14 +266,14 @@ Vue.component("asg-capacity-config", {
             <div class="input-group">
                 <span class="input-group-addon">Min Size</span>
                 <input name="minSize" class="form-control" type="number" min="0" required
-                    v-model="minSize" @keydown.enter.prevent="" >
+                    :value="minSize" @input="onMinSizeChange($event.target.value)" @keydown.enter.prevent="" >
             </div>
         </div>
         <div :class="inputBootstrapClass">
             <div class="input-group">
                 <span class="input-group-addon">Max Size</span>
                 <input name="maxSize" class="form-control" type="number" min="0" required
-                    v-model="maxSize" @keydown.enter.prevent="">
+                    :value="maxSize" @input="onMaxSizeChange($event.target.value)" @keydown.enter.prevent="">
             </div>
         </div>
     </div>
@@ -314,25 +312,23 @@ Vue.component("asg-capacity-config", {
             sizeWarning: '',
         }
     },
-    watch: {
-        minSize: function (value) {
+    methods: {
+        onMinSizeChange: function (value) {
             this.minSize = Number(value);
             if (this.maxSize < this.minSize) {
                 this.maxSize = this.minSize;
             }
             this.validateSize();
-            this.$emit('minchange', value);
+            this.$emit('min-change', this.minSize);
         },
-        maxSize: function (value) {
+        onMaxSizeChange: function (value) {
             this.maxSize = Number(value);
             if (this.maxSize < this.minSize) {
                 this.minSize = this.maxSize;
             }
             this.validateSize();
-            this.$emit('maxchange', value);
+            this.$emit('max-change', this.maxSize);
         },
-    },
-    methods: {
         validateSize: function() {
             const minIncrease = this.minSize - this.originalMinSize;
             const maxIncrease = this.maxSize - this.originalMaxSize;

--- a/deploy-board/deploy_board/static/js/components/capacitycomponents.js
+++ b/deploy-board/deploy_board/static/js/components/capacitycomponents.js
@@ -205,6 +205,11 @@ function getCapacityAlertMessage(isWarning, remainingCapacity, placements, incre
     }
 }
 
+function calculateImbalanceThreshold(totalIncrease, numPlacements) {
+    // average increase per placement
+    return (totalIncrease / numPlacements).toFixed()
+}
+
 function checkImbalance(placements, threshold) {
     var insufficientPlacements = [];
     var showImbalanceWarning = false;
@@ -265,7 +270,7 @@ Vue.component("static-capacity-config", {
             } else {
                 this.showSizeError = false;
             }
-            this.imbalanceWarning = checkImbalance(this.placements, (sizeIncrease / this.placements.length).toFixed());
+            this.imbalanceWarning = checkImbalance(this.placements, calculateImbalanceThreshold(sizeIncrease, this.placements.length));
             this.showImbalanceWarning = this.imbalanceWarning != '';
         }
     }
@@ -370,7 +375,7 @@ Vue.component("asg-capacity-config", {
                 this.showSizeWarning = false;
             }
 
-            const avgSizeIncreasePerPlacement = ((this.maxSize - this.currentSize) / this.placements.length).toFixed();
+            const avgSizeIncreasePerPlacement = calculateImbalanceThreshold(this.maxSize - this.currentSize, this.placements.length);
             this.imbalanceWarning = checkImbalance(this.placements, avgSizeIncreasePerPlacement);
             this.showImbalanceWarning = this.imbalanceWarning != '';
         },

--- a/deploy-board/deploy_board/static/js/components/capacitycomponents.js
+++ b/deploy-board/deploy_board/static/js/components/capacitycomponents.js
@@ -199,7 +199,7 @@ Vue.component("static-capacity-config", {
         Capacity\
     </label>\
     <div class="col-xs-2" >\
-    <input class="form-control" v-bind:value="capacity" v-on:change="updateValue($event.target.value)" @keydown.enter.prevent=""></input>\
+    <input class="form-control" v-bind:value="capacity" v-on:change="updateValue($event.target.value)" @keydown.enter.prevent="" type="number" min="0"></input>\
     </div></div>',
     props: ['capacity'],
     methods: {
@@ -221,13 +221,13 @@ Vue.component("asg-capacity-config", {
             <div class="col-xs-2">\
                 <div class="input-group" >\
                     <span class="input-group-addon">Min Size</span>\
-                    <input class="form-control" v-bind:value="minsize" v-on:change="updateMinSize($event.target.value)" @keydown.enter.prevent=""></input>\
+                    <input class="form-control" v-bind:value="minsize" v-on:change="updateMinSize($event.target.value)"@keydown.enter.prevent="" type="number" min="0"></input>\
                 </div>\
             </div>\
             <div class="col-xs-2">\
                 <div class="input-group" >\
                     <span class="input-group-addon">Max Size</span>\
-                    <input class="form-control" v-bind:value="maxsize" v-on:change="updateMaxSize($event.target.value)" @keydown.enter.prevent=""></input>\
+                    <input class="form-control" v-bind:value="maxsize" v-on:change="updateMaxSize($event.target.value)" @keydown.enter.prevent="" type="number" min="0"></input>\
                 </div>\
             </div>\
     </div>',

--- a/deploy-board/deploy_board/static/js/components/capacitycomponents.js
+++ b/deploy-board/deploy_board/static/js/components/capacitycomponents.js
@@ -214,24 +214,52 @@ Vue.component("static-capacity-config", {
  * In this case, both min size and max size buttons are shown
  */
 Vue.component("asg-capacity-config", {
-    template: '<div class="form-group">\
-    <label for="capacity" class="deployToolTip control-label col-xs-4" title="Number of hosts for this service">\
-        Capacity\
-    </label>\
-            <div class="col-xs-2">\
-                <div class="input-group" >\
-                    <span class="input-group-addon">Min Size</span>\
-                    <input class="form-control" v-bind:value="minsize" v-on:change="updateMinSize($event.target.value)"@keydown.enter.prevent="" type="number" min="0"></input>\
-                </div>\
-            </div>\
-            <div class="col-xs-2">\
-                <div class="input-group" >\
-                    <span class="input-group-addon">Max Size</span>\
-                    <input class="form-control" v-bind:value="maxsize" v-on:change="updateMaxSize($event.target.value)" @keydown.enter.prevent="" type="number" min="0"></input>\
-                </div>\
-            </div>\
-    </div>',
-    props: ['minsize', 'maxsize'],
+    template: `
+    <div class="form-group">
+        <label for="capacity" data-toggle="tooltip" class="deployToolTip control-label" :class="labelbootstrapclass" :title="labeltext">
+            {{ labeltitle }}
+        </label>
+        <div :class="inputbootstrapclass">
+            <div class="input-group">
+                <span class="input-group-addon">Min Size</span>
+                <input name="minSize" class="form-control" type="number" min="0" required
+                    v-bind:value="minsize" v-on:change="updateMinSize($event.target.value)" @keydown.enter.prevent="" >
+            </div>
+        </div>
+        <div :class="inputbootstrapclass">
+            <div class="input-group">
+                <span class="input-group-addon">Max Size</span>
+                <input name="maxSize" class="form-control" type="number" min="0" required
+                    v-bind:value="maxsize" v-on:change="updateMaxSize($event.target.value)" @keydown.enter.prevent="">
+            </div>
+        </div>
+    </div>`,
+    props: {
+        minsize: {
+            type: Number,
+            default: 0,
+        },
+        maxsize: {
+            type: Number,
+            default: 0,
+        },
+        labelbootstrapclass: {
+            type: String,
+            default: 'col-xs-4',
+        },
+        inputbootstrapclass: {
+            type: String,
+            default: 'col-xs-2',
+        },
+        labeltext: {
+            type: String,
+            default: 'Number of hosts for this service',
+        },
+        labeltitle: {
+            type: String,
+            default: 'Capacity'
+        }
+    },
     methods: {
         updateMinSize: function (value) {
             this.$emit('minchange', value)

--- a/deploy-board/deploy_board/static/js/components/capacitycomponents.js
+++ b/deploy-board/deploy_board/static/js/components/capacitycomponents.js
@@ -196,10 +196,11 @@ function getCapacityAlertMessage(isWarning, remainingCapacity, placements, incre
                    `Current placement(s): ${JSON.stringify(placements, null, 2)}`;
 
     if (isWarning) {
-        return errorMessage + `You shouldn't save this configuration because the cluster/ASG will run into capacity issues. ` +
+        return errorMessage + `You can save this configuration but the cluster/ASG might run into capacity issues in the future. ` +
                 instruction + `Requested size increase: ${increase}\n` + status
     } else {
-        return errorMessage + `You can save this configuration but the cluster/ASG might run into capacity issues in the future. ` +
+        // error
+        return errorMessage + `You shouldn't save this configuration because the cluster/ASG will run into capacity issues. ` +
                 instruction + `Requested size increase: ${increase}\n` + status;
     }
 }
@@ -222,9 +223,9 @@ Vue.component("static-capacity-config", {
     <form-error v-show="showSizeError" :alert-text="sizeError"></form-error>
     </div>`,
     props: {
-        originalCapacity: 0,
-        remainingCapacity: Infinity,
-        placements: {},
+        originalCapacity: Number,
+        remainingCapacity: Number,
+        placements: Object,
     },
     data: function() {
         return {
@@ -282,14 +283,26 @@ Vue.component("asg-capacity-config", {
     <form-error v-show="showSizeError" :alert-text="sizeError"></form-error>
     </div>`,
     props: {
-        labelBootstrapClass: 'col-xs-4',
-        inputBootstrapClass: 'col-xs-2',
-        labelText: 'Number of hosts for this service',
-        labelTitle: 'Capacity',
-        originalMinSize: 0,
-        originalMaxSize: 0,
-        remainingCapacity: Infinity,
-        placements: {},
+        labelBootstrapClass: {
+            type: String,
+            default: 'col-xs-4',
+        },
+        inputBootstrapClass: {
+            type: String,
+            default: 'col-xs-2',
+        },
+        labelText: {
+            type: String,
+            default: 'Number of hosts for this service',
+        },
+        labelTitle: {
+            type: String,
+            default: 'Capacity'
+        },
+        originalMinSize: Number,
+        originalMaxSize: Number,
+        remainingCapacity: Number,
+        placements: Object,
     },
     data: function() {
         return {

--- a/deploy-board/deploy_board/static/js/components/capacitycomponents.js
+++ b/deploy-board/deploy_board/static/js/components/capacitycomponents.js
@@ -193,7 +193,7 @@ function getCapacityAlertMessage(isWarning, remainingCapacity, placements, incre
     const instruction = `You can attach additional placements to the corresponding clutter to increase` +
                         ` total potential capacity at Cluster Configuration -> Advanced Settings.\n`;
     const status = `Combined remaining capacity: ${remainingCapacity}\n` +
-                   `Current placement(s): ${JSON.stringify(placements, null, 2)}`;
+                   `Current placement(s): ${JSON.stringify(placements, ['capacity', 'provider_name', 'abstract_name'], 2)}`;
 
     if (isWarning) {
         return errorMessage + `You can save this configuration but the cluster/ASG might run into capacity issues in the future. ` +

--- a/deploy-board/deploy_board/static/js/components/sharedcomponents.js
+++ b/deploy-board/deploy_board/static/js/components/sharedcomponents.js
@@ -264,27 +264,27 @@ Vue.component("help-table", {
 })
 
 /**
- * A form inline alert
+ * A form inline warning alert
  */
  Vue.component("form-warning", {
     template:'<div class="form-group"><div class="col-xs-2"></div>\
     <div class="col-xs-10">\
         <div class="alert alert-warning" style="white-space: pre-wrap;">\
             <button v-if="dismissible" type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>\
-            <strong>Warning!</strong> {{ warningText }}</div>\
+            <strong>Warning!</strong> {{ alertText }}</div>\
     </div></div>',
-    props: ['dismissible', 'warningText']
+    props: ['dismissible', 'alertText']
   })
 
 /**
- * A form inline error
+ * A form inline error alert
  */
  Vue.component("form-error", {
     template:'<div class="form-group"><div class="col-xs-2"></div>\
     <div class="col-xs-10">\
         <div class="alert alert-danger" style="white-space: pre-wrap;">\
             <button v-if="dismissible" type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>\
-            <strong>Error!</strong> {{ errorText }}</div>\
+            <strong>Error!</strong> {{ alertText }}</div>\
     </div></div>',
-    props: ['dismissible', 'errorText']
+    props: ['dismissible', 'alertText']
   })

--- a/deploy-board/deploy_board/static/js/components/sharedcomponents.js
+++ b/deploy-board/deploy_board/static/js/components/sharedcomponents.js
@@ -264,14 +264,27 @@ Vue.component("help-table", {
 })
 
 /**
- * A form inline warning
+ * A form inline alert
  */
  Vue.component("form-warning", {
     template:'<div class="form-group"><div class="col-xs-2"></div>\
     <div class="col-xs-10">\
         <div class="alert alert-warning" style="white-space: pre-wrap;">\
             <button v-if="dismissible" type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>\
-            <strong>Warning!</strong> {{ warningtext }}</div>\
+            <strong>Warning!</strong> {{ warningText }}</div>\
     </div></div>',
-    props: ['dismissible', 'warningtext']
+    props: ['dismissible', 'warningText']
+  })
+
+/**
+ * A form inline error
+ */
+ Vue.component("form-error", {
+    template:'<div class="form-group"><div class="col-xs-2"></div>\
+    <div class="col-xs-10">\
+        <div class="alert alert-danger" style="white-space: pre-wrap;">\
+            <button v-if="dismissible" type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>\
+            <strong>Error!</strong> {{ errorText }}</div>\
+    </div></div>',
+    props: ['dismissible', 'errorText']
   })

--- a/deploy-board/deploy_board/static/js/components/sharedcomponents.js
+++ b/deploy-board/deploy_board/static/js/components/sharedcomponents.js
@@ -269,7 +269,7 @@ Vue.component("help-table", {
  Vue.component("form-warning", {
     template:'<div class="form-group"><div class="col-xs-2"></div>\
     <div class="col-xs-10">\
-        <div class="alert alert-warning">\
+        <div class="alert alert-warning" style="white-space: pre-wrap;">\
             <button v-if="dismissible" type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>\
             <strong>Warning!</strong> {{ warningtext }}</div>\
     </div></div>',

--- a/deploy-board/deploy_board/static/js/components/sharedcomponents.js
+++ b/deploy-board/deploy_board/static/js/components/sharedcomponents.js
@@ -279,12 +279,12 @@ Vue.component("help-table", {
 /**
  * A form inline error alert
  */
- Vue.component("form-error", {
+ Vue.component("form-danger", {
     template:'<div class="form-group"><div class="col-xs-2"></div>\
     <div class="col-xs-10">\
         <div class="alert alert-danger" style="white-space: pre-wrap;">\
             <button v-if="dismissible" type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>\
-            <strong>Error!</strong> {{ alertText }}</div>\
+            <strong>Danger!</strong> {{ alertText }}</div>\
     </div></div>',
     props: ['dismissible', 'alertText']
   })

--- a/deploy-board/deploy_board/templates/clusters/cluster_capacity.tmpl
+++ b/deploy-board/deploy_board/templates/clusters/cluster_capacity.tmpl
@@ -6,9 +6,17 @@
                 <fieldset id="clusterConfigFieldSetId">
                     <label-info title="Cluster State" name="Cluster State" v-bind:text="clusterstate" v-bind:styleclass="clusterStateStyle"></label-info>
                     <label-info title="Cell" name="Cell" v-bind:text="cell"></label-info>
-                    <static-capacity-config v-if="!autoscalingEnabled" v-bind:capacity="desiredCapacity" v-on:change="updateStatic"></static-capacity-config>
-                    <asg-capacity-config v-if="autoscalingEnabled" v-bind:minsize="minsize" v-bind:maxsize="maxsize" v-on:minchange="updateMin" v-on:maxchange="updateMax"></asg-capacity-config>
-                    <form-warning v-show="showSizeWarning" v-bind:warningtext="sizeWarning"></form-warning>
+                    <static-capacity-config v-if="!autoscalingEnabled"
+                        :original-capacity="desiredCapacity"
+                        :remaining-capacity="remainingCapacity" :placements="placements"
+                        v-on:change="updateStatic">
+                    </static-capacity-config>
+                    <asg-capacity-config v-if="autoscalingEnabled"
+                        :original-min-size="minsize" :original-max-size="maxsize"
+                        :remaining-capacity="remainingCapacity" :placements="placements"
+                        v-on:minchange="updateMin" v-on:maxchange="updateMax">
+                    </asg-capacity-config>
+                    <form-warning v-show="showSizeWarning" v-bind:alert-text="sizeWarning"></form-warning>
                 </fieldset>
             </form>
         </div>
@@ -31,7 +39,6 @@
 
 <script>
     var cluster = info.basic_cluster_info;
-    const placements = info.placements;
     if (cluster!=null){
         var asg_launch_info = cluster.asg_info.launchInfo;
         //Decide if we show one capacity box or min/max size
@@ -42,11 +49,6 @@
                 cluster.capacity = asg_launch_info.minSize
             }
         }
-
-        const originalDesiredCapacity = cluster.capacity
-        const originalMinSize = asg_launch_info.minSize
-        const originalMaxSize = asg_launch_info.maxSize
-        const remainingCapacity = placements != null ?  placements.reduce((s, e) => s + e.capacity, 0) : Infinity
 
         var clusterVue = new Vue({
             el:"#clusterPanelId",
@@ -65,42 +67,22 @@
                 canSaveCapacity: cluster.state === "NORMAL",
                 showSizeWarning: false,
                 sizeWarning: "",
+                remainingCapacity: placements != null ?  placements.reduce((s, e) => s + e.capacity, 0) : Infinity,
+                placements: info.placements,
             },
             methods:{
                 updateStatic: function(value){
                    this.desiredCapacity = Number(value)
-                   this.validateSize(originalDesiredCapacity, this.desiredCapacity)
                 },
                 updateMin:function(value){
                     this.minsize = Number(value)
-                    if (this.maxsize<this.minsize){
-                        this.maxsize = this.minsize
-                    }
-                    this.validateSize(originalMinSize, this.minsize)
                 },
                 updateMax: function(value){
                     this.maxsize = Number(value)
-                    if (this.maxsize<this.minsize){
-                        this.minsize = this.maxsize
-                    }
-                    this.validateSize(originalMinSize, this.maxsize)
                 },
                 clickDialog: function(value){
                     if (value){
                         this.save();
-                    }
-                },
-                validateSize: function(fromSize, toSize) {
-                    if (toSize - fromSize >= remainingCapacity) {
-                        this.sizeWarning = `Insufficient combined remaining capacity in this cluster. ` +
-                            `You can save this configuration but the cluster might run into capacity issues in the future. ` +
-                            `You can attach additional placements to the cluter to increase total potential capacity at Cluter Configuration -> Advanced Settings.\n` +
-                            `Combined remaining capacity: ${remainingCapacity}\n` +
-                            `Requested size increase: ${toSize - fromSize}\n` +
-                            `Current placement(s): ${JSON.stringify(placements, null, 2)}`
-                        this.showSizeWarning = true
-                    } else {
-                        this.showSizeWarning = false
                     }
                 },
                 save:function(){

--- a/deploy-board/deploy_board/templates/clusters/cluster_capacity.tmpl
+++ b/deploy-board/deploy_board/templates/clusters/cluster_capacity.tmpl
@@ -10,7 +10,7 @@
                         :original-capacity="cluster.capacity" @change="desiredCapacity = $event"
                         :remaining-capacity="remainingCapacity" :placements="placements">
                     </static-capacity-config>
-                    <asg-capacity-config v-if="autoscalingEnabled"
+                    <asg-capacity-config v-if="autoscalingEnabled" :current-size="cluster.capacity"
                         :original-min-size="asg_launch_info.minSize" @min-change="minsize = $event"
                         :original-max-size="asg_launch_info.maxSize" @max-change="maxsize = $event"
                         :remaining-capacity="remainingCapacity" :placements="placements">

--- a/deploy-board/deploy_board/templates/clusters/cluster_capacity.tmpl
+++ b/deploy-board/deploy_board/templates/clusters/cluster_capacity.tmpl
@@ -7,14 +7,13 @@
                     <label-info title="Cluster State" name="Cluster State" v-bind:text="clusterstate" v-bind:styleclass="clusterStateStyle"></label-info>
                     <label-info title="Cell" name="Cell" v-bind:text="cell"></label-info>
                     <static-capacity-config v-if="!autoscalingEnabled"
-                        :original-capacity="desiredCapacity"
-                        :remaining-capacity="remainingCapacity" :placements="placements"
-                        v-on:change="updateStatic">
+                        :original-capacity="cluster.capacity" @change="desiredCapacity = $event"
+                        :remaining-capacity="remainingCapacity" :placements="placements">
                     </static-capacity-config>
                     <asg-capacity-config v-if="autoscalingEnabled"
-                        :original-min-size="asg_launch_info.minSize" :original-max-size="asg_launch_info.maxSize"
-                        :remaining-capacity="remainingCapacity" :placements="placements"
-                        v-on:minchange="updateMin" v-on:maxchange="updateMax">
+                        :original-min-size="asg_launch_info.minSize" @min-change="minSize = $event"
+                        :original-max-size="asg_launch_info.maxSize" @max-change="maxSize = $event"
+                        :remaining-capacity="remainingCapacity" :placements="placements">
                     </asg-capacity-config>
                     <form-warning v-show="showSizeWarning" v-bind:alert-text="sizeWarning"></form-warning>
                 </fieldset>
@@ -61,8 +60,8 @@
                 confirmDialogId:"confirmClusterCapacityDialog",
                 desiredCapacity: cluster.capacity,
                 instancetype: cluster.hostType,
-                minsize: asg_launch_info.minSize,
-                maxsize: asg_launch_info.maxSize,
+                minSize: asg_launch_info.minSize,
+                maxSize: asg_launch_info.maxSize,
                 autoscalingEnabled:autoscalingEnabled,
                 canSaveCapacity: cluster.state === "NORMAL",
                 showSizeWarning: false,
@@ -71,15 +70,6 @@
                 placements: info.placements,
             },
             methods:{
-                updateStatic: function(value){
-                   this.desiredCapacity = Number(value)
-                },
-                updateMin:function(value){
-                    this.minsize = Number(value)
-                },
-                updateMax: function(value){
-                    this.maxsize = Number(value)
-                },
                 clickDialog: function(value){
                     if (value){
                         this.save();

--- a/deploy-board/deploy_board/templates/clusters/cluster_capacity.tmpl
+++ b/deploy-board/deploy_board/templates/clusters/cluster_capacity.tmpl
@@ -11,8 +11,8 @@
                         :remaining-capacity="remainingCapacity" :placements="placements">
                     </static-capacity-config>
                     <asg-capacity-config v-if="autoscalingEnabled"
-                        :original-min-size="asg_launch_info.minSize" @min-change="minSize = $event"
-                        :original-max-size="asg_launch_info.maxSize" @max-change="maxSize = $event"
+                        :original-min-size="asg_launch_info.minSize" @min-change="minsize = $event"
+                        :original-max-size="asg_launch_info.maxSize" @max-change="maxsize = $event"
                         :remaining-capacity="remainingCapacity" :placements="placements">
                     </asg-capacity-config>
                     <form-warning v-show="showSizeWarning" v-bind:alert-text="sizeWarning"></form-warning>
@@ -60,8 +60,8 @@
                 confirmDialogId:"confirmClusterCapacityDialog",
                 desiredCapacity: cluster.capacity,
                 instancetype: cluster.hostType,
-                minSize: asg_launch_info.minSize,
-                maxSize: asg_launch_info.maxSize,
+                minsize: asg_launch_info.minSize,
+                maxsize: asg_launch_info.maxSize,
                 autoscalingEnabled:autoscalingEnabled,
                 canSaveCapacity: cluster.state === "NORMAL",
                 showSizeWarning: false,

--- a/deploy-board/deploy_board/templates/clusters/cluster_capacity.tmpl
+++ b/deploy-board/deploy_board/templates/clusters/cluster_capacity.tmpl
@@ -127,7 +127,6 @@
                         },
                         success: function (data) {
                             globalNotificationBanner.info = "Capacity updated successfully"
-                            window.location.href='/env/{{ env.envName }}/{{ env.stageName }}/config/capacity/'
                         },
                         error: function (data) {
                             var optionalInstruction = '';

--- a/deploy-board/deploy_board/templates/clusters/cluster_capacity.tmpl
+++ b/deploy-board/deploy_board/templates/clusters/cluster_capacity.tmpl
@@ -12,7 +12,7 @@
                         v-on:change="updateStatic">
                     </static-capacity-config>
                     <asg-capacity-config v-if="autoscalingEnabled"
-                        :original-min-size="minsize" :original-max-size="maxsize"
+                        :original-min-size="asg_launch_info.minSize" :original-max-size="asg_launch_info.maxSize"
                         :remaining-capacity="remainingCapacity" :placements="placements"
                         v-on:minchange="updateMin" v-on:maxchange="updateMax">
                     </asg-capacity-config>
@@ -67,7 +67,7 @@
                 canSaveCapacity: cluster.state === "NORMAL",
                 showSizeWarning: false,
                 sizeWarning: "",
-                remainingCapacity: placements != null ?  placements.reduce((s, e) => s + e.capacity, 0) : Infinity,
+                remainingCapacity: info.placements != null ?  info.placements.reduce((s, e) => s + e.capacity, 0) : Infinity,
                 placements: info.placements,
             },
             methods:{

--- a/deploy-board/deploy_board/templates/clusters/cluster_capacity.tmpl
+++ b/deploy-board/deploy_board/templates/clusters/cluster_capacity.tmpl
@@ -8,6 +8,7 @@
                     <label-info title="Cell" name="Cell" v-bind:text="cell"></label-info>
                     <static-capacity-config v-if="!autoscalingEnabled" v-bind:capacity="desiredCapacity" v-on:change="updateStatic"></static-capacity-config>
                     <asg-capacity-config v-if="autoscalingEnabled" v-bind:minsize="minsize" v-bind:maxsize="maxsize" v-on:minchange="updateMin" v-on:maxchange="updateMax"></asg-capacity-config>
+                    <form-warning v-show="showSizeWarning" v-bind:warningtext="sizeWarning"></form-warning>
                 </fieldset>
             </form>
         </div>
@@ -30,6 +31,7 @@
 
 <script>
     var cluster = info.basic_cluster_info;
+    const placements = info.placements;
     if (cluster!=null){
         var asg_launch_info = cluster.asg_info.launchInfo;
         //Decide if we show one capacity box or min/max size
@@ -40,6 +42,11 @@
                 cluster.capacity = asg_launch_info.minSize
             }
         }
+
+        const originalDesiredCapacity = cluster.capacity
+        const originalMinSize = asg_launch_info.minSize
+        const originalMaxSize = asg_launch_info.maxSize
+        const remainingCapacity = placements != null ?  placements.reduce((s, e) => s + e.capacity, 0) : Infinity
 
         var clusterVue = new Vue({
             el:"#clusterPanelId",
@@ -55,43 +62,57 @@
                 minsize: asg_launch_info.minSize,
                 maxsize: asg_launch_info.maxSize,
                 autoscalingEnabled:autoscalingEnabled,
-                canSaveCapacity: cluster.state === "NORMAL"
+                canSaveCapacity: cluster.state === "NORMAL",
+                showSizeWarning: false,
+                sizeWarning: "",
             },
             methods:{
                 updateStatic: function(value){
                    this.desiredCapacity = Number(value)
+                   this.validateSize(originalDesiredCapacity, this.desiredCapacity)
                 },
                 updateMin:function(value){
                     this.minsize = Number(value)
                     if (this.maxsize<this.minsize){
                         this.maxsize = this.minsize
                     }
+                    this.validateSize(originalMinSize, this.minsize)
                 },
                 updateMax: function(value){
                     this.maxsize = Number(value)
                     if (this.maxsize<this.minsize){
                         this.minsize = this.maxsize
                     }
+                    this.validateSize(originalMinSize, this.maxsize)
                 },
                 clickDialog: function(value){
                     if (value){
                         this.save();
                     }
                 },
+                validateSize: function(fromSize, toSize) {
+                    if (toSize - fromSize >= remainingCapacity) {
+                        this.sizeWarning = `Insufficient combined remaining capacity in this cluster. ` +
+                            `You can save this configuration but the cluster might run into capacity issues in the future. ` +
+                            `You can attach additional placements to the cluter to increase total potential capacity at Cluter Configuration -> Advanced Settings.\n` +
+                            `Combined remaining capacity: ${remainingCapacity}\n` +
+                            `Requested size increase: ${toSize - fromSize}\n` +
+                            `Current placement(s): ${JSON.stringify(placements, null, 2)}`
+                        this.showSizeWarning = true
+                    } else {
+                        this.showSizeWarning = false
+                    }
+                },
                 save:function(){
                     if (!this.autoscalingEnabled){
-                        if (this.desiredCapacity<0){
-                            globalNotificationBanner.error = "Capacity cannot be less than 0"
-                            return
-                        }
                         //Set min and max size directly to group. Right now, cluster itself has no autoscaling info
                         this.minsize = this.desiredCapacity
                         this.maxsize = this.desiredCapacity
                     }
 
-                    if (this.minsize<0 || this.maxsize<0 || this.minsize > this.maxsize){
-                            globalNotificationBanner.error = "Min and Max size cannot be less than 0 and Max size cannot be less than Min size"
-                            return
+                    if (this.minsize > this.maxsize){
+                        globalNotificationBanner.error = "Max size cannot be less than Min size"
+                        return
                     }
 
                     $.ajax({

--- a/deploy-board/deploy_board/templates/clusters/cluster_capacity.tmpl
+++ b/deploy-board/deploy_board/templates/clusters/cluster_capacity.tmpl
@@ -82,11 +82,6 @@
                         this.maxsize = this.desiredCapacity
                     }
 
-                    if (this.minsize > this.maxsize){
-                        globalNotificationBanner.error = "Max size cannot be less than Min size"
-                        return
-                    }
-
                     $.ajax({
                         type: 'POST',
                         url: '/env/{{ env.envName }}/{{ env.stageName }}/config/cluster/capacity/',

--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -66,7 +66,7 @@
                     <securityzone-help v-show="showSecurityZoneHelp" v-bind:data="securityZoneHelpData"></securityzone-help>
                     <placements-select label="Placements" title="Placements" showsubnettype="true" v-bind:selectoptions="placements" v-bind:assignpublicip="assignPublicIP" v-bind:subnettype="subnetType"
                     showhelp="true" v-on:helpclick="placementsHelpClick" v-on:assignpublicipclick="selectpublicip" v-on:subnetfilterclick="changeSubnetType"></placements-select>
-                    <form-warning v-show="showSubnetReplacementAlert" v-bind:warningtext="subnetReplacementWarning"></form-warning>
+                    <form-warning v-show="showSubnetReplacementAlert" v-bind:alert-text="subnetReplacementWarning"></form-warning>
                     <placements-help v-show="showPlacementsHelp" v-bind:data="placementsHelpData"></placements-help>
                     <div v-if="inAdvanced">
                         <div class="form-group"></div>

--- a/deploy-board/deploy_board/templates/groups/asg_config.html
+++ b/deploy-board/deploy_board/templates/groups/asg_config.html
@@ -1,4 +1,5 @@
 {% extends 'environs/env_base.html' %}
+{% load static %}
 {% load utils %}
 
 {% block breadcrumb-items %}
@@ -38,6 +39,8 @@
     </div>
 
     {% if asg_vm_config.asgStatus != "UNKNOWN" %}
+    <script type="text/javascript" src="{% static "js/components/sharedcomponents.js"%}"></script>
+    <script type="text/javascript" src="{% static "js/components/capacitycomponents.js"%}"></script>
     <div id="asgConfigPid" class="panel panel-default">
     {% include "groups/asg_config.tmpl" %}
     </div>

--- a/deploy-board/deploy_board/templates/groups/asg_config.tmpl
+++ b/deploy-board/deploy_board/templates/groups/asg_config.tmpl
@@ -22,64 +22,38 @@
     </div>
 </div>
 <div id="autoscalingConfigId" class="collapse in panel-body">
-<div class="container-fluid">
-    <form id="autoscalingGroupConfigFormId" class="form-horizontal" role="form">
-        <input type="hidden" name="asgStatus" value="{{ asg.status }}" />
-        <input type="hidden" name="groupName" value="{{ group_name }}" />
-        <fieldset id="envConfigFieldSetId">
-            <div class="form-group">
-                <label for="minSize" class="deployToolTip control-label col-xs-2"
-                    data-toggle="tooltip"
-                    title="minimum number of hosts in one autoscaling group">
-                    Min Size (Current size is {{ group_size }})
-                </label>
-                <div class="col-xs-4">
-                    <input class="form-control" name="minSize" required="true" id="minSizeInput"
-                           type="text" value="{{ asg.minSize }}"/>
-                </div>
-
-                <label for="maxSize" class="deployToolTip control-label col-xs-2"
-                    data-toggle="tooltip"
-                    title="maximum number of hosts in one autoscaling group">
-                    Max Size
-                </label>
-                <div class="col-xs-4">
-                    <input class="form-control" name="maxSize" required="true" id="maxSizeInput"
-                           type="text" value="{{ asg.maxSize }}"/>
-                </div>
-            </div>
-
-            <div id="minSizeWarningDivId" class="hidden">
+    <div class="container-fluid">
+        <form id="autoscalingGroupConfigFormId" class="form-horizontal" role="form">
+            <input type="hidden" name="asgStatus" value="{{ asg.status }}">
+            <input type="hidden" name="groupName" value="{{ group_name }}">
+            <fieldset id="envConfigFieldSetId">
+                <asg-capacity-config v-bind:minsize="minsize" v-bind:maxsize="maxsize"
+                    labelbootstrapclass="col-xs-2" inputbootstrapclass="col-xs-4"
+                    labeltitle="Capacity (Current size is {{ group_size }})"
+                    labeltext="Minimun and maximum number of hosts in one autoscaling group"
+                    v-on:minchange="updateMin" v-on:maxchange="updateMax"></asg-capacity-config>
+                <form-warning v-show="showSizeWarning" v-bind:warningtext="sizeWarning"></form-warning>
                 <div class="form-group">
-                    <label class="control-label col-xs-2"></label>
-                    <div class="col-xs-10">
-                    <h4><span class="label label-danger">Minimum size is too low for your group!</span></h4>
+                    <label for="terminationPolicy" class="deployToolTip control-label col-xs-2"
+                            data-toggle="tooltip" title="termination policy">
+                        Termination Policy
+                    </label>
+                    <div class="col-xs-4">
+                        <select class="form-control" name="terminationPolicy" required="true" id="terminationPolicyInput">
+                        {% for policy in terminationPolicies %}
+                            {% if policy == asg.terminationPolicy %}
+                                <option value="{{policy}}" selected>{{policy}}</option>
+                            {% else %}
+                                <option value="{{policy}}">{{policy}}</option>
+                            {% endif %}
+                        {% endfor %}
+                        </select>
                     </div>
                 </div>
-            </div>
-
-            <div class="form-group">
-                <label for="terminationPolicy" class="deployToolTip control-label col-xs-2"
-                  data-toggle="tooltip"
-                  title="termination policy">
-                  Termination Policy
-                </label>
-                <div class="col-xs-4">
-                    <select class="form-control" name="terminationPolicy" required="true" id="terminationPolicyInput">
-                    {% for policy in terminationPolicies %}
-                        {% if policy == asg.terminationPolicy %}
-                            <option value="{{policy}}" selected>{{policy}}</option>
-                        {% else %}
-                            <option value="{{policy}}">{{policy}}</option>
-                        {% endif %}
-                    {% endfor %}
-                    </select>
-                </div>
-            </div>
-        </fieldset>
-      {% csrf_token %}
-       </form>
-</div>
+            </fieldset>
+        {% csrf_token %}
+        </form>
+    </div>
 </div>
 
 
@@ -103,6 +77,61 @@ $(function() {
     $.get('/groups/{{ group_name }}/autoscaling/get_pas_config/', function (response) {
         $('#pasConfigPid').html(response);
     });
+});
+
+{% if placements %}
+const placements = {{ placements | safe }};
+{% else %}
+const placements = null;
+{% endif %}
+const remainingCapacity = placements != null ?  placements.reduce((s, e) => s + e.capacity, 0) : Infinity;
+
+var asgConfigVue = new Vue({
+    el: '#autoscalingConfigId',
+    data: {
+        {% if asg %}
+            minsize: {{ asg.minSize }},
+            maxsize: {{ asg.maxSize }},
+            originalMinSize: {{ asg.minSize }},
+            originalMaxSize: {{ asg.maxSize }},
+        {% else %}
+            minsize: 0,
+            maxsize: 0,
+            originalMinSize: 0,
+            originalMaxSize: 0,
+        {% endif%}
+        showSizeWarning: false,
+        sizeWarning: '',
+    },
+    methods: {
+        updateMin:function(value){
+            this.minsize = Number(value)
+            if (this.maxsize<this.minsize){
+                this.maxsize = this.minsize
+            }
+            this.validateSize(this.originalMinSize, this.minsize)
+        },
+        updateMax: function(value){
+            this.maxsize = Number(value)
+            if (this.maxsize<this.minsize){
+                this.minsize = this.maxsize
+            }
+            this.validateSize(this.originalMinSize, this.maxsize)
+        },
+        validateSize: function(fromSize, toSize) {
+            if (toSize - fromSize >= remainingCapacity) {
+                this.sizeWarning = `Insufficient combined remaining capacity in this cluster. ` +
+                    `You can save this configuration but the cluster might run into capacity issues in the future. ` +
+                    `You can attach additional placements to the cluter to increase total potential capacity at Cluter Configuration -> Advanced Settings.\n` +
+                    `Combined remaining capacity: ${remainingCapacity}\n` +
+                    `Requested size increase: ${toSize - fromSize}\n` +
+                    `Current placement(s): ${JSON.stringify(placements, null, 2)}`
+                this.showSizeWarning = true
+            } else {
+                this.showSizeWarning = false
+            }
+        },
+    }
 });
 
 function loadAsgScheduledActions() {

--- a/deploy-board/deploy_board/templates/groups/asg_config.tmpl
+++ b/deploy-board/deploy_board/templates/groups/asg_config.tmpl
@@ -27,12 +27,14 @@
             <input type="hidden" name="asgStatus" value="{{ asg.status }}">
             <input type="hidden" name="groupName" value="{{ group_name }}">
             <fieldset id="envConfigFieldSetId">
-                <asg-capacity-config v-bind:minsize="minsize" v-bind:maxsize="maxsize"
-                    labelbootstrapclass="col-xs-2" inputbootstrapclass="col-xs-4"
-                    labeltitle="Capacity (Current size is {{ group_size }})"
-                    labeltext="Minimun and maximum number of hosts in one autoscaling group"
-                    v-on:minchange="updateMin" v-on:maxchange="updateMax"></asg-capacity-config>
-                <form-warning v-show="showSizeWarning" v-bind:warningtext="sizeWarning"></form-warning>
+                <asg-capacity-config
+                    original-min-size="{{ asg.minSize }}" original-max-size="{{ asg.maxSize }}"
+                    label-bootstrap-class="col-xs-2" input-bootstrap-class="col-xs-4"
+                    label-title="Capacity (Current size is {{ group_size }})"
+                    label-text="Minimun and maximum number of hosts in one autoscaling group"
+                    :remaining-capacity="remainingCapacity" :placements="placements">
+                </asg-capacity-config>
+
                 <div class="form-group">
                     <label for="terminationPolicy" class="deployToolTip control-label col-xs-2"
                             data-toggle="tooltip" title="termination policy">
@@ -79,58 +81,16 @@ $(function() {
     });
 });
 
-{% if placements %}
-const placements = {{ placements | safe }};
-{% else %}
-const placements = null;
-{% endif %}
-const remainingCapacity = placements != null ?  placements.reduce((s, e) => s + e.capacity, 0) : Infinity;
-
 var asgConfigVue = new Vue({
     el: '#autoscalingConfigId',
     data: {
-        {% if asg %}
-            minsize: {{ asg.minSize }},
-            maxsize: {{ asg.maxSize }},
-            originalMinSize: {{ asg.minSize }},
-            originalMaxSize: {{ asg.maxSize }},
+        {% if placements %}
+        placements: {{ placements | safe }},
+        remainingCapacity: {{placements| safe }}.reduce((s, e) => s + e.capacity, 0),
         {% else %}
-            minsize: 0,
-            maxsize: 0,
-            originalMinSize: 0,
-            originalMaxSize: 0,
-        {% endif%}
-        showSizeWarning: false,
-        sizeWarning: '',
-    },
-    methods: {
-        updateMin:function(value){
-            this.minsize = Number(value)
-            if (this.maxsize<this.minsize){
-                this.maxsize = this.minsize
-            }
-            this.validateSize(this.originalMinSize, this.minsize)
-        },
-        updateMax: function(value){
-            this.maxsize = Number(value)
-            if (this.maxsize<this.minsize){
-                this.minsize = this.maxsize
-            }
-            this.validateSize(this.originalMinSize, this.maxsize)
-        },
-        validateSize: function(fromSize, toSize) {
-            if (toSize - fromSize >= remainingCapacity) {
-                this.sizeWarning = `Insufficient combined remaining capacity in this Auto Scaling Group. ` +
-                    `You can save this configuration but the ASG might run into capacity issues in the future. ` +
-                    `You can attach additional placements to the corresponding cluter to increase total potential capacity at Cluter Configuration -> Advanced Settings.\n` +
-                    `Combined remaining capacity: ${remainingCapacity}\n` +
-                    `Requested size increase: ${toSize - fromSize}\n` +
-                    `Current placement(s): ${JSON.stringify(placements, null, 2)}`
-                this.showSizeWarning = true
-            } else {
-                this.showSizeWarning = false
-            }
-        },
+        placements: {},
+        remainingCapacity: Infinity,
+        {% endif %}
     }
 });
 

--- a/deploy-board/deploy_board/templates/groups/asg_config.tmpl
+++ b/deploy-board/deploy_board/templates/groups/asg_config.tmpl
@@ -28,7 +28,7 @@
             <input type="hidden" name="groupName" value="{{ group_name }}">
             <fieldset id="envConfigFieldSetId">
                 <asg-capacity-config
-                    original-min-size="{{ asg.minSize }}" original-max-size="{{ asg.maxSize }}"
+                    original-min-size="{{ asg.minSize }}" original-max-size="{{ asg.maxSize }}" current-size="{{ group_size }}"
                     label-bootstrap-class="col-xs-2" input-bootstrap-class="col-xs-4"
                     label-title="Capacity (Current size is {{ group_size }})"
                     label-text="Minimun and maximum number of hosts in one autoscaling group"

--- a/deploy-board/deploy_board/templates/groups/asg_config.tmpl
+++ b/deploy-board/deploy_board/templates/groups/asg_config.tmpl
@@ -120,9 +120,9 @@ var asgConfigVue = new Vue({
         },
         validateSize: function(fromSize, toSize) {
             if (toSize - fromSize >= remainingCapacity) {
-                this.sizeWarning = `Insufficient combined remaining capacity in this cluster. ` +
-                    `You can save this configuration but the cluster might run into capacity issues in the future. ` +
-                    `You can attach additional placements to the cluter to increase total potential capacity at Cluter Configuration -> Advanced Settings.\n` +
+                this.sizeWarning = `Insufficient combined remaining capacity in this Auto Scaling Group. ` +
+                    `You can save this configuration but the ASG might run into capacity issues in the future. ` +
+                    `You can attach additional placements to the corresponding cluter to increase total potential capacity at Cluter Configuration -> Advanced Settings.\n` +
                     `Combined remaining capacity: ${remainingCapacity}\n` +
                     `Requested size increase: ${toSize - fromSize}\n` +
                     `Current placement(s): ${JSON.stringify(placements, null, 2)}`

--- a/deploy-board/deploy_board/webapp/capacity_views.py
+++ b/deploy-board/deploy_board/webapp/capacity_views.py
@@ -51,10 +51,10 @@ class EnvCapacityConfigView(View):
                 basic_cluster_info['asg_info'] = asg_cluster
                 basic_cluster_info['base_image_info'] = base_image
                 try:
-                    placements = self.get_placements(
+                    placements = placements_helper.get_simplified_by_ids(
                         request, basic_cluster_info['placement'], basic_cluster_info['provider'], basic_cluster_info['cellName'])
                 except Exception as e:
-                    logger.warning('Failed to get remaining capacity: {}'.format(e))
+                    logger.warning('Failed to get placements: {}'.format(e))
 
             params = request.GET
             if params.get('adv'):
@@ -118,12 +118,3 @@ class EnvCapacityConfigView(View):
                                                 data=groups)
 
         return self.get(request, name, stage)
-
-    def get_placements(self, request, placement_str, provider, cell):
-        current_placement_ids = set(placement_str.split(','))
-        all_placements = placements_helper.get_by_provider_and_cell_name(request, provider, cell)
-        current_placements = filter(lambda p: p['id'] in current_placement_ids, all_placements)
-        return map(lambda p: {'id': p['id'],
-                              'capacity': p['capacity'],
-                              'abstract_name': p['abstract_name'],
-                              'provider_name': p['provider_name']}, current_placements)

--- a/deploy-board/deploy_board/webapp/capacity_views.py
+++ b/deploy-board/deploy_board/webapp/capacity_views.py
@@ -109,12 +109,11 @@ class EnvCapacityConfigView(View):
         logger.info("Post to capacity with data {0}".format(request.body))
         data = json.loads(request.body)
         hosts = data.get('hosts')
-        if hosts is not None:
+        if hosts:
             environs_helper.update_env_capacity(request, name, stage, capacity_type="HOST", data=hosts)
 
         groups = data.get("groups")
-        if groups is not None:
-            environs_helper.update_env_capacity(request, name, stage, capacity_type="GROUP",
-                                                data=groups)
+        if groups:
+            environs_helper.update_env_capacity(request, name, stage, capacity_type="GROUP", data=groups)
 
         return self.get(request, name, stage)

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -24,10 +24,9 @@ import json
 import logging
 import traceback
 
-from helpers import environs_helper, clusters_helper
-from helpers import groups_helper, baseimages_helper
-from helpers import specs_helper, autoscaling_groups_helper
-from helpers import autoscaling_metrics_helper
+from helpers import environs_helper, clusters_helper, groups_helper,\
+    baseimages_helper, specs_helper, autoscaling_groups_helper,\
+    autoscaling_metrics_helper, placements_helper
 from diff_match_patch import diff_match_patch
 from deploy_board import settings
 from helpers.exceptions import TeletraanException
@@ -307,7 +306,15 @@ def get_asg_config(request, group_name):
     policies = autoscaling_groups_helper.TerminationPolicy
     if asg_summary.get("sensitivityRatio", None):
         asg_summary["sensitivityRatio"] *= 100
-    scheduled_actions = autoscaling_groups_helper.get_scheduled_actions(request, group_name)
+
+    placements = None
+    try:
+        basic_cluster_info = clusters_helper.get_cluster(request, group_name)
+        if basic_cluster_info:
+            placements = placements_helper.get_simplified_by_ids(
+                request, basic_cluster_info['placement'], basic_cluster_info['provider'], basic_cluster_info['cellName'])
+    except Exception as e:
+        log.warning('Failed to get placements: {}'.format(e))
     content = render_to_string("groups/asg_config.tmpl", {
         "group_name": group_name,
         "asg": asg_summary,
@@ -316,6 +323,7 @@ def get_asg_config(request, group_name):
         "instanceType": launch_config.get("instanceType"),
         "csrf_token": get_token(request),
         "pas_config": pas_config,
+        "placements": json.dumps(placements),
     })
     return HttpResponse(json.dumps(content), content_type="application/json")
 

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -24,9 +24,8 @@ import json
 import logging
 import traceback
 
-from helpers import environs_helper, clusters_helper, groups_helper,\
-    baseimages_helper, specs_helper, autoscaling_groups_helper,\
-    autoscaling_metrics_helper, placements_helper
+from helpers import (environs_helper, clusters_helper, groups_helper, baseimages_helper,
+                     specs_helper, autoscaling_groups_helper, autoscaling_metrics_helper, placements_helper)
 from diff_match_patch import diff_match_patch
 from deploy_board import settings
 from helpers.exceptions import TeletraanException

--- a/deploy-board/deploy_board/webapp/helpers/placements_helper.py
+++ b/deploy-board/deploy_board/webapp/helpers/placements_helper.py
@@ -36,3 +36,13 @@ def get_by_provider_and_cell_name(request, provider, cell_name):
 
 def get_by_id(request, placement_id):
     return rodimus_client.get("/placements/%s" % placement_id, request.teletraan_user_id.token)
+
+
+def get_simplified_by_ids(request, placement_str, provider, cell):
+    current_placement_ids = set(placement_str.split(','))
+    all_placements = get_by_provider_and_cell_name(request, provider, cell)
+    current_placements = filter(lambda p: p['id'] in current_placement_ids, all_placements)
+    return map(lambda p: {'id': p['id'],
+                          'capacity': p['capacity'],
+                          'abstract_name': p['abstract_name'],
+                          'provider_name': p['provider_name']}, current_placements)

--- a/deploy-board/deploy_board/webapp/helpers/placements_helper.py
+++ b/deploy-board/deploy_board/webapp/helpers/placements_helper.py
@@ -41,8 +41,5 @@ def get_by_id(request, placement_id):
 def get_simplified_by_ids(request, placement_str, provider, cell):
     current_placement_ids = set(placement_str.split(','))
     all_placements = get_by_provider_and_cell_name(request, provider, cell)
-    current_placements = filter(lambda p: p['id'] in current_placement_ids, all_placements)
-    return map(lambda p: {'id': p['id'],
-                          'capacity': p['capacity'],
-                          'abstract_name': p['abstract_name'],
-                          'provider_name': p['provider_name']}, current_placements)
+    return [{k: placement[k] for k in placement if k in ['id', 'capacity', 'abstract_name', 'provider_name']}
+            for placement in all_placements if placement['id'] in current_placement_ids]


### PR DESCRIPTION
Added inline form warning when users try to over-resize ASGs. Specifically, 
1. Unified env view and group view min/max size UI components by extending `asg-capacity-config`. 
2. Updated `asg-capacity-config` and `static-capacity-config` to support displaying inline form warning and error.
3. Extended `EnvCapacityConfigView.get()` and `get_asg_config()` to return placements so the frontend can check remaining capacity.

### Warning shown when max size increase exceeds the remaining capacity
![resize-warning](https://user-images.githubusercontent.com/8442875/173154498-92a05dab-76e1-44dc-b1a0-7078bba23ec3.jpg)

![group_resieze_warning](https://user-images.githubusercontent.com/8442875/173154873-047e719f-f0ad-4889-8909-5333221b86d1.png)


### Warning shown when min size increase exceeds the remaining capacity
![resize-error](https://user-images.githubusercontent.com/8442875/173154646-b98b9e23-cfc4-46c4-b436-d7cd5f7d01b9.png)
![group_resize_error](https://user-images.githubusercontent.com/8442875/173154886-0aa55e1f-e381-42b6-8373-51aef445d241.png)


### Warning shown when potential AZ imbalance is detected.
<img width="1360" alt="imbalance" src="https://user-images.githubusercontent.com/8442875/174403428-508d1e24-7c7d-44fb-adca-6708d2aee76d.png">

