### PR TITLE
Got rid of unused variable `cellValue`

### DIFF
--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -584,7 +584,7 @@
                             })
                             capacitySetting.baseImageHelpData = data
                             capacitySetting.showBaseImageHelp = true
-                        }, {cell: capacitySetting.cellValue})
+                        }, {cell: capacitySetting.currentCell})
                     }
                 },
                 baseImageChange: function(value) {
@@ -626,12 +626,10 @@
                         this.getHelpInfo('get_host_type_info', function(data){
                                 capacitySetting.hostTypeHelpData = data
                                 capacitySetting.showHostTypeHelp = true
-                            }, {cell: capacitySetting.cellValue})
+                            }, {cell: capacitySetting.currentCell})
                     }
                 },
                 cellChange: function(value) {
-                    capacitySetting.cellValue = value;
-                    capacitySetting.currentCell = value;
                     // grab all the image names
                     var scope = this;
                     var provider = capacitySetting.currentProvider;

--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -630,6 +630,7 @@
                     }
                 },
                 cellChange: function(value) {
+                    capacitySetting.currentCell = value;
                     // grab all the image names
                     var scope = this;
                     var provider = capacitySetting.currentProvider;

--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -37,7 +37,7 @@
             <form id="clusterConfigFormId" class="form-horizontal" role="form">
                 <fieldset id="clusterConfigFieldSetId">
                     <cloudprovider-select v-bind:cloudproviders="providers" v-bind:value="currentProvider"></cloudprovider-select>
-                    <cell-select v-bind:cells="cells" v-on:cellchange="cellChange"  v-bind:value="cellValue"></cell-select>
+                    <cell-select v-bind:cells="cells" v-on:cellchange="cellChange"  v-bind:value="currentCell"></cell-select>
                     <label-input label="Capacity" placeholder="# of instances" v-model="instanceCount"></label-input>
                     <baseimage-select v-bind:imagenames="imagenames" v-bind:baseimages="baseimages" v-bind:imagenamevalue="imageNameValue" v-bind:baseImageValue="baseImageValue"
                         v-on:baseimagechange="baseImageChange" v-on:imagenamechange="imageNameChange" inadvanced="true" v-on:helpclick="baseImageHelpClick">
@@ -144,7 +144,6 @@ var capacitySetting = new Vue({
                     isSelected: item.abstract_name === info.defaultHostType
                 }
             }),
-        cellValue: info.defaultCell,
         imageNameValue: info.defaultBaseImage,
         imagenames: info.baseImageNames.map(
             function (o) {
@@ -266,8 +265,6 @@ var capacitySetting = new Vue({
             }
         },
         cellChange: function(value) {
-            capacitySetting.cellValue = value;
-            capacitySetting.currentCell = value;
             // grab all the image names for this cell
             var scope = this;
             var provider = capacitySetting.currentProvider;

--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -265,6 +265,7 @@ var capacitySetting = new Vue({
             }
         },
         cellChange: function(value) {
+            capacitySetting.currentCell = value;
             // grab all the image names for this cell
             var scope = this;
             var provider = capacitySetting.currentProvider;


### PR DESCRIPTION
`cellValue` was renamed in a previous "find and replace" operation, but now it's no longer needed. We should stick to the single variable `currentCell`. 