### PR TITLE
Reposition Remaining Capacity Component 

### DIFF
--- a/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
+++ b/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
@@ -361,12 +361,13 @@ Vue.component("placements-select", {
         <input type="radio" id="private-subnet" value="private" v-model="subnettype" v-on:click="filterclick($event.target.value)">\
         <label for="private">Private subnets</label>\
         <br>\
+        <span class="col-xs-12" v-bind:title="title" v-show="inadvanced">Remaining Capacity: {{remainingcapacity}}</span>\
     </div>\
     <div class="col-xs-2">\
         <input type="checkbox" id="checkbox" v-bind:checked="assignpublicip" v-on:click="assignipchange($event.target.checked)">\
         <label for="checkbox">Assign Public IP</label>\
     </div></div>',
-    props: ['label', 'title', 'selectoptions', 'showhelp', 'assignpublicip', 'subnettype', 'showsubnettype'],
+    props: ['label', 'title', 'selectoptions', 'showhelp', 'assignpublicip', 'subnettype', 'showsubnettype', 'remainingcapacity', 'inadvanced'],
     data: function () {
         return {
             groupStyle: this.showhelp ? 'input-group' : ''
@@ -389,11 +390,11 @@ Vue.component("placements-select", {
 });
 
 Vue.component('remaining-capacity', {
-    template: '<div class="col-xs-6" style="margin-top:-30px;">\
+    template: '<div class="col-xs-6" style="margin-top:-30px;" v-show="inadvanced">\
         <div class="col-xs-4"></div>\
         <span class="col-xs-6" style="padding:0;" v-bind:title="title">Remaining Capacity: {{remainingcapacity}}</span>\
         </div>',
-    props: ['title', 'remainingcapacity']
+    props: ['title', 'remainingcapacity', 'inadvanced']
 });
 
 Vue.component("accessrole-input", {

--- a/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
+++ b/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
@@ -389,11 +389,19 @@ Vue.component("placements-select", {
 });
 
 Vue.component('remaining-capacity', {
-    template: '<div class="col-xs-6" style="margin-top:-30px;" v-show="inadvanced">\
-        <div class="col-xs-4"></div>\
+    template: '<div class="form-group">\
+    <div class="col-xs-2"></div>\
+    <div class="col-xs-6" v-bind:style="marginStyle">\
         <span class="col-xs-6" style="padding:0;" v-bind:title="title">Remaining Capacity: {{remainingcapacity}}</span>\
-        </div>',
-    props: ['title', 'remainingcapacity', 'inadvanced']
+    </div>\
+    </div>',
+    props: ['title', 'remainingcapacity', 'inadvanced'],
+    computed: {
+        marginStyle:function() {
+            return this.inadvanced ? 'margin-top:-15px;' : 'margin-top:-30px;'
+            
+        }
+    }
 });
 
 Vue.component("accessrole-input", {

--- a/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
+++ b/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
@@ -361,13 +361,12 @@ Vue.component("placements-select", {
         <input type="radio" id="private-subnet" value="private" v-model="subnettype" v-on:click="filterclick($event.target.value)">\
         <label for="private">Private subnets</label>\
         <br>\
-        <span class="col-xs-12" v-bind:title="title" v-show="inadvanced">Remaining Capacity: {{remainingcapacity}}</span>\
     </div>\
     <div class="col-xs-2">\
         <input type="checkbox" id="checkbox" v-bind:checked="assignpublicip" v-on:click="assignipchange($event.target.checked)">\
         <label for="checkbox">Assign Public IP</label>\
     </div></div>',
-    props: ['label', 'title', 'selectoptions', 'showhelp', 'assignpublicip', 'subnettype', 'showsubnettype', 'remainingcapacity', 'inadvanced'],
+    props: ['label', 'title', 'selectoptions', 'showhelp', 'assignpublicip', 'subnettype', 'showsubnettype'],
     data: function () {
         return {
             groupStyle: this.showhelp ? 'input-group' : ''

--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -66,8 +66,8 @@
                     showhelp="true" v-on:helpclick="securityZoneHelpClick"></label-select>
                     <securityzone-help v-show="showSecurityZoneHelp" v-bind:data="securityZoneHelpData"></securityzone-help>
                     <placements-select label="Placements" title="Placements" showsubnettype="true" v-bind:selectoptions="placements" v-bind:assignpublicip="assignPublicIP" v-bind:subnettype="subnetType"
-                 showhelp="true" v-on:helpclick="placementsHelpClick" v-on:assignpublicipclick="selectpublicip" v-on:subnetfilterclick="changeSubnetType"></placements-select>
-                    <remaining-capacity title="The total remaining capacity of selected placements" v-bind:remainingcapacity="remainingCapacity"></remaining-capacity>
+                 showhelp="true" v-on:helpclick="placementsHelpClick" v-on:assignpublicipclick="selectpublicip" v-on:subnetfilterclick="changeSubnetType" v-bind:inadvanced="inAdvanced" v-bind:remainingcapacity="remainingCapacity"></placements-select>
+                    <remaining-capacity title="The total remaining capacity of selected placements" v-bind:remainingcapacity="remainingCapacity" v-show="!inAdvanced"></remaining-capacity>
                     <form-warning v-show="showSubnetReplacementAlert" v-bind:alert-text="subnetReplacementWarning"></form-warning>
                     <placements-help v-show="showPlacementsHelp" v-bind:data="placementsHelpData"></placements-help>
                     <label-input v-show="inAdvanced" label="Replacement Timeout" title="Time out for cluster replacement in minutes"

--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -67,7 +67,7 @@
                     <securityzone-help v-show="showSecurityZoneHelp" v-bind:data="securityZoneHelpData"></securityzone-help>
                     <placements-select label="Placements" title="Placements" showsubnettype="true" v-bind:selectoptions="placements" v-bind:assignpublicip="assignPublicIP" v-bind:subnettype="subnetType"
                  showhelp="true" v-on:helpclick="placementsHelpClick" v-on:assignpublicipclick="selectpublicip" v-on:subnetfilterclick="changeSubnetType"></placements-select>
-                    <remaining-capacity title="The total remaining capacity of selected placements" v-bind:remainingcapacity="remainingCapacity" v-show="!inAdvanced"></remaining-capacity>
+                    <remaining-capacity title="The total remaining capacity of selected placements" v-bind:remainingcapacity="remainingCapacity" v-bind:inadvanced="inAdvanced"></remaining-capacity>
                     <form-warning v-show="showSubnetReplacementAlert" v-bind:alert-text="subnetReplacementWarning"></form-warning>
                     <placements-help v-show="showPlacementsHelp" v-bind:data="placementsHelpData"></placements-help>
                     <label-input v-show="inAdvanced" label="Replacement Timeout" title="Time out for cluster replacement in minutes"

--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -66,7 +66,7 @@
                     showhelp="true" v-on:helpclick="securityZoneHelpClick"></label-select>
                     <securityzone-help v-show="showSecurityZoneHelp" v-bind:data="securityZoneHelpData"></securityzone-help>
                     <placements-select label="Placements" title="Placements" showsubnettype="true" v-bind:selectoptions="placements" v-bind:assignpublicip="assignPublicIP" v-bind:subnettype="subnetType"
-                 showhelp="true" v-on:helpclick="placementsHelpClick" v-on:assignpublicipclick="selectpublicip" v-on:subnetfilterclick="changeSubnetType" v-bind:inadvanced="inAdvanced" v-bind:remainingcapacity="remainingCapacity"></placements-select>
+                 showhelp="true" v-on:helpclick="placementsHelpClick" v-on:assignpublicipclick="selectpublicip" v-on:subnetfilterclick="changeSubnetType"></placements-select>
                     <remaining-capacity title="The total remaining capacity of selected placements" v-bind:remainingcapacity="remainingCapacity" v-show="!inAdvanced"></remaining-capacity>
                     <form-warning v-show="showSubnetReplacementAlert" v-bind:alert-text="subnetReplacementWarning"></form-warning>
                     <placements-help v-show="showPlacementsHelp" v-bind:data="placementsHelpData"></placements-help>


### PR DESCRIPTION
Background:

Component doesn't fit below Placements since Replacement Timeout takes up some space

Definition of Done:

Remaining Capacity is displayed in Advanced Configuration between Placements and Replacement Timeout

<img width="1441" alt="image" src="https://user-images.githubusercontent.com/69278532/205991809-479b6fb7-cfa5-45e9-9d72-d42d5e83b47c.png">
<img width="1760" alt="image" src="https://user-images.githubusercontent.com/69278532/205991902-7b675002-9c3c-414e-9c7d-4258d663072f.png">