### PR TITLE
Building deploy agent using Bazel

### DIFF
--- a/deploy-agent/WORKSPACE
+++ b/deploy-agent/WORKSPACE
@@ -1,0 +1,13 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "rules_python",
+    sha256 = "a30abdfc7126d497a7698c29c46ea9901c6392d6ed315171a6df5ce433aa4502",
+    strip_prefix = "rules_python-0.6.0",
+    url = "https://github.com/bazelbuild/rules_python/archive/0.6.0.tar.gz",
+)
+load("@rules_python//python:pip.bzl", "pip_install")
+
+pip_install(
+   name = "python_deps",
+   requirements = "//thirdparty:requirements.txt",
+)

--- a/deploy-agent/WORKSPACE
+++ b/deploy-agent/WORKSPACE
@@ -1,10 +1,12 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 http_archive(
     name = "rules_python",
     sha256 = "a30abdfc7126d497a7698c29c46ea9901c6392d6ed315171a6df5ce433aa4502",
     strip_prefix = "rules_python-0.6.0",
     url = "https://github.com/bazelbuild/rules_python/archive/0.6.0.tar.gz",
 )
+
 load("@rules_python//python:pip.bzl", "pip_install")
 
 pip_install(

--- a/deploy-agent/deployd/BUILD
+++ b/deploy-agent/deployd/BUILD
@@ -1,0 +1,44 @@
+load("@rules_python//python:defs.bzl", "py_test", "py_library")
+load("@python_deps//:requirements.bzl", "requirement")
+
+py_library(
+    name = "lib",
+    srcs = glob(["**/*.py"]),
+    deps = [
+        ":third_party",
+    ],
+    visibility = ["//tests:__pkg__"],
+)
+
+py_binary(
+    name = "deploy-agent",
+    srcs = ["agent.py"],
+    main = "agent.py",
+    deps = [
+       ":lib",
+    ],
+)
+
+py_binary(
+    name = "deploy-downloader",
+    srcs = ["download/downloader.py"],
+    main = "download/downloader.py",
+    deps = [
+       ":lib",
+    ],
+)
+
+py_library(
+  name = "third_party",
+  deps = [
+    requirement("PyYAML"),
+    requirement("zipp"),
+    requirement("configparser"),
+    requirement("python-daemon"),
+    requirement("pinstatsd"),
+    requirement("pinlogger"),
+    requirement("setuptools"),
+    requirement("strictyaml"),
+    requirement("requests")
+  ],
+)

--- a/deploy-agent/deployd/BUILD.bazel
+++ b/deploy-agent/deployd/BUILD.bazel
@@ -19,26 +19,17 @@ py_binary(
     ],
 )
 
-py_binary(
-    name = "deploy-downloader",
-    srcs = ["download/downloader.py"],
-    main = "download/downloader.py",
-    deps = [
-       ":lib",
-    ],
-)
-
 py_library(
   name = "third_party",
   deps = [
     requirement("PyYAML"),
-    requirement("zipp"),
     requirement("configparser"),
     requirement("python-daemon"),
     requirement("pinstatsd"),
     requirement("pinlogger"),
     requirement("setuptools"),
     requirement("strictyaml"),
-    requirement("requests")
+    requirement("requests"),
+    requirement("zipp"),
   ],
 )

--- a/deploy-agent/deployd/teletraan/RESTARTING
+++ b/deploy-agent/deployd/teletraan/RESTARTING
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -ex
+
+cp deploy-agent /usr/local/bin/deploy-agent
+chmod 0755 /usr/local/bin/deploy-agent
+
+deploy-agent -h

--- a/deploy-agent/tests/BUILD.bazel
+++ b/deploy-agent/tests/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@rules_python//python:defs.bzl", "py_library")
+
+py_test(
+    name = "test_base_client", 
+    srcs = ['unit/deploy/client/test_base_client.py'],
+    deps = ["test_lib"],
+    python_version = "PY3",
+)
+
+py_test(
+    name = "test_serverless_client", 
+    srcs = ['unit/deploy/client/test_serverless_client.py'],
+    deps = ["test_lib"],
+    python_version = "PY3",
+)
+
+py_test(
+    name = "test_agent", 
+    srcs = ['unit/deploy/server/test_agent.py'],
+    deps = ["test_lib"],
+    python_version = "PY3",
+)
+
+py_library(
+    name = "test_lib",
+    srcs = ["__init__.py"],
+    deps = ["//deployd:lib"],
+)

