### PR TITLE
Teletraan UI (deployboard) does not gracefully handle nimbus failure

### DIFF
--- a/deploy-board/deploy_board/templates/configs/env_config.html
+++ b/deploy-board/deploy_board/templates/configs/env_config.html
@@ -193,7 +193,7 @@
 {% endblock %}
 
 {% block main %}
-
+{% include "message_banner.tmpl" %}
 {% include "environs/env_tabs.tmpl" with envTabKind="config" %}
 
 <div class="panel panel-default">

--- a/deploy-board/deploy_board/templates/environs/env_landing.html
+++ b/deploy-board/deploy_board/templates/environs/env_landing.html
@@ -128,7 +128,7 @@
         {% endverbatim %}
     </div>
     <div v-if="showCluster" class="row">
-        <side-button styleclass="fa fa-database" text="Capacity" href="/env/{{ env.envName }}/{{ env.stageName }}/config/capacity" title="Configure capacity"></side-button>
+        <side-button styleclass="fa fa-database" v-bind:text="capacityText" href="/env/{{ env.envName }}/{{ env.stageName }}/config/capacity" title="Configure capacity"></side-button>
     </div>
     <div v-if="!showCluster" id="groupsDiv">
     </div>
@@ -209,6 +209,7 @@
 <script>
 
 var capacityInfo = {{capacity_info | safe}}
