### PR TITLE
Show only accepted AMI in new capacity advance

### DIFF
--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -90,12 +90,13 @@ var capacityView = new Vue({
 
 var info = {{capacity_creation_info|safe}}
 var environment = info.environment;
-var accepted = info.baseImages.filter(function (e) {
+var baseImagesAccepted = info.baseImages.filter(function (e) {
         return e.acceptance == 'ACCEPTED';
     });
-var sorted = accepted.sort(function(item1,item2){
+var baseImagesAcceptedSorted = baseImagesAccepted.sort(function(item1,item2){
         return item2.publish_date - item1.publish_date;
 });
+const firstBaseImageId = baseImagesAcceptedSorted[0].id;
 var placements = getDefaultPlacement(info);
 var capacitySetting = new Vue({
     el: "#mainPanel",
@@ -109,16 +110,16 @@ var capacitySetting = new Vue({
             }).filter(function(item){return item.name!='cmp_group'}),
         assignPublicIP: false,
         baseImageHelpData: [],
-        baseimages: info.baseImages.map(
+        baseimages: baseImagesAcceptedSorted.map(
             function (o) {
                 var acceptance = o.acceptance ? ' [' + o.acceptance + ']' : '';
                 return {
                     value: o.id,
                     text: o.provider_name + acceptance,
-                    isSelected: o.id === sorted[0].id
+                    isSelected: o.id === firstBaseImageId
                 }
             }),
-        baseImageValue: sorted[0].id,
+        baseImageValue: firstBaseImageId,
         configOptions: Object.keys(info.configList).map(
             function (key) {
                 return {


### PR DESCRIPTION
Currently we show both denied and accepted amis. We had a logic to filter out but looks like we use it wrongly. This change filtered out to only accepted AMIs when creating a new capacity. 
Tested locally at env/canary/config/newcapacity/advanced/
before: 
![Screen Shot 2022-07-13 at 12 56 12 PM](https://user-images.githubusercontent.com/50259686/178822632-fafa0bba-c538-4faf-8aaa-e04e0c702458.png)
after:
![Screen Shot 2022-07-13 at 12 10 05 PM](https://user-images.githubusercontent.com/50259686/178812698-5570ee22-ce92-4249-84fc-276bb67f4c61.png)

