### PR TITLE
filter host type by cpu arch in help list

### DIFF
--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -637,7 +637,7 @@
                         this.showHostTypeHelp = false;
                     }
                     else{
-                        this.getHelpInfo('get_host_type_info', function(data){
+                        this.getHelpInfo('get_host_types/' + capacitySetting.currentArch, function(data){
                                 capacitySetting.hostTypeHelpData = data
                                 capacitySetting.showHostTypeHelp = true
                             }, {cell: capacitySetting.currentCell})

--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -270,7 +270,7 @@ var capacitySetting = new Vue({
                 this.showHostTypeHelp = false;
             }
             else{
-                this.getHelpInfo('get_host_type_info', function(data){
+                this.getHelpInfo('get_host_types/' + capacitySetting.currentArch, function(data){
                         capacitySetting.hostTypeHelpData = data
                         capacitySetting.showHostTypeHelp = true
                     }, {cell: capacitySetting.currentCell})


### PR DESCRIPTION
teletraan cluster config UI show "host type" help link does not filter by arch_type (https://jira.pinadmin.com/browse/CDP-5905)