### PR TITLE
Changed Auto Scaling Group notification config wording

### DIFF
--- a/deploy-board/deploy_board/templates/groups/group_config.tmpl
+++ b/deploy-board/deploy_board/templates/groups/group_config.tmpl
@@ -8,7 +8,7 @@
                     <label for="chatroom" class="deployToolTip control-label col-xs-2"
                         data-toggle="tooltip"
                         title="Slack channel where to send autoscaling notifications, e.g. room1,room2">
-                        Slack Channel
+                        Slack Channels
                     </label>
                     <div class="col-xs-4">
                         <input class="form-control" name="chatroom" required="false"
@@ -17,8 +17,8 @@
 
                     <label for="chatRecipients" class="deployToolTip control-label col-xs-2"
                         data-toggle="tooltip"
-                        title="Chat user handles where to send autoscaling notifications, e.g. user1,user2">
-                        Channel Recipients
+                        title="Slack users to send autoscaling notifications, e.g. user1,user2">
+                        Slack Users
                     </label>
                     <div class="col-xs-4">
                         <input class="form-control" name="watch_recipients" required="false"
@@ -38,7 +38,7 @@
 
                     <label for="pagerRecipients" class="deployToolTip control-label col-xs-2"
                         data-toggle="tooltip"
-                        title="Pager email addressses to send autoscaling and health check alert, e.g. user1@email.com,user2@email.com">
+                        title="Pager email addressses to send health check alert, e.g. user1@email.com,user2@email.com">
                         Pager Recipients
                     </label>
                     <div class="col-xs-4">


### PR DESCRIPTION
`Channel Recipients` is simply wrong and misleading. Updated to reflect facts. 