### PR TITLE
Base images page improvemetns

### DIFF
--- a/deploy-board/deploy_board/templates/clusters/base_images.html
+++ b/deploy-board/deploy_board/templates/clusters/base_images.html
@@ -9,7 +9,32 @@
     <li><a href="/clouds/baseimages/">Base Images</a></li>
 </ul>
 {% endblock %}
+{% block navbar-search %}
+<form class="navbar-form navbar-left" role="search">
+    <div class="form-group has-feedback">
+        <input id="baseImageSearchInputId" type="text" class="form-control" placeholder="Search by Abstract Name...">
+        <span id="baseImageSearchFeedbackId" class="glyphicon glyphicon-search form-control-feedback"></span>
+    </div>
+</form>
+<script>
+    $('#baseImageSearchInputId').keypress(function (event) {
+        if (event.keyCode != 13) {
+            return true;
+        }
+        search_base_images();
+        return false;
+    });
 
+    $('#baseImageSearchFeedbackId').click(function () {
+        search_base_images();
+    });
+
+    function search_base_images() {
+        abstractName = $('#baseImageSearchInputId').val();
+        window.location = "/clouds/baseimages/" + abstractName;
+    }
+</script>
+{% endblock %}
 {% block side-panel-actions %}
 <div class="panel panel-default">
     <div class="panel-heading clearfix">
@@ -21,12 +46,11 @@
         </a>
     </div>
     <div class="row">
-    <button class="deployToolTip btn btn-default btn-block"
-            data-toggle="modal" data-target="#createBaseImageModalId"
-            title="Create Base Image" id="createBaseImageBtnId">
-        <span class="glyphicon glyphicon-plus"></span> Add Base Image
-    </button>
-</div>
+        <button class="deployToolTip btn btn-default btn-block" data-toggle="modal"
+            data-target="#createBaseImageModalId" title="Create Base Image" id="createBaseImageBtnId">
+            <span class="glyphicon glyphicon-plus"></span> Add Base Image
+        </button>
+    </div>
 </div>
 {% endblock %}
 
@@ -36,38 +60,40 @@
 {% endblock %}
 
 {% block main %}
-
 <div class="panel panel-default">
     <div class="panel-heading clearfix">
         <h4 class="panel-title pull-left">Base Images</h4>
     </div>
     <div class="panel-body table-responsive">
         {% include "clusters/base_images.tmpl" %}
-        {% if configs|length >= 2 %}
-            <ul class="pager">
-                <li>
-                    <a href='/clouds/baseimages/?page_index={{ pageIndex|add:"-1" }}&page_size={{ pageSize }}'
-                       class="btn btn-default {% if disablePrevious %}disabled{% endif %}">
-                        <span class="glyphicon glyphicon-chevron-left"></span> Previous
-                    </a>
-                </li>
-                <li>
-                    <a href='/clouds/baseimages/?page_index={{ pageIndex|add:"1" }}&page_size={{ pageSize }}'
-                       class="btn btn-default {% if disableNext %}disabled{% endif %}">
-                        Next <span class="glyphicon glyphicon-chevron-right"></span>
-                    </a>
-                </li>
-            </ul>
+        {% if base_images|length >= 2 %}
+        <ul class="pager">
+            <li>
+                <a href='/clouds/baseimages/?page_index={{ pageIndex|add:"-1" }}&page_size={{ pageSize }}'
+                    class="btn btn-default {% if disablePrevious %}disabled{% endif %}">
+                    <span class="glyphicon glyphicon-chevron-left"></span> Previous
+                </a>
+            </li>
+            <li>
+                <a href='/clouds/baseimages/?page_index={{ pageIndex|add:"1" }}&page_size={{ pageSize }}'
+                    class="btn btn-default {% if disableNext %}disabled{% endif %}">
+                    Next <span class="glyphicon glyphicon-chevron-right"></span>
+                </a>
+            </li>
+        </ul>
         {% endif %}
     </div>
 </div>
 
-<div class="modal fade" id="createBaseImageModalId" tabindex="-1" role="dialog" aria-labelledby="createBaseImageModalLabel" aria-hidden="true">
+<div class="modal fade" id="createBaseImageModalId" tabindex="-1" role="dialog"
+    aria-labelledby="createBaseImageModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-md">
         <div class="modal-content">
-            <form id="createBaseImageFormId" class="form-horizontal" role="form" method="post" action="/clouds/create_base_image/">
+            <form id="createBaseImageFormId" class="form-horizontal" role="form" method="post"
+                action="/clouds/create_base_image/">
                 <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+                    <button type="button" class="close" data-dismiss="modal"><span
