### PR TITLE
If the user scale down the capacity to 0, we still show CapacityScaleDownAlertMessage on UI

### DIFF
--- a/deploy-board/deploy_board/static/js/components/capacitycomponents.js
+++ b/deploy-board/deploy_board/static/js/components/capacitycomponents.js
@@ -319,10 +319,10 @@ Vue.component("static-capacity-config", {
                         this.showSizeWarning = true;
                         this.sizeWarning = getCapacityDoubleAlertMessage(true);
                     }
-                } else if (-sizeIncrease > this.capacity && this.capacity > 0) {
+                } else if (-sizeIncrease > this.capacity) {
                     this.showSizeError = true;
                     this.sizeError = getCapacityScaleDownAlertMessage(true, false);
-                } else if (-sizeIncrease * 2 > this.capacity && this.capacity > 0) {
+                } else if (-sizeIncrease * 2 > this.capacity) {
                     this.showSizeWarning = true;
                     this.sizeWarning = getCapacityScaleDownAlertMessage(true, true);
                 }


### PR DESCRIPTION
If the user scale down the capacity to 0, we still show CapacityScaleDownAlertMessage on UI