### PR TITLE
Remember scroll position so page doesn't jump after resizing textarea

### DIFF
--- a/deploy-board/deploy_board/templates/configs/config_map.tmpl
+++ b/deploy-board/deploy_board/templates/configs/config_map.tmpl
@@ -176,7 +176,7 @@
             $('#resetConfigMapBtnId').removeAttr('disabled');
         });
 
-        $('#mapConfigFieldSetId').on('change click keyup keydown', 'textarea', function () {
+        $('#mapConfigFieldSetId, #newEntryFormId').on('change click keyup keydown', 'textarea', function () {
             var scrollLeft = window.pageXOffset ||
                 (document.documentElement || document.body.parentNode || document.body).scrollLeft;
 


### PR DESCRIPTION
This fixes a bug that causes UI Auto scrolls to top when editing a Teletraan stage "Script Config", or any text area. Introduced by #563 .

`$('textarea')` was removed because we should not autogrow heights of all textareas in the page.

Bug:

https://user-images.githubusercontent.com/8442875/179045697-e55e26bd-7e8a-4411-9a77-94178274264c.mov

With fix:

https://user-images.githubusercontent.com/8442875/179045728-bef9536e-6ee5-4d4b-994e-948b71976bf0.mov


