### PR TITLE
Rodimus token strip newlines

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/RodimusManagerImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/RodimusManagerImpl.java
@@ -74,7 +74,7 @@ public class RodimusManagerImpl implements RodimusManager {
 
     private void setAuthorization() throws Exception {
         String currKnoxKey = new String(this.fsKnox.getPrimaryKey());
-        String rodimusKey = currKnoxKey.replaceAll("[\n\r\t]*$", "");
+        String rodimusKey = currKnoxKey.replaceAll("[\n\r\t]", "");
         this.headers.put("Authorization", String.format("token %s", rodimusKey));
     }
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/RodimusManagerImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/RodimusManagerImpl.java
@@ -74,7 +74,8 @@ public class RodimusManagerImpl implements RodimusManager {
 
     private void setAuthorization() throws Exception {
         String currKnoxKey = new String(this.fsKnox.getPrimaryKey());
-        this.headers.put("Authorization", String.format("token %s", currKnoxKey));
+        String rodimusKey = currKnoxKey.replaceAll("[\n\r]*$", "");
+        this.headers.put("Authorization", String.format("token %s", rodimusKey));
     }
 
     private String switchHttpClient( Verb verb, String url, String payload ) throws Exception {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/RodimusManagerImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/RodimusManagerImpl.java
@@ -74,7 +74,7 @@ public class RodimusManagerImpl implements RodimusManager {
 
     private void setAuthorization() throws Exception {
         String currKnoxKey = new String(this.fsKnox.getPrimaryKey());
-        String rodimusKey = currKnoxKey.replaceAll("[\n\r]*$", "");
+        String rodimusKey = currKnoxKey.replaceAll("[\n\r\t]*$", "");
         this.headers.put("Authorization", String.format("token %s", rodimusKey));
     }
 

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/common/KnoxKeyTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/common/KnoxKeyTest.java
@@ -60,8 +60,8 @@ public class KnoxKeyTest {
         // Load testKeys
         testKey[0] = "aaa".getBytes(); // auth error
         testKey[1] = "bbb".getBytes(); // auth ok
-        testKey[2] = "aaa\n".getBytes(); // auth error with lf
-        testKey[3] = "bbb\r".getBytes(); // auth ok with cr
+        testKey[2] = "aaa\n\r".getBytes(); // auth error with lf
+        testKey[3] = "bbb\r\n".getBytes(); // auth ok with cr
 
         // Create mock for Knox
         mockKnox = Mockito.mock(Knox.class);
@@ -545,7 +545,7 @@ public class KnoxKeyTest {
     }
 
     private Object deleteAnswer(InvocationOnMock invocation) throws Exception {
-        // HTTPClient "DELETE" answer method
+        // Mock HTTPClient "DELETE" answer method
         Object[] args = invocation.getArguments();
         Object mock = invocation.getMock();
 

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/common/KnoxKeyTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/common/KnoxKeyTest.java
@@ -60,8 +60,8 @@ public class KnoxKeyTest {
         // Load testKeys
         testKey[0] = "aaa".getBytes(); // auth error
         testKey[1] = "bbb".getBytes(); // auth ok
-        testKey[2] = "aaa\n\r\t".getBytes(); // auth error with lf
-        testKey[3] = "bbb\t\r\n".getBytes(); // auth ok with cr
+        testKey[2] = "\na\taa\r".getBytes(); // auth error with lf
+        testKey[3] = "\tbb\rb\n".getBytes(); // auth ok with cr
 
         // Create mock for Knox
         mockKnox = Mockito.mock(Knox.class);

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/common/KnoxKeyTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/common/KnoxKeyTest.java
@@ -114,11 +114,12 @@ public class KnoxKeyTest {
     }
 
     @Test
-    public void thbcnErrorOk() throws Exception {
+    public void thbcnErrorOkCRLF() throws Exception {
         // terminateHostsByClusterName
         // Token does not work, refresh and retry, second try works
 
-        Mockito.when(this.mockKnox.getPrimaryKey()).thenReturn(this.testKey[0], this.testKey[1]);
+        Mockito.when(this.mockKnox.getPrimaryKey()).
+            thenReturn(this.testKey[0], this.testKey[1], this.testKey[2], this.testKey[3]);
 
         Mockito.when(this.mockHttpClient.delete(
             Mockito.any(String.class),
@@ -128,21 +129,25 @@ public class KnoxKeyTest {
 
         this.mockClasses(this.rodimusManager, this.mockKnox, this.mockHttpClient );
 
-        Exception exception = Assert.assertThrows( DeployInternalException.class, () -> {
-            this.rodimusManager.terminateHostsByClusterName("cluster",Collections.singletonList("i-001"));
-            } 
-        );
-        Assert.assertTrue( exception.getMessage().contains(msgUnauthException) );
+        for( int i=1; i<=2; i++ ) {
 
-        try{
-            this.rodimusManager.terminateHostsByClusterName("cluster",Collections.singletonList("i-001"));
-        }catch( Exception e ){
-            Assert.assertTrue( "Unexpected exception: " + e, false );
+            Exception exception = Assert.assertThrows( DeployInternalException.class, () -> {
+                this.rodimusManager.terminateHostsByClusterName("cluster",Collections.singletonList("i-001"));
+                } 
+            );
+            Assert.assertTrue( exception.getMessage().contains(msgUnauthException) );
+
+            try{
+                this.rodimusManager.terminateHostsByClusterName("cluster",Collections.singletonList("i-001"));
+            }catch( Exception e ){
+                Assert.assertTrue( "Unexpected exception: " + e, false );
+            }
+
         }
 
 // DEBUG        System.out.println("(no)answerList-> " + Arrays.toString( this.answerList.toArray() ) );
         final ArrayList<Answer> cmpArray = new ArrayList<Answer>() 
-            {{ add(Answer.EXCEPTION); add(Answer.NULL); }};        
+            {{ add(Answer.EXCEPTION); add(Answer.NULL); add(Answer.EXCEPTION); add(Answer.NULL); }};
         Assert.assertArrayEquals( this.answerList.toArray(), cmpArray.toArray() );
     }
 
@@ -175,35 +180,6 @@ public class KnoxKeyTest {
         Assert.assertArrayEquals( this.answerList.toArray(), cmpArray.toArray() );
     }
 
-    @Test
-    public void thbcnErrorRefreshUnauthorized() throws Exception {
-        // terminateHostsByClusterName
-        // Token does not work, refresh keep offering unauthorized tokens
-
-        Mockito.when(this.mockKnox.getPrimaryKey()).thenAnswer( invocation -> this.swapInvalidKeys(invocation) );
-
-        Mockito.when(this.mockHttpClient.delete(
-            Mockito.any(String.class),
-            Mockito.any(String.class),
-            Mockito.any(Map.class),
-            Mockito.any(Integer.class))).thenAnswer( invocation -> this.deleteAnswer(invocation) );
-
-        this.mockClasses(this.rodimusManager, this.mockKnox, this.mockHttpClient );
-
-        Exception exception = Assert.assertThrows( DeployInternalException.class, () -> {
-            this.rodimusManager.terminateHostsByClusterName("cluster",Collections.singletonList("i-001"));
-            } 
-        );
-
-        Assert.assertTrue( exception.getMessage().contains(msgUnauthException) );
-
-        int retries = this.getRetries(this.rodimusManager);
-        final ArrayList<Answer> cmpArray = new ArrayList<Answer>() 
-        {{ 
-            for( int i=1; i<=retries; i++ ){ add(Answer.EXCEPTION); };
-        }};
-        Assert.assertArrayEquals( this.answerList.toArray(), cmpArray.toArray() );
-    }
 
 
 
@@ -241,11 +217,12 @@ public class KnoxKeyTest {
     }
 
     @Test
-    public void gthErrorOk() throws Exception {
+    public void gthErrorOkCRLF() throws Exception {
         // getTerminatedHosts
         // Token does not work, refresh and retry, second try works
 
-        Mockito.when(this.mockKnox.getPrimaryKey()).thenReturn(this.testKey[0], this.testKey[1]);
+        Mockito.when(this.mockKnox.getPrimaryKey()).
+            thenReturn(this.testKey[0], this.testKey[1], this.testKey[2], this.testKey[3]);
 
         Mockito.when(this.mockHttpClient.post(
             Mockito.any(String.class),
@@ -259,20 +236,24 @@ public class KnoxKeyTest {
 
         Collection<String> res = null;
 
-        Exception exception = Assert.assertThrows( DeployInternalException.class, () -> {
-            this.rodimusManager.getTerminatedHosts(Arrays.asList("i-001","i-002"));
-            } 
-        );
-        Assert.assertTrue( exception.getMessage().contains(msgUnauthException) );
+        for( int i=1; i<=2; i++ ) {
 
-        try{
-            res = this.rodimusManager.getTerminatedHosts(Arrays.asList("i-001","i-002"));
-        }catch( Exception e ){
-            Assert.assertTrue( "Unexpected exception: " + e, false );
+            Exception exception = Assert.assertThrows( DeployInternalException.class, () -> {
+                this.rodimusManager.getTerminatedHosts(Arrays.asList("i-001","i-002"));
+                } 
+            );
+            Assert.assertTrue( exception.getMessage().contains(msgUnauthException) );
+
+            try{
+                res = this.rodimusManager.getTerminatedHosts(Arrays.asList("i-001","i-002"));
+            }catch( Exception e ){
+                Assert.assertTrue( "Unexpected exception: " + e, false );
+            }
+
         }
 
         final ArrayList<Answer> cmpArray = new ArrayList<Answer>() 
-            {{ add(Answer.EXCEPTION); add(Answer.ARRAY); }};
+            {{ add(Answer.EXCEPTION); add(Answer.ARRAY); add(Answer.EXCEPTION); add(Answer.ARRAY); }};
         Assert.assertArrayEquals( this.answerList.toArray(), cmpArray.toArray() );
     }
 
@@ -304,38 +285,6 @@ public class KnoxKeyTest {
 
         final ArrayList<Answer> cmpArray = new ArrayList<Answer>() 
             {{ add(Answer.EXCEPTION); add(Answer.EXCEPTION); }};
-        Assert.assertArrayEquals( this.answerList.toArray(), cmpArray.toArray() );
-    }
-
-    @Test
-    public void gthErrorRefreshUnauthorized() throws Exception {
-        // getTerminatedHosts
-        // Token does not work, refresh keep offering unauthorized tokens
-
-        Mockito.when(this.mockKnox.getPrimaryKey()).thenAnswer( invocation -> this.swapInvalidKeys(invocation) );
-
-        Mockito.when(this.mockHttpClient.post(
-            Mockito.any(String.class),
-            Mockito.any(String.class),
-            Mockito.any(Map.class),
-            Mockito.any(Integer.class))).thenAnswer( invocation -> this.postAnswer(invocation) );
-
-        this.mockClasses(this.rodimusManager, this.mockKnox, this.mockHttpClient );
-
-        this.postAnswerReturn = this.postAnswerArray;
-
-        Exception exception = Assert.assertThrows( DeployInternalException.class, () -> {
-            this.rodimusManager.getTerminatedHosts(Arrays.asList("i-001","i-002"));
-            } 
-        );
-
-        Assert.assertTrue( exception.getMessage().contains(msgUnauthException) );
-
-        int retries = this.getRetries(this.rodimusManager);
-        final ArrayList<Answer> cmpArray = new ArrayList<Answer>() 
-        {{ 
-            for( int i=1; i<=retries; i++ ){ add(Answer.EXCEPTION); }; 
-        }};
         Assert.assertArrayEquals( this.answerList.toArray(), cmpArray.toArray() );
     }
 
@@ -375,11 +324,12 @@ public class KnoxKeyTest {
     }
 
     @Test
-    public void gcilgErrorOk() throws Exception {
+    public void gcilgErrorOkCRLF() throws Exception {
         // getClusterInstanceLaunchGracePeriod
         // Token does not work, refresh and retry, second try works
 
-        Mockito.when(this.mockKnox.getPrimaryKey()).thenReturn(this.testKey[0], this.testKey[1]);
+        Mockito.when(this.mockKnox.getPrimaryKey()).
+            thenReturn(this.testKey[0], this.testKey[1], this.testKey[2], this.testKey[3]);
 
         Mockito.when(this.mockHttpClient.get(
             Mockito.any(String.class),
@@ -394,20 +344,24 @@ public class KnoxKeyTest {
 
         long res = 0;
 
-        Exception exception = Assert.assertThrows( DeployInternalException.class, () -> {
-            this.rodimusManager.getClusterInstanceLaunchGracePeriod("cluster");
-            }
-        );
-        Assert.assertTrue( exception.getMessage().contains("HTTP request failed, status") );
+        for( int i=1; i<=2; i++ ) {
 
-        try{
-            res = this.rodimusManager.getClusterInstanceLaunchGracePeriod("cluster");
-        }catch( Exception e ){
-            Assert.assertTrue( "Unexpected exception: " + e, false );
+            Exception exception = Assert.assertThrows( DeployInternalException.class, () -> {
+                this.rodimusManager.getClusterInstanceLaunchGracePeriod("cluster");
+                }
+            );
+            Assert.assertTrue( exception.getMessage().contains("HTTP request failed, status") );
+
+            try{
+                res = this.rodimusManager.getClusterInstanceLaunchGracePeriod("cluster");
+            }catch( Exception e ){
+                Assert.assertTrue( "Unexpected exception: " + e, false );
+            }
+
         }
 
         final ArrayList<Answer> cmpArray = new ArrayList<Answer>() 
-            {{ add(Answer.EXCEPTION); add(Answer.LATENCY); }};
+            {{ add(Answer.EXCEPTION); add(Answer.LATENCY); add(Answer.EXCEPTION); add(Answer.LATENCY); }};
         Assert.assertArrayEquals( this.answerList.toArray(), cmpArray.toArray() );
     }
 
@@ -438,37 +392,6 @@ public class KnoxKeyTest {
 
         final ArrayList<Answer> cmpArray = new ArrayList<Answer>() 
             {{ add(Answer.EXCEPTION); add(Answer.EXCEPTION); }};
-        Assert.assertArrayEquals( this.answerList.toArray(), cmpArray.toArray() );
-    }
-
-    @Test
-    public void gcilgpErrorRefreshUnauthorized() throws Exception {
-        // getClusterInstanceLaunchGracePeriod
-        // Token does not work, refresh keep offering unauthorized tokens
-
-        Mockito.when(this.mockKnox.getPrimaryKey()).thenAnswer( invocation -> this.swapInvalidKeys(invocation) );
-
-        Mockito.when(this.mockHttpClient.get(
-            Mockito.any(String.class),
-            Mockito.any(String.class),
-            Mockito.any(Map.class),
-            Mockito.any(Map.class),
-            Mockito.any(Integer.class))).thenAnswer( invocation -> this.getAnswer(invocation) );
-
-        this.mockClasses(this.rodimusManager, this.mockKnox, this.mockHttpClient);
-
-        Exception exception = Assert.assertThrows( DeployInternalException.class, () -> {
-            this.rodimusManager.getClusterInstanceLaunchGracePeriod("cluster");
-            } 
-        );
-
-        Assert.assertTrue( exception.getMessage().contains(msgUnauthException) );        
-
-        int retries = this.getRetries(this.rodimusManager);
-        final ArrayList<Answer> cmpArray = new ArrayList<Answer>() 
-        {{ 
-            for( int i=1; i<=retries; i++ ){ add(Answer.EXCEPTION); }; 
-        }};
         Assert.assertArrayEquals( this.answerList.toArray(), cmpArray.toArray() );
     }
 
@@ -511,7 +434,8 @@ public class KnoxKeyTest {
         // getEC2Tags
         // Token does not work, refresh and retry, second try works
 
-        Mockito.when(this.mockKnox.getPrimaryKey()).thenReturn(this.testKey[0], this.testKey[1]);
+        Mockito.when(this.mockKnox.getPrimaryKey()).
+            thenReturn(this.testKey[0], this.testKey[1], this.testKey[2], this.testKey[3]);
 
         Mockito.when(this.mockHttpClient.post(
             Mockito.any(String.class),
@@ -525,20 +449,24 @@ public class KnoxKeyTest {
 
         Map<String, Map<String, String>> res = null;
 
-        Exception exception = Assert.assertThrows( DeployInternalException.class, () -> {
-            this.rodimusManager.getEc2Tags(Arrays.asList("i-001","i-002"));
-            } 
-        );
-        Assert.assertTrue( exception.getMessage().contains("HTTP request failed, status") );
+        for( int i=1; i<=2; i++ ) {
 
-        try{
-            res = this.rodimusManager.getEc2Tags(Arrays.asList("i-001","i-002"));
-        }catch( Exception e ){
-            Assert.assertTrue( "Unexpected exception: " + e, false );
+            Exception exception = Assert.assertThrows( DeployInternalException.class, () -> {
+                this.rodimusManager.getEc2Tags(Arrays.asList("i-001","i-002"));
+                } 
+            );
+            Assert.assertTrue( exception.getMessage().contains("HTTP request failed, status") );
+
+            try{
+                res = this.rodimusManager.getEc2Tags(Arrays.asList("i-001","i-002"));
+            }catch( Exception e ){
+                Assert.assertTrue( "Unexpected exception: " + e, false );
+            }
+
         }
 
         final ArrayList<Answer> cmpArray = new ArrayList<Answer>() 
-            {{ add(Answer.EXCEPTION); add(Answer.ARRAY); }};
+            {{ add(Answer.EXCEPTION); add(Answer.ARRAY); add(Answer.EXCEPTION); add(Answer.ARRAY); }};
         Assert.assertArrayEquals( this.answerList.toArray(), cmpArray.toArray() );
 
     }
@@ -574,37 +502,6 @@ public class KnoxKeyTest {
         Assert.assertArrayEquals( this.answerList.toArray(), cmpArray.toArray() );
     }
 
-    @Test
-    public void ge2tErrorRefreshUnauthorized() throws Exception {
-        // getEC2Tags
-        // Token does not work, refresh keep offering unauthorized tokens
-
-        Mockito.when(this.mockKnox.getPrimaryKey()).thenAnswer( invocation -> this.swapInvalidKeys(invocation) );
-
-        Mockito.when(this.mockHttpClient.post(
-            Mockito.any(String.class),
-            Mockito.any(String.class),
-            Mockito.any(Map.class),
-            Mockito.any(Integer.class))).thenAnswer( invocation -> this.postAnswer(invocation) );
-
-        this.mockClasses(this.rodimusManager, this.mockKnox, this.mockHttpClient);
-
-        this.postAnswerReturn = this.postAnswerTag;
-
-        Exception exception = Assert.assertThrows( DeployInternalException.class, () -> {
-            this.rodimusManager.getEc2Tags(Arrays.asList("i-001","i-002"));
-            } 
-        );
-
-        Assert.assertTrue( exception.getMessage().contains(msgUnauthException) );
-
-        int retries = this.getRetries(this.rodimusManager);
-        final ArrayList<Answer> cmpArray = new ArrayList<Answer>() 
-        {{ 
-            for( int i=1; i<=retries; i++ ){ add(Answer.EXCEPTION); }; 
-        }};
-        Assert.assertArrayEquals( this.answerList.toArray(), cmpArray.toArray() );
-    }
 
 
 

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/common/KnoxKeyTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/common/KnoxKeyTest.java
@@ -50,7 +50,7 @@ public class KnoxKeyTest {
     private Knox mockKnox;
     private HTTPClient mockHttpClient;
     private List<Answer> answerList;
-    private byte[][] testKey = new byte[3][];
+    private byte[][] testKey = new byte[4][];
     private int rodimusManagerRETRIES;
     private String postAnswerReturn = null;
     private boolean swapKey = false;
@@ -60,7 +60,8 @@ public class KnoxKeyTest {
         // Load testKeys
         testKey[0] = "aaa".getBytes(); // auth error
         testKey[1] = "bbb".getBytes(); // auth ok
-        testKey[2] = "ccc".getBytes(); // extra auth error for retries
+        testKey[2] = "aaa\n".getBytes(); // auth error with lf
+        testKey[3] = "bbb\r".getBytes(); // auth ok with cr
 
         // Create mock for Knox
         mockKnox = Mockito.mock(Knox.class);
@@ -127,19 +128,26 @@ public class KnoxKeyTest {
 
         this.mockClasses(this.rodimusManager, this.mockKnox, this.mockHttpClient );
 
+        Exception exception = Assert.assertThrows( DeployInternalException.class, () -> {
+            this.rodimusManager.terminateHostsByClusterName("cluster",Collections.singletonList("i-001"));
+            } 
+        );
+        Assert.assertTrue( exception.getMessage().contains(msgUnauthException) );
+
         try{
             this.rodimusManager.terminateHostsByClusterName("cluster",Collections.singletonList("i-001"));
         }catch( Exception e ){
             Assert.assertTrue( "Unexpected exception: " + e, false );
         }
 
+// DEBUG        System.out.println("(no)answerList-> " + Arrays.toString( this.answerList.toArray() ) );
         final ArrayList<Answer> cmpArray = new ArrayList<Answer>() 
             {{ add(Answer.EXCEPTION); add(Answer.NULL); }};        
         Assert.assertArrayEquals( this.answerList.toArray(), cmpArray.toArray() );
     }
 
     @Test
-    public void thbcnErrorNoRefresh() throws Exception {
+    public void thbcnMultipleError() throws Exception {
         // terminateHostsByClusterName
         // Token does not work, refresh does not offer new token
 
@@ -153,14 +161,17 @@ public class KnoxKeyTest {
 
         this.mockClasses(this.rodimusManager, this.mockKnox, this.mockHttpClient );
 
-        Exception exception = Assert.assertThrows( DeployInternalException.class, () -> {
-            this.rodimusManager.terminateHostsByClusterName("cluster",Collections.singletonList("i-001"));
-            } 
-        );
+        for( int i=1; i<=2; i++ ) {
+            Exception exception = Assert.assertThrows( DeployInternalException.class, () -> {
+                this.rodimusManager.terminateHostsByClusterName("cluster",Collections.singletonList("i-001"));
+                } 
+            );
 
-        Assert.assertTrue( exception.getMessage().contains(msgUnauthException) );
+            Assert.assertTrue( exception.getMessage().contains(msgUnauthException) );
+        }
 
-        final ArrayList<Answer> cmpArray = new ArrayList<Answer>() {{ add(Answer.EXCEPTION); }};
+        final ArrayList<Answer> cmpArray = new ArrayList<Answer>() 
+            {{ add(Answer.EXCEPTION); add(Answer.EXCEPTION); }};
         Assert.assertArrayEquals( this.answerList.toArray(), cmpArray.toArray() );
     }
 
@@ -247,6 +258,13 @@ public class KnoxKeyTest {
         this.postAnswerReturn = this.postAnswerArray;
 
         Collection<String> res = null;
+
+        Exception exception = Assert.assertThrows( DeployInternalException.class, () -> {
+            this.rodimusManager.getTerminatedHosts(Arrays.asList("i-001","i-002"));
+            } 
+        );
+        Assert.assertTrue( exception.getMessage().contains(msgUnauthException) );
+
         try{
             res = this.rodimusManager.getTerminatedHosts(Arrays.asList("i-001","i-002"));
         }catch( Exception e ){
@@ -259,7 +277,7 @@ public class KnoxKeyTest {
     }
 
     @Test
-    public void gthErrorNoRefresh() throws Exception {
+    public void gthMultipleError() throws Exception {
         // getTerminatedHosts
         // Token does not work, refresh does not offer new token
 
@@ -275,14 +293,17 @@ public class KnoxKeyTest {
 
         this.postAnswerReturn = this.postAnswerArray;
 
-        Exception exception = Assert.assertThrows( DeployInternalException.class, () -> {
-            this.rodimusManager.getTerminatedHosts(Arrays.asList("i-001","i-002"));
-            } 
-        );
+        for( int i=1; i<=2; i++ ) {
+            Exception exception = Assert.assertThrows( DeployInternalException.class, () -> {
+                this.rodimusManager.getTerminatedHosts(Arrays.asList("i-001","i-002"));
+                } 
+            );
 
-        Assert.assertTrue( exception.getMessage().contains(msgUnauthException) );
+            Assert.assertTrue( exception.getMessage().contains(msgUnauthException) );
+        }
 
-        final ArrayList<Answer> cmpArray = new ArrayList<Answer>() {{ add(Answer.EXCEPTION); }};
+        final ArrayList<Answer> cmpArray = new ArrayList<Answer>() 
+            {{ add(Answer.EXCEPTION); add(Answer.EXCEPTION); }};
         Assert.assertArrayEquals( this.answerList.toArray(), cmpArray.toArray() );
     }
 
@@ -372,6 +393,13 @@ public class KnoxKeyTest {
         this.postAnswerReturn = this.postAnswerArray;
 
         long res = 0;
+
+        Exception exception = Assert.assertThrows( DeployInternalException.class, () -> {
+            this.rodimusManager.getClusterInstanceLaunchGracePeriod("cluster");
+            }
+        );
+        Assert.assertTrue( exception.getMessage().contains("HTTP request failed, status") );
+
         try{
             res = this.rodimusManager.getClusterInstanceLaunchGracePeriod("cluster");
         }catch( Exception e ){
@@ -384,7 +412,7 @@ public class KnoxKeyTest {
     }
 
     @Test
-    public void gcilgpErrorNoRefresh() throws Exception {
+    public void gcilgpMultipleError() throws Exception {
         // getClusterInstanceLaunchGracePeriod
         // Token does not work, refresh does not offer new token
 
@@ -399,14 +427,17 @@ public class KnoxKeyTest {
 
         this.mockClasses(this.rodimusManager, this.mockKnox, this.mockHttpClient );
 
-        Exception exception = Assert.assertThrows( DeployInternalException.class, () -> {
-            this.rodimusManager.getClusterInstanceLaunchGracePeriod("cluster");
-            }
-        );
+        for( int i=1; i<=2; i++ ) {
+            Exception exception = Assert.assertThrows( DeployInternalException.class, () -> {
+                this.rodimusManager.getClusterInstanceLaunchGracePeriod("cluster");
+                }
+            );
 
-        Assert.assertTrue( exception.getMessage().contains("HTTP request failed, status") );
+            Assert.assertTrue( exception.getMessage().contains("HTTP request failed, status") );
+        }
 
-        final ArrayList<Answer> cmpArray = new ArrayList<Answer>() {{ add(Answer.EXCEPTION); }};
+        final ArrayList<Answer> cmpArray = new ArrayList<Answer>() 
+            {{ add(Answer.EXCEPTION); add(Answer.EXCEPTION); }};
         Assert.assertArrayEquals( this.answerList.toArray(), cmpArray.toArray() );
     }
 
@@ -493,6 +524,13 @@ public class KnoxKeyTest {
         this.postAnswerReturn = this.postAnswerTag;
 
         Map<String, Map<String, String>> res = null;
+
+        Exception exception = Assert.assertThrows( DeployInternalException.class, () -> {
+            this.rodimusManager.getEc2Tags(Arrays.asList("i-001","i-002"));
+            } 
+        );
+        Assert.assertTrue( exception.getMessage().contains("HTTP request failed, status") );
+
         try{
             res = this.rodimusManager.getEc2Tags(Arrays.asList("i-001","i-002"));
         }catch( Exception e ){
@@ -506,7 +544,7 @@ public class KnoxKeyTest {
     }
 
     @Test
-    public void ge2tErrorNoRefresh() throws Exception {
+    public void ge2tMultipleError() throws Exception {
         // getEC2Tags
         // Token does not work, refresh does not offer new token
 
@@ -522,14 +560,17 @@ public class KnoxKeyTest {
 
         this.postAnswerReturn = this.postAnswerTag;
 
-        Exception exception = Assert.assertThrows( DeployInternalException.class, () -> {
-            this.rodimusManager.getEc2Tags(Arrays.asList("i-001","i-002"));
-            } 
-        );
+        for( int i=1; i<=2; i++ ) {
+            Exception exception = Assert.assertThrows( DeployInternalException.class, () -> {
+                this.rodimusManager.getEc2Tags(Arrays.asList("i-001","i-002"));
+                } 
+            );
 
-        Assert.assertTrue( exception.getMessage().contains("HTTP request failed, status") );
+            Assert.assertTrue( exception.getMessage().contains("HTTP request failed, status") );
+        }
 
-        final ArrayList<Answer> cmpArray = new ArrayList<Answer>() {{ add(Answer.EXCEPTION); }};
+        final ArrayList<Answer> cmpArray = new ArrayList<Answer>() 
+            {{ add(Answer.EXCEPTION); add(Answer.EXCEPTION); }};
         Assert.assertArrayEquals( this.answerList.toArray(), cmpArray.toArray() );
     }
 

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/common/KnoxKeyTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/common/KnoxKeyTest.java
@@ -430,7 +430,7 @@ public class KnoxKeyTest {
     }
 
     @Test
-    public void ge2tErrorOk() throws Exception {
+    public void ge2tErrorOkCRLF() throws Exception {
         // getEC2Tags
         // Token does not work, refresh and retry, second try works
 
@@ -511,14 +511,6 @@ public class KnoxKeyTest {
 //                   getTerminatedHosts                  2
 //                   getClusterInstanceLaunchGracePeriod 3
 //                   getEc2Tags                          4
-//          actions: token ok                                        1234
-//                     (everyday operation)
-//                   token error and retry ok                        1234
-//                     (expected behaviour when token changes)
-//                   token error and no new token given              1234
-//                     (do not try more than once with same token)
-//                   token error and new token does not work neither 1234
-//                     (do not try indefinitely)
 
 // =======================================================
 
@@ -540,20 +532,7 @@ public class KnoxKeyTest {
         classHttpClient.set(rodimusMngr, mokHttpClient);
         classHttpClient.setAccessible(false);
     }
-
-    private int getRetries(RodimusManager rodimusMngr) throws Exception {
-        // Get how many retries rodimusManager should do
-/*        
-        int RETRIES;
-        Field retries = rodimusMngr.getClass().getDeclaredField("RETRIES");
-        retries.setAccessible(true);
-        RETRIES = (int)retries.get(rodimusMngr);
-        retries.setAccessible(false);
-*/
-        int RETRIES = 2; // fixed to 2 due to logic change on retry loop
-        return RETRIES;
-    }
-
+    
     private String getToken(Map<String, String> headers) {
         // Get token out of Map of headers
 
@@ -563,14 +542,6 @@ public class KnoxKeyTest {
             if( entry.getKey()=="Authorization" ) return entry.getValue();
         }
         return null;
-    }
-
-    private Object swapInvalidKeys(InvocationOnMock invocation) {
-        // Keep returning invalid keys, but never twice the same
-
-        this.swapKey = !this.swapKey;
-        if( this.swapKey ) return this.testKey[0];
-        else return this.testKey[2];
     }
 
     private Object deleteAnswer(InvocationOnMock invocation) throws Exception {

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/common/KnoxKeyTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/common/KnoxKeyTest.java
@@ -60,8 +60,8 @@ public class KnoxKeyTest {
         // Load testKeys
         testKey[0] = "aaa".getBytes(); // auth error
         testKey[1] = "bbb".getBytes(); // auth ok
-        testKey[2] = "aaa\n\r".getBytes(); // auth error with lf
-        testKey[3] = "bbb\r\n".getBytes(); // auth ok with cr
+        testKey[2] = "aaa\n\r\t".getBytes(); // auth error with lf
+        testKey[3] = "bbb\t\r\n".getBytes(); // auth ok with cr
 
         // Create mock for Knox
         mockKnox = Mockito.mock(Knox.class);


### PR DESCRIPTION
Teletraan API and Teletraan Worker read Rodimus API keys from Knox. A newline can be inserted into a Knox key and result in a malformed authentication header. Defensive programming should avoid this mistake.