### PR TITLE
Link to group configs for the cluster and show cluster update status

### DIFF
--- a/deploy-board/deploy_board/templates/clusters/base_image_info.tmpl
+++ b/deploy-board/deploy_board/templates/clusters/base_image_info.tmpl
@@ -1,7 +1,6 @@
 {% load utils %}
 {% load static %}
 
-
 <div class="panel-body table-responsive">
     <table class="table table-striped table-bordered table-condensed table-hover">
         <tr>
@@ -57,4 +56,22 @@
         </tr>
         {% endif %}
     </table>
+    <div class="panel-body table-responsive">
+        {% for cluster in cluster_statuses %}
+            {% if cluster.status == "FAILED" %}
+                <a href="/groups/{{cluster.cluster_name}}" type="button" class="deployToolTip btn btn-xs btn-danger host-btn">
+            {% else %}
+                <a href="/groups/{{cluster.cluster_name}}" type="button" class="deployToolTip btn btn-xs btn-default host-btn">
+            {% endif %}
+            <small> {{cluster.cluster_name}}</small>
+            {% if cluster.status == "FAILED" %}
+            <i class="fa fa-fw fa-exclamation-triangle"></i>
+            {% elif cluster.status == "SUCCEEDED" %}
+            <i class="fa fa-fw fa-check"></i>
+            {% else %}
+            <i class="fa fa-fw fa-spinner fa-spin"></i>
+            {% endif %}
+            </a>
+        {% endfor %}
+    </div>
 </div>

--- a/deploy-board/deploy_board/templates/clusters/base_images_events.tmpl
+++ b/deploy-board/deploy_board/templates/clusters/base_images_events.tmpl
@@ -14,7 +14,12 @@
         </tr>
         {% for base_images_event in base_images_events %}
         <tr>
-            <td> {{ base_images_event.cluster_name }} </td>
+            <td>
+                <a id="listGroupsBtnId" href="/groups/{{ base_images_event.cluster_name }}"
+                    title="Click to see image update events">
+                    {{ base_images_event.cluster_name }}
+                </a>
+            </td>
             <td> {{ base_images_event.old_image_id }} </td>
             <td> {{ base_images_event.new_image_id }} </td>
             <td> {{ base_images_event.status }} </td>

--- a/deploy-board/deploy_board/webapp/cluster_view.py
+++ b/deploy-board/deploy_board/webapp/cluster_view.py
@@ -428,10 +428,13 @@ def get_base_image_events(request, image_id):
     cancel = any(event['state'] == 'INIT' for event in update_events)
     latest_update_events = baseimages_helper.get_latest_image_update_events(update_events)
     progress_info = baseimages_helper.get_base_image_update_progress(latest_update_events)
-
     show_promote_ui = current_image['abstract_name'].startswith('cmp') 
+    cluster_statuses = [{'cluster_name': event['cluster_name'], 'status': event['status']} for event in latest_update_events]
+    cluster_statuses = sorted(cluster_statuses, key=lambda event: event['status'], reverse=True)
+    
     return render(request, 'clusters/base_images_events.html', {
         'base_images_events': update_events,
+        'cluster_statuses': cluster_statuses,
         'current_image': current_image,
         'image_id': image_id,
         'tags': tags,


### PR DESCRIPTION
## Summary 
- Include link to group configs in base image update events 
- Show updated clusters for overview progress. Similar to sidecar deployment. 

## Test plan 
tested on dev 
![Screenshot 2023-03-31 at 2 27 41 PM](https://user-images.githubusercontent.com/50259686/229234822-d8a18b0d-771b-4910-b0c2-5ec4f5777d0f.png)

tested with mocking data locally 
![Screenshot 2023-03-31 at 2 24 17 PM](https://user-images.githubusercontent.com/50259686/229234695-dc91643d-7eb4-4605-8664-9d5bda495dd3.png)
