### PR TITLE
[Configurable Replacement Timeout] UI changes

### DIFF
--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -68,7 +68,7 @@
                     showhelp="true" v-on:helpclick="placementsHelpClick" v-on:assignpublicipclick="selectpublicip" v-on:subnetfilterclick="changeSubnetType"></placements-select>
                     <form-warning v-show="showSubnetReplacementAlert" v-bind:alert-text="subnetReplacementWarning"></form-warning>
                     <placements-help v-show="showPlacementsHelp" v-bind:data="placementsHelpData"></placements-help>
-                    <label-input v-show="inAdvanced" label="Replacement Timeout" title="Time out for cluster replacement in seconds"
+                    <label-input v-show="inAdvanced" label="Replacement Timeout" title="Time out for cluster replacement in minutes"
                         v-model="replacementTimeout"></label-input>
                     <div v-if="inAdvanced">
                         <div class="form-group"></div>
@@ -822,8 +822,8 @@
                     }
 
                     const replacementTimeout = clusterInfo['replacementTimeout']
-                    if (replacementTimeout == null || isNaN(replacementTimeout) || replacementTimeout < 5 * 60 || replacementTimeout > 24 * 60 * 60) {
-                        globalNotificationBanner.error = "Replacement timeout must be a number between 5 minutes and 24 hours."
+                    if (replacementTimeout == null || isNaN(replacementTimeout) || replacementTimeout < 5 || replacementTimeout > 24 * 60) {
+                        globalNotificationBanner.error = "Replacement timeout must be a number between 5 and 1440 minutes (24 hours)"
                         return false
                     }
 

--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -68,6 +68,8 @@
                     showhelp="true" v-on:helpclick="placementsHelpClick" v-on:assignpublicipclick="selectpublicip" v-on:subnetfilterclick="changeSubnetType"></placements-select>
                     <form-warning v-show="showSubnetReplacementAlert" v-bind:alert-text="subnetReplacementWarning"></form-warning>
                     <placements-help v-show="showPlacementsHelp" v-bind:data="placementsHelpData"></placements-help>
+                    <label-input v-show="inAdvanced" label="Replacement Timeout" title="Time out for cluster replacement in seconds"
+                        v-model="replacementTimeout"></label-input>
                     <div v-if="inAdvanced">
                         <div class="form-group"></div>
                         <div class="form-group">
@@ -506,6 +508,7 @@
                             isSelected: item.name == currentCluster.cellName
                         }
                     }),
