### PR TITLE
Deploy board and deploy service changes for auto decrement capacity

### DIFF
--- a/deploy-board/deploy_board/templates/host_side_panel.html
+++ b/deploy-board/deploy_board/templates/host_side_panel.html
@@ -29,9 +29,9 @@
                         </div>
                     {% endif %}
 
-                    {% if asg_group %}
-                        <input type="checkbox" id="replace_host" name="replaceHost" checked> Check to replace host (Uncheck to to decrement desired capacity)
-                    {% endif %}
+                    <input type="checkbox" id="replace_host" name="replaceHost" checked> Check to replace host (Uncheck to to decrement desired capacity)
+                    <br><em>Note replacement will only work if the host belongs to an auto scaling group.</em>
+                    <br><em>If you choose to not replace host, it can't be guarenteed that the auto scaling group's min and max sizes will keep identical.</em>
                 </div>
                 <div class="modal-footer">
                     <button type="submit" class="btn btn-primary" id="terminateInstanceBtnId">Terminate</button>
@@ -58,13 +58,13 @@
             <form id="forceTerminateHostForm" class="form-horizontal" method="post" role="form"  action="/env/{{ env_name }}/{{ stage_name }}/force_terminate_hosts/?host_id={{ host_id }}">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
-                    <h4 class="modal-title">Host Termination Confirm</h4>
+                    <h4 class="modal-title">Host Force Termination Confirm</h4>
                 </div>
                 <div class="modal-body">
                     <p> Are you sure to force terminate {{ hostname }}?</p>
-                    {% if asg_group %}
-                        <input type="checkbox" id="replace_host" name="replaceHost" checked> Check to replace host (Uncheck to to decrement desired capacity)
-                    {% endif %}
+                    <input type="checkbox" id="replace_host" name="replaceHost" checked> Check to replace host (Uncheck to to decrement desired capacity)
+                    <br><em>Note replacement will only work if the host belongs to an auto scaling group.</em>
+                    <br><em>If you choose to not replace host, it can't be guarenteed that the auto scaling group's min and max sizes will keep identical.</em>
                 </div>
 
                 <div class="modal-footer">

--- a/deploy-board/deploy_board/templates/host_side_panel.html
+++ b/deploy-board/deploy_board/templates/host_side_panel.html
@@ -31,7 +31,7 @@
 
                     <input type="checkbox" id="replace_host" name="replaceHost" checked> Check to replace host (Uncheck to to decrement desired capacity)
                     <br><em>Note replacement will only work if the host belongs to an auto scaling group.</em>
-                    <br><em>If you choose to not replace host, it can't be guarenteed that the auto scaling group's min and max sizes will keep identical.</em>
+                    <br><em>If you choose to not replace host, it can't be guaranteed that the auto scaling group's min and max sizes will keep identical.</em>
                 </div>
                 <div class="modal-footer">
                     <button type="submit" class="btn btn-primary" id="terminateInstanceBtnId">Terminate</button>
@@ -64,7 +64,7 @@
                     <p> Are you sure to force terminate {{ hostname }}?</p>
                     <input type="checkbox" id="replace_host" name="replaceHost" checked> Check to replace host (Uncheck to to decrement desired capacity)
                     <br><em>Note replacement will only work if the host belongs to an auto scaling group.</em>
-                    <br><em>If you choose to not replace host, it can't be guarenteed that the auto scaling group's min and max sizes will keep identical.</em>
+                    <br><em>If you choose to not replace host, it can't be guaranteed that the auto scaling group's min and max sizes will keep identical.</em>
                 </div>
 
                 <div class="modal-footer">

--- a/deploy-board/deploy_board/templates/host_side_panel.html
+++ b/deploy-board/deploy_board/templates/host_side_panel.html
@@ -28,6 +28,10 @@
                             <strong>Warning!</strong> This host is unreachable. It cannot be gracefully shut down.
                         </div>
                     {% endif %}
+
+                    {% if asg_group %}
+                        <input type="checkbox" id="replace_host" name="replaceHost" checked> Check to replace host (Uncheck to to decrement desired capacity)
+                    {% endif %}
                 </div>
                 <div class="modal-footer">
                     <button type="submit" class="btn btn-primary" id="terminateInstanceBtnId">Terminate</button>
@@ -58,16 +62,9 @@
                 </div>
                 <div class="modal-body">
                     <p> Are you sure to force terminate {{ hostname }}?</p>
-
-                    <a data-toggle="collapse" href="#collapseExample" aria-expanded="false" aria-controls="collapseExample">
-                    <span id="collapseToggler" class="glyphicon glyphicon-chevron-right"></span>
-                    </a>
-
-                    <div class="collapse" id="collapseExample">
-                      <div class="card card-block">
-                        <input type="checkbox" id="replace_host" name="replaceHost" checked> Check to replace host
-                      </div>
-                    </div>
+                    {% if asg_group %}
+                        <input type="checkbox" id="replace_host" name="replaceHost" checked> Check to replace host (Uncheck to to decrement desired capacity)
+                    {% endif %}
                 </div>
 
                 <div class="modal-footer">

--- a/deploy-board/deploy_board/templates/hosts/hosts.tmpl
+++ b/deploy-board/deploy_board/templates/hosts/hosts.tmpl
@@ -8,27 +8,27 @@
           <button id="pauseButton"
           class="btn btn-default btn-sm" data-toggle="tooltip"
           title="Pause selected hosts">
-          <span class="glyphicon glyphicon-pause"></span> Pause 
+          <span class="glyphicon glyphicon-pause"></span> Pause
           </button>
           <button id="resumeButton"
           class="btn btn-default btn-sm" data-toggle="tooltip"
           title="Resume selected hosts">
-          <span class="glyphicon glyphicon-play"></span> Resume 
+          <span class="glyphicon glyphicon-play"></span> Resume
           </button>
           <button id="resetButton"
           class="btn btn-default btn-sm" data-toggle="tooltip"
           title="reset selected hosts">
-          <span class="glyphicon glyphicon-repeat"></span> Reset 
+          <span class="glyphicon glyphicon-repeat"></span> Reset
           </button>
           <button id="terminateButton"
           class="btn btn-default btn-sm" data-toggle="tooltip"
           title="Soft terminate selected hosts">
-          <span class="glyphicon glyphicon-off"></span> Terminate 
+          <span class="glyphicon glyphicon-off"></span> Terminate
           </button>
           <button id="forceTerminateButton"
           class="btn btn-default btn-sm" data-toggle="tooltip"
           title="Soft terminate selected hosts">
-          <span class="glyphicon glyphicon-remove"></span> Force Terminate 
+          <span class="glyphicon glyphicon-remove"></span> Force Terminate
           </button>
         </div>
   </div>
@@ -145,7 +145,7 @@
                 checkedHosts.push($(this).val());
             }
         });
