### PR TITLE
fixing broken link [DRAFT]

### DIFF
--- a/deploy-board/deploy_board/templates/hosts/host_details.html
+++ b/deploy-board/deploy_board/templates/hosts/host_details.html
@@ -36,7 +36,7 @@
 <div class="alert alert-danger" role="alert">
     <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
     <strong>Warning!</strong> Cannot add host {{ hostname }} to multiple stages. Please remove it from
-    <a href="/{{ env_name }}/{{ duplicate_stage }}/config/capacity/">{{ env_name }}/{{ duplicate_stage }}</a>
+    <a href="/env/{{ env_name }}/{{ duplicate_stage }}/config/capacity/">{{ env_name }}/{{ duplicate_stage }}</a>
 </div>
 {% endif %}
 


### PR DESCRIPTION
Fixing broken link in the warning 


The link points to https://deploy.pinadmin.com/metrics-agent/beta-2/config/capacity/
but it should point to https://deploy.pinadmin.com/env/metrics-agent/beta-2/config/capacity/
(missing "/env")

Testing pending