### PR TITLE
Prompt User if there is no Access Role on cluster creation [Updated]

### DIFF
--- a/deploy-board/deploy_board/templates/configs/new_capacity.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity.html
@@ -155,8 +155,8 @@ var capacitySetting = new Vue({
                 globalNotificationBanner.error = "Placement must be specified";
                 return false;
             }
-            var access_role = clusterInfo.configs['access_role'];
-            if (access_role === undefined || access_role === null || access_role === "") {
+            var access_role = clusterInfo.configs['access_role'].trim();
+            if (!access_role) {
                 globalNotificationBanner.error = "Access Role must be specified";
                 return false;
             }

--- a/deploy-board/deploy_board/templates/configs/new_capacity.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity.html
@@ -156,7 +156,7 @@ var capacitySetting = new Vue({
                 return false;
             }
             var access_role = clusterInfo.configs['access_role'];
-            if (access_role === undefined || access_role === null) {
+            if (access_role === undefined || access_role === null || access_role === "") {
                 globalNotificationBanner.error = "Access Role must be specified";
                 return false;
             }

--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -488,7 +488,7 @@ var capacitySetting = new Vue({
                 return false
             }
             var access_role = clusterInfo.configs['access_role'];
-            if (access_role === undefined || access_role === null) {
+            if (access_role === undefined || access_role === null || access_role === "") {
                 globalNotificationBanner.error = "Access Role must be specified";
                 return false;
             }

--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -487,8 +487,8 @@ var capacitySetting = new Vue({
                 globalNotificationBanner.error = "Replacement timeout must be a number between 5 and 1440 minutes (24 hours)"
                 return false
             }
-            var access_role = clusterInfo.configs['access_role'];
-            if (access_role === undefined || access_role === null || access_role === "") {
+            var access_role = clusterInfo.configs['access_role'].trim();
+            if (!access_role) {
                 globalNotificationBanner.error = "Access Role must be specified";
                 return false;
             }


### PR DESCRIPTION
Refer to for details: https://github.com/pinterest/teletraan/pull/1060

Default CMP Access Role is "" so, validation needed to be added for that scenario