-      
+
         if ($("#hostTable input:checkbox:checked").length <= 0) {
             $(".btn").prop("disabled", true);
         } else {
@@ -155,12 +155,12 @@
 
     $("#pauseButton").on("click", function() {
         $('#pauseSelectedHosts').modal();
-        $('#pauseSelectedHosts .modal-body #hostsList').val(checkedHosts);  
+        $('#pauseSelectedHosts .modal-body #hostsList').val(checkedHosts);
     });
 
     $("#resumeButton").on("click", function() {
         $('#resumeSelectedHosts').modal();
-        $('#resumeSelectedHosts .modal-body #hostsList').val(checkedHosts);  
+        $('#resumeSelectedHosts .modal-body #hostsList').val(checkedHosts);
     });
 
     $("#resetButton").on("click", function() {
@@ -259,6 +259,8 @@
                 <div class="modal-body">
                     <p> Are you sure you would like to terminate the following hosts?</p>
                     <input id="hostsList" class="form-control" name="hostIds" type="text" value=""/>
+                    <br>
+                    <input type="checkbox" id="replace_host" name="replaceHost" checked> Check to replace host (Uncheck to to decrement desired capacity)
                 </div>
                 <div class="modal-footer">
                     <button type="submit" class="btn btn-primary">Terminate</button>
@@ -281,6 +283,8 @@
                 <div class="modal-body">
                     <p> Are you sure you would like to force terminate the following hosts?</p>
                     <input id="hostsList" class="form-control" name="hostIds" type="text" value=""/>
+                    <br>
+                    <input type="checkbox" id="replace_host" name="replaceHost" checked> Check to replace host (Uncheck to to decrement desired capacity)
                 </div>
                 <div class="modal-footer">
                     <button type="submit" class="btn btn-primary" id="terminateInstanceBtnId">Force Terminate</button>

--- a/deploy-board/deploy_board/templates/hosts/hosts.tmpl
+++ b/deploy-board/deploy_board/templates/hosts/hosts.tmpl
@@ -262,7 +262,7 @@
                     <br>
                     <input type="checkbox" id="replace_host" name="replaceHost" checked> Check to replace host (Uncheck to to decrement desired capacity)
                     <br><em>Note replacement will only work if the host belongs to an auto scaling group.</em>
-                    <br><em>If you choose to not replace host, it can't be guarenteed that the auto scaling group's min and max sizes will keep identical.</em>
+                    <br><em>If you choose to not replace host, it can't be guaranteed that the auto scaling group's min and max sizes will keep identical.</em>
                 </div>
                 <div class="modal-footer">
                     <button type="submit" class="btn btn-primary">Terminate</button>
@@ -280,7 +280,7 @@
             <form id="forceTerminateSelectedHostForm" class="form-horizontal" method="post" role="form"  action="/env/{{ env.envName }}/{{ env.stageName }}/force_terminate_hosts/">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
-                    <h4 class="modal-title">Host(s) Force Termination Confirma</h4>
+                    <h4 class="modal-title">Host(s) Force Termination Confirm</h4>
                 </div>
                 <div class="modal-body">
                     <p> Are you sure you would like to force terminate the following hosts?</p>
@@ -288,7 +288,7 @@
                     <br>
                     <input type="checkbox" id="replace_host" name="replaceHost" checked> Check to replace host (Uncheck to to decrement desired capacity)
                     <br><em>Note replacement will only work if the host belongs to an auto scaling group.</em>
-                    <br><em>If you choose to not replace host, it can't be guarenteed that the auto scaling group's min and max sizes will keep identical.</em>                </div>
+                    <br><em>If you choose to not replace host, it can't be guaranteed that the auto scaling group's min and max sizes will keep identical.</em>                </div>
                 <div class="modal-footer">
                     <button type="submit" class="btn btn-primary" id="terminateInstanceBtnId">Force Terminate</button>
                     <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>

--- a/deploy-board/deploy_board/templates/hosts/hosts.tmpl
+++ b/deploy-board/deploy_board/templates/hosts/hosts.tmpl
@@ -122,7 +122,7 @@
         });
     });
 
