### PR TITLE
Groups should not trigger cluster config view

### DIFF
--- a/deploy-board/deploy_board/templates/configs/capacity.html
+++ b/deploy-board/deploy_board/templates/configs/capacity.html
@@ -67,7 +67,7 @@ window.groups = info.groups;
 window.showExistingCapacity = !window.info.is_pinterest || getUrlParameter("addexisting") || (hosts!=null && hosts.length>0)||(groups!=null && groups.length>0)
 
 if (info.is_pinterest){
-    hasCMPCluster = (info.basic_cluster_info != null) || $.inArray(env.envName+"-"+env.stageName, groups) >= 0;
+    hasCMPCluster = info.basic_cluster_info != null;
 }
 else{
     hasCMPCluster = false


### PR DESCRIPTION
We shouldn't rely on `$.inArray(env.envName+"-"+env.stageName, groups) >= 0` to check if a stage has CMP cluster. A stage can have a group whose name is in the format `env.envName+"-"+env.stageName`.

In the backend, we also have
```python
if cluster_name in groups:
    groups.remove(cluster_name)
```

Based on above, we have the following scenarios (here use envName-stageName):
- A stage doesn't have a CMP cluster, and originally `groups = ["envName-stageName"]`
    - `cluster_name` is `None`, so nothing is removed from `groups`
    - `info.basic_cluster_info == null`, so `hasCMPCluster` is evaluated to false.
    - We shouldn't evaluate `$.inArray(env.envName+"-"+env.stageName, groups) >= 0`
- A stage has a CMP cluster, and originally `groups = ["envName-stageName"]` resulted from the cluster.
    - `cluster_name` is `"envName-stageName"`, so `groups = []`
    -  `info.basic_cluster_info != null`, so `hasCMPCluster` is evaluated to true.
    - `$.inArray(env.envName+"-"+env.stageName, groups) >= 0` is never evaluated.
- A stage has a CMP cluster, and originally `groups = ["envName-stageName", "envName-stageName"]` resulted from the cluster and an existing group.
    - This is impossible. We don't allow duplicate group names in a stage.
    - Assuming this happens, the python code will remove the first occurrence of "envName-stageName" in `groups`. So  `groups = ["envName-stageName"]`. Then since `info.basic_cluster_info != null`, so `hasCMPCluster` is evaluated to true.