+                            aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
                     <h4 class="modal-title">Create Base Image Confirm</h4>
                 </div>
                 <div class="modal-body" id="createBaseImageModal">
@@ -78,7 +104,7 @@
                         <div class="col-md-6">
                             <select class="form-control" name="cellName" required id="cellName">
                                 {% for cell in cells_list %}
-                                    <option value="{{ cell.name }}" >{{ cell.name }}</option>
+                                <option value="{{ cell.name }}">{{ cell.name }}</option>
                                 {% endfor %}
                             </select>
                         </div>
@@ -90,7 +116,7 @@
                         <div class="col-md-6">
                             <select class="form-control" name="archName" required id="archName">
                                 {% for arch in arches_list %}
-                                    <option value="{{ arch.name }}" >{{ arch.name }}</option>
+                                <option value="{{ arch.name }}">{{ arch.name }}</option>
                                 {% endfor %}
                             </select>
                         </div>
@@ -100,7 +126,7 @@
                             Abstract Name
                         </label>
                         <div class="col-md-6">
-                            <input class="form-control" name="abstractName" required="true" type="text" value=""/>
+                            <input class="form-control" name="abstractName" required="true" type="text" value="" />
                         </div>
                     </div>
                     <div class="form-group">
@@ -108,7 +134,7 @@
                             Cloud specific image id
                         </label>
                         <div class="col-md-6">
-                            <input class="form-control" name="providerName" required="true" type="text" value=""/>
+                            <input class="form-control" name="providerName" required="true" type="text" value="" />
                         </div>
                     </div>
                     <div class="form-group">
@@ -118,7 +144,7 @@
                         <div class="col-md-6">
                             <select class="form-control" name="provider" required id="providerNameId">
                                 {% for provider in provider_list %}
-                                    <option value="{{ provider }}" >{{ provider }}</option>
+                                <option value="{{ provider }}">{{ provider }}</option>
                                 {% endfor %}
                             </select>
                         </div>
@@ -128,13 +154,14 @@
                             Description
                         </label>
                         <div class="col-md-6">
-                            <input class="form-control" name="description" type="text" value=""/>
+                            <input class="form-control" name="description" type="text" value="" />
                         </div>
                     </div>
                 </div>
                 <div class="modal-footer">
                     <button id="modalConfirmBtnId" type="submit" class="btn btn-primary">Create</button>
-                    <button id="modalCloseBtnId" type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                    <button id="modalCloseBtnId" type="button" class="btn btn-default"
+                        data-dismiss="modal">Cancel</button>
                 </div>
                 {% csrf_token %}
             </form>

--- a/deploy-board/deploy_board/templates/clusters/base_images.tmpl
+++ b/deploy-board/deploy_board/templates/clusters/base_images.tmpl
@@ -19,15 +19,15 @@
         <tr>
             <td> 
             {% if enable_ami_auto_update %}
-            <a id="listGroupsBtnId" href="/clouds/baseimages/events/{{base_image.id}}" title="Click to see image update events">
-            {{ base_image.id }} 
-            </a>
+                <a id="listGroupsBtnId" href="/clouds/baseimages/events/{{base_image.id}}" title="Click to see image update events">
+                    {{ base_image.id }} 
+                </a>
             {% else %}
-             {{ base_image.id }}
+                {{ base_image.id }}
             {% endif %}
             </td>
             {% if base_image.tag %}
-            <td> <span class="glyphicon glyphicon-ok"></span>Current Golden</td>
+                <td> <span class="glyphicon glyphicon-ok"></span>Current Golden</td>
             {% else %}
             <td></td>
             {% endif %}

