### PR TITLE
Swap the location of provider_name and abstract_name on Host Type selector

### DIFF
--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -481,7 +481,7 @@
                 hostTypeOptions: info.hostTypes.map(function(item, idx) {
                     return {
                         value: item.id,
-                        text: item.abstract_name + " (" + item.core + " cores, " + item.mem + " GB, " + item.storage + ", " + item.provider + ": " + item.provider_name + ")",
+                        text: item.provider_name + " (" + item.core + " cores, " + item.mem + " GB, " + item.storage + ", " + item.provider + ": " + item.abstract_name + ")",
                         isSelected: item.id === currentCluster.hostType
                     }
                 }),
@@ -764,7 +764,7 @@
                                     function (item) {
                                         return {
                                             value: item.id,
-                                            text: item.abstract_name + " (" + item.core + " cores, " + item.mem + " GB, " + item.storage + ", " + item.provider + ": " + item.provider_name + ")",
+                                            text: item.provider_name + " (" + item.core + " cores, " + item.mem + " GB, " + item.storage + ", " + item.provider + ": " + item.abstract_name + ")",
                                             isSelected: item.id === data[0].id
                                         }
                                     });


### PR DESCRIPTION
Background:
Trying to find the correct instance type when the name is known like c5.9xlarge is very hard. Since this is a dropdown, using the browser Find function does not work.

Solution:
Move the provider name to the far left of the text displayed in the host type dropdown to make it easier to find host types in Teletraan UI 

Test:
Navigate to Cluster Configuration
Click the Host Type dropdown
Confirm that  the provider name (ex. c5.2xlarge) to be on the far left, in place of the abstract name (ex. EbsComputeLo)
