### PR TITLE
Handle multi-line in script config

### DIFF
--- a/deploy-board/deploy_board/templates/base.html
+++ b/deploy-board/deploy_board/templates/base.html
@@ -113,6 +113,9 @@
         <div id="vuePageErrorBanner" style="display:none; text-align:center" class="alert alert-danger alert-dismissible" v-show="error" role="alert">{{error}}
             <button type="button" class="close" v-on:click="error=''" ><span aria-hidden="true">&times;</span></button>
         </div>
+        <div id="vuePageWarningBanner" style="display:none; text-align:center" class="alert alert-warning alert-dismissible" v-show="warning" role="alert">{{warning}}
+            <button type="button" class="close" v-on:click="warning=''" ><span aria-hidden="true">&times;</span></button>
+        </div>
     </div>
     <script type="text/javascript">
         globalNotificationBanner = new Vue({
@@ -120,6 +123,7 @@
             data:{
                 error:"",
                 info:"",
+                warning: "",
             }
         });
     </script>

--- a/deploy-board/deploy_board/templates/configs/config_map.tmpl
+++ b/deploy-board/deploy_board/templates/configs/config_map.tmpl
@@ -104,6 +104,15 @@
             $('#resetConfigMapBtnId').removeAttr('disabled');
         });
 
+        $('#mapConfigFormId,#newEntryFormId').on('input', 'textarea', function() {
+            const currentVal = $(this).val();
+            if (currentVal.match(/[\r\n\v]+/g)) {
+                $(this).val(currentVal.replace(/[\r\n\v]+/g, ''));
+                globalNotificationBanner.warning =
+                    "New line (\\r\\n) is not allowed in script configs and removed. Also note that line wraping is enabled.";
+            }
+        });
+
         $('#addConfigMapBtnId').click(function () {
             $('#newEntryModalId').modal()
             $('#saveConfigMapBtnId').removeAttr('disabled');

--- a/deploy-board/deploy_board/templates/configs/config_map.tmpl
+++ b/deploy-board/deploy_board/templates/configs/config_map.tmpl
@@ -11,6 +11,7 @@
                         <textarea class="form-control" name="TELETRAAN_{{ key }}"
                         rows="1" style="resize: none;"
                         >{{ value|default_if_none:'' }}</textarea>
+                        <p class="lineTooLong" {% if value|length < 256 %}hidden{% endif %}>Value too long > 256, we sugguest breaking it into multiple key-value paris.</p>
                     </div>
                     <div class="col-xs-3">
                         <button type="button" class="delete_button btn btn-default">Delete</button>
@@ -107,9 +108,16 @@
         $('#mapConfigFormId,#newEntryFormId').on('input', 'textarea', function() {
             const currentVal = $(this).val();
             if (currentVal.match(/[\r\n\v]+/g)) {
-                $(this).val(currentVal.replace(/[\r\n\v]+/g, ''));
+                $(this).val(currentVal.replace(/[\r\n\v]+/g, ' '));
                 globalNotificationBanner.warning =
-                    "New line (\\r\\n) is not allowed in script configs and removed. Also note that line wraping is enabled.";
+                    "Multi-line (\\r\\n) is not allowed in script config and thus replaced by SPACE. Also note that line wraping is enabled.";
+            }
+
+            const lineTooLong = $(this).siblings(".lineTooLong");
+            if ($(this).val().length > 256) {
+                lineTooLong.show();
+            } else {
+                lineTooLong.hide();
             }
         });
 
@@ -130,7 +138,9 @@
                     '<div class="form-group">' +
                     '<label for="properties" class="control-label col-xs-3">' + name + '</label>' +
                     '<div class="col-xs-6"><textarea class="form-control" name="TELETRAAN_' +
-                    name + '" type="text" rows="1" style="resize: none;">' + value + '</textarea></div>' +
+                    name + '" type="text" rows="1" style="resize: none;">' + value + '</textarea>' +
+                    '<p class="lineTooLong" ' + (value.length > 256 ? '' : 'hidden') +
+                    '>Value too long > 256, we sugguest breaking it into multiple key-value paris.</p></div>' +
                     '<div class="col-xs-3 {{ flavor }}_remover">' +
                     '<button type="button" class="delete_button btn btn-default">Delete</button></div>' +
                     '</div>');


### PR DESCRIPTION
When users try to insert a multi-line script config, by either typing or pasting, prevent that by replacing \r or \n with a space and show a warning banner. 
In order to do so, introduced the "warning" type banner. 

Additionally, added warning if line is too long ( > 256)


https://user-images.githubusercontent.com/8442875/211421982-ea48c4b1-d711-46d6-a715-56e379b34f35.mov


