### PR TITLE
DeployBoard syntax error update

### DIFF
--- a/deploy-board/deploy_board/webapp/env_views.py
+++ b/deploy-board/deploy_board/webapp/env_views.py
@@ -802,7 +802,6 @@ def post_create_env(request):
 
     if clone_env_name and clone_stage_name:
         try:
-            raise TeletraanException("test") #test
             external_id = environs_helper.create_identifier_for_new_stage(request, env_name, stage_name)
             common.clone_from_stage_name(request, env_name, stage_name, clone_env_name,
                                         clone_stage_name, description, external_id)

--- a/deploy-board/deploy_board/webapp/env_views.py
+++ b/deploy-board/deploy_board/webapp/env_views.py
@@ -865,38 +865,34 @@ def post_add_stage(request, name):
     external_id = None
     if from_stage:
         try:
-            raise TeletraanException("test") #test
             external_id = environs_helper.create_identifier_for_new_stage(request, name, stage)
             common.clone_from_stage_name(request, name, stage, name, from_stage, description, external_id)
         except TeletraanException as detail:
-            if external_id:
-                try:
-                    environs_helper.delete_nimbus_identifier(request, external_id)
-                except:
-                    message = 'Also failed to delete Nimbus identifier {}. Please verify that identifier no longer exists, Error Message: {}'.format(external_id, detail)
-                    log.error(message)
-                    raise detail
-            else:
-                message = 'Failed to create identifier for {}/{}: {}'.format(name, stage, detail)
-                log.error(message)
-                messages.add_message(request, messages.ERROR, message)
-    else:
-        try:
-            raise TeletraanException("test") #test
-            external_id = environs_helper.create_identifier_for_new_stage(request, name, stage)
-            common.create_simple_stage(request,name, stage, description, external_id)
-        except TeletraanException as detail:
+            message = 'Failed to create stage {}/{}: {}'.format(name, stage, detail)
+            log.error(message)
+            messages.add_message(request, messages.ERROR, message)
             if external_id:
                 try:
                     environs_helper.delete_nimbus_identifier(request, external_id)
                 except TeletraanException as detail:
-                    message = 'Failed to delete Nimbus identifier {}, Error Message: {}'.format(external_id, detail)
+                    message = 'Also failed to delete Nimbus identifier {}. Please verify that identifier no longer exists, Error Message: {}'.format(external_id, detail)
                     log.error(message)
                     messages.add_message(request, messages.ERROR, message)
-            else:
-                message = 'Failed to create stage {}, Error Message: {}'.format(stage, detail)
-                log.error(message)
-                messages.add_message(request, messages.ERROR, message)
+    else:
+        try:
+            external_id = environs_helper.create_identifier_for_new_stage(request, name, stage)
+            common.create_simple_stage(request,name, stage, description, external_id)
+        except TeletraanException as detail:
+            message = 'Failed to create stage {}, Error Message: {}'.format(stage, detail)
+            log.error(message)
+            messages.add_message(request, messages.ERROR, message)
+            if external_id:
+                try:
+                    environs_helper.delete_nimbus_identifier(request, external_id)
+                except TeletraanException as detail:
+                    message = 'Also Failed to delete Nimbus identifier {}, Please verify that identifier no longer exists, Error Message: {}'.format(external_id, detail)
+                    log.error(message)
+                    messages.add_message(request, messages.ERROR, message)
 
     return redirect('/env/' + name + '/' + stage + '/config/')
 

--- a/deploy-board/deploy_board/webapp/env_views.py
+++ b/deploy-board/deploy_board/webapp/env_views.py
@@ -350,11 +350,11 @@ class EnvLandingView(View):
             if project_name:
                 project_info = {}
                 project_info['project_name'] = project_name
-            try:    
+            try:
                 project_info['project_url'] = environs_helper.get_nimbus_project_console_url(project_name)
             except TeletraanException as detail:
                 log.error('Handling TeletraanException when trying to access nimbus API, error message {}'.format(detail))
-                messages.add_message(request, messages.ERROR, detail)    
+                messages.add_message(request, messages.ERROR, detail)
 
         if IS_PINTEREST:
             basic_cluster_info = clusters_helper.get_cluster(request, env.get('clusterName'))
@@ -365,7 +365,7 @@ class EnvLandingView(View):
                 placements = placements_helper.get_simplified_by_ids(
                         request, basic_cluster_info['placement'], basic_cluster_info['provider'], basic_cluster_info['cellName'])
                 remaining_capacity = functools.reduce(lambda s, e: s + e['capacity'], placements, 0)
-          
+
         if not env['deployId']:
             capacity_hosts = deploys_helper.get_missing_hosts(request, name, stage)
             provisioning_hosts = environ_hosts_helper.get_hosts(request, name, stage)
