### PR TITLE
UI improvement for manually triggering health check host

### DIFF
--- a/deploy-board/deploy_board/templates/groups/health_check_activities.html
+++ b/deploy-board/deploy_board/templates/groups/health_check_activities.html
@@ -52,6 +52,9 @@
 {% else %}
 <div class="panel panel-default">
 {% endif %}
+    {%if healthcheck_state == False %}
+    <span class="label label-info">Health Check Disabled for cluster. Enable it to manually trigger healthcheck <a href="/groups/{{ group_name }}/config/">{{ group_name }}</a>. Don't forget to save after enabling the setting.</span>
+    {% endif %}
     <div class="panel-heading clearfix">
         <h4 class="panel-title pull-left">
             {% if not scaling_down_event_enabled and asg_status == "ENABLED" %}
@@ -63,9 +66,6 @@
             {% endif %}
         </h4>
 
-        {%if healthcheck_state == False %}
-            <span class="label label-info">Health Check Disabled for cluster. Enable it to manually trigger healthcheck <a href="/groups/{{ group_name }}/config/">{{ group_name }}</a></span>
-        {% endif %}
          <!---- Buttons --->
         {% if not scaling_down_event_enabled and asg_status == "ENABLED" %}
             <div class="btn-group pull-right">

--- a/deploy-board/deploy_board/templates/groups/health_check_activities.html
+++ b/deploy-board/deploy_board/templates/groups/health_check_activities.html
@@ -162,7 +162,7 @@
                 <h4 class="modal-title">Create Health Check Confirm</h4>
             </div>
             <div class="modal-body">
-                <p>Are you sure to create a new health check for group {{ group_name }}?</p>
+                <p>Are you sure to create a new health check for group {{ group_name }} Rashmi?</p>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>

--- a/deploy-board/deploy_board/templates/groups/health_check_activities.html
+++ b/deploy-board/deploy_board/templates/groups/health_check_activities.html
@@ -53,7 +53,7 @@
 <div class="panel panel-default">
 {% endif %}
     {%if healthcheck_state == False %}
-    <span class="label label-info">Health Check disabled for cluster. Enable it to manually trigger healthcheck <a href="/groups/{{ group_name }}/config/">{{ group_name }}</a>. Don't forget to save after enabling the setting.</span>
+        <h4 class="label label-info">Health Check disabled for cluster. Enable it to manually trigger healthcheck <a href="/groups/{{ group_name }}/config/">{{ group_name }}</a>. Don't forget to save after enabling the setting.</h4>
     {% endif %}
     <div class="panel-heading clearfix">
         <h4 class="panel-title pull-left">

--- a/deploy-board/deploy_board/templates/groups/health_check_activities.html
+++ b/deploy-board/deploy_board/templates/groups/health_check_activities.html
@@ -168,7 +168,7 @@
                 <h4 class="modal-title">Create Health Check Confirm</h4>
             </div>
             <div class="modal-body">
-                <p>Are you sure to create a new health check for group {{ group_name }} Rashmi?</p>
+                <p>Are you sure to create a new health check for group {{ group_name }}?</p>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>

--- a/deploy-board/deploy_board/templates/groups/health_check_activities.html
+++ b/deploy-board/deploy_board/templates/groups/health_check_activities.html
@@ -53,7 +53,7 @@
 <div class="panel panel-default">
 {% endif %}
     {%if healthcheck_state == False %}
-    <span class="label label-info">Health Check Disabled for cluster. Enable it to manually trigger healthcheck <a href="/groups/{{ group_name }}/config/">{{ group_name }}</a>. Don't forget to save after enabling the setting.</span>
+    <span class="label label-info">Health Check disabled for cluster. Enable it to manually trigger healthcheck <a href="/groups/{{ group_name }}/config/">{{ group_name }}</a>. Don't forget to save after enabling the setting.</span>
     {% endif %}
     <div class="panel-heading clearfix">
         <h4 class="panel-title pull-left">

