### PR TITLE
Init database for local dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     build: ./deploy-service/teletraanservice
     ports:
       - "8080:8080"
-      - "8081:8081"
+      - "8082:8082"
     command: "/opt/deploy-service/teletraanservice/bin/run.sh -c /opt/deploy-service/teletraanservice/bin/server.yaml"
     environment:
       - TELETRAAN_DB_HOST=mysql
@@ -37,6 +37,6 @@ services:
       - "/tmp/.data/deploydb:/var/lib/mysql"
       - "./deploy-service/common/src/main/resources/sql:/var/teletraan/sql"
       - "./tools/mysql:/var/teletraan/tools"
+      - "./tools/mysql/docker-init:/docker-entrypoint-initdb.d"
     environment:
-      MYSQL_ROOT_PASSWORD: ""
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"

--- a/tools/mysql/docker-init/initdb.sh
+++ b/tools/mysql/docker-init/initdb.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Exit upon any errors
+set -e
+
+cd /var/teletraan/tools
+
+./deploydb.sh -f ../sql/deploy.sql
+./upgrade.sh


### PR DESCRIPTION
Update docker compose file to init database for local dev purpose. To test on devapp,

1. Build
2. Clean up local data: `sudo rm -rf /tmp/.data/deploydb`
3. `docker compose down && docker compose up`
4. Verify deploy service can start successfully.

Without this change, the above steps will result in deploy service could not start because database is not created.