### PR TITLE
Remove linesep from comment

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/ConfigHistoryBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/ConfigHistoryBean.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *    
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,7 +26,7 @@ import org.apache.commons.lang.builder.ReflectionToStringBuilder;
  * operator	    VARCHAR(64)	  NOT NULL,
  * type		    VARCHAR(64)	  NOT NULL,
  * config_change    VARCHAR(8192) NOT NULL,
- * PRIMARY KEY (group_name, config_change_id) );
+ * PRIMARY KEY (group_name, config_change_id));
  */
 
 public class ConfigHistoryBean implements Updatable {


### PR DESCRIPTION
For consistency and better editor support,
remove line separator (U+2028) from comment.

Also, remove trailing whitespace in comment.