--- a/deploy-board/deploy_board/templates/groups/health_check_activities.html
+++ b/deploy-board/deploy_board/templates/groups/health_check_activities.html
@@ -45,6 +45,10 @@
 
 {% block main %}
 
+{%if healthcheck_state == False %}
+    <h4 class="label label-info">Health Check disabled for cluster. Enable it to manually trigger healthcheck <a href="/groups/{{ group_name }}/config/">{{ group_name }}</a>. Don't forget to save after enabling the setting.</h4>
+{% endif %}
+
 {% if not scaling_down_event_enabled and asg_status == "ENABLED" %}
 <div class="panel panel-warning">
 {% elif asg_status == "DISABLED" %}
@@ -52,9 +56,6 @@
 {% else %}
 <div class="panel panel-default">
 {% endif %}
-    {%if healthcheck_state == False %}
-        <h4 class="label label-info">Health Check disabled for cluster. Enable it to manually trigger healthcheck <a href="/groups/{{ group_name }}/config/">{{ group_name }}</a>. Don't forget to save after enabling the setting.</h4>
-    {% endif %}
     <div class="panel-heading clearfix">
         <h4 class="panel-title pull-left">
             {% if not scaling_down_event_enabled and asg_status == "ENABLED" %}

--- a/deploy-board/deploy_board/templates/groups/health_check_activities.html
+++ b/deploy-board/deploy_board/templates/groups/health_check_activities.html
@@ -63,6 +63,9 @@
             {% endif %}
         </h4>
 
+        {%if healthcheck_state == False %}
+            <span class="label label-info">Health Check Disabled for cluster. Enable it to manually trigger healthcheck <a href="/groups/{{ group_name }}/config/">{{ group_name }}</a></span>
+        {% endif %}
          <!---- Buttons --->
         {% if not scaling_down_event_enabled and asg_status == "ENABLED" %}
             <div class="btn-group pull-right">
@@ -81,13 +84,15 @@
                 </button>
             </div>
         {% endif %}
-        <div class="btn-group pull-right">
-            <button type="button" class="deployToolTip btn btn-default btn-sm"
-                    data-toggle="modal" data-target="#addHealthCheckModelId"
-                    title="Manually create a new Health Check ">
-            <span class="glyphicon glyphicon-plus"></span> Create a health check
-            </button>
-        </div>
+        {% if healthcheck_state %}
+            <div class="btn-group pull-right">
+                <button type="button" class="deployToolTip btn btn-default btn-sm"
+                        data-toggle="modal" data-target="#addHealthCheckModelId"
+                        title="Manually create a new Health Check ">
+                <span class="glyphicon glyphicon-plus"></span> Create a health check
+                </button>
+            </div>
+        {% endif %}    
     </div>
     <div class="panel-body table-responsive">
         {% include "groups/health_check_activities.tmpl" %}

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -1250,7 +1250,7 @@ def create_manually_health_check(request, group_name):
     health_check_info["type"] = "MANUALLY_TRIGGERED"
     output = autoscaling_groups_helper.create_health_check(request, group_name, health_check_info)
     print(output, group_name)
-    raise Exception('output returned: %s' % (output))
+    raise Exception('output returned:')
     return redirect('/groups/{}/health_check_activities/'.format(group_name))
 
 

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -1244,16 +1244,16 @@ def get_health_check_details(request, id):
     })
 
 
