### PR TITLE
Remove showPinImage in baseimage-select element

### DIFF
--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -50,7 +50,7 @@
                     <label-input label="Capacity" placeholder="# of instances" v-model="instanceCount"></label-input>
                     <arch-select v-bind:arches="arches" v-on:archchange="archChange"  v-bind:value="archValue"></arch-select>
                     <baseimage-select v-model="pinImage" :image-names="imageNames" :base-images="baseImages"
-                        :selected-image-name="imageNameValue" :selected-base-image="baseImageValue" :pin-image-enabled="pinImageEnabled" :show-pin-image="showPinImage"
+                        :selected-image-name="imageNameValue" :selected-base-image="baseImageValue" :pin-image-enabled="pinImageEnabled"
                         @base-image-change="baseImageChange" @image-name-change="imageNameChange" @help-clicked="baseImageHelpClick" >
                     </baseimage-select>
                     <base-image-help v-show="showBaseImageHelp" v-bind:data="baseImageHelpData"></base-image-help>


### PR DESCRIPTION
## Summary 
This one got left out during the previous PR. Show error in console 
```
ReferenceError: showPinImage is not defined
    at nt.eval (eval at li (vue.min.js:7:14879), <anonymous>:3:1442)
```
## Test Plan 
Built and tested on dev1. Tested with create new clusters and existing clusters. 
![Screenshot 2023-03-13 at 2 12 02 PM](https://user-images.githubusercontent.com/50259686/224833399-b6a320b1-24f3-41d2-ab27-d51be495f62a.png)
