### PR TITLE
Surface up attaching instances to ASG results to user

### DIFF
--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -1149,10 +1149,12 @@ def attach_instances(request, group_name):
         hosts = params.get("other_hosts")
         host_ids = hosts.split(',')
         autoscaling_groups_helper.hosts_action_in_group(request, group_name, host_ids, "ATTACH")
-        return redirect('/groups/{}/'.format(group_name))
-    except:
+        content = "Successfully attached instances to ASG."
+        messages.add_message(request, messages.SUCCESS, content)
+    except Exception as e:
+        messages.add_message(request, messages.ERROR, str(e))
         log.error(traceback.format_exc())
-        return redirect('/groups/{}/'.format(group_name))
+    return redirect('/groups/{}/'.format(group_name))
 
 
 # Health Check related


### PR DESCRIPTION
We want the users know the result of attaching instances to ASG.