### PR TITLE
Allow promote for cmp base images only

### DIFF
--- a/deploy-board/deploy_board/templates/clusters/base_images.tmpl
+++ b/deploy-board/deploy_board/templates/clusters/base_images.tmpl
@@ -6,10 +6,10 @@
         <tr>
             <th class="col-lg-2">ID</th>
             <th class="col-lg-2">Golden</th>
+            <th class="col-lg-2">Provider Name</th>
+            <th class="col-lg-2">Abstract Name</th>
             <th class="col-lg-2">Cell</th>
             <th class="col-lg-2">Arch</th>
-            <th class="col-lg-2">Abstract Name</th>
-            <th class="col-lg-2">Provider Name</th>
             <th class="col-lg-1">Cloud Provider</th>
             <th class="col-lg-2">Publish Date</th>
             <th class="col-lg-2">Description</th>
@@ -17,25 +17,31 @@
         </tr>
         {% for base_image in base_images %}
         <tr>
-            <td> 
-            {% if enable_ami_auto_update %}
-                <a id="listGroupsBtnId" href="/clouds/baseimages/events/{{base_image.id}}" title="Click to see image update events">
-                    {{ base_image.id }} 
+            <td>
+                {% if enable_ami_auto_update %}
+                <a id="listGroupsBtnId" href="/clouds/baseimages/events/{{base_image.id}}"
+                    title="Click to see image update events">
+                    {{ base_image.id }}
                 </a>
-            {% else %}
+                {% else %}
                 {{ base_image.id }}
-            {% endif %}
+                {% endif %}
             </td>
             {% if base_image.tag %}
-                <td> <span class="glyphicon glyphicon-ok"></span>Current Golden</td>
+            <td> <span class="glyphicon glyphicon-ok-sign"></span>Current Golden</td>
             {% else %}
             <td></td>
             {% endif %}
+            <td> {{ base_image.provider_name }} </td>
+            <td>
+                <a id="listGroupsBtnId" href="/clouds/baseimages/{{ base_image.abstract_name }}"
+                    title="Click to see image update events">
+                    {{ base_image.abstract_name }}
+                </a>
+            </td>
             <td> {{ base_image.cell_name }} </td>
             <td> {{ base_image.arch_name }} </td>
-            <td> {{ base_image.abstract_name }} </td>
-            <td> {{ base_image.provider_name }}  </td>
-            <td> {{ base_image.provider }}  </td>
+            <td> {{ base_image.provider }} </td>
             <td> {{ base_image.publish_date | convertTimestamp }} </td>
             <td> {{ base_image.description }} </td>
             {% if base_image.acceptance %}

--- a/deploy-board/deploy_board/templates/clusters/base_images_events.html
+++ b/deploy-board/deploy_board/templates/clusters/base_images_events.html
@@ -21,6 +21,7 @@
             <span class="glyphicon glyphicon-wrench"></span> Back to Base Images List
         </a>
     </div>
+    {% if show_promote_ui %}
     <div class="row">
         {% if tags %}
         <button class="deployToolTip btn btn-default btn-block" id="demoteBtnId">
@@ -38,6 +39,7 @@
             <span class="glyphicon glyphicon-remove-circle"></span> Cancel
         </button>
     </div>
+    {% endif %}
     {% endif %}
 </div>
 <script>

--- a/deploy-board/deploy_board/webapp/cluster_view.py
+++ b/deploy-board/deploy_board/webapp/cluster_view.py
@@ -429,6 +429,7 @@ def get_base_image_events(request, image_id):
     latest_update_events = baseimages_helper.get_latest_image_update_events(update_events)
     progress_info = baseimages_helper.get_base_image_update_progress(latest_update_events)
 
+    show_promote_ui = current_image['abstract_name'].startswith('cmp') 
     return render(request, 'clusters/base_images_events.html', {
         'base_images_events': update_events,
         'current_image': current_image,
@@ -436,6 +437,7 @@ def get_base_image_events(request, image_id):
         'tags': tags,
         'cancellable': cancel,
         'progress': progress_info,
+        'show_promote_ui': show_promote_ui, 
     })
 
 


### PR DESCRIPTION
## Summary 
Allows promote ui for cmp base only. 
Include the link to see all images from abstract name 
Reorder the columns for better usability 
## Test plan 
Test locally 
![Screenshot 2023-03-17 at 5 16 12 PM](https://user-images.githubusercontent.com/50259686/226073348-e3337ef9-26e0-469d-8525-337059327ef6.png)
![Screenshot 2023-03-17 at 5 16 30 PM](https://user-images.githubusercontent.com/50259686/226073353-55ed0715-8c18-4497-b8cf-a1be925ee24e.png)
