### PR TITLE
update the api to get the host type lists for asg which is created outside of Teletraan

### DIFF
--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -24,7 +24,7 @@ import json
 import logging
 import traceback
 
-from helpers import (environs_helper, clusters_helper, groups_helper, baseimages_helper,
+from helpers import (environs_helper, clusters_helper, hosttypes_helper, groups_helper, baseimages_helper,
                      specs_helper, autoscaling_groups_helper, autoscaling_metrics_helper, placements_helper)
 from diff_match_patch import diff_match_patch
 from deploy_board import settings
@@ -1034,7 +1034,9 @@ def get_sg_settings(request):
 
 
 def get_instance_type_settings(request):
-    instance_types = specs_helper.get_instance_types(request)
+    # hardcode the arch to be "x86_64" since this feature is only for very old clusters with cpu arch x86_64
+    # thus, abandon this API https://github.com/pinternal/rodimus/pull/148/files which gets the host type list according to the current provider_name
+    instance_types = hosttypes_helper.get_by_arch(request, "x86_64")
     curr_instance_type = request.GET.get("curr_instance_type", "")
     contents = render_to_string("groups/get_hosttype.tmpl",
                                 {"instance_types": instance_types,

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -1037,9 +1037,12 @@ def get_instance_type_settings(request):
     # hardcode the arch to be "x86_64" since this feature is only for very old clusters with cpu arch x86_64
     # thus, abandon this API https://github.com/pinternal/rodimus/pull/148/files which gets the host type list according to the current provider_name
     instance_types = hosttypes_helper.get_by_arch(request, "x86_64")
+    host_types = []
+    for instance_type in instance_types:
+            host_types.append(instance_type['provider_name'])
     curr_instance_type = request.GET.get("curr_instance_type", "")
     contents = render_to_string("groups/get_hosttype.tmpl",
-                                {"instance_types": instance_types,
+                                {"instance_types": host_types,
                                  "curr_instance_type": curr_instance_type})
     return HttpResponse(json.dumps(contents), content_type="application/json")
 


### PR DESCRIPTION
Try to fix a bug for the ASGs created outside of Teletraan.