### PR TITLE
Rodimus token remove cache

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/RodimusManagerImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/RodimusManagerImpl.java
@@ -82,13 +82,13 @@ public class RodimusManagerImpl implements RodimusManager {
 
         switch(verb) {
             case GET:
-                res = httpClient.get(url, payload, null, this.headers, this.RETRIES);
+                res = httpClient.get(url, payload, null, this.headers, RETRIES);
                 break;
             case POST:
-                res = httpClient.post(url, payload, this.headers, this.RETRIES);
+                res = httpClient.post(url, payload, this.headers, RETRIES);
                 break;
             case DELETE:
-                res = httpClient.delete(url, payload, this.headers, this.RETRIES);
+                res = httpClient.delete(url, payload, this.headers, RETRIES);
                 break;
         }
 

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/common/KnoxKeyTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/common/KnoxKeyTest.java
@@ -112,7 +112,7 @@ public class KnoxKeyTest {
     }
 
     @Test
-    public void thbcnErrorOkCRLF() throws Exception {
+    public void thbcnErrorOk() throws Exception {
         // terminateHostsByClusterName
         // Token does not work, refresh and retry, second try works
 
@@ -211,7 +211,7 @@ public class KnoxKeyTest {
     }
 
     @Test
-    public void gthErrorOkCRLF() throws Exception {
+    public void gthErrorOk() throws Exception {
         // getTerminatedHosts
         // Token does not work, refresh and retry, second try works
 


### PR DESCRIPTION
Knox keys should be able to be rotated without restarting. Knox already has means to rotate the primary key on a live service, and Knox libraries recommend to access the local storage each time the key is used. So all the caching logic is being removed. 