### PR TITLE
Fix cluster configs page

### DIFF
--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -430,6 +430,7 @@
 </script>
 <script>
     var info = {{capacity_creation_info | safe}};
+    var enable_ami_auto_update = info.enable_ami_auto_update;
     var env = info.environment;
     var currentCluster = info.currentCluster;
     console.log('currentCluster:', currentCluster);


### PR DESCRIPTION
Passing enable_ami_auto_update from info in cluster configs page. 
Tested on dev1. Cannot test locally due to a permission error. 
```
Teletraan failed to call backend server.Hint: 500, {"code":500,"message":"com.amazonaws.services.autoscaling.model.AmazonAutoScalingException Exception: User: arn:aws:sts::998131032990:assumed-role/Devapp/i-019dca6d0f0f30c7b is not authorized to perform: autoscaling:DescribeAutoScalingGroups because no identity-based policy allows the autoscaling:DescribeAutoScalingGroups action (Service: AmazonAutoScaling; Status Code: 403; Error Code: AccessDenied; Request ID: 8f85cc0f-3342-4ddf-b454-21a8f2d61062; Proxy: null)\nResource: http://rodimus-service-pinterest:8012/v1/groups/deploy-open-sentinel-deploy-init-poc\nMethod: GET\nThere was an error processing your request. It has been logged (ID 88c02ff09e752453)."}
```
![Screenshot 2023-02-21 at 7 45 12 PM](https://user-images.githubusercontent.com/50259686/220516640-d1be66d0-11ec-4ab6-9171-dd039c99793d.png)
![Screenshot 2023-02-21 at 7 45 17 PM](https://user-images.githubusercontent.com/50259686/220516641-95f772ba-b58b-4037-94b3-87f09fe611d6.png)
