### PR TITLE
Use v-on:change instead of @input

### DIFF
--- a/deploy-board/deploy_board/static/js/components/capacitycomponents.js
+++ b/deploy-board/deploy_board/static/js/components/capacitycomponents.js
@@ -236,7 +236,7 @@ Vue.component("static-capacity-config", {
         </label>
         <div class="col-xs-2" >
             <input name="capacity" class="form-control" type="number" min="0" required
-                :value="capacity" @input="onCapacityChange($event.target.value)" @keydown.enter.prevent="">
+                :value="capacity" v-on:change="onCapacityChange($event.target.value)" @keydown.enter.prevent="">
         </div>
     </div>
     <form-danger v-show="showSizeError" :alert-text="sizeError"></form-danger>
@@ -290,14 +290,14 @@ Vue.component("asg-capacity-config", {
             <div class="input-group">
                 <span class="input-group-addon">Min Size</span>
                 <input name="minSize" class="form-control" type="number" min="0" required
-                    :value="minSize" @input="onMinSizeChange($event.target.value)" @keydown.enter.prevent="" >
+                    :value="minSize" v-on:change="onMinSizeChange($event.target.value)" @keydown.enter.prevent="" >
             </div>
         </div>
         <div :class="inputBootstrapClass">
             <div class="input-group">
                 <span class="input-group-addon">Max Size</span>
                 <input name="maxSize" class="form-control" type="number" min="0" required
-                    :value="maxSize" @input="onMaxSizeChange($event.target.value)" @keydown.enter.prevent="">
+                    :value="maxSize" v-on:change="onMaxSizeChange($event.target.value)" @keydown.enter.prevent="">
             </div>
         </div>
     </div>


### PR DESCRIPTION
> The oninput event occurs when an element gets user input. This event occurs when the value of an <input> or <textarea> element is changed. Tip: This event is similar to the [onchange](https://www.w3schools.com/jsref/event_onchange.asp) event. The difference is that the oninput event occurs immediately after the value of an element has changed, while onchange occurs when the element loses focus, after the content has been changed.

We don't want to run the validation immediately when user starts input, because the value can be incomplete. i.e. user wants to input 200, but the validation runs against 2. 