### PR TITLE
fixed 2 issues

### DIFF
--- a/deploy-board/deploy_board/templates/groups/asg_metrics.tmpl
+++ b/deploy-board/deploy_board/templates/groups/asg_metrics.tmpl
@@ -94,7 +94,7 @@ $(function() {
     });
 });
 
-let alarmVuew{{ alarm.alarmId }} = new Vue({
+let alarmVue = new Vue({
     el: "#alarm_{{ alarm.alarmId }}",
     delimiters: ['[[', ']]'],
     data: {

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -522,7 +522,7 @@ def get_alarms(request, group_name):
     content = render_to_string("groups/asg_metrics.tmpl", {
         "group_name": group_name,
         "alarms": alarms,
-        "aws_metric_names": aws_metric_names,
+        "aws_metric_names": json.dumps(aws_metric_names),
         "csrf_token": get_token(request),
         "comparators": json.dumps(comparators),
     })


### PR DESCRIPTION
`alarm.alarmId` can contain invalid characters. Also the variable `alarmVue` doesn't have to be unique, thus discarding the suffix. 

Use `json.dumps` to get rid of `u''` prefix. 