### PR TITLE
Render Error Message when Unsupported Characters are in a Script Name

### DIFF
--- a/deploy-board/deploy_board/webapp/user_views.py
+++ b/deploy-board/deploy_board/webapp/user_views.py
@@ -24,6 +24,7 @@ from django.template.loader import render_to_string
 from helpers import users_helper
 from deploy_board.settings import IS_PINTEREST
 import logging
+import re
 
 # TODO call backend instead of hardcode
 ALL_ROLES = ['OPERATOR', 'ADMIN']
@@ -80,6 +81,10 @@ def update_users_config(request, name):
             user_name = key[len('TELETRAAN_NEW_'):].lower()
             if ' ' in user_name:
                 raise Exception('Name cannot contain spaces!')
+            unsupported_pattern = re.compile("[^a-zA-Z0-9\\-_]+")
+            if unsupported_pattern.search(user_name):
+                unsupported_chars = re.findall(unsupported_pattern, user_name.encode('ascii'))
+                raise Exception('Script Name cannot contain unsupported characters: %s' % (unsupported_chars))
             if user_name in origin_user_dict:
                 if value != origin_user_dict[user_name]:
                     updated_user_dict[user_name] = value


### PR DESCRIPTION
Definition of Done:

Creation of Script Token with unsupported Characters in Name result in an error when user attempts to save

Background:

https://jira.pinadmin.com/browse/CDP-5209  

Test Plan:

1. Navigate to the script token page
2. Click add and populate the script token name with unsupported characters(e.g. test:token//&) and click Add
3. Save the the token
4. Confirm that you receive the following error message: 'Script Name cannot contain unsupported characters {{unsupported_chars}}
5. 
<img width="864" alt="image" src="https://user-images.githubusercontent.com/69278532/187748512-36f3a167-83e4-464c-88c3-c6bd79d76c5c.png">

6. Revoke the invalid token
7. Click add and populate the script token name with supported characters(e.g. test_token) and click Add
8. Save the the token
9. Confirm that the token is successfully saved and you are view the token value by clicking Show Token 
10. Revoke the token and save
11. 
<img width="866" alt="image" src="https://user-images.githubusercontent.com/69278532/187748628-7cad7322-e6fe-40cc-adc4-9ff63fa71497.png">

