### PR TITLE
show all AMIs on cluster configuration page

### DIFF
--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -464,7 +464,7 @@
                         }).filter(function(item){return item.name!='assign_public_ip'}),
                 assignPublicIP: initialAssignPublicIP,
                 awsRole: currentCluster.configs.aws_role,
-                baseimages: baseImageSorted.map(function(o) {
+                baseimages: info.baseImages.map(function(o) {
                     var acceptance = o.acceptance ? ' [' + o.acceptance + ']' : '';
                     return {
                         value: o.id,


### PR DESCRIPTION
In cluster page when the cluster is already created, there is only the image which is being in use is showing (https://jira.pinadmin.com/browse/CDP-5662)