### PR TITLE
Re-release of Teletraan UI (deployboard) does not gracefully handle nimbus failure + fixes

### DIFF
--- a/deploy-board/deploy_board/templates/configs/env_config.html
+++ b/deploy-board/deploy_board/templates/configs/env_config.html
@@ -193,7 +193,7 @@
 {% endblock %}
 
 {% block main %}
-
+{% include "message_banner.tmpl" %}
 {% include "environs/env_tabs.tmpl" with envTabKind="config" %}
 
 <div class="panel panel-default">

--- a/deploy-board/deploy_board/templates/environs/env_landing.html
+++ b/deploy-board/deploy_board/templates/environs/env_landing.html
@@ -311,22 +311,7 @@ $('#privateBldUploadBtnId button').click(function () {
 
 {% endif %}
 
-{% if messages %}
-    {% for message in messages %}
-        {% if message.level == 40 %}
-            <div class="alert alert-danger" role="alert">
-                <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                <strong>Warning!</strong> {{ message | safe}}
-            </div>
-        {% else %}
-            <div class="alert alert-success" role="alert">
-                <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                <strong>Launch Succeeded!</strong> {{ message | safe}}
-            </div>
-        {% endif %}
-    {% endfor %}
-{% endif %}
-
+{% include "message_banner.tmpl" %}
 {% include "environs/env_tabs.tmpl" with envTabKind="deploy" %}
 {% include "environs/site_health.tmpl" with metricsKind="service" %}
 

--- a/deploy-board/deploy_board/templates/groups/group_details.html
+++ b/deploy-board/deploy_board/templates/groups/group_details.html
@@ -136,22 +136,7 @@
 </div>
 
 <!--- launch instances button dialog-->
-{% if messages %}
-    {% for message in messages %}
-        {% if message.level == 40 %}
-            <div class="alert alert-danger" role="alert">
-                <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                <strong>Warning!</strong> {{ message | safe}}
-            </div>
-        {% else %}
-            <div class="alert alert-success" role="alert">
-                <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                <strong>Launch Succeeded!</strong> {{ message | safe}}
-            </div>
-        {% endif %}
-
-    {% endfor %}
-{% endif %}
+{% include "message_banner.tmpl" %}
 
 <!---- Group Details Panel --->
 {% if not scaling_down_event_enabled and asg_status == "ENABLED" %}

--- a/deploy-board/deploy_board/templates/message_banner.tmpl
+++ b/deploy-board/deploy_board/templates/message_banner.tmpl
@@ -1,0 +1,15 @@
+{% if messages %}
+    {% for message in messages %}
+        {% if message.level == 40 %}
+            <div class="alert alert-danger" role="alert">
+                <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <strong>Warning!</strong> {{ message | safe}}
+            </div>
+        {% else %}
+            <div class="alert alert-success" role="alert">
+                <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <strong>Launch Succeeded!</strong> {{ message | safe}}
+            </div>
+        {% endif %}
+    {% endfor %}
+{% endif %}

--- a/deploy-board/deploy_board/webapp/cluster_view.py
+++ b/deploy-board/deploy_board/webapp/cluster_view.py
@@ -810,14 +810,23 @@ def clone_cluster(request, src_name, src_stage):
     except NotAuthorizedException as e:
         log.error("Have an NotAuthorizedException error {}".format(e))
         if external_id is not None:
-            environs_helper.delete_nimbus_identifier(request, external_id)
+            try:
+                environs_helper.delete_nimbus_identifier(request, external_id)
+            except TeletraanException as detail:
+                message = 'Failed to delete Nimbus identifier {}. Please verify that identifier no longer exists, Error Message: {}'.format(external_id, detail)
+                log.error(message)
 
         return HttpResponse(e, status=403, content_type="application/json")
     except Exception as e:
         log.error("Failed to clone cluster env_name: %s, stage_name: %s" % (src_name, src_stage))
         log.error(traceback.format_exc())
         if external_id is not None:
-            environs_helper.delete_nimbus_identifier(request, external_id)
+            try:
+                environs_helper.delete_nimbus_identifier(request, external_id)
+            except TeletraanException as detail:
+                message = 'Failed to delete Nimbus identifier {}. Please verify that identifier no longer exists, Error Message: {}'.format(external_id, detail)
+                log.error(message)
+                
         return HttpResponse(e, status=500, content_type="application/json")
 
 

--- a/deploy-board/deploy_board/webapp/env_views.py
+++ b/deploy-board/deploy_board/webapp/env_views.py
@@ -342,6 +342,7 @@ class EnvLandingView(View):
                 project_name_is_default = True if existing_stage_identifier is not None and existing_stage_identifier['projectName'] == "default" else False
             except TeletraanException as detail:
                 log.error('Handling TeletraanException when trying to access nimbus API, error message {}'.format(detail))
+                messages.add_message(request, messages.ERROR, detail)
 
         project_info = None
         if existing_stage_identifier:
@@ -349,7 +350,11 @@ class EnvLandingView(View):
             if project_name:
                 project_info = {}
                 project_info['project_name'] = project_name
+            try:    
                 project_info['project_url'] = environs_helper.get_nimbus_project_console_url(project_name)
+            except TeletraanException as detail:
+                log.error('Handling TeletraanException when trying to access nimbus API, error message {}'.format(detail))
+                messages.add_message(request, messages.ERROR, detail)    
 
         if IS_PINTEREST:
             basic_cluster_info = clusters_helper.get_cluster(request, env.get('clusterName'))
@@ -793,9 +798,23 @@ def post_create_env(request):
     clone_env_name = data.get("clone_env_name")
     clone_stage_name = data.get("clone_stage_name")
     description = data.get('description')
+    
     if clone_env_name and clone_stage_name:
-        common.clone_from_stage_name(request, env_name, stage_name, clone_env_name,
-                                     clone_stage_name, description)
+        try:
+            external_id = environs_helper.create_identifier_for_new_stage(request, env_name, stage_name)
+            common.clone_from_stage_name(request, env_name, stage_name, clone_env_name,
+                                        clone_stage_name, description, external_id)
+        except TeletraanException as detail:
+            if external_id:
+                try:
+                    environs_helper.delete_nimbus_identifier(request, external_id)
+                except:
+                    message = 'Also failed to delete Nimbus identifier {}. Please verify that identifier no longer exists, Error Message: {}'.format(external_id, detail)
+                    log.error(message)
+            else:
+                message = 'Failed to create identifier for {}/{}: {}'.format(env_name, stage_name, detail)
+                messages.add_message(request, messages.ERROR, message)
+            raise detail
     else:
         data = {}
         data['envName'] = env_name
@@ -840,16 +859,35 @@ def post_add_stage(request, name):
     if from_stage and from_stage not in stages:
         raise Exception("Can not clone from non-existing stage!")
 
-    external_id = environs_helper.create_identifier_for_new_stage(request, name, stage)
-
-    try:
-        if from_stage:
+    if from_stage:
+        try:
+            external_id = environs_helper.create_identifier_for_new_stage(request, name, stage)
             common.clone_from_stage_name(request, name, stage, name, from_stage, description, external_id)
-        else:
+        except TeletraanException as detail:
+            if external_id:
+                try:
+                    environs_helper.delete_nimbus_identifier(request, external_id)
+                except:
+                    message = 'Also failed to delete Nimbus identifier {}. Please verify that identifier no longer exists, Error Message: {}'.format(external_id, detail)
+                    log.error(message)
+                    raise detail
+            else:
+                message = 'Failed to create identifier for {}/{}: {}'.format(name, stage, detail)
+                messages.add_message(request, messages.ERROR, message) 
+    else:
+        try:
+            external_id = environs_helper.create_identifier_for_new_stage(request, name, stage)
             common.create_simple_stage(request,name, stage, description, external_id)
-    except:
-        environs_helper.delete_nimbus_identifier(request, external_id)
-        raise
+        except TeletraanException as detail:
+            try:
+                message = 'Failed to create stage {}, Error Message: {}'.format(external_id, detail)
+                log.error(message)
+                messages.add_message(request, messages.ERROR, message)
+                environs_helper.delete_nimbus_identifier(request, external_id)
+            except TeletraanException as detail:
+                message = 'Failed to delete Nimbus identifier {}, Error Message: {}'.format(external_id, detail)
+                log.error(message)
+                messages.add_message(request, messages.ERROR, message)
 
     return redirect('/env/' + name + '/' + stage + '/config/')
 
@@ -863,7 +901,12 @@ def remove_stage(request, name, stage):
             break
 
     if current_env_stage_with_external_id is not None and current_env_stage_with_external_id['externalId'] is not None:
-        environs_helper.delete_nimbus_identifier(request, current_env_stage_with_external_id['externalId'])
+        try:
+            environs_helper.delete_nimbus_identifier(request, current_env_stage_with_external_id['externalId'])
+        except TeletraanException as detail:
+            message = 'Failed to delete Nimbus identifier {}. Please verify that identifier no longer exists, Error Message: {}'.format(current_env_stage_with_external_id['externalId'], detail)
+            log.error(message)
+            messages.add_message(request, messages.ERROR, message)
 
     environs_helper.delete_env(request, name, stage)
     envs = environs_helper.get_all_env_stages(request, name)


### PR DESCRIPTION
Reverting the revert of https://github.com/pinterest/teletraan/pull/1059 
Background:

Previous commit caused a bug (https://pinterest.pagerduty.com/incidents/Q3IH0TONU59FZ4) with the root cause documented here https://docs.google.com/document/d/1_5xYvphQfQcGu4foYCLsx_myGXQorzpnFUJJH8nZq7g/edit#
 

Definition of Done:
Fix try-except env_view.py  on lines 878, 879
Remove Generic exceptions

Test Plan:
1. Update the code to force an exception
2. Try to Clone a cluster
3. Confirm proper logs are displayed 
4. 
<img width="1937" alt="Screenshot 2023-02-13 at 3 37 42 PM" src="https://user-images.githubusercontent.com/69278532/218610029-fcbe158f-d848-4f7c-a063-ab6d6ce02b52.png">

5. Comment out not authorized block of code
6. Try to clone a cluster
7. Confirm proper logs are displayed 
8. 
<img width="1952" alt="Screenshot 2023-02-13 at 3 41 39 PM" src="https://user-images.githubusercontent.com/69278532/218610079-ec0341e2-cd64-4de6-a12e-8b101f654d95.png">

9. Try to add a stage
10. Confirm that the exception is raised on a new page and a failed to delete nimbus id error is logged
11. 
<img width="1952" alt="Screenshot 2023-02-13 at 3 44 08 PM" src="https://user-images.githubusercontent.com/69278532/218610267-8cbbe3cb-bf6b-46ee-88f8-67fef95b6a07.png">

12. try to add a stage from clone
13. Confirm that two exception banners are raised and logged failed to delete nimbus id and failed to create stage
14. 
<img width="1484" alt="Screenshot 2023-02-13 at 3 44 49 PM" src="https://user-images.githubusercontent.com/69278532/218610293-75927549-2237-4227-8a37-c37f2f5f73f4.png">

15. Remove a stage  
16. Confirm that exception banner is raised and logged failed to delete nimbus id and failed to create stage
17. 
<img width="1945" alt="Screenshot 2023-02-13 at 3 44 57 PM" src="https://user-images.githubusercontent.com/69278532/218610328-f4fa97a8-86df-441a-8081-2942a476ae0f.png">
