### PR TITLE
Fix `stage_type` handling issue when updating `EnvStage`

### DIFF
--- a/deploy-board/deploy_board/webapp/cluster_view.py
+++ b/deploy-board/deploy_board/webapp/cluster_view.py
@@ -79,8 +79,9 @@ class EnvCapacityBasicCreateView(View):
             if 'configs' in cluster_info:
                 for field in TELETRAAN_CLUSTER_READONLY_FIELDS:
                     if field in cluster_info['configs']:
-                        log.error("Teletraan does not support user to change %s %s" % (field, cluster_info[field]))
-                        raise TeletraanException("Teletraan does not support user to create %s" % s)
+                        msg = "Teletraan does not support user to change %s %s" % (field, cluster_info[field])
+                        log.error(msg)
+                        raise TeletraanException(msg)
 
             log.info("Associate cluster_name to environment")
             # Update cluster info
@@ -93,7 +94,7 @@ class EnvCapacityBasicCreateView(View):
                 request, name, stage, capacity_type="GROUP", data=cluster_name)
 
             clusters_helper.create_cluster_with_env(request, cluster_name, name, stage, cluster_info)
-            
+
             return HttpResponse("{}", content_type="application/json")
         except NotAuthorizedException as e:
             log.error("Have an NotAuthorizedException error {}".format(e))

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
@@ -111,8 +111,8 @@ public class EnvStages {
         }
 
         if (environBean.getStage_type() == null) {
-            // Request has no intention to change stage type, so set it to current value to
-            // avoid the default value being used.
+            // Request has no intention to change stage type, so set it to the current value
+            // to avoid the default value being used.
             environBean.setStage_type(origBean.getStage_type());
         } else if (origBean.getStage_type() != Constants.DEFAULT_STAGE_TYPE) {
             throw new TeletaanInternalException(Response.Status.BAD_REQUEST,

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
@@ -109,9 +109,16 @@ public class EnvStages {
         } catch (Exception e) {
             throw new TeletaanInternalException(Response.Status.BAD_REQUEST, e.toString());
         }
-        if (origBean.getStage_type() != EnvType.DEFAULT && origBean.getStage_type() != environBean.getStage_type()) {
-            throw new TeletaanInternalException(Response.Status.BAD_REQUEST, "Modification of stage type is not allowed!");
+
+        if (environBean.getStage_type() == null) {
+            // Request has no intention to change stage type, so set it to current value to
+            // avoid the default value being used.
+            environBean.setStage_type(origBean.getStage_type());
+        } else if (origBean.getStage_type() != Constants.DEFAULT_STAGE_TYPE) {
+            throw new TeletaanInternalException(Response.Status.BAD_REQUEST,
+                    "Modification of non-default stage type is not allowed!");
         }
+
         environBean.setEnv_name(origBean.getEnv_name());
         environBean.setStage_name(origBean.getStage_name());
         environHandler.updateStage(environBean, operator);


### PR DESCRIPTION
# Problem
```java
if (origBean.getStage_type() != EnvType.DEFAULT && origBean.getStage_type() != environBean.getStage_type()) {
```
The if statement results in true when the original environment stage has a non-default `stage_type` and the request doesn't intend to change the `stage_type`, which is `null`. 

# Fix
When a request has no intention to change stage type, we should set `stage_type` to the current value. Otherwise the default value will be used.