### PR TITLE
Add metrics for telefig is unavailable in deploy agent

### DIFF
--- a/deploy-agent/deployd/__init__.py
+++ b/deploy-agent/deployd/__init__.py
@@ -18,5 +18,6 @@ import os
 IS_PINTEREST = True if os.getenv("IS_PINTEREST", "false") == "true" else False
 METRIC_PORT_HEALTH = int(os.getenv('METRIC_PORT_HEALTH')) if os.getenv('METRIC_PORT_HEALTH', False) else None
 METRIC_CACHE_PATH = os.getenv('METRIC_CACHE_PATH', None)
+TELEFIG_BINARY = os.getenv('TELEFIG_BINARY', "")
 
 __version__ = '1.2.40'

--- a/deploy-agent/deployd/common/types.py
+++ b/deploy-agent/deployd/common/types.py
@@ -55,7 +55,11 @@ class DeployType(object):
 class DeployErrorSource(object): 
     TELEFIG = 'TELEFIG'
     UNKNOWN = 'UNKNOWN'
-    
+
+class DeployError(object): 
+    TELEFIG_UNAVAILABLE = 'TELEFIG_UNAVAILABLE'
+    UNKNOWN = 'UNKNOWN'
+
 class OpCode(object):
     NOOP = 'NOOP'
     DEPLOY = 'DEPLOY'

--- a/deploy-agent/deployd/common/utils.py
+++ b/deploy-agent/deployd/common/utils.py
@@ -24,7 +24,7 @@ import traceback
 import subprocess
 import yaml
 import json
-from deployd import IS_PINTEREST
+from deployd import IS_PINTEREST, TELEFIG_BINARY
 from deployd.common.stats import TimeElapsed, create_sc_increment, create_sc_timing
 
 log = logging.getLogger(__name__)
@@ -147,3 +147,8 @@ def check_not_none(arg, msg=None):
         raise ValueError(msg)
     return arg
 
+def check_telefig_unavailable_error(msg):
+    if not TELEFIG_BINARY:
+        return False
+    telefig_unavailable_error = "{}: No such file or directory".format(TELEFIG_BINARY)
+    return msg.find(telefig_unavailable_error) != -1

--- a/deploy-agent/tests/unit/deploy/server/test_agent.py
+++ b/deploy-agent/tests/unit/deploy/server/test_agent.py
@@ -545,5 +545,31 @@ class TestDeployAgent(tests.TestCase):
         self.assertEqual(agent._curr_report.report.deployStage, DeployStage.PRE_DOWNLOAD)
         self.assertEqual(agent._curr_report.report.status, AgentStatus.UNKNOWN)
 
+    @mock.patch('deployd.agent.create_sc_increment')
+    @mock.patch('deployd.common.utils.TELEFIG_BINARY', "telefig")
+    def test_send_deploy_status_with_telefig_unavailable_errors(self, mock_create_sc):
+        status = DeployStatus()
+        status.report = PingReport(jsonValue=self.deploy_goal1)
+
+        envs = {'abc': status}
+        client = mock.Mock()
+        estatus = mock.Mock()
+        estatus.load_envs = mock.Mock(return_value=envs)
+        ping_response_list = [
+            PingResponse(jsonValue=self.ping_response1),
+            PingResponse(jsonValue=self.ping_noop_response)
+        ]
+        mock_create_sc.return_value = None
+        client = mock.Mock()
+        client.send_reports = mock.Mock(side_effect=ping_response_list)
+        agent = DeployAgent(client=client, estatus=estatus, conf=self.config,
+                            executor=self.executor, helper=self.helper)
+        report = DeployReport(status_code=AgentStatus.UNKNOWN, error_code=1, output_msg="/usr/local/bin/telefig: No such file or directory", retry_times=3)
+        agent.process_deploy= mock.Mock(side_effect=[report])
+        agent.serve_build()
+        mock_create_sc.assert_called_once_with('deployd.stats.deploy.status', tags={
+                                            'first_run': False, 'deploy_stage': 'PRE_DOWNLOAD', 'env_name': 'abc', 'stage_name': 'beta', 'status_code': 'UNKNOWN', 'error_source': 'TELEFIG', 'error':'TELEFIG_UNAVAILABLE'})
+        self.assertEqual(agent._curr_report.report.deployStage, DeployStage.PRE_DOWNLOAD)
+        self.assertEqual(agent._curr_report.report.status, AgentStatus.UNKNOWN)
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add metrics for telefig is unavailable in deploy agent. It checks message error log if there is configure-serviceset: No such file or directory
Tested by UT. `tox`
```
tests/unit/deploy/client/test_base_client.py .                                                                                 [  1%]
tests/unit/deploy/client/test_serverless_client.py ...                                                                         [  5%]
tests/unit/deploy/common/test_config.py .                                                                                      [  7%]
tests/unit/deploy/common/test_stats.py ................                                                                        [ 31%]
tests/unit/deploy/download/test_download_helper.py .                                                                           [ 32%]
tests/unit/deploy/download/test_local_download_helper.py .                                                                     [ 34%]
tests/unit/deploy/server/test_agent.py ..............                                                                          [ 55%]
tests/unit/deploy/staging/test_helper.py ...                                                                                   [ 59%]
tests/unit/deploy/staging/test_transformer.py ...                                                                              [ 64%]
tests/unit/deploy/types/test_build.py ....                                                                                     [ 70%]
tests/unit/deploy/types/test_deploy_goal.py ......                                                                             [ 79%]
tests/unit/deploy/utils/test_agent.py ....                                                                                     [ 85%]
tests/unit/deploy/utils/test_exec.py .......                                                                                   [ 95%]
tests/unit/deploy/utils/test_status.py ...                                                                                     [100%]
```