### PR TITLE
Notify users that disabled ASG won't have immediate instance increase

### DIFF
--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -1055,6 +1055,9 @@ def add_instance(request, group_name):
                       'to check new hosts information.'.format(num, group_name, group_name)
             if 'customSubnet' in params:
                 content += '\nNote: the subnet {} you selected was ignored.'.format(subnet)
+            if asg_status == 'DISABLED':
+                content += '\nNote: The ASG is currently DISABLED, so the instance you '\
+                           'requested will be launched when ASG is ENABLED.'
             messages.add_message(request, messages.SUCCESS, content)
         else:
             # Launch hosts outside ASG / static hosts


### PR DESCRIPTION
#983 ensures that users cannot launch instances outside ASG when one exists. However it has a minor problem. When the ASG is disabled, the requested instance are not launched immediately. Instead, the new desired capacity will be added to the ASG when it's re-enabled. We should notify users this implication to reduce false expectations. 

There is an alternatives that I considered.
1. Only allowing users to launch instances when `asg_status != "DISABLED"` in the UI. A potential risk is that we are unsure about how people use the advanced launch configurations. It might cause unintentional interruption to those users, since they won't be able launch into placement groups.
