### PR TITLE
Consolidate logic for Pin image

### DIFF
--- a/deploy-board/deploy_board/static/js/base-image-utils.js
+++ b/deploy-board/deploy_board/static/js/base-image-utils.js
@@ -39,6 +39,14 @@ function ensureCurrentImageIsIncluded(baseImages, currentBaseImage) {
     }
 }
 
-function isPinImageEnabled(imageName) {
-    return imageName.toLowerCase().startsWith('cmp_');
+function isPinImageEnabled(goldenImage) {
+    // If there is golden - enable Pin Image checkbox 
+    // If there is no golden - disable Pin Image checkbox 
+    return !!goldenImage;
+}
+
+function getPinImageValue(goldenImage, clusterAutoUpdateBaseImage) {
+    // If there is golden: getPinImageValue = !clusterAutoUpdateBaseImage
+    // if there is no golden: getPinImageValue = true. Always pin
+    return !!goldenImage ? !clusterAutoUpdateBaseImage : true; 
 }

--- a/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
+++ b/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
@@ -52,7 +52,7 @@ Vue.component('baseimage-select', {
                 :disabled="!pinImage" :options="baseImages" :selected="selectedBaseImage"
                 @input="$emit('base-image-change', $event)" @help-clicked="helpClick">
             </label-select2>
-            <div v-show="showPinImage" class="col-xs-2">
+            <div class="col-xs-2">
                 <base-checkbox :checked="pinImage" :enabled="pinImageEnabled"
                     @input="pinImageClick"></base-checkbox>
                 <label for='pinImageCB'>Pin Image</label>
@@ -69,7 +69,7 @@ Vue.component('baseimage-select', {
             warningText: '',
         }
     },
-    props: ['imageNames', 'baseImages', 'selectedImageName', 'selectedBaseImage', 'pinImage', 'pinImageEnabled', 'showPinImage'],
+    props: ['imageNames', 'baseImages', 'selectedImageName', 'selectedBaseImage', 'pinImage', 'pinImageEnabled'],
     methods: {
         helpClick: function () {
             this.$emit('help-clicked')

--- a/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
+++ b/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
@@ -19,7 +19,7 @@ Vue.component('cell-select', {
         updateValue: function (value) {
             this.$emit('input', value);
         },
-        updateCellValue: function(value) {
+        updateCellValue: function (value) {
             this.$emit('cellchange', value);
         }
     }
@@ -34,7 +34,7 @@ Vue.component('arch-select', {
         updateValue: function (value) {
             this.$emit('input', value);
         },
-        updateArchValue: function(value) {
+        updateArchValue: function (value) {
             this.$emit('archchange', value);
         }
     }
@@ -63,7 +63,7 @@ Vue.component('baseimage-select', {
     model: {
         prop: 'pinImage',
     },
-    data: function() {
+    data: function () {
         return {
             showWarning: false,
             warningText: '',
@@ -89,7 +89,7 @@ Vue.component('baseimage-select', {
                 }
             }
         },
-        pinImageClick: function(pin) {
+        pinImageClick: function (pin) {
             this.$emit('input', pin);
             if (pin) {
                 this.tryShowWarning(this.selectedBaseImage, pin);
@@ -99,7 +99,7 @@ Vue.component('baseimage-select', {
         }
     },
     watch: {
-        selectedBaseImage: function(baseImageId) {
+        selectedBaseImage: function (baseImageId) {
             this.tryShowWarning(baseImageId, this.pinImage);
         }
     }
@@ -233,7 +233,7 @@ Vue.component("aws-config-modal", {
                 </div>\
             </form></div></div></div>',
     props: ["options", "id"],
-    data: function() {
+    data: function () {
         return {
             useCustomizedName: false,
             shouldShowError: false,
@@ -245,18 +245,18 @@ Vue.component("aws-config-modal", {
         };
     },
     methods: {
-        updateValue: function(value) {
+        updateValue: function (value) {
             this.selectedValue = value;
             if (value === "") {
                 this.selectedOptionValue = "";
             } else {
-                this.selectedOption = this.options.filter(function(item) {
+                this.selectedOption = this.options.filter(function (item) {
                     return item.name === value;
                 })[0];
                 this.selectedOptionValue = this.selectedOption.default;
             }
         },
-        addConfig: function() {
+        addConfig: function () {
             if (this.useCustomizedName) {
                 if (
                     this.customizedName != "spiffe_id" &&
@@ -304,7 +304,7 @@ Vue.component("aws-config-modal", {
                 }
             }
         },
-        toggleCustomizedName: function(checked) {
+        toggleCustomizedName: function (checked) {
             if (checked) {
                 this.selectedOption = null;
                 this.selectedValue = "";
@@ -424,7 +424,7 @@ Vue.component("placements-select", {
         assignipchange: function (value) {
             this.$emit('assignpublicipclick', value)
         },
-        filterclick: function(value) {
+        filterclick: function (value) {
             this.$emit('subnetfilterclick', value)
         }
     }
@@ -471,7 +471,7 @@ Vue.component('remaining-capacity', {
     </div>',
     props: ['title', 'remainingcapacity', 'inadvanced'],
     computed: {
-        marginStyle:function() {
+        marginStyle: function () {
             return this.inadvanced ? 'margin-top:-15px;' : 'margin-top:-30px;'
         }
     }
@@ -506,7 +506,7 @@ Vue.component("accessrole-input", {
     },
     methods: {
         updateValue: function (value) {
-        this.$emit('input', value)
+            this.$emit('input', value)
         },
         helpClick: function () {
             this.$emit('helpclick')

--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -67,7 +67,7 @@
                     <cloudprovider-select v-bind:cloudproviders="providers" v-bind:value="currentProvider" v-show="inAdvanced"></cloudprovider-select>
                     <cell-select v-bind:cells="cells" v-on:cellchange="cellChange"  v-bind:value="currentCell"></cell-select>
                     <arch-select v-bind:arches="arches" v-on:archchange="archChange"  v-bind:value="currentArch"></arch-select>
-                    <baseimage-select v-show="inAdvanced" v-model="pinImage" :pin-image-enabled="pinImageEnabled" :show-pin-image="showPinImage"
+                    <baseimage-select v-show="inAdvanced" v-model="pinImage" :pin-image-enabled="pinImageEnabled"
                         :image-names="imageNames" :base-images="baseImages"
                         :selected-image-name="imageNameValue" :selected-base-image="baseImageValue"
                         @base-image-change="baseImageChange" @image-name-change="imageNameChange" @help-clicked="baseImageHelpClick" >
@@ -430,10 +430,9 @@
 </script>
 <script>
     var info = {{capacity_creation_info | safe}};
-    var enable_ami_auto_update = info.enable_ami_auto_update;
     var env = info.environment;
     var currentCluster = info.currentCluster;
-    console.log('currentCluster:', currentCluster);
+    const goldenImage = info.baseImages.find(goldenImageFinder);
     if (currentCluster!=null){
         var currentPlacements = currentCluster.placement.split(',');
         var placements = getDefaultPlacement(info);
@@ -473,9 +472,8 @@
                 useLaunchTemplate: currentCluster.useLaunchTemplate != null ? currentCluster.useLaunchTemplate : false,
                 baseImages: mapBaseImagesToOptions(baseImagesSorted),
                 baseImageValue: currentCluster.baseImageId,
-                showPinImage: enable_ami_auto_update,
-                pinImage: enable_ami_auto_update ? !currentCluster.autoUpdateBaseImage : true,
-                pinImageEnabled: isPinImageEnabled(currentCluster.baseImageName),
+                pinImage: getPinImageValue(goldenImage, currentCluster.autoUpdateBaseImage),
+                pinImageEnabled: isPinImageEnabled(goldenImage),
                 confirmDialogTitle: "Update Cluster Settings",
                 confirmDialogId: "updateClusterSettings",
                 currentProvider: currentCluster.provider,
@@ -794,12 +792,8 @@
 
                             capacitySetting.baseImages = mapBaseImagesToOptions(baseImagesSorted);
                             capacitySetting.baseImageValue = defaultImageId;
-                            if (!goldenImage) {
-                                capacitySetting.pinImage = true;
-                            } else {
-                                capacitySetting.pinImage = !currentCluster.autoUpdateBaseImage;
-                            }
-                            capacitySetting.pinImageEnabled = isPinImageEnabled(capacitySetting.imageNameValue);
+                            capacitySetting.pinImage = getPinImageValue(goldenImage, currentCluster.autoUpdateBaseImage)
+                            capacitySetting.pinImageEnabled = isPinImageEnabled(goldenImage);
                         },
                         error: function(data) {
                             globalNotificationBanner.error = data

--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -124,7 +124,9 @@ var capacitySetting = new Vue({
         baseImageHelpData: [],
         baseImages: mapBaseImagesToOptions(baseImagesSorted),
         baseImageValue: defaultImageId,
-        pinImage: getPinImageValue(goldenImage, true ), // Default auto update if there is a golden image 
+        // Default to Pin image if there is a golden image before GA
+        // After GA, default to Auto Update.
+        pinImage: getPinImageValue(goldenImage, false),
         pinImageEnabled: isPinImageEnabled(goldenImage),
         configOptions: Object.keys(info.configList).map(
             function (key) {
@@ -416,8 +418,9 @@ var capacitySetting = new Vue({
                     const defaultImageId = goldenImage ? goldenImage.id : getDefaultBaseImageId(baseImageSorted);
                     capacitySetting.baseImages = mapBaseImagesToOptions(baseImageSorted);
                     capacitySetting.baseImageValue = defaultImageId;
-                    // Default auto update if there is a golden image
-                    capacitySetting.pinImage = getPinImageValue(goldenImage, true);
+                    // Default not auto update if there is a golden image before GA
+                    // Default auto update if there is a golden image after GA
+                    capacitySetting.pinImage = getPinImageValue(goldenImage, false);
                     capacitySetting.pinImageEnabled = isPinImageEnabled(goldenImage);
                 },
                 error: function (data) {

--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -101,11 +101,8 @@ var capacityView = new Vue({
 )
 
 var info = {{capacity_creation_info|safe}};
-var enable_ami_auto_update = info.enable_ami_auto_update;
 var environment = info.environment;
-
 var placements = getDefaultPlacement(info);
-
 const goldenImage = info.baseImages.find(goldenImageFinder);
 const baseImagesSorted = info.baseImages.sort(baseImageSorter);
 const defaultImageId = goldenImage ? goldenImage.id : getDefaultBaseImageId(baseImagesSorted);
@@ -127,9 +124,8 @@ var capacitySetting = new Vue({
         baseImageHelpData: [],
         baseImages: mapBaseImagesToOptions(baseImagesSorted),
         baseImageValue: defaultImageId,
-        showPinImage: enable_ami_auto_update,
-        pinImage: enable_ami_auto_update ? goldenImage == null : true,
-        pinImageEnabled: isPinImageEnabled(info.defaultBaseImage),
+        pinImage: getPinImageValue(goldenImage, true ), // Default auto update if there is a golden image 
+        pinImageEnabled: isPinImageEnabled(goldenImage),
         configOptions: Object.keys(info.configList).map(
             function (key) {
                 return {
@@ -420,8 +416,9 @@ var capacitySetting = new Vue({
                     const defaultImageId = goldenImage ? goldenImage.id : getDefaultBaseImageId(baseImageSorted);
                     capacitySetting.baseImages = mapBaseImagesToOptions(baseImageSorted);
                     capacitySetting.baseImageValue = defaultImageId;
-                    capacitySetting.pinImage = !goldenImage;
-                    capacitySetting.pinImageEnabled = isPinImageEnabled(capacitySetting.imageNameValue);
+                    // Default auto update if there is a golden image
+                    capacitySetting.pinImage = getPinImageValue(goldenImage, true);
+                    capacitySetting.pinImageEnabled = isPinImageEnabled(goldenImage);
                 },
                 error: function (data) {
                     globalNotificationBanner.error = data


### PR DESCRIPTION
## Summary 
Always show Pin image. That’s the reflection of DB status.
- If there is golden - allow unpin (auto update) and pin
- If there is no golden  - disabled pin image
  - if cluster is pinned, no problem
  - if cluster is unpinned, automatically pin image
## Test plan 
Test locally and dev1
No golden, disable Pin Image checkbox and auto checked.
![Screenshot 2023-03-10 at 12 03 37 PM](https://user-images.githubusercontent.com/50259686/224417786-e4279a31-3ef6-4726-94f3-9ba2050954da.png)
There is a golden, reflect db status 
 Auto update
![Screenshot 2023-03-10 at 12 10 55 AM](https://user-images.githubusercontent.com/50259686/224418002-29d7ed3d-8eb7-4a52-84aa-1832db273792.png)
Pin Image 
![Screenshot 2023-03-10 at 12 09 38 PM](https://user-images.githubusercontent.com/50259686/224418112-656d4e93-f13d-4374-93d4-b749268e954b.png)
Save and it works. 