@@ -798,9 +798,11 @@ def post_create_env(request):
     clone_env_name = data.get("clone_env_name")
     clone_stage_name = data.get("clone_stage_name")
     description = data.get('description')
-    
+    external_id = None
+
     if clone_env_name and clone_stage_name:
         try:
+            raise TeletraanException("test") #test
             external_id = environs_helper.create_identifier_for_new_stage(request, env_name, stage_name)
             common.clone_from_stage_name(request, env_name, stage_name, clone_env_name,
                                         clone_stage_name, description, external_id)
@@ -813,6 +815,7 @@ def post_create_env(request):
                     log.error(message)
             else:
                 message = 'Failed to create identifier for {}/{}: {}'.format(env_name, stage_name, detail)
+                log.error(message)
                 messages.add_message(request, messages.ERROR, message)
             raise detail
     else:
@@ -859,8 +862,10 @@ def post_add_stage(request, name):
     if from_stage and from_stage not in stages:
         raise Exception("Can not clone from non-existing stage!")
 
+    external_id = None
     if from_stage:
         try:
+            raise TeletraanException("test") #test
             external_id = environs_helper.create_identifier_for_new_stage(request, name, stage)
             common.clone_from_stage_name(request, name, stage, name, from_stage, description, external_id)
         except TeletraanException as detail:
@@ -873,19 +878,23 @@ def post_add_stage(request, name):
                     raise detail
             else:
                 message = 'Failed to create identifier for {}/{}: {}'.format(name, stage, detail)
-                messages.add_message(request, messages.ERROR, message) 
+                log.error(message)
+                messages.add_message(request, messages.ERROR, message)
     else:
         try:
+            raise TeletraanException("test") #test
             external_id = environs_helper.create_identifier_for_new_stage(request, name, stage)
             common.create_simple_stage(request,name, stage, description, external_id)
         except TeletraanException as detail:
-            try:
-                message = 'Failed to create stage {}, Error Message: {}'.format(external_id, detail)
-                log.error(message)
-                messages.add_message(request, messages.ERROR, message)
-                environs_helper.delete_nimbus_identifier(request, external_id)
-            except TeletraanException as detail:
-                message = 'Failed to delete Nimbus identifier {}, Error Message: {}'.format(external_id, detail)
+            if external_id:
+                try:
+                    environs_helper.delete_nimbus_identifier(request, external_id)
+                except TeletraanException as detail:
+                    message = 'Failed to delete Nimbus identifier {}, Error Message: {}'.format(external_id, detail)
+                    log.error(message)
+                    messages.add_message(request, messages.ERROR, message)
+            else:
+                message = 'Failed to create stage {}, Error Message: {}'.format(stage, detail)
                 log.error(message)
                 messages.add_message(request, messages.ERROR, message)
 


### PR DESCRIPTION
Background:
Previously, for error messages using the external_id from nimbus, there could be situations where it is not intialized and assigned, so updated need to be made to code to ensure that any nimbus issues are correctly logged and surfaced to the user instead of syntax errors. 

Test plan:
Create a stage 
<img width="950" alt="Screenshot 2023-04-12 at 10 12 28 AM" src="https://user-images.githubusercontent.com/69278532/231871104-70a4ab19-3ba7-4842-a58e-d57ac30d4482.png">
Confirm that you receive two error messages in the Ui and in the logs stating that the stage could not be created and the nimbus id could not be deleted. 
<img width="1884" alt="Screenshot 2023-04-12 at 10 12 34 AM" src="https://user-images.githubusercontent.com/69278532/231871134-cc43cc1b-a94a-4e81-bb37-8247e4241427.png">
<img width="1561" alt="Screenshot 2023-04-12 at 10 12 49 AM" src="https://user-images.githubusercontent.com/69278532/231871154-f7e84810-a3c4-4042-927a-61027c5b662b.png">

Create a stage by cloning an existing one

<img width="945" alt="Screenshot 2023-04-12 at 10 15 31 AM" src="https://user-images.githubusercontent.com/69278532/231871384-f1ba07e1-bb54-4f05-8b07-7d9a64cb710d.png">

Confirm that you receive two error messages in the Ui and in the logs stating that the stage could not be created and the nimbus id could not be deleted. 
<img width="1489" alt="Screenshot 2023-04-12 at 10 17 02 AM" src="https://user-images.githubusercontent.com/69278532/231871412-65f2b4df-ea6d-47b8-a11d-4f4a628617e8.png">
<img width="1565" alt="Screenshot 2023-04-12 at 10 18 50 AM" src="https://user-images.githubusercontent.com/69278532/231871443-ca600952-f7c1-46e2-8415-3e304ef61e0b.png">