--- a/deploy-agent/tests/__init__.py
+++ b/deploy-agent/tests/__init__.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
+from unittest import mock
+import unittest
 import logging
 import os
 import shutil
 import tempfile
-import unittest
 
 from deployd.common.types import OpCode
 

--- a/deploy-agent/tests/unit/deploy/client/test_base_client.py
+++ b/deploy-agent/tests/unit/deploy/client/test_base_client.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tests
+import unittest
+from tests import TestCase
 
 from deployd.client.base_client import BaseClient
 
 
-class TestBaseClient(tests.TestCase):
+class TestBaseClient(TestCase):
 
     def test_missing_abstract_method_impl_cause_error(self):
 
@@ -26,3 +27,7 @@ class TestBaseClient(tests.TestCase):
 
         with self.assertRaises(TypeError):
             myclient = MyClient()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/deploy-agent/tests/unit/deploy/client/test_serverless_client.py
+++ b/deploy-agent/tests/unit/deploy/client/test_serverless_client.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 import unittest
-import tests
+from tests import TestCase
 
 from deployd.client.serverless_client import ServerlessClient
 from deployd.common.types import DeployStatus, AgentStatus
 from deployd.types.ping_report import PingReport
 
 
-class TestServerlessClient(tests.TestCase):
+class TestServerlessClient(TestCase):
 
     def setUp(self):
         self.env_name = "test"

--- a/deploy-agent/tests/unit/deploy/server/test_agent.py
+++ b/deploy-agent/tests/unit/deploy/server/test_agent.py
@@ -14,8 +14,8 @@
 
 import os
 import unittest
-import mock
-import tests
+from unittest import mock
+from tests import TestCase
 
 from deployd.agent import DeployAgent
 from deployd.common.utils import ensure_dirs
@@ -25,7 +25,7 @@ from deployd.types.ping_report import PingReport
 from deployd.types.ping_response import PingResponse
 
 
-class TestDeployAgent(tests.TestCase):
+class TestDeployAgent(TestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -571,5 +571,7 @@ class TestDeployAgent(tests.TestCase):
                                             'first_run': False, 'deploy_stage': 'PRE_DOWNLOAD', 'env_name': 'abc', 'stage_name': 'beta', 'status_code': 'UNKNOWN', 'error_source': 'TELEFIG', 'error':'TELEFIG_UNAVAILABLE'})
         self.assertEqual(agent._curr_report.report.deployStage, DeployStage.PRE_DOWNLOAD)
         self.assertEqual(agent._curr_report.report.status, AgentStatus.UNKNOWN)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/deploy-agent/thirdparty/requirements.txt
+++ b/deploy-agent/thirdparty/requirements.txt
@@ -1,0 +1,10 @@
+PyYAML==5.3.1
+configparser==4.0.2
+pinlogger==0.53.0
+pinstatsd==1.4.6
+python-daemon==2.0.6
+requests==2.20.0
+setuptools==44.1.1; python_version < '3'
+setuptools==54.2.0; python_version >= '3'
+strictyaml==1.6.1
+zipp==1.2.0

--- a/deploy-agent/tox.ini
+++ b/deploy-agent/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py37,py38,py39
+envlist=py36,py38,py39
 recreate=True
 
 [flake8]
@@ -12,7 +12,6 @@ commands=py.test --cov=deployd {posargs}
 
 [gh-actions]
 python =
-    2.7: py27
-    3.7: py37
+    3.6: py36
     3.8: py38
     3.9: py39

--- a/deploy-agent/tox.ini
+++ b/deploy-agent/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py36,py38,py39
+envlist=py36,py37,py38,py39
 recreate=True
 
 [flake8]
@@ -13,5 +13,6 @@ commands=py.test --cov=deployd {posargs}
 [gh-actions]
 python =
     3.6: py36
+    3.7: py37
     3.8: py38
     3.9: py39


### PR DESCRIPTION
## Summary
Create build configs and targets for deploy agent to build with Bazel. 
This allows us to quickly test deploy agent change and deploy a change to a host. 
Added some test targets 

## Test plan 
Build locally 
`bazel build --build_python_zip //deployd:deploy-agent`
Run locally
`bazel-bin/deployd/deploy-agent -h`
Run test 
`bazel test tests:*`
result:
```
/tests:test_agent                                                       PASSED in 0.5s
//tests:test_base_client                                                 PASSED in 0.2s
//tests:test_serverless_client                                           PASSED in 0.3s
```