-    $('input[type="checkbox"]').click(function(){
+    $('#hostTable input[type="checkbox"]').click(function(){
         if ($("#hostTable input:checkbox:checked").length <= 0) {
           $(".btn").prop("disabled", true);
         } else {
@@ -140,7 +140,7 @@
     });
 
     $(document).ready(function() {
-        $('input[type=checkbox]').each(function () {
+        $('#hostTable input[type=checkbox]').each(function () {
             if (this.checked) {
                 checkedHosts.push($(this).val());
             }

--- a/deploy-board/deploy_board/templates/hosts/hosts.tmpl
+++ b/deploy-board/deploy_board/templates/hosts/hosts.tmpl
@@ -254,13 +254,15 @@
             <form id="terminateSelectedHostForm" class="form-horizontal"  method="post" role="form"  action="/env/{{ env.envName }}/{{ env.stageName }}/terminate_hosts/">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
-                    <h4 class="modal-title">Host(s) Termination Confirmation</h4>
+                    <h4 class="modal-title">Host(s) Termination Confirm</h4>
                 </div>
                 <div class="modal-body">
                     <p> Are you sure you would like to terminate the following hosts?</p>
                     <input id="hostsList" class="form-control" name="hostIds" type="text" value=""/>
                     <br>
                     <input type="checkbox" id="replace_host" name="replaceHost" checked> Check to replace host (Uncheck to to decrement desired capacity)
+                    <br><em>Note replacement will only work if the host belongs to an auto scaling group.</em>
+                    <br><em>If you choose to not replace host, it can't be guarenteed that the auto scaling group's min and max sizes will keep identical.</em>
                 </div>
                 <div class="modal-footer">
                     <button type="submit" class="btn btn-primary">Terminate</button>
@@ -278,14 +280,15 @@
             <form id="forceTerminateSelectedHostForm" class="form-horizontal" method="post" role="form"  action="/env/{{ env.envName }}/{{ env.stageName }}/force_terminate_hosts/">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
-                    <h4 class="modal-title">Host(s) Force Termination Confirmation</h4>
+                    <h4 class="modal-title">Host(s) Force Termination Confirma</h4>
                 </div>
                 <div class="modal-body">
                     <p> Are you sure you would like to force terminate the following hosts?</p>
                     <input id="hostsList" class="form-control" name="hostIds" type="text" value=""/>
                     <br>
                     <input type="checkbox" id="replace_host" name="replaceHost" checked> Check to replace host (Uncheck to to decrement desired capacity)
-                </div>
+                    <br><em>Note replacement will only work if the host belongs to an auto scaling group.</em>
+                    <br><em>If you choose to not replace host, it can't be guarenteed that the auto scaling group's min and max sizes will keep identical.</em>                </div>
                 <div class="modal-footer">
                     <button type="submit" class="btn btn-primary" id="terminateInstanceBtnId">Force Terminate</button>
                     <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>

--- a/deploy-board/deploy_board/webapp/cluster_view.py
+++ b/deploy-board/deploy_board/webapp/cluster_view.py
@@ -752,7 +752,7 @@ def terminate_hosts(request, name, stage):
         hosts_str = post_params['hostIds']
         host_ids = [x.strip() for x in hosts_str.split(',')]
 
-    replace_host = True if 'replaceHost' in post_params else False
+    replace_host = 'replaceHost' in post_params
     environ_hosts_helper.stop_service_on_host(request, name, stage, host_ids, replace_host)
     return redirect('/env/{}/{}/'.format(name, stage))
 

--- a/deploy-board/deploy_board/webapp/cluster_view.py
+++ b/deploy-board/deploy_board/webapp/cluster_view.py
@@ -768,7 +768,7 @@ def force_terminate_hosts(request, name, stage):
         hosts_str = post_params['hostIds']
         host_ids = [x.strip() for x in hosts_str.split(',')]
 
-    replace_host = True if 'replaceHost' in post_params else False
+    replace_host = 'replaceHost' in post_params
     cluster_name = common.get_cluster_name(request, name, stage)
     if not cluster_name:
         groups = environs_helper.get_env_capacity(

--- a/deploy-board/deploy_board/webapp/cluster_view.py
+++ b/deploy-board/deploy_board/webapp/cluster_view.py
@@ -751,7 +751,9 @@ def terminate_hosts(request, name, stage):
     if 'hostIds' in post_params:
         hosts_str = post_params['hostIds']
         host_ids = [x.strip() for x in hosts_str.split(',')]
-    environ_hosts_helper.stop_service_on_host(request, name, stage, host_ids)
+
+    replace_host = True if 'replaceHost' in post_params else False
+    environ_hosts_helper.stop_service_on_host(request, name, stage, host_ids, replace_host)
     return redirect('/env/{}/{}/'.format(name, stage))
 
 
@@ -766,11 +768,7 @@ def force_terminate_hosts(request, name, stage):
         hosts_str = post_params['hostIds']
         host_ids = [x.strip() for x in hosts_str.split(',')]
 
-    if 'replaceHost' in post_params:
-        replace_host = True
-    else:
-        replace_host = False
-
+    replace_host = True if 'replaceHost' in post_params else False
     cluster_name = common.get_cluster_name(request, name, stage)
     if not cluster_name:
         groups = environs_helper.get_env_capacity(

--- a/deploy-board/deploy_board/webapp/helpers/environ_hosts_helper.py
+++ b/deploy-board/deploy_board/webapp/helpers/environ_hosts_helper.py
@@ -28,7 +28,7 @@ def get_host_by_env_and_hostname(request, env_name, stage_name, host_name):
 
 
 def stop_service_on_host(request, env_name, stage_name, host_ids, replace_host):
-    return deploy_client.delete("/envs/%s/%s/hosts" % (env_name, stage_name), request.teletraan_user_id.token,
+    return deploy_client.delete("/envs/%s/%s/hosts?replaceHost=%s" % (env_name, stage_name, replace_host), request.teletraan_user_id.token,
                                 data=host_ids)
 
 

--- a/deploy-board/deploy_board/webapp/helpers/environ_hosts_helper.py
+++ b/deploy-board/deploy_board/webapp/helpers/environ_hosts_helper.py
@@ -27,7 +27,7 @@ def get_host_by_env_and_hostname(request, env_name, stage_name, host_name):
     return deploy_client.get("/envs/%s/%s/hosts/%s" % (env_name, stage_name, host_name), request.teletraan_user_id.token)
 
 
-def stop_service_on_host(request, env_name, stage_name, host_ids):
+def stop_service_on_host(request, env_name, stage_name, host_ids, replace_host):
     return deploy_client.delete("/envs/%s/%s/hosts" % (env_name, stage_name), request.teletraan_user_id.token,
                                 data=host_ids)
 

--- a/deploy-board/deploy_board/webapp/host_views.py
+++ b/deploy-board/deploy_board/webapp/host_views.py
@@ -63,7 +63,7 @@ def get_asg_name(request, hosts):
 
 def get_show_terminate(hosts):
     for host in hosts:
-        if host and host.get('state') and host.get('state') not in ('PENDING_TERMINATE', 'TERMINATING', 'TERMINATED', 'PENDING_REPLACEABLE_TERMINATE'):
+        if host and host.get('state') and host.get('state') not in ('PENDING_TERMINATE', 'TERMINATING', 'TERMINATED', 'PENDING_TERMINATE_NO_REPLACE'):
             return True
     return False
 

--- a/deploy-board/deploy_board/webapp/host_views.py
+++ b/deploy-board/deploy_board/webapp/host_views.py
@@ -63,7 +63,7 @@ def get_asg_name(request, hosts):
 
 def get_show_terminate(hosts):
     for host in hosts:
-        if host and host.get('state') and host.get('state') not in ('PENDING_TERMINATE', 'TERMINATING', 'TERMINATED', 'PENDING_TERMINATE_NO_REPLACE'):
+        if host and host.get('state') and host.get('state') not in {'PENDING_TERMINATE', 'TERMINATING', 'TERMINATED', 'PENDING_TERMINATE_NO_REPLACE'}:
             return True
     return False
 

--- a/deploy-board/deploy_board/webapp/host_views.py
+++ b/deploy-board/deploy_board/webapp/host_views.py
@@ -63,7 +63,7 @@ def get_asg_name(request, hosts):
 
 def get_show_terminate(hosts):
     for host in hosts:
-        if host and host.get('state') and host.get('state') != 'PENDING_TERMINATE' and host.get('state') != 'TERMINATING' and host.get('state') != 'TERMINATED':
+        if host and host.get('state') and host.get('state') not in ('PENDING_TERMINATE', 'TERMINATING', 'TERMINATED', 'PENDING_REPLACEABLE_TERMINATE'):
             return True
     return False
 

--- a/deploy-board/deploy_board/webapp/templatetags/utils.py
+++ b/deploy-board/deploy_board/webapp/templatetags/utils.py
@@ -161,6 +161,7 @@ _HEALTH_TYPE_TO_ICONS = {
     "MANUALLY_TRIGGERED": "fa fa-hand-o-left",
 }
 
+_TERMINATING_STATES = {"PENDING_TERMINATE", "TERMINATING", "PENDING_TERMINATE_NO_REPLACE"}
 
 # convert epoch (in milliseconds) to time
 @register.filter("convertTimestamp")
@@ -446,7 +447,7 @@ def successRateTip(deploy):
 
 @register.filter("hostStateClass")
 def hostStateClass(state):
-    if state in ("PENDING_TERMINATE", "TERMINATING", "PENDING_TERMINATE_NO_REPLACE"):
+    if state in _TERMINATING_STATES:
         return "danger"
     else:
         return ""
@@ -605,7 +606,7 @@ def agentIcon(agentStats):
 
 @register.filter("hostButton")
 def hostButton(host):
-    if host['state'] in ('PENDING_TERMINATE', 'TERMINATING', 'PENDING_TERMINATE_NO_REPLACE'):
+    if host['state'] in _TERMINATING_STATES:
         return 'btn-warning'
 
     return 'btn-default'

--- a/deploy-board/deploy_board/webapp/templatetags/utils.py
+++ b/deploy-board/deploy_board/webapp/templatetags/utils.py
@@ -446,7 +446,7 @@ def successRateTip(deploy):
 
 @register.filter("hostStateClass")
 def hostStateClass(state):
-    if state == "PENDING_TERMINATE" or state == "TERMINATING":
+    if state in ("PENDING_TERMINATE", "TERMINATING", "PENDING_REPLACEABLE_TERMINATE"):
         return "danger"
     else:
         return ""
@@ -605,7 +605,7 @@ def agentIcon(agentStats):
 
 @register.filter("hostButton")
 def hostButton(host):
-    if host['state'] == 'PENDING_TERMINATE' or host['state'] == 'TERMINATING':
+    if host['state'] in ('PENDING_TERMINATE', 'TERMINATING', 'PENDING_REPLACEABLE_TERMINATE'):
         return 'btn-warning'
 
     return 'btn-default'

--- a/deploy-board/deploy_board/webapp/templatetags/utils.py
+++ b/deploy-board/deploy_board/webapp/templatetags/utils.py
@@ -446,7 +446,7 @@ def successRateTip(deploy):
 
 @register.filter("hostStateClass")
 def hostStateClass(state):
-    if state in ("PENDING_TERMINATE", "TERMINATING", "PENDING_REPLACEABLE_TERMINATE"):
+    if state in ("PENDING_TERMINATE", "TERMINATING", "PENDING_TERMINATE_NO_REPLACE"):
         return "danger"
     else:
         return ""
@@ -605,7 +605,7 @@ def agentIcon(agentStats):
 
 @register.filter("hostButton")
 def hostButton(host):
-    if host['state'] in ('PENDING_TERMINATE', 'TERMINATING', 'PENDING_REPLACEABLE_TERMINATE'):
+    if host['state'] in ('PENDING_TERMINATE', 'TERMINATING', 'PENDING_TERMINATE_NO_REPLACE'):
         return 'btn-warning'
 
     return 'btn-default'

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/HostBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/HostBean.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *    
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -127,6 +127,10 @@ public class HostBean implements Updatable {
 
     public void setCan_retire(Integer can_retire) {
         this.can_retire = can_retire;
+    }
+
+    public Boolean isPendingTerminate() {
+        return this.state == HostState.PENDING_TERMINATE || this.state == HostState.PENDING_REPLACEABLE_TERMINATE;
     }
 
     @Override

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/HostBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/HostBean.java
@@ -130,7 +130,7 @@ public class HostBean implements Updatable {
     }
 
     public Boolean isPendingTerminate() {
-        return this.state == HostState.PENDING_TERMINATE || this.state == HostState.PENDING_REPLACEABLE_TERMINATE;
+        return this.state == HostState.PENDING_TERMINATE || this.state == HostState.PENDING_TERMINATE_NO_REPLACE;
     }
 
     @Override

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/HostState.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/HostState.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *    
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,11 +26,14 @@ package com.pinterest.deployservice.bean;
  *      Host if being terminated
  * TERMINATED:
  *      Host is terminated
+ * PENDING_REPLACEABLE_TERMINATE:
+ *      Host is pending terminate with replacement request
  */
 public enum HostState {
     PROVISIONED,
     ACTIVE,
     PENDING_TERMINATE,
     TERMINATING,
-    TERMINATED
+    TERMINATED,
+    PENDING_REPLACEABLE_TERMINATE
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/HostState.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/HostState.java
@@ -21,13 +21,13 @@ package com.pinterest.deployservice.bean;
  * ACTIVE:
  *      Host is ready to deploy
  * PENDING_TERMINATE:
- *      Host is pending terminate
+ *      Host is pending terminate with replacement request
  * TERMINATING:
  *      Host if being terminated
  * TERMINATED:
  *      Host is terminated
- * PENDING_REPLACEABLE_TERMINATE:
- *      Host is pending terminate with replacement request
+ * PENDING_TERMINATE_NO_REPLACE:
+ *      Host is pending terminate without replacement request
  */
 public enum HostState {
     PROVISIONED,
@@ -35,5 +35,5 @@ public enum HostState {
     PENDING_TERMINATE,
     TERMINATING,
     TERMINATED,
-    PENDING_REPLACEABLE_TERMINATE
+    PENDING_TERMINATE_NO_REPLACE
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostDAOImpl.java
@@ -23,8 +23,6 @@ import com.pinterest.deployservice.bean.HostState;
 import com.pinterest.deployservice.bean.SetClause;
 import com.pinterest.deployservice.dao.HostDAO;
 
-import io.jsonwebtoken.lang.Collections;
-
 import org.apache.commons.dbcp.BasicDataSource;
 import org.apache.commons.dbutils.QueryRunner;
 import org.apache.commons.dbutils.ResultSetHandler;

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostDAOImpl.java
@@ -114,7 +114,7 @@ public class DBHostDAOImpl implements HostDAO {
     public void insertOrUpdate(String hostName, String ip, String hostId, String state, Set<String> groupNames) throws Exception {
         long now = System.currentTimeMillis();
         //TODO need to refactoring this to be more generic to all columns, e.g. use genStringGroupClause() like the other DAOs
-        // If state is PENDING_TERMINATE, PENDING_REPLACEABLE_TERMINATE or TERMINATING, do not overwrite its state
+        // If state is PENDING_TERMINATE, PENDING_TERMINATE_NO_REPLACE or TERMINATING, do not overwrite its state
         StringBuilder names = new StringBuilder("(host_id,group_name,create_date,last_update,state");
         if (hostName != null) {
             names.append(",host_name");
@@ -152,7 +152,7 @@ public class DBHostDAOImpl implements HostDAO {
         sb.setLength(sb.length() - 1);
         new QueryRunner(dataSource).update(String.format(INSERT_UPDATE_TEMPLATE, names, sb.toString(),
                 HostState.PENDING_TERMINATE.toString(), HostState.TERMINATING.toString(),
-                HostState.PENDING_REPLACEABLE_TERMINATE.toString()), ip, now, hostName, hostName, ip);
+                HostState.PENDING_TERMINATE_NO_REPLACE.toString()), ip, now, hostName, hostName, ip);
     }
 
     @Override
@@ -192,7 +192,7 @@ public class DBHostDAOImpl implements HostDAO {
     public List<HostBean> getTerminatingHosts() throws Exception {
         ResultSetHandler<List<HostBean>> h = new BeanListHandler<>(HostBean.class);
         return new QueryRunner(dataSource).query(GET_HOSTS_BY_STATES, h, HostState.PENDING_TERMINATE.toString(),
-                HostState.TERMINATING.toString(), HostState.PENDING_REPLACEABLE_TERMINATE.toString());
+                HostState.TERMINATING.toString(), HostState.PENDING_TERMINATE_NO_REPLACE.toString());
     }
 
     @Override
@@ -236,7 +236,7 @@ public class DBHostDAOImpl implements HostDAO {
         return new QueryRunner(dataSource).query(GET_RETIRED_HOSTIDS_BY_GROUP,
                 SingleResultSetHandlerFactory.<String>newListObjectHandler(), groupName,
                 HostState.PENDING_TERMINATE.toString(), HostState.TERMINATING.toString(),
-                HostState.PENDING_REPLACEABLE_TERMINATE.toString());
+                HostState.PENDING_TERMINATE_NO_REPLACE.toString());
     }
 
     @Override
@@ -244,7 +244,7 @@ public class DBHostDAOImpl implements HostDAO {
         return new QueryRunner(dataSource).query(GET_RETIRED_AND_FAILED_HOSTIDS_BY_GROUP,
                 SingleResultSetHandlerFactory.<String>newListObjectHandler(), groupName,
                 HostState.PENDING_TERMINATE.toString(), HostState.TERMINATING.toString(),
-                HostState.PENDING_REPLACEABLE_TERMINATE.toString(),
+                HostState.PENDING_TERMINATE_NO_REPLACE.toString(),
                 AgentStatus.UNKNOWN.toString(), AgentStatus.SUCCEEDED.toString());
     }
 
@@ -254,7 +254,7 @@ public class DBHostDAOImpl implements HostDAO {
                 SingleResultSetHandlerFactory.<String>newListObjectHandler(),
                 AgentState.NORMAL.toString(), DeployStage.SERVING_BUILD.toString(), groupName,
                 HostState.PENDING_TERMINATE.toString(), HostState.TERMINATING.toString(),
-                HostState.PENDING_REPLACEABLE_TERMINATE.toString());
+                HostState.PENDING_TERMINATE_NO_REPLACE.toString());
     }
 
     @Override
@@ -262,7 +262,7 @@ public class DBHostDAOImpl implements HostDAO {
         return new QueryRunner(dataSource).query(GET_NEW_HOSTIDS_BY_GROUP,
             SingleResultSetHandlerFactory.<String>newListObjectHandler(), groupName,
             HostState.PENDING_TERMINATE.toString(), HostState.TERMINATING.toString(),
-            HostState.PENDING_REPLACEABLE_TERMINATE.toString());
+            HostState.PENDING_TERMINATE_NO_REPLACE.toString());
     }
 
     @Override
@@ -270,7 +270,7 @@ public class DBHostDAOImpl implements HostDAO {
         return new QueryRunner(dataSource).query(GET_FAILED_HOSTIDS_BY_GROUP,
                 SingleResultSetHandlerFactory.<String>newListObjectHandler(), groupName,
                 HostState.PENDING_TERMINATE.toString(), HostState.TERMINATING.toString(),
-                HostState.PENDING_REPLACEABLE_TERMINATE.toString(),
+                HostState.PENDING_TERMINATE_NO_REPLACE.toString(),
                 AgentStatus.UNKNOWN.toString(), AgentStatus.SUCCEEDED.toString());
     }
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostDAOImpl.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *    
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,6 +22,8 @@ import com.pinterest.deployservice.bean.HostBean;
 import com.pinterest.deployservice.bean.HostState;
 import com.pinterest.deployservice.bean.SetClause;
 import com.pinterest.deployservice.dao.HostDAO;
+
+import io.jsonwebtoken.lang.Collections;
 
 import org.apache.commons.dbcp.BasicDataSource;
 import org.apache.commons.dbutils.QueryRunner;
@@ -39,7 +41,7 @@ public class DBHostDAOImpl implements HostDAO {
     private static final String UPDATE_HOST_BY_ID = "UPDATE hosts SET %s WHERE host_id=?";
     private static final String INSERT_HOST_TEMPLATE = "INSERT INTO hosts SET %s ON DUPLICATE KEY UPDATE %s";
     private static final String INSERT_UPDATE_TEMPLATE = "INSERT INTO hosts %s VALUES %s ON DUPLICATE KEY UPDATE ip=?, last_update=?, " +
-            "state=IF(state!='%s' AND state!='%s', VALUES(state), state), " +
+            "state=IF(state!='%s' AND state!='%s' AND state!='%s', VALUES(state), state), " +
             "host_name=CASE WHEN host_name IS NULL THEN ? WHEN host_name=host_id THEN ? ELSE host_name END, " +
             "ip=CASE WHEN ip IS NULL THEN ? ELSE ip END";
     private static final String DELETE_HOST_BY_ID = "DELETE FROM hosts WHERE host_id=?";
@@ -49,7 +51,7 @@ public class DBHostDAOImpl implements HostDAO {
     private static final String GET_ALL_HOSTS_BY_GROUP = "SELECT * FROM hosts WHERE group_name=? AND state!='TERMINATING'";
     private static final String GET_HOST_BY_NAME = "SELECT * FROM hosts WHERE host_name=?";
     private static final String GET_HOST_BY_HOSTID = "SELECT * FROM hosts WHERE host_id=?";
-    private static final String GET_HOSTS_BY_STATES = "SELECT * FROM hosts WHERE state in (?, ?) GROUP BY host_id";
+    private static final String GET_HOSTS_BY_STATES = "SELECT * FROM hosts WHERE state in (?, ?, ?) GROUP BY host_id";
     private static final String GET_GROUP_NAMES_BY_HOST = "SELECT group_name FROM hosts WHERE host_name=?";
     private static final String GET_STALE_ENV_HOST = "SELECT DISTINCT hosts.* FROM hosts INNER JOIN hosts_and_envs ON hosts.host_name=hosts_and_envs.host_name WHERE hosts.last_update<?";
     private static final String GET_STALE_HOST = "SELECT DISTINCT hosts.* FROM hosts WHERE hosts.last_update<?";
@@ -59,16 +61,16 @@ public class DBHostDAOImpl implements HostDAO {
     private static final String GET_HOST_BY_ENVID_AND_HOSTID = "SELECT DISTINCT e.* FROM hosts e INNER JOIN groups_and_envs ge ON ge.group_name = e.group_name WHERE ge.env_id=? AND e.host_id=?";
     private static final String GET_HOST_BY_ENVID_AND_HOSTNAME1 = "SELECT hs.* FROM hosts hs INNER JOIN groups_and_envs ge ON ge.group_name = hs.group_name WHERE ge.env_id=? AND hs.host_name=?";
     private static final String GET_HOST_BY_ENVID_AND_HOSTNAME2 = "SELECT hs.* FROM hosts hs INNER JOIN hosts_and_envs he ON he.host_name = hs.host_name WHERE he.env_id=? AND he.host_name=?";
-    private static final String GET_RETIRED_HOSTIDS_BY_GROUP = "SELECT DISTINCT host_id FROM hosts WHERE can_retire=1 AND group_name=? AND state not in (?,?)";
+    private static final String GET_RETIRED_HOSTIDS_BY_GROUP = "SELECT DISTINCT host_id FROM hosts WHERE can_retire=1 AND group_name=? AND state not in (?,?,?)";
     private static final String GET_RETIRED_AND_FAILED_HOSTIDS_BY_GROUP =
-            "SELECT DISTINCT h.host_id FROM hosts h INNER JOIN agents a ON a.host_id=h.host_id WHERE h.can_retire=1 AND h.group_name=? AND h.state not in (?,?) and a.status not in (?,?)";
+            "SELECT DISTINCT h.host_id FROM hosts h INNER JOIN agents a ON a.host_id=h.host_id WHERE h.can_retire=1 AND h.group_name=? AND h.state not in (?,?,?) and a.status not in (?,?)";
     private static final String GET_FAILED_HOSTIDS_BY_GROUP =
-            "SELECT DISTINCT h.host_id FROM hosts h INNER JOIN agents a ON a.host_id=h.host_id WHERE h.group_name=? AND h.state not in (?,?) and a.status not in (?,?)";
+            "SELECT DISTINCT h.host_id FROM hosts h INNER JOIN agents a ON a.host_id=h.host_id WHERE h.group_name=? AND h.state not in (?,?,?) and a.status not in (?,?)";
     private static final String GET_NEW_AND_SERVING_BUILD_HOSTIDS_BY_GROUP =
             "SELECT host_id FROM agents x WHERE x.state = ? AND x.deploy_stage = ? " +
-            "AND x.host_id IN (SELECT DISTINCT h.host_id AS host_id FROM hosts h INNER JOIN agents a ON a.host_id=h.host_id WHERE h.can_retire=0 AND h.group_name=? AND h.state not in (?,?)) " +
+            "AND x.host_id IN (SELECT DISTINCT h.host_id AS host_id FROM hosts h INNER JOIN agents a ON a.host_id=h.host_id WHERE h.can_retire=0 AND h.group_name=? AND h.state not in (?,?,?)) " +
             "GROUP BY x.host_id HAVING count(*) = (SELECT count(*) FROM agents y WHERE y.host_id = x.host_id)";
-    private static final String GET_NEW_HOSTIDS_BY_GROUP = "SELECT DISTINCT host_id FROM hosts WHERE can_retire=0 AND group_name=? AND state not in (?,?)";
+    private static final String GET_NEW_HOSTIDS_BY_GROUP = "SELECT DISTINCT host_id FROM hosts WHERE can_retire=0 AND group_name=? AND state not in (?,?,?)";
 
     private BasicDataSource dataSource;
 
@@ -112,7 +114,7 @@ public class DBHostDAOImpl implements HostDAO {
     public void insertOrUpdate(String hostName, String ip, String hostId, String state, Set<String> groupNames) throws Exception {
         long now = System.currentTimeMillis();
         //TODO need to refactoring this to be more generic to all columns, e.g. use genStringGroupClause() like the other DAOs
-        // If state is PENDING_TERMINATE or TERMINATING, do not overwrite its state
+        // If state is PENDING_TERMINATE, PENDING_REPLACEABLE_TERMINATE or TERMINATING, do not overwrite its state
         StringBuilder names = new StringBuilder("(host_id,group_name,create_date,last_update,state");
         if (hostName != null) {
             names.append(",host_name");
@@ -149,7 +151,8 @@ public class DBHostDAOImpl implements HostDAO {
         }
         sb.setLength(sb.length() - 1);
         new QueryRunner(dataSource).update(String.format(INSERT_UPDATE_TEMPLATE, names, sb.toString(),
-                HostState.PENDING_TERMINATE.toString(), HostState.TERMINATING.toString()), ip, now, hostName, hostName, ip);
+                HostState.PENDING_TERMINATE.toString(), HostState.TERMINATING.toString(),
+                HostState.PENDING_REPLACEABLE_TERMINATE.toString()), ip, now, hostName, hostName, ip);
     }
 
     @Override
@@ -189,7 +192,7 @@ public class DBHostDAOImpl implements HostDAO {
     public List<HostBean> getTerminatingHosts() throws Exception {
         ResultSetHandler<List<HostBean>> h = new BeanListHandler<>(HostBean.class);
         return new QueryRunner(dataSource).query(GET_HOSTS_BY_STATES, h, HostState.PENDING_TERMINATE.toString(),
-                HostState.TERMINATING.toString());
+                HostState.TERMINATING.toString(), HostState.PENDING_REPLACEABLE_TERMINATE.toString());
     }
 
     @Override
@@ -232,7 +235,8 @@ public class DBHostDAOImpl implements HostDAO {
     public Collection<String> getToBeRetiredHostIdsByGroup(String groupName) throws Exception {
         return new QueryRunner(dataSource).query(GET_RETIRED_HOSTIDS_BY_GROUP,
                 SingleResultSetHandlerFactory.<String>newListObjectHandler(), groupName,
-                HostState.PENDING_TERMINATE.toString(), HostState.TERMINATING.toString());
+                HostState.PENDING_TERMINATE.toString(), HostState.TERMINATING.toString(),
+                HostState.PENDING_REPLACEABLE_TERMINATE.toString());
     }
 
     @Override
@@ -240,6 +244,7 @@ public class DBHostDAOImpl implements HostDAO {
         return new QueryRunner(dataSource).query(GET_RETIRED_AND_FAILED_HOSTIDS_BY_GROUP,
                 SingleResultSetHandlerFactory.<String>newListObjectHandler(), groupName,
                 HostState.PENDING_TERMINATE.toString(), HostState.TERMINATING.toString(),
+                HostState.PENDING_REPLACEABLE_TERMINATE.toString(),
                 AgentStatus.UNKNOWN.toString(), AgentStatus.SUCCEEDED.toString());
     }
 
@@ -248,14 +253,16 @@ public class DBHostDAOImpl implements HostDAO {
         return new QueryRunner(dataSource).query(GET_NEW_AND_SERVING_BUILD_HOSTIDS_BY_GROUP,
                 SingleResultSetHandlerFactory.<String>newListObjectHandler(),
                 AgentState.NORMAL.toString(), DeployStage.SERVING_BUILD.toString(), groupName,
-                HostState.PENDING_TERMINATE.toString(), HostState.TERMINATING.toString());
+                HostState.PENDING_TERMINATE.toString(), HostState.TERMINATING.toString(),
+                HostState.PENDING_REPLACEABLE_TERMINATE.toString());
     }
 
     @Override
     public Collection<String> getNewHostIdsByGroup(String groupName) throws Exception {
         return new QueryRunner(dataSource).query(GET_NEW_HOSTIDS_BY_GROUP,
             SingleResultSetHandlerFactory.<String>newListObjectHandler(), groupName,
-            HostState.PENDING_TERMINATE.toString(), HostState.TERMINATING.toString());
+            HostState.PENDING_TERMINATE.toString(), HostState.TERMINATING.toString(),
+            HostState.PENDING_REPLACEABLE_TERMINATE.toString());
     }
 
     @Override
@@ -263,6 +270,7 @@ public class DBHostDAOImpl implements HostDAO {
         return new QueryRunner(dataSource).query(GET_FAILED_HOSTIDS_BY_GROUP,
                 SingleResultSetHandlerFactory.<String>newListObjectHandler(), groupName,
                 HostState.PENDING_TERMINATE.toString(), HostState.TERMINATING.toString(),
+                HostState.PENDING_REPLACEABLE_TERMINATE.toString(),
                 AgentStatus.UNKNOWN.toString(), AgentStatus.SUCCEEDED.toString());
     }
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/EnvironHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/EnvironHandler.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *    
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -497,7 +497,7 @@ public class EnvironHandler {
         return envBean;
     }
 
-    public void stopServiceOnHost(String hostId) throws Exception {
+    public void stopServiceOnHost(String hostId, boolean replaceHost) throws Exception {
         LOG.info(String.format("Start to stop host %s", hostId));
         AgentBean agentBean = new AgentBean();
         agentBean.setState(AgentState.STOP);
@@ -510,9 +510,9 @@ public class EnvironHandler {
         hostDAO.updateHostById(hostId, hostBean);
     }
 
-    public void stopServiceOnHosts(Collection<String> hostIds) throws Exception {
+    public void stopServiceOnHosts(Collection<String> hostIds, boolean replaceHost) throws Exception {
         for (String hostId : hostIds) {
-            stopServiceOnHost(hostId);
+            stopServiceOnHost(hostId, replaceHost);
         }
     }
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/EnvironHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/EnvironHandler.java
@@ -505,7 +505,7 @@ public class EnvironHandler {
         agentDAO.updateAgentById(hostId, agentBean);
 
         HostBean hostBean = new HostBean();
-        HostState state = replaceHost ? HostState.PENDING_REPLACEABLE_TERMINATE : HostState.PENDING_TERMINATE;
+        HostState state = replaceHost ? HostState.PENDING_TERMINATE : HostState.PENDING_TERMINATE_NO_REPLACE;
         hostBean.setState(state);
         hostBean.setLast_update(System.currentTimeMillis());
         hostDAO.updateHostById(hostId, hostBean);

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/EnvironHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/EnvironHandler.java
@@ -505,7 +505,8 @@ public class EnvironHandler {
         agentDAO.updateAgentById(hostId, agentBean);
 
         HostBean hostBean = new HostBean();
-        hostBean.setState(HostState.PENDING_TERMINATE);
+        HostState state = replaceHost ? HostState.PENDING_REPLACEABLE_TERMINATE : HostState.PENDING_TERMINATE;
+        hostBean.setState(state);
         hostBean.setLast_update(System.currentTimeMillis());
         hostDAO.updateHostById(hostId, hostBean);
     }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/DefaultRodimusManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/DefaultRodimusManager.java
@@ -29,6 +29,11 @@ public class DefaultRodimusManager implements RodimusManager {
     }
 
     @Override
+    public void terminateHostsByClusterName(String clusterName, Collection<String> hostIds, Boolean replaceHost)
+            throws Exception {
+    }
+
+    @Override
     public Collection<String> getTerminatedHosts(Collection<String> hostIds) throws Exception {
         return Collections.emptyList();
     }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/RodimusManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/RodimusManager.java
@@ -23,6 +23,9 @@ import java.util.Map;
 public interface RodimusManager {
     void terminateHostsByClusterName(String clusterName, Collection<String> hostIds) throws Exception;
 
+    void terminateHostsByClusterName(String clusterName, Collection<String> hostIds, Boolean replaceHost)
+    throws Exception;
+
     Collection<String> getTerminatedHosts(Collection<String> hostIds) throws Exception;
 
     Long getClusterInstanceLaunchGracePeriod(String clusterName) throws Exception;

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/RodimusManagerImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/RodimusManagerImpl.java
@@ -37,7 +37,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.List;
 
 public class RodimusManagerImpl implements RodimusManager {
     private static final Logger LOG = LoggerFactory.getLogger(RodimusManagerImpl.class);
@@ -87,7 +86,6 @@ public class RodimusManagerImpl implements RodimusManager {
         }else{
             return ! prevKnoxKey.equals( this.cachedKey );
         }
-        
     }
 
     private void setAuthorization() throws Exception {
@@ -132,12 +130,18 @@ public class RodimusManagerImpl implements RodimusManager {
 
     @Override
     public void terminateHostsByClusterName(String clusterName, Collection<String> hostIds) throws Exception {
+        terminateHostsByClusterName(clusterName, hostIds, true);
+    }
+
+    @Override
+    public void terminateHostsByClusterName(String clusterName, Collection<String> hostIds, Boolean replaceHost)
+            throws Exception {
         if (hostIds.isEmpty()) {
             return;
         }
-        
-        String url = String.format("%s/v1/clusters/%s/hosts", this.rodimusUrl, clusterName);
-        callHttpClient( Verb.DELETE, url, gson.toJson(hostIds) );
+
+        String url = String.format("%s/v1/clusters/%s/hosts?replaceHost=%s", this.rodimusUrl, clusterName, replaceHost);
+        callHttpClient(Verb.DELETE, url, gson.toJson(hostIds) );
     } // terminateHostsByClusterName
 
     @Override

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/db/DBDAOTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/db/DBDAOTest.java
@@ -740,16 +740,24 @@ public class DBDAOTest {
         assertEquals(hostBeans3.get(0).getHost_name(), "i-9");
 
         HashSet<String> groups9 = new HashSet<>(Arrays.asList("test_dup"));
-        hostDAO
-            .insertOrUpdate("h-9", "9.9.9.9", "i-9", HostState.PENDING_TERMINATE.toString(),
-                groups9);
+        hostDAO.insertOrUpdate("h-8", "9.9.9.9", "i-8", HostState.TERMINATING.toString(), groups9);
+        hostDAO.insertOrUpdate("h-9", "9.9.9.9", "i-9", HostState.PENDING_TERMINATE.toString(), groups9);
+        hostDAO.insertOrUpdate("h-10", "9.9.9.9", "i-10", HostState.PENDING_TERMINATE_NO_REPLACE.toString(), groups9);
+
         List<HostBean> hostBeans4 = hostDAO.getHosts("h-9");
         assertEquals(hostBeans4.size(), 1);
         assertEquals(hostBeans4.get(0).getHost_name(), "h-9");
         assertEquals(hostBeans4.get(0).getHost_id(), "i-9");
 
         List<HostBean> hostBeans5 = hostDAO.getTerminatingHosts();
-        assertEquals(hostBeans5.size(), 2);
+        assertEquals(4, hostBeans5.size());
+
+        // If state is PENDING_TERMINATE, PENDING_TERMINATE_NO_REPLACE or TERMINATING, cannot overwrite its state
+        hostDAO.insertOrUpdate("h-8", "9.9.9.8", "i-8", HostState.PROVISIONED.toString(), groups9);
+        hostDAO.insertOrUpdate("h-9", "9.9.9.8", "i-9", HostState.PROVISIONED.toString(), groups9);
+        hostDAO.insertOrUpdate("h-10", "9.9.9.8", "i-10", HostState.PROVISIONED.toString(), groups9);
+        hostBeans5 = hostDAO.getTerminatingHosts();
+        assertEquals(4, hostBeans5.size());
 
         // Test can retire hosts
         HostBean hostBean6 = new HostBean();
@@ -772,27 +780,38 @@ public class DBDAOTest {
         hostBean7.setGroup_name("retire-group");
         hostBean7.setCreate_date(currentTime);
         hostBean7.setLast_update(currentTime);
-        hostBean7.setState(HostState.TERMINATING);
-        hostBean7.setCan_retire(1);
+        hostBean7.setState(HostState.ACTIVE);
         hostDAO.insert(hostBean7);
-
-        Collection<String>
-            retiredHostBeanIds =
-            hostDAO.getToBeRetiredHostIdsByGroup("retire-group");
-        assertEquals(retiredHostBeanIds.size(), 2);
 
         AgentBean
             agentBean1 =
             genDefaultAgentBean("i-11", "i-11", "e-1", "d-1", DeployStage.RESTARTING);
         agentBean1.setStatus(AgentStatus.AGENT_FAILED);
         agentDAO.insertOrUpdate(agentBean1);
-        Collection<String>
-            retiredAndFailedHostIds =
-            hostDAO.getToBeRetiredAndFailedHostIdsByGroup("retire-group");
-        assertEquals(retiredAndFailedHostIds.size(), 1);
 
-        Collection<String> failedHostIds = hostDAO.getFailedHostIdsByGroup("retire-group");
-        assertEquals(failedHostIds.size(), 1);
+        HostState[] nonRetirableStates = { HostState.TERMINATING, HostState.PENDING_TERMINATE_NO_REPLACE,
+                HostState.PENDING_TERMINATE };
+
+        for (HostState state: nonRetirableStates) {
+            hostBean7.setCan_retire(1);
+            hostBean7.setState(state);
+            hostDAO.updateHostById("i-13", hostBean7);
+
+            Collection<String> retiredHostBeanIds = hostDAO.getToBeRetiredHostIdsByGroup("retire-group");
+            assertEquals(2, retiredHostBeanIds.size());
+
+            Collection<String> retiredAndFailedHostIds = hostDAO.getToBeRetiredAndFailedHostIdsByGroup("retire-group");
+            assertEquals(1, retiredAndFailedHostIds.size());
+
+            Collection<String> failedHostIds = hostDAO.getFailedHostIdsByGroup("retire-group");
+            assertEquals(1, failedHostIds.size());
+
+            hostBean7.setCan_retire(0);
+            hostDAO.updateHostById("i-13", hostBean7);
+
+            Collection<String> newHostIds = hostDAO.getNewHostIdsByGroup("retire-group");
+            assertEquals(0, newHostIds.size());
+        }
     }
 
     @Test

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/handler/EnvironHandlerTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/handler/EnvironHandlerTest.java
@@ -1,0 +1,58 @@
+package com.pinterest.deployservice.handler;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.pinterest.deployservice.ServiceContext;
+import com.pinterest.deployservice.bean.HostBean;
+import com.pinterest.deployservice.bean.HostState;
+import com.pinterest.deployservice.dao.AgentDAO;
+import com.pinterest.deployservice.dao.HostDAO;
+
+public class EnvironHandlerTest {
+    private final static String DEFAULT_HOST_ID = "hostId";
+
+    private EnvironHandler environHandler;
+
+    private HostDAO mockHostDAO;
+    private AgentDAO mockAgentDAO;
+
+    private ServiceContext createMockServiceContext() throws Exception {
+        mockHostDAO = mock(HostDAO.class);
+        mockAgentDAO = mock(AgentDAO.class);
+
+        ServiceContext serviceContext = new ServiceContext();
+        serviceContext.setHostDAO(mockHostDAO);
+        serviceContext.setAgentDAO(mockAgentDAO);
+        return serviceContext;
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        environHandler = new EnvironHandler(createMockServiceContext());
+    }
+
+    @Test
+    public void stopServiceOnHost_withReplaceHost_hostBeanStateIsPendingTerminate() throws Exception {
+        ArgumentCaptor<HostBean> argument = ArgumentCaptor.forClass(HostBean.class);
+
+        environHandler.stopServiceOnHost(DEFAULT_HOST_ID, true);
+        verify(mockHostDAO).updateHostById(eq(DEFAULT_HOST_ID), argument.capture());
+        assertEquals(HostState.PENDING_TERMINATE, argument.getValue().getState());
+    }
+
+    @Test
+    public void stopServiceOnHost_withoutReplaceHost_hostBeanStateIsPendingTerminateNoReplace() throws Exception {
+        ArgumentCaptor<HostBean> argument = ArgumentCaptor.forClass(HostBean.class);
+
+        environHandler.stopServiceOnHost(DEFAULT_HOST_ID, false);
+        verify(mockHostDAO).updateHostById(eq(DEFAULT_HOST_ID), argument.capture());
+        assertEquals(HostState.PENDING_TERMINATE_NO_REPLACE, argument.getValue().getState());
+    }
+}

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvHosts.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvHosts.java
@@ -17,6 +17,7 @@
 package com.pinterest.teletraan.resource;
 
 
+import com.google.common.base.Optional;
 import com.pinterest.deployservice.bean.EnvironBean;
 import com.pinterest.deployservice.bean.HostBean;
 import com.pinterest.deployservice.bean.Resource;
@@ -43,6 +44,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.SecurityContext;
@@ -95,14 +97,18 @@ public class EnvHosts {
 
     @DELETE
     public void stopServiceOnHost(@Context SecurityContext sc,
-                                  @PathParam("envName") String envName,
-                                  @PathParam("stageName") String stageName,
-                                  @Valid Collection<String> hostIds) throws Exception {
+            @PathParam("envName") String envName,
+            @PathParam("stageName") String stageName,
+            @Valid Collection<String> hostIds,
+            @ApiParam(value = "Replace the host or not") @QueryParam("replaceHost") Optional<Boolean> replaceHost)
+            throws Exception {
         String operator = sc.getUserPrincipal().getName();
         EnvironBean envBean = Utils.getEnvStage(environDAO, envName, stageName);
         authorizer.authorize(sc, new Resource(envBean.getEnv_name(), Resource.Type.ENV), Role.OPERATOR);
-        environHandler.stopServiceOnHosts(hostIds);
-        configHistoryHandler.updateConfigHistory(envBean.getEnv_id(), Constants.TYPE_HOST_ACTION, String.format("STOP %s", hostIds.toString()), operator);
-        LOG.info(String.format("Successfully stopped %s/%s service on hosts %s by %s", envName, stageName, hostIds.toString(), operator));
+        environHandler.stopServiceOnHosts(hostIds, replaceHost.or(true));
+        configHistoryHandler.updateConfigHistory(envBean.getEnv_id(), Constants.TYPE_HOST_ACTION,
+                String.format("STOP %s", hostIds.toString()), operator);
+        LOG.info(String.format("Successfully stopped %s/%s service on hosts %s by %s", envName, stageName,
+                hostIds.toString(), operator));
     }
 }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Hosts.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Hosts.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *    
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,6 +15,7 @@
  */
 package com.pinterest.teletraan.resource;
 
+import com.google.common.base.Optional;
 import com.pinterest.deployservice.bean.HostBean;
 import com.pinterest.deployservice.bean.HostState;
 import com.pinterest.deployservice.dao.HostDAO;
@@ -84,9 +85,11 @@ public class Hosts {
     @DELETE
     @Path("/{hostId : [a-zA-Z0-9\\-_]+}")
     public void stopHost(@Context SecurityContext sc,
-                         @PathParam("hostId") String hostId) throws Exception {
+            @PathParam("hostId") String hostId,
+            @ApiParam(value = "Replace the host or not") @QueryParam("replaceHost") Optional<Boolean> replaceHost)
+            throws Exception {
         String operator = sc.getUserPrincipal().getName();
-        environHandler.stopServiceOnHost(hostId);
+        environHandler.stopServiceOnHost(hostId, replaceHost.or(true));
         LOG.info(String.format("Successfully stopped host %s by %s", hostId, operator));
     }
 

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AgentJanitor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AgentJanitor.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *    
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -94,22 +94,22 @@ public class AgentJanitor extends SimpleAgentJanitor {
         if ((hostBean.getState() == HostState.PROVISIONED) && (current_time - hostAgentBean.getLast_update() >= launchGracePeriod)) {
             return true;
         }
-        if (hostBean.getState() != HostState.TERMINATING && hostBean.getState() != HostState.PENDING_TERMINATE && 
-            (current_time - hostAgentBean.getLast_update() >= maxStaleHostThreshold)) {
-                return true;
+        if (hostBean.getState() != HostState.TERMINATING && !hostBean.isPendingTerminate() &&
+                (current_time - hostAgentBean.getLast_update() >= maxStaleHostThreshold)) {
+            return true;
         }
         return false;
     }
 
     // Process stale hosts (hosts which have not pinged for more than max threshold period)
-    // Marks hosts unreachable if it's stale for max threshold 
+    // Marks hosts unreachable if it's stale for max threshold
     // Removes hosts once confirmed with source
     private void processHighWatermarkHosts() throws Exception {
         long current_time = System.currentTimeMillis();
         long maxThreshold = current_time - Math.min(maxStaleHostThreshold, maxLaunchLatencyThreshold);
         List<HostAgentBean> maxStaleHosts = hostAgentDAO.getStaleHosts(maxThreshold);
         Set<String> staleHostIds = new HashSet<>();
-        
+
         for (HostAgentBean hostAgentBean : maxStaleHosts) {
             if (isHostStale(hostAgentBean)) {
                 staleHostIds.add(hostAgentBean.getHost_id());

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/HostTerminator.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/HostTerminator.java
@@ -67,7 +67,8 @@ public class HostTerminator implements Runnable {
         if (stopSucceeded) {
             LOG.info(String.format("Host %s is stopped. Terminate it.", hostId));
             String clusterName = host.getGroup_name();
-            rodimusManager.terminateHostsByClusterName(clusterName, Collections.singletonList(hostId));
+            Boolean replaceHost = host.getState() == HostState.PENDING_TERMINATE;
+            rodimusManager.terminateHostsByClusterName(clusterName, Collections.singletonList(hostId), replaceHost);
         }
     }
 

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/HostTerminator.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/HostTerminator.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *    
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -91,7 +91,7 @@ public class HostTerminator implements Runnable {
             if (connection != null) {
                 LOG.info(String.format("DB lock operation is successful: get lock %s", lockName));
                 try {
-                    if (host.getState() == HostState.PENDING_TERMINATE) {
+                    if (host.isPendingTerminate()) {
                         terminateHost(host);
                     } else if (host.getState() == HostState.TERMINATING) {
                         removeTerminatedHost(host);

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/worker/HostTerminatorTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/worker/HostTerminatorTest.java
@@ -1,0 +1,131 @@
+package com.pinterest.teletraan.worker;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.util.Collection;
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.pinterest.deployservice.ServiceContext;
+import com.pinterest.deployservice.bean.AgentBean;
+import com.pinterest.deployservice.bean.DeployStage;
+import com.pinterest.deployservice.bean.HostAgentBean;
+import com.pinterest.deployservice.bean.HostBean;
+import com.pinterest.deployservice.bean.HostState;
+import com.pinterest.deployservice.dao.AgentDAO;
+import com.pinterest.deployservice.dao.HostAgentDAO;
+import com.pinterest.deployservice.dao.HostDAO;
+import com.pinterest.deployservice.dao.UtilDAO;
+import com.pinterest.deployservice.rodimus.RodimusManager;
+
+
+public class HostTerminatorTest {
+    private static String TEST_HOST_ID = "i-testHostId";
+    private static String TEST_ASG_NAME = "test-asg-name";
+    private static String TEST_GROUP_NAME = "test-group-name";
+
+    private HostTerminator hostTerminator;
+
+    private AgentDAO mockAgentDAO;
+    private HostAgentDAO mockHostAgentDAO;
+    private HostDAO mockHostDAO;
+    private RodimusManager mockRodimusManager;
+    private UtilDAO mockUtilDAO;
+
+    private Collection<String> testHostIds = Collections.singletonList(TEST_HOST_ID);;
+    private AgentBean testAgentBean;
+    private HostAgentBean testHostAgentBean;
+    private HostBean testHostBean;
+
+    private ServiceContext createMockServiceContext() throws Exception {
+        ServiceContext serviceContext = new ServiceContext();
+        serviceContext.setAgentDAO(mockAgentDAO);
+        serviceContext.setHostAgentDAO(mockHostAgentDAO);
+        serviceContext.setHostDAO(mockHostDAO);
+        serviceContext.setRodimusManager(mockRodimusManager);
+        serviceContext.setUtilDAO(mockUtilDAO);
+
+        return serviceContext;
+    }
+
+    private AgentBean createAgentBean() {
+        AgentBean bean = new AgentBean();
+        bean.setHost_id(TEST_HOST_ID);
+        bean.setDeploy_stage(DeployStage.STOPPED);
+        return bean;
+    }
+
+    private HostAgentBean createHostAgentBean() {
+        HostAgentBean bean = new HostAgentBean();
+        bean.setHost_id(TEST_HOST_ID);
+        bean.setAuto_scaling_group(TEST_ASG_NAME);
+        return bean;
+    }
+
+    private HostBean createHostBean() {
+        HostBean bean = new HostBean();
+        bean.setHost_id(TEST_HOST_ID);
+        bean.setGroup_name(TEST_GROUP_NAME);
+        bean.setState(HostState.PENDING_TERMINATE);
+        return bean;
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        mockAgentDAO = mock(AgentDAO.class);
+        mockHostAgentDAO = mock(HostAgentDAO.class);
+        mockHostDAO = mock(HostDAO.class);
+        mockRodimusManager = mock(RodimusManager.class);
+        mockUtilDAO = mock(UtilDAO.class);
+
+        ServiceContext mockServiceContext = createMockServiceContext();
+        hostTerminator = new HostTerminator(mockServiceContext);
+
+        testAgentBean = createAgentBean();
+        testHostAgentBean = createHostAgentBean();
+        testHostBean = createHostBean();
+
+        when(mockUtilDAO.getLock(any())).thenReturn(mock(Connection.class));
+    }
+
+    @Test
+    public void hostAgentHasHost_ASGNameIsUsed() throws Exception {
+        when(mockAgentDAO.getByHostId(TEST_HOST_ID)).thenReturn(Collections.singletonList(testAgentBean));
+        when(mockHostAgentDAO.getHostById(TEST_HOST_ID)).thenReturn(testHostAgentBean);
+        when(mockHostDAO.getTerminatingHosts()).thenReturn(Collections.singletonList(testHostBean));
+
+        hostTerminator.run();
+
+        verify(mockRodimusManager).terminateHostsByClusterName(TEST_ASG_NAME, testHostIds, true);
+    }
+
+    @Test
+    public void hostAgentDoesNotHaveHost_ASGNameIsUsed() throws Exception {
+        when(mockAgentDAO.getByHostId(TEST_HOST_ID)).thenReturn(Collections.singletonList(testAgentBean));
+        when(mockHostAgentDAO.getHostById(TEST_HOST_ID)).thenReturn(null);
+        when(mockHostDAO.getTerminatingHosts()).thenReturn(Collections.singletonList(testHostBean));
+
+        hostTerminator.run();
+
+        verify(mockRodimusManager).terminateHostsByClusterName(TEST_GROUP_NAME, testHostIds, true);
+    }
+
+    @Test
+    public void hostBeanStateIsPendingNoReplace_terminateHostWithoutReplace() throws Exception {
+        testHostBean.setState(HostState.PENDING_TERMINATE_NO_REPLACE);
+        when(mockAgentDAO.getByHostId(TEST_HOST_ID)).thenReturn(Collections.singletonList(testAgentBean));
+        when(mockHostAgentDAO.getHostById(TEST_HOST_ID)).thenReturn(null);
+        when(mockHostDAO.getTerminatingHosts()).thenReturn(Collections.singletonList(testHostBean));
+
+        hostTerminator.run();
+
+        verify(mockRodimusManager).terminateHostsByClusterName(TEST_GROUP_NAME, testHostIds, false);
+    }
+
+}


### PR DESCRIPTION
# Changes
- Introduced unified the experience for terminate and force terminate host(s). 
- Added support for the `replaceHost` flag in deploy board and deploy service. 
- Introduced a new state `PENDING_TERMINATE_NO_REPLACE` to `HostState` and updated all references to `PENDING_TERMINATE`, including DB query templates.
    - Note that the existing `PENDING_TERMINATE` state corresponds to the "replace host" behavior. This is intentional because the "replace host" behavior is the default and also during roll out we will not accidentally decrement desired capacities for clusters.  

## Screenshots
### Individual termination
![individual terminate](https://user-images.githubusercontent.com/8442875/189232854-8902d571-0b61-4cdf-9a0d-efb026e32e1b.png)

### Force termination
![force terminate](https://user-images.githubusercontent.com/8442875/189232939-20727572-e448-4543-986c-d1dd1487b4be.png)


### Batch termination
<img width="1652" alt="batch termination" src="https://user-images.githubusercontent.com/8442875/189200486-8b578eb2-046a-42e4-9f3c-ae1b4f214c85.png">

### Force Batch Termination
<img width="1652" alt="batch force termination" src="https://user-images.githubusercontent.com/8442875/189200501-0d98ed39-ec23-4ebb-94a1-fb31bf0f6cc5.png">

# Test plan
1. Visit host detail page, check both _terminate host_ and _force terminate_ work.
    1. Host is terminated.
    2. Host is replaced when replace host is specified.
    3. Capacity is decreased when replace host is not specified.
4. Visit all hosts view, check both batch terminate and batch force terminate work.  
    1. Host is terminated.
    2. Host is replaced when replace host is specified.
    3. Capacity is decreased when replace host is not specified.