### PR TITLE
Add metrics for missing host info and skip pinging when az info is missing

### DIFF
--- a/deploy-agent/deployd/__init__.py
+++ b/deploy-agent/deployd/__init__.py
@@ -20,4 +20,4 @@ METRIC_PORT_HEALTH = int(os.getenv('METRIC_PORT_HEALTH')) if os.getenv('METRIC_P
 METRIC_CACHE_PATH = os.getenv('METRIC_CACHE_PATH', None)
 TELEFIG_BINARY = os.getenv('TELEFIG_BINARY', "")
 
-__version__ = '1.2.41'
+__version__ = '1.2.42'

--- a/deploy-agent/deployd/client/client.py
+++ b/deploy-agent/deployd/client/client.py
@@ -174,6 +174,13 @@ class Client(BaseClient):
                  "Host name: {}, IP: {}, host id: {}, agent_version={}, autoscaling_group: {}, "
                  "availability_zone: {}, stage_type: {}, group: {}".format(self._hostname, self._ip, self._id, 
                  self._agent_version, self._autoscaling_group, self._availability_zone, self._stage_type, self._hostgroup))
+
+        if not self._availability_zone:
+            log.error("Fail to read host info: availablity zone")
+            create_sc_increment(name='deploy.failed.agent.hostinfocollection',
+                                tags={'host': self._hostname, 'info': 'availability_zone'})
+            return False
+
         return True
 
     def send_reports(self, env_reports=None):


### PR DESCRIPTION
## Summary 
Add metrics for missing AZ info and skip pinging to agent service when az info is missing.

## Test plan 
Tested on `helloworlddummyservice-server-cmp-u20-0a03a461` with the fact is forced missing, metric is emitted and no deployment happens. 
https://statsboard.pinadmin.com/share/pqp5v

## Jira
CDP-6537