### PR TITLE
making default to gp3

### DIFF
--- a/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
+++ b/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
@@ -209,7 +209,7 @@ Vue.component("aws-config-modal", {
                 ) {
                     this.$emit("click", {
                         name: this.customizedName,
-                        value: this.selectedOptionValue
+                        value: this.selectedOptionValue.trim()
                     });
                 } else {
                     document.getElementById(
@@ -219,7 +219,7 @@ Vue.component("aws-config-modal", {
             } else {
                 this.$emit("click", {
                     name: this.selectedOption.name,
-                    value: this.selectedOptionValue
+                    value: this.selectedOptionValue.trim()
                 });
             }
         },

--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -591,6 +591,9 @@
                     this.baseImageValue = value
                 },
                 deleteConfig: function(name) {
+                    if (name == 'root_volume_type') {
+                        globalNotificationBanner.info = "On deleteing this configuration and saving it, the root volume type will be set to default value, which is gp3 currently"
+                    }
                     this.allUserData = this.allUserData.filter(function(config) {
                         return config.name != name
                     })
@@ -820,8 +823,8 @@
                         return false
                     }
 
-                    if ('ebs_volume_type' in clusterInfo.configs && (clusterInfo.configs['ebs_volume_type'] != "gp2" && clusterInfo.configs['ebs_volume_type'] != "gp3")) {
-                        globalNotificationBanner.error = "At time time only gp2 and gp3 volume types are supported"
+                    if ('root_volume_type' in clusterInfo.configs && (clusterInfo.configs['root_volume_type'] != "gp2" && clusterInfo.configs['root_volume_type'] != "gp3")) {
+                        globalNotificationBanner.error = "At time time only gp2 and gp3 root volume types are supported"
                         return false
                     }
 

--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -823,8 +823,8 @@
                         return false
                     }
 
-                    if ('root_volume_type' in clusterInfo.configs && (clusterInfo.configs['root_volume_type'] != "gp2" && clusterInfo.configs['root_volume_type'] != "gp3")) {
-                        globalNotificationBanner.error = "At time time only gp2 and gp3 root volume types are supported"
+                    if ('root_volume_type' in clusterInfo.configs && !(["gp2", "gp3"].includes(clusterInfo.configs['root_volume_type']))) {
+                        globalNotificationBanner.error = "At this time only gp2 and gp3 root volume types are supported"
                         return false
                     }
 

--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -592,7 +592,7 @@
                 },
                 deleteConfig: function(name) {
                     if (name == 'root_volume_type') {
-                        globalNotificationBanner.info = "On deleteing this configuration and saving it, the root volume type will be set to default value, which is gp3 currently"
+                        globalNotificationBanner.info = "On deleting this configuration and saving it, the root volume type will be set to default value, which is gp3 currently"
                     }
                     this.allUserData = this.allUserData.filter(function(config) {
                         return config.name != name

--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -561,6 +561,7 @@
                 },
                 configChange: function(input){
                     this.allUserData = this.allUserData.map(function(item){
+                        item.text = item.text.trim()
                         if (item.name===input.name){
                             return input
                         }

--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -802,7 +802,6 @@
                             globalNotificationBanner.error = "cmp_base image must have pinfo_role set to cmp_base"
                             return false
                         }
-
                     }
                     else{
                         if ('pinfo_role' in clusterInfo.configs && clusterInfo.configs['pinfo_role']==='cmp_base'){
@@ -818,6 +817,11 @@
 
                     if (imageNameValue === 'cmp_base' && clusterInfo.hostType.startsWith('EbsCompute')){
                         globalNotificationBanner.error = "EbsCompute  instance must use ebs AMI. Try cmp_base-ebs"
+                        return false
+                    }
+
+                    if ('ebs_volume_type' in clusterInfo.configs && (clusterInfo.configs['ebs_volume_type'] != "gp2" && clusterInfo.configs['ebs_volume_type'] != "gp3")) {
+                        globalNotificationBanner.error = "At time time only gp2 and gp3 volume types are supported"
                         return false
                     }
 

--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -561,7 +561,6 @@
                 },
                 configChange: function(input){
                     this.allUserData = this.allUserData.map(function(item){
-                        item.text = item.text.trim()
                         if (item.name===input.name){
                             return input
                         }

--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -474,8 +474,8 @@ var capacitySetting = new Vue({
                 return false
             }
 
-            if ('ebs_volume_type' in clusterInfo.configs && (clusterInfo.configs['ebs_volume_type'] != "gp2" && clusterInfo.configs['ebs_volume_type'] != "gp3")) {
-                globalNotificationBanner.error = "At time time only gp2 and gp3 volume types are supported"
+            if ('root_volume_type' in clusterInfo.configs && (clusterInfo.configs['root_volume_type'] != "gp2" && clusterInfo.configs['root_volume_type'] != "gp3")) {
+                globalNotificationBanner.error = "At time time only gp2 and gp3 root volume types are supported"
                 return false
             }
 

--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -474,8 +474,8 @@ var capacitySetting = new Vue({
                 return false
             }
 
-            if ('root_volume_type' in clusterInfo.configs && (clusterInfo.configs['root_volume_type'] != "gp2" && clusterInfo.configs['root_volume_type'] != "gp3")) {
-                globalNotificationBanner.error = "At time time only gp2 and gp3 root volume types are supported"
+            if ('root_volume_type' in clusterInfo.configs && !(["gp2", "gp3"].includes(clusterInfo.configs['root_volume_type']))) {
+                globalNotificationBanner.error = "At this time only gp2 and gp3 root volume types are supported"
                 return false
             }
 

--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -220,6 +220,7 @@ var capacitySetting = new Vue({
         },
         configChange: function(input){
                 this.allUserData = this.allUserData.map(function(item){
+                    item.text = item.text.trim()
                     if (item.name===input.name){
                         return input
                     }

--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -220,7 +220,6 @@ var capacitySetting = new Vue({
         },
         configChange: function(input){
                 this.allUserData = this.allUserData.map(function(item){
-                    item.text = item.text.trim()
                     if (item.name===input.name){
                         return input
                     }

--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -474,6 +474,11 @@ var capacitySetting = new Vue({
                 return false
             }
 
+            if ('ebs_volume_type' in clusterInfo.configs && (clusterInfo.configs['ebs_volume_type'] != "gp2" && clusterInfo.configs['ebs_volume_type'] != "gp3")) {
+                globalNotificationBanner.error = "At time time only gp2 and gp3 volume types are supported"
+                return false
+            }
+
             const replacementTimeout = clusterInfo['replacementTimeout']
             if (replacementTimeout == null || isNaN(replacementTimeout) || replacementTimeout < 5 || replacementTimeout > 24 * 60) {
                 globalNotificationBanner.error = "Replacement timeout must be a number between 5 and 1440 minutes (24 hours)"

--- a/deploy-board/deploy_board/webapp/cluster_view.py
+++ b/deploy-board/deploy_board/webapp/cluster_view.py
@@ -723,6 +723,7 @@ def get_aws_config_name_list_by_image(image_name):
         config_map['ebs_size'] = 500
         config_map['ebs_mount'] = '/backup'
         config_map['ebs_volume_type'] = 'gp3'
+        config_map['root_volume_type'] = 'gp3'
         config_map['root_volume_size'] = 100
         if image_name == DEFAULT_CMP_IMAGE:
             config_map['pinfo_role'] = 'cmp_base'

--- a/deploy-board/deploy_board/webapp/cluster_view.py
+++ b/deploy-board/deploy_board/webapp/cluster_view.py
@@ -722,7 +722,7 @@ def get_aws_config_name_list_by_image(image_name):
         config_map['ebs'] = 'true'
         config_map['ebs_size'] = 500
         config_map['ebs_mount'] = '/backup'
-        config_map['ebs_volume_type'] = 'gp2'
+        config_map['ebs_volume_type'] = 'gp3'
         config_map['root_volume_size'] = 100
         if image_name == DEFAULT_CMP_IMAGE:
             config_map['pinfo_role'] = 'cmp_base'


### PR DESCRIPTION
This PR should only go in after https://github.com/pinternal/rodimus/pull/30

We are migrating to gp3 and making it as default.

Considerations made:
- Ensuring that only supported volume types are passed
- Showing banner to user when root_volume_type is deleted to inform them that the eoot_volume_type will be reset to default which is gp3
- As this code is only run for pinterest based on is_pinterest flag, others should be unaffected


https://user-images.githubusercontent.com/12591127/193708678-ce2362d4-66aa-4d5a-8407-55a004763fa9.mov

