### PR TITLE
Fix teletraan displays incorrect AMI

### DIFF
--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -426,8 +426,18 @@
         });
         const initialAssignPublicIP = currentCluster.configs.assign_public_ip === "true" ;
         const initialCell = currentCluster.cellName;
+        var baseImageAccepted = info.baseImages.filter(function (o) {
+            return o.acceptance == 'ACCEPTED';
+        });
 
-        var sorted = info.baseImages.sort(function(item1, item2) {
+        if (currentCluster.baseImage != null) {
+            // Make sure in the base image dropdown the current base image exists.
+            if (!baseImageAccepted.some(image => image.id === currentCluster.baseImage.id)) {
+                baseImageAccepted.push(currentCluster.baseImage);
+            }
+        }
+
+        var baseImageSorted = baseImageAccepted.sort(function(item1, item2) {
             return item2.publish_date - item1.publish_date;
         });
 
@@ -449,7 +459,7 @@
                         }).filter(function(item){return item.name!='assign_public_ip'}),
                 assignPublicIP: initialAssignPublicIP,
                 awsRole: currentCluster.configs.aws_role,
-                baseimages: info.baseImages.map(function(o) {
+                baseimages: baseImageSorted.map(function(o) {
                     var acceptance = o.acceptance ? ' [' + o.acceptance + ']' : '';
                     return {
                         value: o.id,

--- a/deploy-board/deploy_board/webapp/cluster_view.py
+++ b/deploy-board/deploy_board/webapp/cluster_view.py
@@ -183,7 +183,9 @@ class ClusterConfigurationView(View):
             request, DEFAULT_PROVIDER)
         current_image = baseimages_helper.get_by_id(
             request, current_cluster['baseImageId'])
+        # TODO: remove baseImageName and access the prop from baseImage directly.
         current_cluster['baseImageName'] = current_image['abstract_name']
+        current_cluster['baseImage'] = current_image
         for host_type in host_types:
             host_type['mem'] = float(host_type['mem']) / 1024
 


### PR DESCRIPTION
Teletraan UI shows latest AMI selected, however, new instances will launch on an older AMI. When the AMI is older, the UI shows the first (latest) AMI selected, when in reality the cluster does not have this configuration. This confused users. Fix by including the current ami in the selection dropdown. 