--- a/deploy-board/deploy_board/webapp/cluster_urls.py
+++ b/deploy-board/deploy_board/webapp/cluster_urls.py
@@ -22,7 +22,7 @@ urlpatterns = [
     url(r'^clouds/baseimages/$', cluster_view.get_base_images),
     url(r'^clouds/baseimages/(?P<abstract_name>[a-zA-Z0-9\-_\.]+)/$', cluster_view.get_base_images_by_abstract_name),
     url(r'^clouds/baseimages/events/(?P<image_id>[a-zA-Z0-9\-_\.]+)/$', cluster_view.get_base_image_events),
-    url(r'^clouds/baseimages/events/(?P<ami_name>[a-zA-Z0-9\-_\.]+)/$', cluster_view.get_base_image_events_by_ami_name),
+    url(r'^clouds/baseimages/events/(?P<provider_name>[a-zA-Z0-9\-_\.]+)/$', cluster_view.get_base_image_events_by_provider_name),
     url(r'^clouds/get_image_names/$', cluster_view.get_image_names),
     url(r'^clouds/image_names/(?P<provider>[a-zA-Z0-9\-_\.]+)/(?P<cell>[a-zA-Z0-9\-_\.]+)/$',
         cluster_view.get_image_names_by_provider_and_cell),

--- a/deploy-board/deploy_board/webapp/cluster_urls.py
+++ b/deploy-board/deploy_board/webapp/cluster_urls.py
@@ -20,7 +20,9 @@ import capacity_views
 urlpatterns = [
     url(r'^clouds/create_base_image/$', cluster_view.create_base_image),
     url(r'^clouds/baseimages/$', cluster_view.get_base_images),
+    url(r'^clouds/baseimages/(?P<abstract_name>[a-zA-Z0-9\-_\.]+)/$', cluster_view.get_base_images_by_abstract_name),
     url(r'^clouds/baseimages/events/(?P<image_id>[a-zA-Z0-9\-_\.]+)/$', cluster_view.get_base_image_events),
+    url(r'^clouds/baseimages/events/(?P<ami_name>[a-zA-Z0-9\-_\.]+)/$', cluster_view.get_base_image_events_by_ami_name),
     url(r'^clouds/get_image_names/$', cluster_view.get_image_names),
     url(r'^clouds/image_names/(?P<provider>[a-zA-Z0-9\-_\.]+)/(?P<cell>[a-zA-Z0-9\-_\.]+)/$',
         cluster_view.get_image_names_by_provider_and_cell),

--- a/deploy-board/deploy_board/webapp/cluster_view.py
+++ b/deploy-board/deploy_board/webapp/cluster_view.py
@@ -439,8 +439,8 @@ def get_base_image_events(request, image_id):
     })
 
 
-def get_base_image_events_by_ami_name(request, ami_name):
-    base_image = baseimages_helper.get_by_provider_name(request, ami_name)
+def get_base_image_events_by_provider_name(request, provider_name):
+    base_image = baseimages_helper.get_by_provider_name(request, provider_name)
     return get_base_image_events(request, base_image["id"])
 
 

--- a/deploy-board/deploy_board/webapp/helpers/baseimages_helper.py
+++ b/deploy-board/deploy_board/webapp/helpers/baseimages_helper.py
@@ -38,7 +38,6 @@ def get_all(request, index, size):
     params = [('pageIndex', index), ('pageSize', size)]
     return rodimus_client.get("/base_images", request.teletraan_user_id.token, params=params)
 
-
 def get_all_with_acceptance(request, index, size):
     base_images = get_all(request, index, size)
     fetched_names = set()
@@ -88,7 +87,6 @@ def get_all_by(request, provider, cell_name):
 def get_by_name(request, name, cell_name):
     params = [('cellName', cell_name)]
     return rodimus_client.get("/base_images/names/%s" % name, request.teletraan_user_id.token, params=params)
-
 
 def get_acceptance_by_name(request, name, cell_name):
     params = [('cellName', cell_name)]


### PR DESCRIPTION
## Summary 
Some improvements in the base images: 
- Include search AMIs based on image type (such as cmp_base_blah) 
- Fix pagination in base images pages 
- Add new page to filter AMIs based on image type. Currently, it's hard to navigate or find AMIs coming from different types. 
- Add new page to see AMI update events of an AMI based on AMI name instead of its Id. It makes it easier for monitoring during the update process. 
- apply some auto format for the touched files. 

## Test Plan
Tested locally
Search box
<img width="245" alt="Screenshot 2023-03-01 at 10 34 51 AM" src="https://user-images.githubusercontent.com/50259686/222233586-1dc101ee-a661-472a-a7a3-acb61d10a7a3.png">
Update Events per ami-id 
<img width="641" alt="Screenshot 2023-03-01 at 10 35 17 AM" src="https://user-images.githubusercontent.com/50259686/222233589-4a95e558-498a-4d07-89ba-8634f420f7f1.png">
Filtered by abstract name
<img width="1413" alt="Screenshot 2023-03-01 at 10 35 36 AM" src="https://user-images.githubusercontent.com/50259686/222233591-db5d6052-d049-4002-a509-d83f5708dcac.png">
Pagination
<img width="348" alt="Screenshot 2023-03-01 at 10 36 08 AM" src="https://user-images.githubusercontent.com/50259686/222233676-a31dc7e7-680d-495e-9a79-1a27b2427988.png">