+var placements = {{placements | safe}}
 function loadGroupConfig() {
     var selected_value = $("#group_name option:selected").val();
     var config_url = "/aws_info/get_configs/?group_name=" + selected_value;
@@ -226,7 +227,10 @@ var capacityPanel = new Vue({
             data:{
                title: renderCapacity ? "Cluster" : "Deploy Groups",
                showCluster: renderCapacity,
-
+               remainingCapacity: placements != null ? placements.reduce((s, e) => s + e.capacity, 0) : Infinity,
+            },
+            computed: {
+                capacityText: function() {return `Capacity (max remaining ${this.remainingCapacity})`}
             },
             mounted: function(){
                 if (!renderCapacity){
@@ -340,6 +344,12 @@ $('#privateBldUploadBtnId button').click(function () {
             </h4>
             {% if pinterest %}
                 {% if project_info %}
+                    {% if detail %}
+                    <div class="alert alert-info">
+                        <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                        <strong>Warning!</strong> This environment stage has scheduled cluster rolling upgrade.
+                    </div>
+                    {% endif %}
                 <div class="btn-project-info">
                     <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
                     <a href="{{ project_info.project_url }}" target="_blank">Project: {{ project_info.project_name }}</a>

--- a/deploy-board/deploy_board/templates/environs/env_landing.html
+++ b/deploy-board/deploy_board/templates/environs/env_landing.html
@@ -128,7 +128,7 @@
         {% endverbatim %}
     </div>
     <div v-if="showCluster" class="row">
-        <side-button styleclass="fa fa-database" v-bind:text="capacityText" href="/env/{{ env.envName }}/{{ env.stageName }}/config/capacity" title="Configure capacity"></side-button>
+        <side-button styleclass="fa fa-database" text="Capacity" href="/env/{{ env.envName }}/{{ env.stageName }}/config/capacity" title="Configure capacity"></side-button>
     </div>
     <div v-if="!showCluster" id="groupsDiv">
     </div>
@@ -209,7 +209,6 @@
 <script>
 
 var capacityInfo = {{capacity_info | safe}}
-var placements = {{placements | safe}}
 function loadGroupConfig() {
     var selected_value = $("#group_name option:selected").val();
     var config_url = "/aws_info/get_configs/?group_name=" + selected_value;
@@ -227,10 +226,6 @@ var capacityPanel = new Vue({
             data:{
                title: renderCapacity ? "Cluster" : "Deploy Groups",
                showCluster: renderCapacity,
-               remainingCapacity: placements != null ? placements.reduce((s, e) => s + e.capacity, 0) : Infinity,
-            },
-            computed: {
-                capacityText: function() {return `Capacity (max remaining ${this.remainingCapacity})`}
             },
             mounted: function(){
                 if (!renderCapacity){
@@ -347,7 +342,7 @@ $('#privateBldUploadBtnId button').click(function () {
                     {% if detail %}
                     <div class="alert alert-info">
                         <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                        <strong>Warning!</strong> This environment stage has scheduled cluster rolling upgrade.
+                        <strong>Warning!</strong>
                     </div>
                     {% endif %}
                 <div class="btn-project-info">

--- a/deploy-board/deploy_board/templates/environs/env_landing.html
+++ b/deploy-board/deploy_board/templates/environs/env_landing.html
@@ -227,7 +227,6 @@ var capacityPanel = new Vue({
                title: renderCapacity ? "Cluster" : "Deploy Groups",
                showCluster: renderCapacity,
             },
-            
             mounted: function(){
                 if (!renderCapacity){
                     $('#groupsDiv').load('/env/{{ env.envName }}/{{ env.stageName }}/groups/');

--- a/deploy-board/deploy_board/templates/environs/env_landing.html
+++ b/deploy-board/deploy_board/templates/environs/env_landing.html
@@ -226,7 +226,7 @@ var capacityPanel = new Vue({
             data:{
                title: renderCapacity ? "Cluster" : "Deploy Groups",
                showCluster: renderCapacity,
-               
+
             },
             mounted: function(){
                 if (!renderCapacity){

--- a/deploy-board/deploy_board/templates/environs/env_landing.html
+++ b/deploy-board/deploy_board/templates/environs/env_landing.html
@@ -339,12 +339,6 @@ $('#privateBldUploadBtnId button').click(function () {
             </h4>
             {% if pinterest %}
                 {% if project_info %}
-                    {% if detail %}
-                    <div class="alert alert-info">
-                        <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                        <strong>Warning!</strong>
-                    </div>
-                    {% endif %}
                 <div class="btn-project-info">
                     <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
                     <a href="{{ project_info.project_url }}" target="_blank">Project: {{ project_info.project_name }}</a>

--- a/deploy-board/deploy_board/templates/environs/env_landing.html
+++ b/deploy-board/deploy_board/templates/environs/env_landing.html
@@ -300,22 +300,7 @@ $('#privateBldUploadBtnId button').click(function () {
 
 {% endif %}
 
-{% if messages %}
-    {% for message in messages %}
-        {% if message.level == 40 %}
-            <div class="alert alert-danger" role="alert">
-                <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                <strong>Warning!</strong> {{ message | safe}}
-            </div>
-        {% else %}
-            <div class="alert alert-success" role="alert">
-                <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                <strong>Launch Succeeded!</strong> {{ message | safe}}
-            </div>
-        {% endif %}
-    {% endfor %}
-{% endif %}
-
+{% include "message_banner.tmpl" %}
 {% include "environs/env_tabs.tmpl" with envTabKind="deploy" %}
 {% include "environs/site_health.tmpl" with metricsKind="service" %}
 

--- a/deploy-board/deploy_board/templates/environs/env_landing.html
+++ b/deploy-board/deploy_board/templates/environs/env_landing.html
@@ -226,6 +226,7 @@ var capacityPanel = new Vue({
             data:{
                title: renderCapacity ? "Cluster" : "Deploy Groups",
                showCluster: renderCapacity,
+               
             },
             mounted: function(){
                 if (!renderCapacity){

--- a/deploy-board/deploy_board/templates/environs/env_landing.html
+++ b/deploy-board/deploy_board/templates/environs/env_landing.html
@@ -227,6 +227,7 @@ var capacityPanel = new Vue({
                title: renderCapacity ? "Cluster" : "Deploy Groups",
                showCluster: renderCapacity,
             },
+            
             mounted: function(){
                 if (!renderCapacity){
                     $('#groupsDiv').load('/env/{{ env.envName }}/{{ env.stageName }}/groups/');

--- a/deploy-board/deploy_board/templates/groups/group_details.html
+++ b/deploy-board/deploy_board/templates/groups/group_details.html
@@ -136,22 +136,7 @@
 </div>
 
 <!--- launch instances button dialog-->
-{% if messages %}
-    {% for message in messages %}
-        {% if message.level == 40 %}
-            <div class="alert alert-danger" role="alert">
-                <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                <strong>Warning!</strong> {{ message | safe}}
-            </div>
-        {% else %}
-            <div class="alert alert-success" role="alert">
-                <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                <strong>Launch Succeeded!</strong> {{ message | safe}}
-            </div>
-        {% endif %}
-
-    {% endfor %}
-{% endif %}
+{% include "message_banner.tmpl" %}
 
 <!---- Group Details Panel --->
 {% if not scaling_down_event_enabled and asg_status == "ENABLED" %}

--- a/deploy-board/deploy_board/templates/message_banner.tmpl
+++ b/deploy-board/deploy_board/templates/message_banner.tmpl
@@ -1,0 +1,15 @@
+{% if messages %}
+    {% for message in messages %}
+        {% if message.level == 40 %}
+            <div class="alert alert-danger" role="alert">
+                <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <strong>Warning!</strong> {{ message | safe}}
+            </div>
+        {% else %}
+            <div class="alert alert-success" role="alert">
+                <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <strong>Launch Succeeded!</strong> {{ message | safe}}
+            </div>
+        {% endif %}
+    {% endfor %}
+{% endif %}

--- a/deploy-board/deploy_board/webapp/cluster_view.py
+++ b/deploy-board/deploy_board/webapp/cluster_view.py
@@ -698,14 +698,22 @@ def clone_cluster(request, src_name, src_stage):
     except NotAuthorizedException as e:
         log.error("Have an NotAuthorizedException error {}".format(e))
         if external_id is not None:
-            environs_helper.delete_nimbus_identifier(request, external_id)
+            try:
+                environs_helper.delete_nimbus_identifier(request, external_id)
+            except TeletraanException as detail:
+                log.error('Handling TeletraanException when trying to access nimbus API, error message {}'.format(detail))
+                messages.add_message(request, messages.ERROR, detail) 
 
         return HttpResponse(e, status=403, content_type="application/json")
     except Exception as e:
         log.error("Failed to clone cluster env_name: %s, stage_name: %s" % (src_name, src_stage))
         log.error(traceback.format_exc())
         if external_id is not None:
-            environs_helper.delete_nimbus_identifier(request, external_id)
+            try:
+                environs_helper.delete_nimbus_identifier(request, external_id)
+            except TeletraanException as detail:
+                log.error('Handling TeletraanException when trying to access nimbus API, error message {}'.format(detail))
+                messages.add_message(request, messages.ERROR, detail) 
         return HttpResponse(e, status=500, content_type="application/json")
 
 

--- a/deploy-board/deploy_board/webapp/cluster_view.py
+++ b/deploy-board/deploy_board/webapp/cluster_view.py
@@ -703,7 +703,6 @@ def clone_cluster(request, src_name, src_stage):
             except Exception as detail:
                 message = 'Failed to delete Nimbus identifier {}. Please verify that identifier no longer exists, Error Message: {}'.format(external_id, detail)
                 log.error(message)
-                return HttpResponse(message, status=403, content_type="application/json")
 
         return HttpResponse(e, status=403, content_type="application/json")
     except Exception as e:
@@ -715,7 +714,6 @@ def clone_cluster(request, src_name, src_stage):
             except Exception as detail:
                 message = 'Failed to delete Nimbus identifier {}. Please verify that identifier no longer exists, Error Message: {}'.format(external_id, detail)
                 log.error(message)
-                return HttpResponse(message, status=500, content_type="application/json")
                 
         return HttpResponse(e, status=500, content_type="application/json")
 

--- a/deploy-board/deploy_board/webapp/cluster_view.py
+++ b/deploy-board/deploy_board/webapp/cluster_view.py
@@ -700,9 +700,10 @@ def clone_cluster(request, src_name, src_stage):
         if external_id is not None:
             try:
                 environs_helper.delete_nimbus_identifier(request, external_id)
-            except TeletraanException as detail:
-                log.error('Handling TeletraanException when trying to access nimbus API, error message {}'.format(detail))
-                messages.add_message(request, messages.ERROR, detail) 
+            except Exception as detail:
+                message = 'Failed to delete Nimbus identifier {}. Please verify that identifier no longer exists, Error Message: {}'.format(external_id, detail)
+                log.error(message)
+                return HttpResponse(message, status=403, content_type="application/json")
 
         return HttpResponse(e, status=403, content_type="application/json")
     except Exception as e:
@@ -711,9 +712,11 @@ def clone_cluster(request, src_name, src_stage):
         if external_id is not None:
             try:
                 environs_helper.delete_nimbus_identifier(request, external_id)
-            except TeletraanException as detail:
-                log.error('Handling TeletraanException when trying to access nimbus API, error message {}'.format(detail))
-                messages.add_message(request, messages.ERROR, detail) 
+            except Exception as detail:
+                message = 'Failed to delete Nimbus identifier {}. Please verify that identifier no longer exists, Error Message: {}'.format(external_id, detail)
+                log.error(message)
+                return HttpResponse(message, status=500, content_type="application/json")
+                
         return HttpResponse(e, status=500, content_type="application/json")
 
 

--- a/deploy-board/deploy_board/webapp/env_views.py
+++ b/deploy-board/deploy_board/webapp/env_views.py
@@ -795,7 +795,7 @@ def post_create_env(request):
             external_id = environs_helper.create_identifier_for_new_stage(request, env_name, stage_name)
             common.clone_from_stage_name(request, env_name, stage_name, clone_env_name,
                                         clone_stage_name, description, external_id)
-        except TeletraanException as detail:
+        except Exception as detail:
             if external_id:
                 try:
                     environs_helper.delete_nimbus_identifier(request, external_id)
@@ -805,7 +805,7 @@ def post_create_env(request):
             else:
                 message = 'Failed to create identifier for {}/{}: {}'.format(env_name, stage_name, detail)
                 messages.add_message(request, messages.ERROR, message)
-                raise detail
+        raise detail
     else:
         data = {}
         data['envName'] = env_name
@@ -864,7 +864,7 @@ def post_add_stage(request, name):
             else:
                 message = 'Failed to create identifier for {}/{}: {}'.format(name, stage, detail)
                 messages.add_message(request, messages.ERROR, message)
-                raise detail   
+            raise detail 
     else:
         external_id = environs_helper.create_identifier_for_new_stage(request, name, stage)
         common.create_simple_stage(request,name, stage, description, external_id)

--- a/deploy-board/deploy_board/webapp/env_views.py
+++ b/deploy-board/deploy_board/webapp/env_views.py
@@ -331,16 +331,17 @@ class EnvLandingView(View):
         stage_with_external_id = None
         existing_stage_identifier = None
         for env_stage in envs:
-            if env_stage['externalId'] is None and env_stage['stageName'] == stage:
+            if env_stage['externalId'] is not None and env_stage['stageName'] == stage:
                 stage_with_external_id = env_stage
                 break
-
-        try:
-            existing_stage_identifier = environs_helper.get_nimbus_identifier(request, stage_with_external_id['externalId'])
-            project_name_is_default = True if existing_stage_identifier is not None and existing_stage_identifier['projectName'] == "default" else False
-        except TeletraanException as detail:
-            log.error('Handling TeletraanException when trying to access nimbus API, error message {}'.format(detail))
-            messages.add_message(request, messages.ERROR, detail)
+            
+        if stage_with_external_id is not None and stage_with_external_id['externalId'] is not None:       
+            try:
+                existing_stage_identifier = environs_helper.get_nimbus_identifier(request, stage_with_external_id['externalId'])
+                project_name_is_default = True if existing_stage_identifier is not None and existing_stage_identifier['projectName'] == "default" else False
+            except TeletraanException as detail:
+                log.error('Handling TeletraanException when trying to access nimbus API, error message {}'.format(detail))
+                messages.add_message(request, messages.ERROR, detail)
 
         project_info = None
         if existing_stage_identifier:

--- a/deploy-board/deploy_board/webapp/env_views.py
+++ b/deploy-board/deploy_board/webapp/env_views.py
@@ -847,9 +847,9 @@ def post_add_stage(request, name):
         try:
             environs_helper.delete_nimbus_identifier(request, external_id)
         except TeletraanException as detail:
-            log.error('Handling TeletraanException when trying to access nimbus API, error message {}'.format(detail))
-            messages.add_message(request, messages.ERROR, detail)     
-        raise
+            message = 'Failed to delete Nimbus identifier {}, Error Message: {}'.format(external_id, detail)
+            log.error(message)
+            messages.add_message(request, messages.ERROR, message)
 
     return redirect('/env/' + name + '/' + stage + '/config/')
 
@@ -866,8 +866,9 @@ def remove_stage(request, name, stage):
         try:
             environs_helper.delete_nimbus_identifier(request, current_env_stage_with_external_id['externalId'])
         except TeletraanException as detail:
-            log.error('Handling TeletraanException when trying to access nimbus API, error message {}'.format(detail))
-            messages.add_message(request, messages.ERROR, detail)    
+            message = 'Failed to delete Nimbus identifier {}, Error Message: {}'.format(current_env_stage_with_external_id['externalId'], detail)
+            log.error(message)
+            messages.add_message(request, messages.ERROR, message)
 
     environs_helper.delete_env(request, name, stage)
     envs = environs_helper.get_all_env_stages(request, name)

--- a/deploy-board/deploy_board/webapp/env_views.py
+++ b/deploy-board/deploy_board/webapp/env_views.py
@@ -334,7 +334,7 @@ class EnvLandingView(View):
             if env_stage['externalId'] is not None and env_stage['stageName'] == stage:
                 stage_with_external_id = env_stage
                 break
-            
+    
         if stage_with_external_id is not None and stage_with_external_id['externalId'] is not None:       
             try:
                 existing_stage_identifier = environs_helper.get_nimbus_identifier(request, stage_with_external_id['externalId'])

--- a/deploy-board/deploy_board/webapp/env_views.py
+++ b/deploy-board/deploy_board/webapp/env_views.py
@@ -334,8 +334,8 @@ class EnvLandingView(View):
             if env_stage['externalId'] is not None and env_stage['stageName'] == stage:
                 stage_with_external_id = env_stage
                 break
-    
-        if stage_with_external_id is not None and stage_with_external_id['externalId'] is not None:       
+
+        if stage_with_external_id is not None and stage_with_external_id['externalId'] is not None:
             try:
                 existing_stage_identifier = environs_helper.get_nimbus_identifier(request, stage_with_external_id['externalId'])
                 project_name_is_default = True if existing_stage_identifier is not None and existing_stage_identifier['projectName'] == "default" else False

--- a/deploy-board/deploy_board/webapp/env_views.py
+++ b/deploy-board/deploy_board/webapp/env_views.py
@@ -843,10 +843,10 @@ def post_add_stage(request, name):
             common.clone_from_stage_name(request, name, stage, name, from_stage, description, external_id)
         else:
             common.create_simple_stage(request,name, stage, description, external_id)
-    except:
+    except TeletraanException as detail:
         try:
             environs_helper.delete_nimbus_identifier(request, external_id)
-        except TeletraanException as detail:
+        except:
             message = 'Failed to delete Nimbus identifier {}, Error Message: {}'.format(external_id, detail)
             log.error(message)
             messages.add_message(request, messages.ERROR, message)
@@ -866,7 +866,7 @@ def remove_stage(request, name, stage):
         try:
             environs_helper.delete_nimbus_identifier(request, current_env_stage_with_external_id['externalId'])
         except TeletraanException as detail:
-            message = 'Failed to delete Nimbus identifier {}, Error Message: {}'.format(current_env_stage_with_external_id['externalId'], detail)
+            message = 'Failed to delete Nimbus identifier {}. Please verify that identifier no longer exists, Error Message: {}'.format(current_env_stage_with_external_id['externalId'], detail)
             log.error(message)
             messages.add_message(request, messages.ERROR, message)
 

--- a/deploy-board/deploy_board/webapp/env_views.py
+++ b/deploy-board/deploy_board/webapp/env_views.py
@@ -341,6 +341,7 @@ class EnvLandingView(View):
                 project_name_is_default = True if existing_stage_identifier is not None and existing_stage_identifier['projectName'] == "default" else False
             except TeletraanException as detail:
                 log.error('Handling TeletraanException when trying to access nimbus API, error message {}'.format(detail))
+                messages.add_message(request, messages.ERROR, detail)
 
         project_info = None
         if existing_stage_identifier:

--- a/deploy-board/deploy_board/webapp/helpers/environs_helper.py
+++ b/deploy-board/deploy_board/webapp/helpers/environs_helper.py
@@ -19,7 +19,10 @@ import logging
 from deploy_board.webapp.helpers.deployclient import DeployClient
 from deploy_board.settings import IS_PINTEREST
 from django.contrib import messages
-from exceptions import TeletraanException
+from exceptions import NotFoundException, TeletraanException
+from django.http import HttpResponse
+from django.shortcuts import render, redirect
+import json
 
 log = logging.getLogger(__name__)
 
@@ -95,7 +98,7 @@ def create_identifier_for_new_stage(request, env_name, stage_name):
         existing_stage_identifier = get_nimbus_identifier(request, stage_with_external_id['externalId'])
     except TeletraanException as detail:
         log.error('Handling TeletraanException when trying to access nimbus API, error message {}'.format(detail))
-        messages.add_message(request, messages.ERROR, detail)
+        raise
     # create Nimbus Identifier for the new stage
     new_stage_identifier = None
     if existing_stage_identifier is not None:
@@ -106,7 +109,7 @@ def create_identifier_for_new_stage(request, env_name, stage_name):
             new_stage_identifier = create_nimbus_identifier(request, nimbus_request_data)
         except TeletraanException as detail:
             log.error('Handling TeletraanException when trying to access nimbus API, error message {}'.format(detail))
-            messages.add_message(request, messages.ERROR, detail)   
+            raise
 
     # if there is no stage in this env with externalId, still create the new stage
     if new_stage_identifier is None:

--- a/deploy-board/deploy_board/webapp/helpers/environs_helper.py
+++ b/deploy-board/deploy_board/webapp/helpers/environs_helper.py
@@ -18,11 +18,6 @@
 import logging
 from deploy_board.webapp.helpers.deployclient import DeployClient
 from deploy_board.settings import IS_PINTEREST
-from django.contrib import messages
-from exceptions import NotFoundException, TeletraanException
-from django.http import HttpResponse
-from django.shortcuts import render, redirect
-import json
 
 log = logging.getLogger(__name__)
 
@@ -94,22 +89,14 @@ def create_identifier_for_new_stage(request, env_name, stage_name):
         return None
 
     # retrieve Nimbus identifier for existing_stage
-    try:
-        existing_stage_identifier = get_nimbus_identifier(request, stage_with_external_id['externalId'])
-    except TeletraanException as detail:
-        log.error('Handling TeletraanException when trying to access nimbus API, error message {}'.format(detail))
-        raise
+    existing_stage_identifier = get_nimbus_identifier(request, stage_with_external_id['externalId'])
     # create Nimbus Identifier for the new stage
     new_stage_identifier = None
     if existing_stage_identifier is not None:
         nimbus_request_data = existing_stage_identifier.copy()
         nimbus_request_data['stage_name'] = stage_name
         nimbus_request_data['env_name'] = env_name
-        try:
-            new_stage_identifier = create_nimbus_identifier(request, nimbus_request_data)
-        except TeletraanException as detail:
-            log.error('Handling TeletraanException when trying to access nimbus API, error message {}'.format(detail))
-            raise
+        new_stage_identifier = create_nimbus_identifier(request, nimbus_request_data)
 
     # if there is no stage in this env with externalId, still create the new stage
     if new_stage_identifier is None:

--- a/deploy-board/deploy_board/webapp/helpers/environs_helper.py
+++ b/deploy-board/deploy_board/webapp/helpers/environs_helper.py
@@ -19,7 +19,7 @@ import logging
 from deploy_board.webapp.helpers.deployclient import DeployClient
 from deploy_board.settings import IS_PINTEREST
 from django.contrib import messages
-from helpers.exceptions import TeletraanException
+from exceptions import TeletraanException
 
 log = logging.getLogger(__name__)
 

--- a/deploy-board/deploy_board/webapp/helpers/nimbusclient.py
+++ b/deploy-board/deploy_board/webapp/helpers/nimbusclient.py
@@ -12,19 +12,19 @@ log = logging.getLogger(__name__)
 @singleton
 class NimbusClient(object):
     def handle_response(self, response):
-        # if response.status_code == 404:
-        #     log.error("Resource not found. Nimbus API response - %s" % response.content)
-        #     return None
+        if response.status_code == 404:
+            log.error("Resource not found. Nimbus API response - %s" % response.content)
+            return None
 
-        # if response.status_code == 409:
-        #     log.error("Resource already exists. Nimbus API response - %s" % response.content)
-        #     raise TeletraanException('Resource conflict - Nimbus already has an Identifier for your proposed new stage. ')
+        if response.status_code == 409:
+            log.error("Resource already exists. Nimbus API response - %s" % response.content)
+            raise TeletraanException('Resource conflict - Nimbus already has an Identifier for your proposed new stage. ')
 
-        # if 400 <= response.status_code < 600:
-        log.error("Nimbus API Error %s, %s" % (response.content, response.status_code))
-        raise TeletraanException(
-            "Teletraan failed to successfully call Nimbus. Contact your friendly Teletraan owners for assistance. Hint: %s, %s" % (response.status_code, response.content)
-        )
+        if 400 <= response.status_code < 600:
+            log.error("Nimbus API Error %s, %s" % (response.content, response.status_code))
+            raise TeletraanException(
+                "Teletraan failed to successfully call Nimbus. Contact your friendly Teletraan owners for assistance. Hint: %s, %s" % (response.status_code, response.content)
+            )
 
         if response.status_code == 200 or response.status_code == 201:
             return response.json()

--- a/deploy-board/deploy_board/webapp/helpers/nimbusclient.py
+++ b/deploy-board/deploy_board/webapp/helpers/nimbusclient.py
@@ -21,8 +21,10 @@ class NimbusClient(object):
             raise TeletraanException('Resource conflict - Nimbus already has an Identifier for your proposed new stage. ')
 
         if 400 <= response.status_code < 600:
-            log.error("Teletraan failed to successfully call Nimbus. Contact your friendly Teletraan owners for assistance. Hint: %s, %s" % (response.status_code, response.content))
-            return response.json()
+            log.error("Nimbus API Error %s, %s" % (response.content, response.status_code))
+            raise TeletraanException(
+                "Teletraan failed to successfully call Nimbus. Contact your friendly Teletraan owners for assistance. Hint: %s, %s" % (response.status_code, response.content)
+            )
 
         if response.status_code == 200 or response.status_code == 201:
             return response.json()

--- a/deploy-board/deploy_board/webapp/helpers/nimbusclient.py
+++ b/deploy-board/deploy_board/webapp/helpers/nimbusclient.py
@@ -12,19 +12,19 @@ log = logging.getLogger(__name__)
 @singleton
 class NimbusClient(object):
     def handle_response(self, response):
-        if response.status_code == 404:
-            log.error("Resource not found. Nimbus API response - %s" % response.content)
-            return None
+        # if response.status_code == 404:
+        #     log.error("Resource not found. Nimbus API response - %s" % response.content)
+        #     return None
 
-        if response.status_code == 409:
-            log.error("Resource already exists. Nimbus API response - %s" % response.content)
-            raise TeletraanException('Resource conflict - Nimbus already has an Identifier for your proposed new stage. ')
+        # if response.status_code == 409:
+        #     log.error("Resource already exists. Nimbus API response - %s" % response.content)
+        #     raise TeletraanException('Resource conflict - Nimbus already has an Identifier for your proposed new stage. ')
 
-        if 400 <= response.status_code < 600:
-            log.error("Nimbus API Error %s, %s" % (response.content, response.status_code))
-            raise TeletraanException(
-                "Teletraan failed to successfully call Nimbus. Contact your friendly Teletraan owners for assistance. Hint: %s, %s" % (response.status_code, response.content)
-            )
+        # if 400 <= response.status_code < 600:
+        log.error("Nimbus API Error %s, %s" % (response.content, response.status_code))
+        raise TeletraanException(
+            "Teletraan failed to successfully call Nimbus. Contact your friendly Teletraan owners for assistance. Hint: %s, %s" % (response.status_code, response.content)
+        )
 
         if response.status_code == 200 or response.status_code == 201:
             return response.json()

--- a/deploy-board/deploy_board/webapp/helpers/nimbusclient.py
+++ b/deploy-board/deploy_board/webapp/helpers/nimbusclient.py
@@ -21,10 +21,8 @@ class NimbusClient(object):
             raise TeletraanException('Resource conflict - Nimbus already has an Identifier for your proposed new stage. ')
 
         if 400 <= response.status_code < 600:
-            log.error("Nimbus API Error %s, %s" % (response.content, response.status_code))
-            raise TeletraanException(
-                "Teletraan failed to successfully call Nimbus. Contact your friendly Teletraan owners for assistance. Hint: %s, %s" % (response.status_code, response.content)
-            )
+            log.error("Teletraan failed to successfully call Nimbus. Contact your friendly Teletraan owners for assistance. Hint: %s, %s" % (response.status_code, response.content))
+            return response.json()
 
         if response.status_code == 200 or response.status_code == 201:
             return response.json()


### PR DESCRIPTION
Background:
In deployboard if nimbus returns a 5xx http status then deployboard page fails. This means that browsing some pages will fail to load if nimbus is unavailable.

See https://github.com/pinterest/teletraan/blob/master/deploy-board/deploy_board/webapp/helpers/nimbusclient.py#L25

Solution:
Surface the Nimbus error message to the user as a banner rather than a whole page that restrict access to deploy-board 

Test Plan:

- Modify the code to force an Nimbus error
- Navigate to an environment and confirm that the error banner is displayed and that the environment page renders properly
- <img width="872" alt="image (6)" src="https://user-images.githubusercontent.com/69278532/196280758-4c9fa26b-275b-45ad-8a79-b1b94629889a.png">