### PR TITLE
Allow multi-line script config

### DIFF
--- a/deploy-agent/deployd/agent.py
+++ b/deploy-agent/deployd/agent.py
@@ -101,8 +101,8 @@ class DeployAgent(object):
 
     def _send_deploy_status_stats(self, deploy_report):
         if not self._response.deployGoal or not deploy_report:
-            return 
-        
+            return
+
         tags = {'first_run': self.first_run}
         if self._response.deployGoal.deployStage:
             tags['deploy_stage'] = self._response.deployGoal.deployStage
@@ -112,15 +112,15 @@ class DeployAgent(object):
             tags['stage_name'] = self._response.deployGoal.stageName
         if deploy_report.status_code:
             tags['status_code'] = deploy_report.status_code
-        if deploy_report.output_msg: 
+        if deploy_report.output_msg:
             if check_telefig_unavailable_error(deploy_report.output_msg):
                 tags['error_source'] = DeployErrorSource.TELEFIG
                 tags['error'] = DeployError.TELEFIG_UNAVAILABLE
             elif deploy_report.output_msg.find("teletraan_config_manager") != -1:
                 tags['error_source'] = DeployErrorSource.TELEFIG
-            
+
         create_sc_increment('deployd.stats.deploy.status', tags=tags)
-        
+
     def serve_build(self):
         """This is the main function of the ``DeployAgent``.
         """
@@ -168,7 +168,7 @@ class DeployAgent(object):
 
             if PingStatus.PING_FAILED == self.update_deploy_status(deploy_report):
                 return
-                
+
             if deploy_report.status_code in [AgentStatus.AGENT_FAILED,
                                              AgentStatus.TOO_MANY_RETRY,
                                              AgentStatus.SCRIPT_TIMEOUT]:
@@ -379,7 +379,7 @@ class DeployAgent(object):
             working_dir = os.path.join(env_dir, "{}_SCRIPT_CONFIG".format(env_name))
             with open(working_dir, "w+") as f:
                 for key, value in deploy_goal.scriptVariables.items():
-                    f.write("{}={}\n".format(key, value))
+                    f.write("{}={}\n".format(key, value.strip('\n').replace('\n', '\\n')))
 
         # timing stats - deploy stage start
         if deploy_goal != self.deploy_goal_previous:

--- a/deploy-agent/deployd/staging/transformer.py
+++ b/deploy-agent/deployd/staging/transformer.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -43,7 +43,8 @@ class Transformer(object):
             return
 
         with open(fn, 'r') as f:
-            self._dictionary = dict((n.strip('\"\n\' ') for n in line.split("=", 1)) for line in f)
+            self._dictionary = dict((n.strip('\"\n\' ').replace('\\n', '\n')
+                                    for n in line.split("=", 1)) for line in f)
 
     def dict_size(self):
         return len(self._dictionary)

--- a/deploy-agent/tests/unit/deploy/staging/test_transformer.py
+++ b/deploy-agent/tests/unit/deploy/staging/test_transformer.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -48,7 +48,8 @@ class TransformTest(unittest.TestCase):
 
         lines = ['foo = \"bar\"\n',
                  'Wh-O =   \'test2\'\n',
-                 'TEST = test3\n']
+                 'TEST = test3\n',
+                 'NEW_LINE = arg1 \\n arg2\\n']
         with open(os.path.join(self.base_dir, '123_SCRIPT_CONFIG'), 'w') as f:
             f.writelines(lines)
 

--- a/deploy-agent/tests/unit/deploy/staging/test_transformer.py
+++ b/deploy-agent/tests/unit/deploy/staging/test_transformer.py
@@ -49,7 +49,7 @@ class TransformTest(unittest.TestCase):
         lines = ['foo = \"bar\"\n',
                  'Wh-O =   \'test2\'\n',
                  'TEST = test3\n',
-                 'NEW_LINE = arg1 \\n arg2\\n']
+                 'NEW_LINE = arg1 \\n arg2\\narg3\n']
         with open(os.path.join(self.base_dir, '123_SCRIPT_CONFIG'), 'w') as f:
             f.writelines(lines)
 
@@ -61,6 +61,7 @@ class TransformTest(unittest.TestCase):
         self.assertEqual(transformer._dictionary.get('foo'), 'bar')
         self.assertEqual(transformer._dictionary.get('Wh-O'), 'test2')
         self.assertEqual(transformer._dictionary.get('TEST'), 'test3')
+        self.assertEqual(transformer._dictionary.get('NEW_LINE'), 'arg1 \n arg2\narg3')
 
     def test_translate1(self):
         transformer = Transformer(agent_dir=self.base_dir, env_name="123")

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/common/CommonUtilsTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/common/CommonUtilsTest.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *    
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,7 +16,6 @@
 package com.pinterest.deployservice.common;
 
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -35,21 +34,15 @@ public class CommonUtilsTest {
         data.put("simple", "How are you!");
         data.put("complicate", script);
 
-        data = CommonUtils.encodeScript(data);
-
-        String encodedScript1 = data.get("complicate");
-
         String encoded = CommonUtils.encodeData(data);
         Map<String, String> decoded = CommonUtils.decodeData(encoded);
+        assertEquals(data.get("simple"), decoded.get("simple"));
+        assertEquals(data.get("complicate"), decoded.get("complicate"));
 
-        String encodedScript2 = decoded.get("complicate");
-
-        decoded = CommonUtils.decodeScript(decoded);
-
-        String decodedScript3 = decoded.get("complicate");
-
-        assertEquals(decoded.get("simple"), "How are you!");
-        assertEquals(decoded.get("complicate"), script);
+        Map<String, String> encodedScript = CommonUtils.encodeScript(data);
+        decoded = CommonUtils.decodeScript(encodedScript);
+        assertEquals(data.get("simple"), decoded.get("simple"));
+        assertEquals(data.get("complicate"), decoded.get("complicate"));
     }
 
     @Test


### PR DESCRIPTION
Users might accidentally have a new line in their script config. Previous this will cause an exception like 
```
ValueError: dictionary update sequence element #1 has length 1; 2 is required
```
This is not actionable. With this change, application can still fail, but not due to deploy agent error. Something likely more direct will happen. 

On the other hand, users will be able to have formatted arguments if they want. 
```
arg1=v1 \
arg2=v2
```