+                replacementTimeout: currentCluster.replacementTimeout,
                 securityZones: info.securityZones.map(function(item) {
                     return {
                         value: item.abstract_name,
@@ -818,6 +821,12 @@
                         return false
                     }
 
+                    const replacementTimeout = clusterInfo['replacementTimeout']
+                    if (replacementTimeout == null || isNaN(replacementTimeout) || replacementTimeout < 5 * 60 || replacementTimeout > 24 * 60 * 60) {
+                        globalNotificationBanner.error = "Replacement timeout must be a number between 5 minutes and 24 hours."
+                        return false
+                    }
+
                     return true
                 },
                 sendRequest: function(clusterInfo) {
@@ -887,6 +896,7 @@
                     clusterInfo['hostType'] = this.selectedHostTypeValue;
                     clusterInfo['securityZone'] = this.selectedSecurityZoneValue;
                     clusterInfo['placement'] = this.selectedPlacements.join(',');
+                    clusterInfo['replacementTimeout'] = this.replacementTimeout;
                     clusterInfo['configs'] = this.allUserData.reduce(function(map, obj) {
                         map[obj.name] = obj.value;
                         return map

--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -52,6 +52,7 @@
                     <placements-select label="Placements" title="Placements" v-bind:selectoptions="placements" v-bind:assignpublicip="assignPublicIP"
                         showhelp="true" v-on:helpclick="placementsHelpClick" v-on:assignpublicipclick="selectpublicip"></placements-select>
                     <placements-help v-show="showPlacementsHelp" v-bind:data="placementsHelpData"></placements-help>
+                    <label-input label="Replacement Timeout" placeholder="2700" v-model="replacementTimeout"></label-input>
                     <div>
                         <div class="form-group"></div>
                         <div class="form-group">
@@ -167,6 +168,7 @@ var capacitySetting = new Vue({
                     isSelected: item.name == info.defaultCell
                 }
             }),
+        replacementTimeout: 2700,
         securityZoneHelpData: [],
         securityZones: info.securityZones.map(
             function (item) {
@@ -472,6 +474,12 @@ var capacitySetting = new Vue({
                 return false
             }
 
+            const replacementTimeout = clusterInfo['replacementTimeout']
+            if (replacementTimeout == null || isNaN(replacementTimeout) || replacementTimeout < 5 * 60 || replacementTimeout > 24 * 60 * 60) {
+                globalNotificationBanner.error = "Replacement timeout must be a number between 5 minutes and 24 hours."
+                return false
+            }
+
             return true
         },
         sendRequest: function (clusterInfo) {
@@ -503,6 +511,7 @@ var capacitySetting = new Vue({
             clusterInfo['baseImageId'] = this.baseImageValue;
             clusterInfo['hostType'] = this.selectedHostTypeValue;
             clusterInfo['securityZone'] = this.selectedSecurityZoneValue;
+            clusterInfo['replacementTimeout'] = this.replacementTimeout;
             if (this.selectedPlacements != null && this.selectedPlacements.length>0){
                 clusterInfo['placement'] = this.selectedPlacements.join(',');
             }

--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -52,7 +52,7 @@
                     <placements-select label="Placements" title="Placements" v-bind:selectoptions="placements" v-bind:assignpublicip="assignPublicIP"
                         showhelp="true" v-on:helpclick="placementsHelpClick" v-on:assignpublicipclick="selectpublicip"></placements-select>
                     <placements-help v-show="showPlacementsHelp" v-bind:data="placementsHelpData"></placements-help>
-                    <label-input label="Replacement Timeout" placeholder="2700" v-model="replacementTimeout"></label-input>
+                    <label-input label="Replacement Timeout" placeholder="2700" v-model="replacementTimeout" title="Time out for cluster replacement in seconds"></label-input>
                     <div>
                         <div class="form-group"></div>
                         <div class="form-group">

--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -52,7 +52,7 @@
                     <placements-select label="Placements" title="Placements" v-bind:selectoptions="placements" v-bind:assignpublicip="assignPublicIP"
                         showhelp="true" v-on:helpclick="placementsHelpClick" v-on:assignpublicipclick="selectpublicip"></placements-select>
                     <placements-help v-show="showPlacementsHelp" v-bind:data="placementsHelpData"></placements-help>
-                    <label-input label="Replacement Timeout" placeholder="2700" v-model="replacementTimeout" title="Time out for cluster replacement in seconds"></label-input>
+                    <label-input label="Replacement Timeout" placeholder="45" v-model="replacementTimeout" title="Time out for cluster replacement in minutes"></label-input>
                     <div>
                         <div class="form-group"></div>
                         <div class="form-group">
@@ -168,7 +168,7 @@ var capacitySetting = new Vue({
                     isSelected: item.name == info.defaultCell
                 }
             }),
-        replacementTimeout: 2700,
+        replacementTimeout: 45,
         securityZoneHelpData: [],
         securityZones: info.securityZones.map(
             function (item) {
@@ -475,8 +475,8 @@ var capacitySetting = new Vue({
             }
 
             const replacementTimeout = clusterInfo['replacementTimeout']
-            if (replacementTimeout == null || isNaN(replacementTimeout) || replacementTimeout < 5 * 60 || replacementTimeout > 24 * 60 * 60) {
-                globalNotificationBanner.error = "Replacement timeout must be a number between 5 minutes and 24 hours."
+            if (replacementTimeout == null || isNaN(replacementTimeout) || replacementTimeout < 5 || replacementTimeout > 24 * 60) {
+                globalNotificationBanner.error = "Replacement timeout must be a number between 5 and 1440 minutes (24 hours)"
                 return false
             }
 


### PR DESCRIPTION
Added the text input fields with validation for replacement timeout configuration

<img width="1609" alt="replacement_timeout" src="https://user-images.githubusercontent.com/8442875/187803225-1c3a712e-afc2-4216-8c95-660629be7753.png">

## Tests
### New cluster
1. Navigate to advanced new capacity page /env/helloworlddummyservice-server/test-integ-1/config/newcapacity/advanced/.
2. Observed that 
   1. the field _Replacement Timeout_ exist **only** in the advanced view.
   2. can't save a value smaller than 5 or larger than 1440.
   3. the default 45 is populated.
   4. hovering the title will show the help message.
   5. can save the new value successfully.
 ### Existing cluster
1. Navigate to advanced cluster config page /env/helloworlddummyservice-server/test-tyler/config/cluster/config/.
2. Observed that 
   1. the field _Replacement Timeout_ exist **only** in the advanced view.
   2. can't save a value smaller than 5 or larger than 1440.
   3. the correct current value populated.
   4. hovering the title will show the help message.
   5. can save the new value successfully.