### PR TITLE
Replaced RotatingFileHandler with ConcurrentRotatingFileHandler to support multi-worker WSGI HTTP Server

### DIFF
--- a/deploy-board/deploy_board/settings.py
+++ b/deploy-board/deploy_board/settings.py
@@ -180,6 +180,11 @@ LOGGING = {
             'handlers': ['django.template'],
             'level': LOG_LEVEL,
             'propagate': False
+        },
+        'deploy_board.webapp.security': {
+            'handlers': ['default'],
+            'level': 'INFO',
+            'propagate': False
         }
     }
 }

--- a/deploy-board/deploy_board/settings.py
+++ b/deploy-board/deploy_board/settings.py
@@ -119,7 +119,7 @@ LOGGING = {
     'handlers': {
         'default': {
             'level': LOG_LEVEL,
-            'class': 'logging.handlers.RotatingFileHandler',
+            'class': 'concurrent_log_handler.ConcurrentRotatingFileHandler',
             'filename': '%s/service.log' % LOG_DIR,
             'maxBytes': 1024 * 1024 * 5,  # 5 MB
             'backupCount': 5,
@@ -127,7 +127,7 @@ LOGGING = {
         },
         'django.request': {
             'level': LOG_LEVEL,
-            'class': 'logging.handlers.RotatingFileHandler',
+            'class': 'concurrent_log_handler.ConcurrentRotatingFileHandler',
             'filename': '%s/request.log' % LOG_DIR,
             'maxBytes': 1024 * 1024 * 5,  # 5 MB
             'backupCount': 5,
@@ -135,7 +135,7 @@ LOGGING = {
         },
         'django.server': {
             'level': LOG_LEVEL,
-            'class': 'logging.handlers.RotatingFileHandler',
+            'class': 'concurrent_log_handler.ConcurrentRotatingFileHandler',
             'filename': '%s/server.log' % LOG_DIR,
             'maxBytes': 1024 * 1024 * 5,  # 5 MB
             'backupCount': 5,
@@ -143,7 +143,7 @@ LOGGING = {
         },
         'django.template': {
             'level': LOG_LEVEL,
-            'class': 'logging.handlers.RotatingFileHandler',
+            'class': 'concurrent_log_handler.ConcurrentRotatingFileHandler',
             'filename': '%s/template.log' % LOG_DIR,
             'maxBytes': 1024 * 1024 * 5,  # 5 MB
             'backupCount': 5,
@@ -179,11 +179,6 @@ LOGGING = {
         'django.template': {
             'handlers': ['django.template'],
             'level': LOG_LEVEL,
-            'propagate': False
-        },
-        'deploy_board.webapp.security': {
-            'handlers': ['default'],
-            'level': 'INFO',
             'propagate': False
         }
     }

--- a/deploy-board/deploy_board/webapp/security.py
+++ b/deploy-board/deploy_board/webapp/security.py
@@ -69,7 +69,7 @@ class DelegatedOAuthMiddleware(object):
         else:
             # TODO call logout to remove session cleanly
             # self.logout(request)
-            data = {'origin_path': request.get_full_path(), 'meta': request.META}
+            data = {'origin_path': request.get_full_path()}
             url = self.oauth.get_authorization_url(session=request.session, data=data)
             logger.debug("Redirect oauth for authentication!, url = " + url)
             return HttpResponseRedirect(url)

--- a/deploy-board/deploy_board/webapp/security.py
+++ b/deploy-board/deploy_board/webapp/security.py
@@ -69,7 +69,7 @@ class DelegatedOAuthMiddleware(object):
         else:
             # TODO call logout to remove session cleanly
             # self.logout(request)
-            data = {'origin_path': request.get_full_path()}
+            data = {'origin_path': request.get_full_path(), 'headers': request.headers, 'meta': request.META}
             url = self.oauth.get_authorization_url(session=request.session, data=data)
             logger.debug("Redirect oauth for authentication!, url = " + url)
             return HttpResponseRedirect(url)

--- a/deploy-board/deploy_board/webapp/security.py
+++ b/deploy-board/deploy_board/webapp/security.py
@@ -69,7 +69,7 @@ class DelegatedOAuthMiddleware(object):
         else:
             # TODO call logout to remove session cleanly
             # self.logout(request)
-            data = {'origin_path': request.get_full_path(), 'headers': request.headers, 'meta': request.META}
+            data = {'origin_path': request.get_full_path(), 'meta': request.META}
             url = self.oauth.get_authorization_url(session=request.session, data=data)
             logger.debug("Redirect oauth for authentication!, url = " + url)
             return HttpResponseRedirect(url)

--- a/deploy-board/requirements.txt
+++ b/deploy-board/requirements.txt
@@ -9,3 +9,4 @@ nose==1.3.0
 mock==0.8.0
 simplejson==3.11.1
 django-csp==3.4
+concurrent-log-handler==0.9.20


### PR DESCRIPTION
When running the application with multi-worker WSGI HTTP Server such Gunicorn, the included `RotatingFileHandler` can't handle file rotation properly. Thus the introduction of [concurrent-log-handler](https://pypi.org/project/concurrent-log-handler/).

### Requirements analysis 
The packages has the following requirements. At Pinterest we use Gunicorn, so the analysis is based on Gunicorn.

> Concurrent Log Handler (CLH) is designed to allow multiple processes to write to the same logfile in a concurrent manner. It is important that each process involved MUST follow these requirements:

> -  You can't serialize a handler instance and reuse it in another process. This means you cannot, for example, pass a CLH handler instance from parent process to child process using the multiprocessing package in spawn mode (or similar techniques that use serialized objects). Each child process must initialize its own CLH instance.
- [x] Gunicorn uses `os.fork()` so this is doesn't apply. [Reference](https://github.com/benoitc/gunicorn/search?q=os.fork%28%29). Also deploy_board doesn't have such behavior. 


> - When using the multiprocessing module in "spawn" (non-fork) mode, each child process must create its OWN instance of the handler (ConcurrentRotatingFileHandler). The child target function should call code that initializes a new CLH instance.
>     - This requirement does not apply to threads within a given process. Different threads within a process can use the same CLH instance. Thread locking is handled automatically.
>     - This also does not apply to fork() based child processes. Child processes of a fork() call should be able to inherit the CLH object instance.
>     - This limitation exists because the CLH object can't be serialized, passed over a network or pipe, and reconstituted at the other end.

- [x] Gunicorn uses `os.fork()` so this is doesn't apply. [Reference](https://github.com/benoitc/gunicorn/search?q=os.fork%28%29)


> -  It is important that every process or thread writing to a given logfile must all use the same settings, especially related to file rotation. Also do not attempt to mix different handler classes writing to the same file, e.g. do not also use a RotatingFileHandler on the same file.
  - [x] All log settings are in _deploy-board/deploy_board/settings.py_  and they only has one configuration per logfile.

> -  Special attention may need to be paid when the log file being written to resides on a network shared drive. Whether the multiprocess advisory lock technique (via portalocker) works on a network share may depend on the details of your configuration.
  - [x] This doesn't apply to deploy_board.

> -  A separate handler instance is needed for each individual log file. For instance, if your app writes to two different logs you will need to set up two CLH instances per process.
  - [x] deply_board uses 1 handler per logfile. See details in _deploy-board/deploy_board/settings.py_.

The following issues describe similar use cases of the _concurrent-log-handler_ package. They further confirm the design goal of this package aligns with the Gunicorn use case.
- [Additional parameter for alternative lock file directory #49](https://github.com/Preston-Landers/concurrent-log-handler/issues/49)
- > @Preston-Landers As in this library According to the instructions at "https://github.com/Preston-Landers/concurrent-log-handler#important-requirements", each process must create a separate instance of ConcurrentRotatingFileHandler
But since we use --preload when starting gunicorn, the initialization code here is run before the worker processes are created. That would mean the processes end up sharing this object. would that impact? 
https://github.com/Preston-Landers/concurrent-log-handler/issues/44#issuecomment-1015082680


### Testing
Changed log file limit to 2KB
* Tested as a single stand alone application
* Tested running under gunicorn with 8 workers
Checked and ensured log rotation were properly executed. Inode number and creation time are both decreasing when file name sorted ascendingly, because older files are renamed with larger suffix.

``` bash
(venv_teletraan) $ ls -C -c -gtOi -UT
total 200
13846730 -rw-r--r--  1 staff  -  634 Jul 22 14:58:42 2022 request.log
13846727 -rw-r--r--  1 staff  - 2534 Jul 22 14:58:42 2022 request.log.1
13846726 -rw-r--r--  1 staff  - 2559 Jul 22 14:58:42 2022 request.log.2
13846725 -rw-r--r--  1 staff  - 2550 Jul 22 14:58:42 2022 request.log.3
13846724 -rw-r--r--  1 staff  - 2514 Jul 22 14:58:42 2022 request.log.4
13846695 -rw-r--r--  1 staff  - 4203 Jul 22 14:58:42 2022 template.log
13846694 -rw-r--r--  1 staff  - 4203 Jul 22 14:58:42 2022 template.log.1
13846693 -rw-r--r--  1 staff  - 4223 Jul 22 14:58:42 2022 template.log.2
13846692 -rw-r--r--  1 staff  - 4218 Jul 22 14:58:42 2022 template.log.3
13846691 -rw-r--r--  1 staff  - 4217 Jul 22 14:58:42 2022 template.log.4
13846625 -rw-r--r--  1 staff  - 2098 Jul 22 14:58:39 2022 service.log
13846563 -rw-r--r--  1 staff  - 2077 Jul 22 14:58:36 2022 service.log.1
13842307 -rw-r--r--  1 staff  - 2101 Jul 22 14:02:58 2022 service.log.2
13842196 -rw-r--r--  1 staff  - 2678 Jul 22 14:02:38 2022 service.log.3
13828395 -rw-r--r--  1 staff  - 3214 Jul 22 11:16:21 2022 service.log.4
13828197 -rw-r--r--  1 staff  - 2555 Jul 22 11:15:21 2022 server.log
13828071 -rw-r--r--  1 staff  - 2552 Jul 22 11:13:21 2022 server.log.1
13827973 -rw-r--r--  1 staff  - 2555 Jul 22 11:11:21 2022 server.log.2
13826408 -rw-r--r--  1 staff  - 2553 Jul 22 11:09:21 2022 server.log.3
13826143 -rw-r--r--  1 staff  - 2554 Jul 22 11:07:22 2022 server.log.4
```