### PR TITLE
Update changedate on deploy-board.js

### DIFF
--- a/deploy-board/deploy_board/static/js/deploy-board.js
+++ b/deploy-board/deploy_board/static/js/deploy-board.js
@@ -56,14 +56,14 @@ function getUrlParameter(sParam) {
     }
 }
 
-function getRemainingCapacity(capacityInfo, placementList) { 
-    if (!capacityInfo || !placementList) {
-        return Infinity;
-    }
-    let filteredPlacements = capacityInfo.filter(placement => placementList.includes(placement.id));
-    let totalCapacity = filteredPlacements.reduce((s, e) => s + e.capacity, 0);
-    return totalCapacity;
-}
+// function getRemainingCapacity(capacityInfo, placementList) { 
+//     if (!capacityInfo || !placementList) {
+//         return Infinity;
+//     }
+//     let filteredPlacements = capacityInfo.filter(placement => placementList.includes(placement.id));
+//     let totalCapacity = filteredPlacements.reduce((s, e) => s + e.capacity, 0);
+//     return totalCapacity;
+// }
 
 function getDefaultPlacement(capacityCreationInfo) {
     this.capacityCreationInfo = capacityCreationInfo

--- a/deploy-board/deploy_board/static/js/deploy-board.js
+++ b/deploy-board/deploy_board/static/js/deploy-board.js
@@ -56,14 +56,14 @@ function getUrlParameter(sParam) {
     }
 }
 
-// function getRemainingCapacity(capacityInfo, placementList) { 
-//     if (!capacityInfo || !placementList) {
-//         return Infinity;
-//     }
-//     let filteredPlacements = capacityInfo.filter(placement => placementList.includes(placement.id));
-//     let totalCapacity = filteredPlacements.reduce((s, e) => s + e.capacity, 0);
-//     return totalCapacity;
-// }
+function getRemainingCapacity(capacityInfo, placementList) { 
+    if (!capacityInfo || !placementList) {
+        return Infinity;
+    }
+    let filteredPlacements = capacityInfo.filter(placement => placementList.includes(placement.id));
+    let totalCapacity = filteredPlacements.reduce((s, e) => s + e.capacity, 0);
+    return totalCapacity;
+}
 
 function getDefaultPlacement(capacityCreationInfo) {
     this.capacityCreationInfo = capacityCreationInfo

--- a/deploy-board/deploy_board/templates/base.html
+++ b/deploy-board/deploy_board/templates/base.html
@@ -39,7 +39,7 @@
 <!-- Placed at the end of the document so the pages load faster (but it does not work ) -->
 <script src="{% static "js/jquery-1.11.1.min.js" %}"></script>
 <script src="{% static "js/bootstrap.min.js" %}"></script>
-<script src="{% static "js/deploy-board.js"%}?changedate=2018.01.12.150000"></script>
+<script src="{% static "js/deploy-board.js"%}?changedate=2022.12.06.150000"></script>
 <script src="{% static "js/fuelux.min.js" %}"></script>
 <script src="{% static "js/typeahead.bundle.min.js" %}"></script>
 <script src="{% static "js/star-rating.min.js" %}"></script>

--- a/deploy-board/deploy_board/templates/base.html
+++ b/deploy-board/deploy_board/templates/base.html
@@ -39,7 +39,7 @@
 <!-- Placed at the end of the document so the pages load faster (but it does not work ) -->
 <script src="{% static "js/jquery-1.11.1.min.js" %}"></script>
 <script src="{% static "js/bootstrap.min.js" %}"></script>
-<script src="{% static "js/deploy-board.js"%}?changedate=2022.12.06.150000"></script>
+<script src="{% static "js/deploy-board.js"%}?changedate=2018.01.12.150000"></script>
 <script src="{% static "js/fuelux.min.js" %}"></script>
 <script src="{% static "js/typeahead.bundle.min.js" %}"></script>
 <script src="{% static "js/star-rating.min.js" %}"></script>

--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -21,7 +21,7 @@
 <script type="text/javascript" src="//cdn.jsdelivr.net/chartist.js/latest/chartist.min.js"></script>
 <script type="text/javascript" src="{% static "js/components/sharedcomponents.js"%}?changedate=2016.12.19.150000"></script>
 <script type="text/javascript" src="{% static "js/components/capacitycomponents.js"%}?changedate=2017.07.05.180000"></script>
-<script type="text/javascript" src="{% static "js/components/clusterconfigcomponents.js"%}?changedate=2022.12.06.153000"></script>
+<script type="text/javascript" src="{% static "js/components/clusterconfigcomponents.js"%}?changedate=2018.05.17.153000"></script>
 
 <div class="panel panel-default" id="side-panel">
     <div class="panel-heading clearfix">

--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -21,7 +21,7 @@
 <script type="text/javascript" src="//cdn.jsdelivr.net/chartist.js/latest/chartist.min.js"></script>
 <script type="text/javascript" src="{% static "js/components/sharedcomponents.js"%}?changedate=2016.12.19.150000"></script>
 <script type="text/javascript" src="{% static "js/components/capacitycomponents.js"%}?changedate=2017.07.05.180000"></script>
-<script type="text/javascript" src="{% static "js/components/clusterconfigcomponents.js"%}?changedate=2018.05.17.153000"></script>
+<script type="text/javascript" src="{% static "js/components/clusterconfigcomponents.js"%}?changedate=2022.12.06.153000"></script>
 
 <div class="panel panel-default" id="side-panel">
     <div class="panel-heading clearfix">

--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -21,7 +21,7 @@
 <script type="text/javascript" src="//cdn.jsdelivr.net/chartist.js/latest/chartist.min.js"></script>
 <script type="text/javascript" src="{% static "js/components/sharedcomponents.js"%}?changedate=2016.12.19.150000"></script>
 <script type="text/javascript" src="{% static "js/components/capacitycomponents.js"%}?changedate=2017.07.05.180000"></script>
-<script type="text/javascript" src="{% static "js/components/clusterconfigcomponents.js"%}?changedate=2022.12.06.153000"></script>
+<script type="text/javascript" src="{% static "js/components/clusterconfigcomponents.js"%}?changedate=2022.12.06.150000"></script>
 
 <div class="panel panel-default" id="side-panel">
     <div class="panel-heading clearfix">


### PR DESCRIPTION
updating changedate so users do not have to clear cache to get latest js - cache busting 

The fix is the changing of the date, which forces chrome to treat deploy-board.js as a new file rather than use the cached version.

Test Plan:
1. Locally, render the cluster configuration page
2. Validate that the page renders correctly
3. Comment out the getRemainingCapacity method in deploy-board.js
4. Change the changedate on the static resource for deploy-board.js in the base.html
5. go to the cluster configuration age
6. Confirm that the page is not render properly and you see a getRemainingCapacity is not defined error in the console

1. Deploy build to integ with the getRemainingCapacity method commented out in deploy-board.js (the goal is to cache a broken version of the page)
2. Go to cluster configuration to cache the page
3. deploy a build with the fixed getRemainingCapacity method with the changedate on the static resource for deploy-board.js in the base.html updated
4. Clear cache and confirm that the cluster configuration page render correctly 