### PR TITLE
Fix slow db query for host tags

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostTagDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostTagDAOImpl.java
@@ -39,9 +39,8 @@ public class DBHostTagDAOImpl implements HostTagDAO {
     private static final String DELETE_BY_HOST_ID = "DELETE FROM host_tags WHERE host_id = ?";
     private static final String GET_HOST_TAG_BY_HOST_ID_AND_TAG_NAME = "SELECT * FROM host_tags WHERE host_id = ? AND tag_name = ? ";
     private static final String GET_PREREQUISITES_TAG_VALUES_BY_HOST_ID_AND_TAG_NAME = "SELECT DISTINCT(tag_value) AS tag_value FROM host_tags WHERE env_id = ? AND tag_name = ? AND tag_value < ?";
-    private static final String GET_HOSTS_BY_ENV_ID_AND_TAG_NAME = "SELECT host_id, tag_value, tag_name, host_name FROM ( SELECT DISTINCT(host_tags.host_id) AS host_id, host_tags.tag_value AS tag_value, host_tags.tag_name AS tag_name, agents.host_name AS host_name, host_tags.env_id AS env_id FROM agents " +
-        "INNER JOIN host_tags ON agents.host_id = host_tags.host_id ) AS p1 " +
-        "WHERE p1.tag_name = ? AND p1.env_id = ?";
+    private static final String GET_HOSTS_BY_ENV_ID_AND_TAG_NAME = "SELECT DISTINCT(host_tags.host_id) AS host_id, host_tags.tag_value AS tag_value, host_tags.tag_name AS tag_name, agents.host_name AS host_name FROM agents " +
+        "INNER JOIN host_tags ON agents.host_id = host_tags.host_id WHERE host_tags.tag_name = ? AND agents.env_id = ?";
     private static final String GET_HOSTS_BY_ENV_ID = "SELECT DISTINCT(host_tags.host_id) AS host_id, host_tags.tag_value AS tag_value, host_tags.tag_name AS tag_name, hosts.host_name AS host_name FROM hosts " +
         "INNER JOIN host_tags ON hosts.host_id = host_tags.host_id " +
         "WHERE host_tags.env_id = ?";


### PR DESCRIPTION
While looking into CDP-4769, this database query was very slow:

```
SELECT host_id, tag_value, tag_name, host_name
FROM (
  SELECT DISTINCT(host_tags.host_id) AS host_id, host_tags.tag_value AS tag_value, host_tags.tag_name AS tag_name, agents.host_name AS host_name, host_tags.env_id AS env_id
  FROM agents INNER JOIN host_tags ON agents.host_id = host_tags.host_id
) AS p1
WHERE p1.tag_name = 'availability_zone' AND p1.env_id = 'REDACTED';

... rows in set (3.74 sec)
```

Removing the unnecessary subquery greatly improved the performance:

```
SELECT DISTINCT(host_tags.host_id) AS host_id, host_tags.tag_value AS tag_value, host_tags.tag_name AS tag_name, agents.host_name AS host_name
FROM agents INNER JOIN host_tags ON agents.host_id = host_tags.host_id
WHERE host_tags.tag_name = 'availability_zone' AND agents.env_id = 'REDACTED';

... rows in set (0.01 sec)
```