### PR TITLE
Use `is not None` so empty list can pass if check.

### DIFF
--- a/deploy-board/deploy_board/webapp/capacity_views.py
+++ b/deploy-board/deploy_board/webapp/capacity_views.py
@@ -109,11 +109,11 @@ class EnvCapacityConfigView(View):
         logger.info("Post to capacity with data {0}".format(request.body))
         data = json.loads(request.body)
         hosts = data.get('hosts')
-        if hosts:
+        if hosts is not None:
             environs_helper.update_env_capacity(request, name, stage, capacity_type="HOST", data=hosts)
 
         groups = data.get("groups")
-        if groups:
+        if groups is not None:
             environs_helper.update_env_capacity(request, name, stage, capacity_type="GROUP", data=groups)
 
         return self.get(request, name, stage)


### PR DESCRIPTION
Use `is not None` so empty list can pass if check. This is required when use tries to delete all hosts or groups.

Regression introduced in #987 

Tests:
Test in local setup that the last existing capacity can be deleted. 