### PR TITLE
Add basic backend metrics for deploy success and failures

### DIFF
--- a/deploy-service/common/pom.xml
+++ b/deploy-service/common/pom.xml
@@ -16,6 +16,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <dropwizard.metrics.version>3.1.0</dropwizard.metrics.version>
     </properties>
 
     <dependencies>
@@ -242,6 +243,11 @@
             <artifactId>jjwt-impl</artifactId>
             <version>0.10.5</version>
             <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+            <version>${dropwizard.metrics.version}</version>
         </dependency>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>


### PR DESCRIPTION
Use dropwizard metrics to add simple metrics about deployment failures and success counters. Dropwizard metrics supports different advanced metrics as well so we can extend later on. I'm piggybacking on the current finish notify job. Will check the metrics using statsboard later on. 