### PR TITLE
add path when getting github commits

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/scm/GithubManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/scm/GithubManager.java
@@ -191,6 +191,7 @@ public class GithubManager extends BaseManager {
         // TODO: Do not RETRY since it will timeout the thrift caller, need to revisit
         Map<String, String> params = new HashMap<String, String>();
         params.put("sha", startSha);
+        params.put("path", path);
 
         setHeaders();
         String jsonPayload = httpClient.get(url, null, params, headers, 1);

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Commits.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Commits.java
@@ -39,7 +39,7 @@ import java.util.List;
 @Consumes(MediaType.APPLICATION_JSON)
 public class Commits {
     private final static String DEFAULT_PATH = "";
-    private final static int DEFAULT_SIZE = 30;
+    private final static int DEFAULT_SIZE = 100;
     private SourceControlManagerProxy sourceControlManagerProxy;
 
     public Commits(TeletraanServiceContext context) throws Exception {


### PR DESCRIPTION
For now, when getting github commits, there is no way to provide path.
In this PR, I added path as one param when querying github api.
Also, increase the default size from 30 to 100 for sending metrics to pinalytics for Pinboard services.