### PR TITLE
Updating message 

### DIFF
--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -87,7 +87,7 @@
         </div>
     </div>
     <modal v-bind:title="confirmDialogTitle" v-bind:id="confirmDialogId" v-on:input="clickDialog">
-        <div slot="body">Are you sure to save the changes?</div>
+        <div slot="body">Are you sure to save the changes? <br><br>Please note that the saved settings will only apply for newly launched hosts. If you have existing hosts in your cluster, you can use the "Replace Cluster" feature on the left to perform a rolling replacement of all existing hosts in your cluster.</div>
     </modal>
 
     <div class="panel-footer clearfix">


### PR DESCRIPTION
Teletraan customers frequently change their cluster settings (ami, instance type, etc) and wonder why their changes don't do anything. Hence updating the message to 

Are you sure to save the changes?

Please note that the saved settings will only apply for newly launched hosts. If you have existing hosts in your cluster, you can use the "Replace Cluster" feature on the left to perform a rolling replacement of all existing hosts in your cluster.