-def create_manually_health_check(request, group_name):
-    
-        health_check_info = {}
-        health_check_info["group_name"] = group_name
-        health_check_info["type"] = "MANUALLY_TRIGGERED"
-        output = autoscaling_groups_helper.create_health_check(request, group_name, health_check_info)
-        print(output, group_name)
-        #raise TeletraanException("Invalid capacity: {}. Desired capacity must be within the limits of ASG's minimum capacity ({}) and maximum capacity ({}). Please change the value you input for Capacity.".format(params['capacity'], asg_minsize, asg_maxsize))
-        raise TeletraanException("output returned:{} | {}".format(output, group_name))
+def create_manually_health_check(request, group_name):  
+    health_check_info = {}
+    health_check_info["group_name"] = group_name
+    health_check_info["type"] = "MANUALLY_TRIGGERED"
+    output = autoscaling_groups_helper.create_health_check(request, group_name, health_check_info)
+    if(output == False) {
+        raise TeletraanException("Healthcheck host could not be created. One of the most primary reason is having healthcheck disabled. Please click on configuration tab to enable health check for the autoscaling setting")
+    } else {
         return redirect('/groups/{}/health_check_activities/'.format(group_name))
+    }
 
 
 def enable_scaling_down_event(request, group_name):

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -1250,9 +1250,7 @@ def create_manually_health_check(request, group_name):
     health_check_info["type"] = "MANUALLY_TRIGGERED"
     output = autoscaling_groups_helper.create_health_check(request, group_name, health_check_info)
     
