### PR TITLE
Add tool tip for the pin image checkbox

### DIFF
--- a/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
+++ b/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
@@ -55,7 +55,7 @@ Vue.component('baseimage-select', {
             <div class="col-xs-2">
                 <base-checkbox :checked="pinImage" :enabled="pinImageEnabled"
                     @input="pinImageClick"></base-checkbox>
-                <label for='pinImageCB' title="Select AMI manually by checking the box; AMI will be auto-updated when unchecked. If there is no Golden AMI, only Manual selection is supported.">Pin This Image</label>
+                <label for="pinImageCB" title="Check the box to select AMI manually. If unchecked, AMI will be auto-updated. If there is no Golden AMI, then only manual selection is supported.">Pin This Image</label>
             </div>
         </div>
         <form-warning v-show="showWarning" :alert-text="warningText"></form-warning>

--- a/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
+++ b/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
@@ -55,7 +55,7 @@ Vue.component('baseimage-select', {
             <div class="col-xs-2">
                 <base-checkbox :checked="pinImage" :enabled="pinImageEnabled"
                     @input="pinImageClick"></base-checkbox>
-                <label for='pinImageCB'>Pin Image</label>
+                <label for='pinImageCB' title="Select AMI manually by checking the box; AMI will be auto-updated when unchecked. If there is no Golden AMI, only Manual selection is supported.">Pin This Image</label>
             </div>
         </div>
         <form-warning v-show="showWarning" :alert-text="warningText"></form-warning>


### PR DESCRIPTION
## Summary 
Added tooltip for Pin image check box. 
Changed from "Pin Image" to Pin this Image. 

The current tool tip text is: 
`"Select AMI manually by checking the box; AMI will be auto-updated when unchecked. If there is no Golden AMI, only Manual selection is supported."` 

## Test plan 
![Screenshot 2023-03-31 at 5 30 22 PM](https://user-images.githubusercontent.com/50259686/229256507-c877b64e-b573-4388-8548-493664f3ec5e.png)


