### PR TITLE
Add proxy option for teletraan

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/HTTPClient.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/HTTPClient.java
@@ -30,7 +30,7 @@ import java.util.Map;
 
 // A simple HttpURLConnection wrapper
 public class HTTPClient {
-    private static final int TIMEOUT = 15*1000;  // http timeout in 15 seconds
+    private static final int TIMEOUT = 15 * 1000; // http timeout in 15 seconds
     private static final Logger LOG = LoggerFactory.getLogger(HTTPClient.class);
     public static String secretMask = "xxxxxxxxx";
     private boolean useProxy = false;
@@ -51,13 +51,16 @@ public class HTTPClient {
             this.httpProxyPort = httpProxyPort;
         }
     }
+
     public boolean getUseProxy() {
         // HTTPClient useProxy default is false
         return useProxy;
     }
+
     public String getHttpProxyAddr() {
         return httpProxyAddr;
     }
+
     public int getHttpProxyPort() {
         return httpProxyPort;
     }
@@ -72,17 +75,17 @@ public class HTTPClient {
         for (Map.Entry<String, String> entry : params.entrySet()) {
             sb.append(prefix);
             prefix = "&";
-            // note:  scrubUrlQueryValue could be expensive with many filtered values
-            //        consider using it only in only a DEBUG logging context in the future
+            // note: scrubUrlQueryValue could be expensive with many filtered values
+            // consider using it only in only a DEBUG logging context in the future
             String reportedValue = scrubUrl ? scrubUrlQueryValue(entry.getKey(), entry.getValue()) : entry.getValue();
             sb.append(String.format("%s=%s", entry.getKey(),
-                URLEncoder.encode(reportedValue, "UTF-8")));
+                    URLEncoder.encode(reportedValue, "UTF-8")));
         }
         return sb.toString();
     }
 
     private String scrubUrlQueryValue(String queryParamKey, String queryParamValue) {
-        String[] filteredQueryKeySubstrings = {"token"};
+        String[] filteredQueryKeySubstrings = { "token" };
 
         for (String filteredQueryKeySubstring : filteredQueryKeySubstrings) {
             if (StringUtils.containsIgnoreCase(queryParamKey, filteredQueryKeySubstring)) {
@@ -92,7 +95,8 @@ public class HTTPClient {
         return queryParamValue;
     }
 
-    public String get(String url, String payload, Map<String, String> params, Map<String, String> headers, int retries) throws Exception {
+    public String get(String url, String payload, Map<String, String> params, Map<String, String> headers, int retries)
+            throws Exception {
         return internalCall(url, params, "GET", payload, headers, retries);
     }
 
@@ -108,7 +112,8 @@ public class HTTPClient {
         return internalCall(url, null, "DELETE", payload, headers, retries);
     }
 
-    private String internalCall(String base_url, Map<String, String> params, String method, String payload, Map<String, String> headers, int retries) throws Exception {
+    private String internalCall(String base_url, Map<String, String> params, String method, String payload,
+            Map<String, String> headers, int retries) throws Exception {
         HttpURLConnection conn = null;
         Exception lastException = null;
 
@@ -147,7 +152,7 @@ public class HTTPClient {
                 int responseCode = conn.getResponseCode();
                 if (responseCode >= 400) {
                     throw new DeployInternalException("HTTP request failed, status = {}, content = {}",
-                        responseCode, ret);
+                            responseCode, ret);
                 }
                 LOG.info("HTTP Request returned with response code {} for URL {}", responseCode, scrubbedUrl);
                 return ret;
@@ -155,10 +160,10 @@ public class HTTPClient {
                 lastException = e;
                 String proxyMsg = "";
                 if (useProxy) {
-                    proxyMsg = String.format(" via proxy %s:%s,",httpProxyAddr, httpProxyPort);
+                    proxyMsg = String.format(" via proxy %s:%s,", httpProxyAddr, httpProxyPort);
                 }
                 LOG.error("Failed to send HTTP Request to {},{} with method {} with payload {}, with headers {}",
-                    scrubbedUrl, proxyMsg, method, payload, headers, e);
+                        scrubbedUrl, proxyMsg, method, payload, headers, e);
             } finally {
                 if (conn != null) {
                     conn.disconnect();

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/RodimusManagerImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/RodimusManagerImpl.java
@@ -49,12 +49,27 @@ public class RodimusManagerImpl implements RodimusManager {
     private Knox fsKnox = null;
     private String cachedKey = null;
 
-    public RodimusManagerImpl(String rodimusUrl, String knoxKey) throws Exception {
+    public RodimusManagerImpl(String rodimusUrl, String knoxKey, boolean useProxy, String httpProxyAddr, String httpProxyPort) throws Exception {
         this.rodimusUrl = rodimusUrl;
         this.httpClient = new HTTPClient();
         this.headers = new HashMap<>();
         this.headers.put("Content-Type", "application/json");
         this.headers.put("Accept", "*/*");
+        int httpProxyPortInt;
+
+        if (Boolean.TRUE.equals(useProxy)) {
+            try {
+                httpProxyPortInt = Integer.parseInt(httpProxyPort);
+            }
+            catch (NumberFormatException exception) {
+                LOG.error(httpProxyPort, exception);
+                throw exception;
+            }
+            this.httpClient = new HTTPClient(useProxy, httpProxyAddr, httpProxyPortInt);
+        } else {
+            this.httpClient = new HTTPClient();
+        }
+
         if (knoxKey != null) {
             this.fsKnox = new FileSystemKnox(knoxKey);
         }

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/common/KnoxKeyTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/common/KnoxKeyTest.java
@@ -70,7 +70,7 @@ public class KnoxKeyTest {
 
         // Create RodimusManagerImpl to test, if not already created
         if ( rodimusManager == null ) {
-                rodimusManager = new RodimusManagerImpl( "http://localhost", "teletraan:test" );
+                rodimusManager = new RodimusManagerImpl( "http://localhost", "teletraan:test", false, null, null);
         }
 
         // Allocate answerList

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/ConfigHelper.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/ConfigHelper.java
@@ -157,7 +157,13 @@ public class ConfigHelper {
 
         RodimusFactory rodimusFactory = configuration.getRodimusFactory();
         if (rodimusFactory != null) {
-            context.setRodimusManager(new RodimusManagerImpl(rodimusFactory.getRodimusUrl(), rodimusFactory.getKnoxKey()));
+            context.setRodimusManager(
+                new RodimusManagerImpl(
+                    rodimusFactory.getRodimusUrl(),
+                    rodimusFactory.getKnoxKey(),
+                    rodimusFactory.getUseProxy(),
+                    rodimusFactory.getHttpProxyAddr(),
+                    rodimusFactory.getHttpProxyPort()));
         } else {
             context.setRodimusManager(new DefaultRodimusManager());
         }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/RodimusFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/RodimusFactory.java
@@ -10,6 +10,39 @@ public class RodimusFactory {
     @JsonProperty
     private String knoxKey;
 
+    @JsonProperty
+    private boolean useProxy;
+
+    @JsonProperty
+    private String httpProxyAddr;
+
+    @JsonProperty
+    private String httpProxyPort;
+
+    public boolean getUseProxy() {
+        return useProxy;
+    }
+
+    public void setUseProxy(boolean useProxy) {
+        this.useProxy = useProxy;
+    }
+
+    public String getHttpProxyAddr() {
+        return httpProxyAddr;
+    }
+
+    public void setHttpProxyAddr(String httpProxyAddr) {
+        this.httpProxyAddr = httpProxyAddr;
+    }
+
+    public String getHttpProxyPort() {
+        return httpProxyPort;
+    }
+
+    public void setHttpProxyPort(String httpProxyPort) {
+        this.httpProxyPort = httpProxyPort;
+    }
+
     public String getRodimusUrl() {
         return rodimusUrl;
     }


### PR DESCRIPTION
add HTTP proxy support to the Teletraan service.  Configuration of the proxy is optional and disabled by default.  Tested with a locally listening proxy.