-    raise TeletraanException("Healthcheck host could not be created. \\
-            One of the most primary reason is having healthcheck disabled. \\
-            Please click on configuration tab to enable health check for the autoscaling setting {}".format(type(output)))
+    raise TeletraanException("Healthcheck host could not be created. One of the most primary reason is having healthcheck disabled. Please click on configuration tab to enable health check for the autoscaling setting {}".format(type(output)))
     
         
     return redirect('/groups/{}/health_check_activities/'.format(group_name))

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -1252,7 +1252,7 @@ def create_manually_health_check(request, group_name):
         output = autoscaling_groups_helper.create_health_check(request, group_name, health_check_info)
         print(output, group_name)
         #raise TeletraanException("Invalid capacity: {}. Desired capacity must be within the limits of ASG's minimum capacity ({}) and maximum capacity ({}). Please change the value you input for Capacity.".format(params['capacity'], asg_minsize, asg_maxsize))
-        raise TeletraanException("output returned:{} | {}".format(output, group_name))
+        #raise TeletraanException("output returned:{} | {}".format(output, group_name))
         return redirect('/groups/{}/health_check_activities/'.format(group_name))
     except:
         pass

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -1245,14 +1245,17 @@ def get_health_check_details(request, id):
 
 
 def create_manually_health_check(request, group_name):
-    health_check_info = {}
-    health_check_info["group_name"] = group_name
-    health_check_info["type"] = "MANUALLY_TRIGGERED"
-    output = autoscaling_groups_helper.create_health_check(request, group_name, health_check_info)
-    print(output, group_name)
-    #raise TeletraanException("Invalid capacity: {}. Desired capacity must be within the limits of ASG's minimum capacity ({}) and maximum capacity ({}). Please change the value you input for Capacity.".format(params['capacity'], asg_minsize, asg_maxsize))
-    raise TeletraanException("output returned:{}".format(output))
-    return redirect('/groups/{}/health_check_activities/'.format(group_name))
+    try:
+        health_check_info = {}
+        health_check_info["group_name"] = group_name
+        health_check_info["type"] = "MANUALLY_TRIGGERED"
+        output = autoscaling_groups_helper.create_health_check(request, group_name, health_check_info)
+        print(output, group_name)
+        #raise TeletraanException("Invalid capacity: {}. Desired capacity must be within the limits of ASG's minimum capacity ({}) and maximum capacity ({}). Please change the value you input for Capacity.".format(params['capacity'], asg_minsize, asg_maxsize))
+        raise TeletraanException("output returned:{} | {}".format(output, group_name))
+        return redirect('/groups/{}/health_check_activities/'.format(group_name))
+    except:
+        pass
 
 
 def enable_scaling_down_event(request, group_name):

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -1251,9 +1251,10 @@ def create_manually_health_check(request, group_name):
     output = autoscaling_groups_helper.create_health_check(request, group_name, health_check_info)
     if(output == False) {
         raise TeletraanException("Healthcheck host could not be created. One of the most primary reason is having healthcheck disabled. Please click on configuration tab to enable health check for the autoscaling setting")
-    } else {
-        return redirect('/groups/{}/health_check_activities/'.format(group_name))
-    }
+    } 
+        
+    return redirect('/groups/{}/health_check_activities/'.format(group_name))
+    
 
 
 def enable_scaling_down_event(request, group_name):

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -1250,7 +1250,9 @@ def create_manually_health_check(request, group_name):
     health_check_info["type"] = "MANUALLY_TRIGGERED"
     output = autoscaling_groups_helper.create_health_check(request, group_name, health_check_info)
     if (output) {
-        raise TeletraanException("Healthcheck host could not be created. One of the most primary reason is having healthcheck disabled. Please click on configuration tab to enable health check for the autoscaling setting %s", type(output))
+        raise TeletraanException("Healthcheck host could not be created. \\
+            One of the most primary reason is having healthcheck disabled. \\
+            Please click on configuration tab to enable health check for the autoscaling setting {}".format(type(output)))
     } 
         
     return redirect('/groups/{}/health_check_activities/'.format(group_name))

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -1250,7 +1250,7 @@ def create_manually_health_check(request, group_name):
     health_check_info["type"] = "MANUALLY_TRIGGERED"
     output = autoscaling_groups_helper.create_health_check(request, group_name, health_check_info)
     
-    raise TeletsraanException("Healthcheck host could not be created. \\
+    raise TeletraanException("Healthcheck host could not be created. \\
             One of the most primary reason is having healthcheck disabled. \\
             Please click on configuration tab to enable health check for the autoscaling setting {}".format(type(output)))
     

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -1249,8 +1249,8 @@ def create_manually_health_check(request, group_name):
     health_check_info["group_name"] = group_name
     health_check_info["type"] = "MANUALLY_TRIGGERED"
     output = autoscaling_groups_helper.create_health_check(request, group_name, health_check_info)
-    if(output == False) {
-        raise TeletraanException("Healthcheck host could not be created. One of the most primary reason is having healthcheck disabled. Please click on configuration tab to enable health check for the autoscaling setting")
+    if (output) {
+        raise TeletraanException("Healthcheck host could not be created. One of the most primary reason is having healthcheck disabled. Please click on configuration tab to enable health check for the autoscaling setting %s", type(output))
     } 
         
     return redirect('/groups/{}/health_check_activities/'.format(group_name))

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -1249,11 +1249,11 @@ def create_manually_health_check(request, group_name):
     health_check_info["group_name"] = group_name
     health_check_info["type"] = "MANUALLY_TRIGGERED"
     output = autoscaling_groups_helper.create_health_check(request, group_name, health_check_info)
-    if (output) {
-        raise TeletraanException("Healthcheck host could not be created. \\
+    
+    raise TeletsraanException("Healthcheck host could not be created. \\
             One of the most primary reason is having healthcheck disabled. \\
             Please click on configuration tab to enable health check for the autoscaling setting {}".format(type(output)))
-    } 
+    
         
     return redirect('/groups/{}/health_check_activities/'.format(group_name))
     

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -1249,17 +1249,12 @@ def get_health_check_details(request, id):
     })
 
 
-def create_manually_health_check(request, group_name):  
+def create_manually_health_check(request, group_name):
     health_check_info = {}
     health_check_info["group_name"] = group_name
     health_check_info["type"] = "MANUALLY_TRIGGERED"
-    output = autoscaling_groups_helper.create_health_check(request, group_name, health_check_info)
-    
-    raise TeletraanException("Healthcheck host could not be created. One of the most primary reason is having healthcheck disabled. Please click on configuration tab to enable health check for the autoscaling setting {}".format(type(output)))
-    
-        
+    autoscaling_groups_helper.create_health_check(request, group_name, health_check_info)
     return redirect('/groups/{}/health_check_activities/'.format(group_name))
-    
 
 
 def enable_scaling_down_event(request, group_name):

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -1252,7 +1252,7 @@ def create_manually_health_check(request, group_name):
         output = autoscaling_groups_helper.create_health_check(request, group_name, health_check_info)
         print(output, group_name)
         #raise TeletraanException("Invalid capacity: {}. Desired capacity must be within the limits of ASG's minimum capacity ({}) and maximum capacity ({}). Please change the value you input for Capacity.".format(params['capacity'], asg_minsize, asg_maxsize))
-        #raise TeletraanException("output returned:{} | {}".format(output, group_name))
+        raise TeletraanException("output returned:{} | {}".format(output, group_name))
         return redirect('/groups/{}/health_check_activities/'.format(group_name))
     except:
         pass

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -1250,7 +1250,8 @@ def create_manually_health_check(request, group_name):
     health_check_info["type"] = "MANUALLY_TRIGGERED"
     output = autoscaling_groups_helper.create_health_check(request, group_name, health_check_info)
     print(output, group_name)
-    raise Exception('output returned:')
+    #raise TeletraanException("Invalid capacity: {}. Desired capacity must be within the limits of ASG's minimum capacity ({}) and maximum capacity ({}). Please change the value you input for Capacity.".format(params['capacity'], asg_minsize, asg_maxsize))
+    raise TeletraanException("output returned:{}".format(output))
     return redirect('/groups/{}/health_check_activities/'.format(group_name))
 
 

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -1207,11 +1207,16 @@ def get_health_check_activities(request, group_name):
         check['env_name'] = env.get('envName')
         check['stage_name'] = env.get('stageName')
 
+    group_info = autoscaling_groups_helper.get_group_info(request, group_name)
+    group_config = group_info.get("groupInfo")
+    healthcheck_state = group_config.get("healthcheckState")
+
     return render(request, 'groups/health_check_activities.html', {
         "group_name": group_name,
         "health_checks": health_checks,
         "asg_status": asg_status,
         "scaling_down_event_enabled": scaling_down_event_enabled,
+        "healthcheck_state": healthcheck_state,
         "pageIndex": index,
         "pageSize": DEFAULT_PAGE_SIZE,
         "disablePrevious": index <= 1,

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -1245,7 +1245,7 @@ def get_health_check_details(request, id):
 
 
 def create_manually_health_check(request, group_name):
-    try:
+    
         health_check_info = {}
         health_check_info["group_name"] = group_name
         health_check_info["type"] = "MANUALLY_TRIGGERED"
@@ -1254,8 +1254,6 @@ def create_manually_health_check(request, group_name):
         #raise TeletraanException("Invalid capacity: {}. Desired capacity must be within the limits of ASG's minimum capacity ({}) and maximum capacity ({}). Please change the value you input for Capacity.".format(params['capacity'], asg_minsize, asg_maxsize))
         raise TeletraanException("output returned:{} | {}".format(output, group_name))
         return redirect('/groups/{}/health_check_activities/'.format(group_name))
-    except:
-        pass
 
 
 def enable_scaling_down_event(request, group_name):

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -1248,7 +1248,9 @@ def create_manually_health_check(request, group_name):
     health_check_info = {}
     health_check_info["group_name"] = group_name
     health_check_info["type"] = "MANUALLY_TRIGGERED"
-    autoscaling_groups_helper.create_health_check(request, group_name, health_check_info)
+    output = autoscaling_groups_helper.create_health_check(request, group_name, health_check_info)
+    print(output, group_name)
+    raise Exception('output returned: %s' % (output))
     return redirect('/groups/{}/health_check_activities/'.format(group_name))
 
 


### PR DESCRIPTION
As per current implementation, user is left wondering why 'Create a Health Check' button is not working. 
When user clicks the 'Create a Health Check' button, nothing happens because of some reason. The reason might be that the enable health check button is not checked. It will be good to have a UI feedback to tell the user the reason why health check host cant be created at the moment.

Changes made
When enable health check button is not checked,
 - Dont show the Create a health check button
 - Display a banner that to trigger a health check, the setting has to be enabled

When enable health check button is checked,
- Show Create a health check button as before
- No banner displayed

Tested in integ

https://user-images.githubusercontent.com/12591127/188762770-49031e32-6f57-4e9c-8b7d-3dc2645bde28.mov


