### PR TITLE
Show Pin Image checkbox when there is a golden image in cmp only

### DIFF
--- a/deploy-board/deploy_board/static/js/base-image-utils.js
+++ b/deploy-board/deploy_board/static/js/base-image-utils.js
@@ -39,6 +39,6 @@ function ensureCurrentImageIsIncluded(baseImages, currentBaseImage) {
     }
 }
 
-function isPinImageEnabled(imageName) {
-    return imageName.toLowerCase().startsWith('cmp_');
+function showPinImage(enableAMIUpdate, goldenAMI, imageName) {
+    return enableAMIUpdate && !!goldenAMI && imageName.toLowerCase().startsWith('cmp_');
 }

--- a/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
+++ b/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
@@ -53,7 +53,7 @@ Vue.component('baseimage-select', {
                 @input="$emit('base-image-change', $event)" @help-clicked="helpClick">
             </label-select2>
             <div v-show="showPinImage" class="col-xs-2">
-                <base-checkbox :checked="pinImage" :enabled="pinImageEnabled"
+                <base-checkbox :checked="pinImage" enabled="true"
                     @input="pinImageClick"></base-checkbox>
                 <label for='pinImageCB'>Pin Image</label>
             </div>
@@ -69,7 +69,7 @@ Vue.component('baseimage-select', {
             warningText: '',
         }
     },
-    props: ['imageNames', 'baseImages', 'selectedImageName', 'selectedBaseImage', 'pinImage', 'pinImageEnabled', 'showPinImage'],
+    props: ['imageNames', 'baseImages', 'selectedImageName', 'selectedBaseImage', 'pinImage', 'showPinImage'],
     methods: {
         helpClick: function () {
             this.$emit('help-clicked')

--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -67,7 +67,7 @@
                     <cloudprovider-select v-bind:cloudproviders="providers" v-bind:value="currentProvider" v-show="inAdvanced"></cloudprovider-select>
                     <cell-select v-bind:cells="cells" v-on:cellchange="cellChange"  v-bind:value="currentCell"></cell-select>
                     <arch-select v-bind:arches="arches" v-on:archchange="archChange"  v-bind:value="currentArch"></arch-select>
-                    <baseimage-select v-show="inAdvanced" v-model="pinImage" :pin-image-enabled="pinImageEnabled" :show-pin-image="showPinImage"
+                    <baseimage-select v-show="inAdvanced" v-model="pinImage" :show-pin-image="showPinImage"
                         :image-names="imageNames" :base-images="baseImages"
                         :selected-image-name="imageNameValue" :selected-base-image="baseImageValue"
                         @base-image-change="baseImageChange" @image-name-change="imageNameChange" @help-clicked="baseImageHelpClick" >
@@ -430,10 +430,11 @@
 </script>
 <script>
     var info = {{capacity_creation_info | safe}};
-    var enable_ami_auto_update = info.enable_ami_auto_update;
+    const goldenImage = info.baseImages.find(goldenImageFinder);
+    const enableAMIAutoUpdate = info.enable_ami_auto_update;
     var env = info.environment;
     var currentCluster = info.currentCluster;
-    console.log('currentCluster:', currentCluster);
+    
     if (currentCluster!=null){
         var currentPlacements = currentCluster.placement.split(',');
         var placements = getDefaultPlacement(info);
@@ -456,7 +457,7 @@
             obj[field] = field in currentCluster.configs ? currentCluster.configs[field] : null
             return obj;
         }, {});
-
+        
         var capacitySetting = new Vue({
             el: "#mainPanel",
             data: Object.assign(readonlyValues, {
@@ -473,9 +474,8 @@
                 useLaunchTemplate: currentCluster.useLaunchTemplate != null ? currentCluster.useLaunchTemplate : false,
                 baseImages: mapBaseImagesToOptions(baseImagesSorted),
                 baseImageValue: currentCluster.baseImageId,
-                showPinImage: enable_ami_auto_update,
-                pinImage: enable_ami_auto_update ? !currentCluster.autoUpdateBaseImage : true,
-                pinImageEnabled: isPinImageEnabled(currentCluster.baseImageName),
+                showPinImage: showPinImage(enableAMIAutoUpdate, goldenImage, currentCluster.baseImageName),
+                pinImage: enableAMIAutoUpdate ? !currentCluster.autoUpdateBaseImage : true,
                 confirmDialogTitle: "Update Cluster Settings",
                 confirmDialogId: "updateClusterSettings",
                 currentProvider: currentCluster.provider,
@@ -796,10 +796,11 @@
                             capacitySetting.baseImageValue = defaultImageId;
                             if (!goldenImage) {
                                 capacitySetting.pinImage = true;
+                                capacitySetting.showPinImage = false;
                             } else {
                                 capacitySetting.pinImage = !currentCluster.autoUpdateBaseImage;
+                                capacitySetting.showPinImage = showPinImage(enableAMIAutoUpdate, goldenImage, capacitySetting.imageNameValue);
                             }
-                            capacitySetting.pinImageEnabled = isPinImageEnabled(capacitySetting.imageNameValue);
                         },
                         error: function(data) {
                             globalNotificationBanner.error = data

--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -50,7 +50,7 @@
                     <label-input label="Capacity" placeholder="# of instances" v-model="instanceCount"></label-input>
                     <arch-select v-bind:arches="arches" v-on:archchange="archChange"  v-bind:value="archValue"></arch-select>
                     <baseimage-select v-model="pinImage" :image-names="imageNames" :base-images="baseImages"
-                        :selected-image-name="imageNameValue" :selected-base-image="baseImageValue" :pin-image-enabled="pinImageEnabled" :show-pin-image="showPinImage"
+                        :selected-image-name="imageNameValue" :selected-base-image="baseImageValue" :show-pin-image="showPinImage"
                         @base-image-change="baseImageChange" @image-name-change="imageNameChange" @help-clicked="baseImageHelpClick" >
                     </baseimage-select>
                     <base-image-help v-show="showBaseImageHelp" v-bind:data="baseImageHelpData"></base-image-help>
@@ -101,7 +101,7 @@ var capacityView = new Vue({
 )
 
 var info = {{capacity_creation_info|safe}};
-var enable_ami_auto_update = info.enable_ami_auto_update;
+var enableAMIAutoUpdate = info.enable_ami_auto_update;
 var environment = info.environment;
 
 var placements = getDefaultPlacement(info);
@@ -127,9 +127,8 @@ var capacitySetting = new Vue({
         baseImageHelpData: [],
         baseImages: mapBaseImagesToOptions(baseImagesSorted),
         baseImageValue: defaultImageId,
-        showPinImage: enable_ami_auto_update,
-        pinImage: enable_ami_auto_update ? goldenImage == null : true,
-        pinImageEnabled: isPinImageEnabled(info.defaultBaseImage),
+        pinImage: enableAMIAutoUpdate ? !goldenImage : true,
+        showPinImage: showPinImage(enableAMIAutoUpdate, goldenImage, info.defaultBaseImage),
         configOptions: Object.keys(info.configList).map(
             function (key) {
                 return {
@@ -421,7 +420,7 @@ var capacitySetting = new Vue({
                     capacitySetting.baseImages = mapBaseImagesToOptions(baseImageSorted);
                     capacitySetting.baseImageValue = defaultImageId;
                     capacitySetting.pinImage = !goldenImage;
-                    capacitySetting.pinImageEnabled = isPinImageEnabled(capacitySetting.imageNameValue);
+                    capacitySetting.showPinImage = showPinImage(enableAMIAutoUpdate, goldenImage, capacitySetting.imageNameValue);
                 },
                 error: function (data) {
                     globalNotificationBanner.error = data


### PR DESCRIPTION
## Summary 
Show Pin Image checkbox only when feature is enabled, there is a golden ami and cmp image type. 

## Test plan 
Tested locally. 