### PR TITLE
show all tags on base image list ui

### DIFF
--- a/deploy-board/deploy_board/templates/clusters/base_images.tmpl
+++ b/deploy-board/deploy_board/templates/clusters/base_images.tmpl
@@ -27,11 +27,19 @@
                 {{ base_image.id }}
                 {% endif %}
             </td>
-            {% if base_image.tag %}
-            <td> <span class="glyphicon glyphicon-ok-sign"></span>Current Golden</td>
-            {% else %}
-            <td></td>
-            {% endif %}
+            <td>
+                {% if base_image.golden_latest %}
+                    <span class="label label-primary">GOLDEN_LATEST</span>
+                {% endif %}
+                {% if base_image.golden_canary %}
+                    <span class="label label-success">GOLDEN_CANARY</span>
+                {% endif %}
+                {% if base_image.tag %}
+                    <span class="label label-warning">CURRENT_GOLDEN</span>
+                {% elif golden_prod %}
+                    <span class="label label-warning">GOLDEN</span>
+                {% endif %}
+            </td>
             <td> {{ base_image.provider_name }} </td>
             <td>
                 <a id="listGroupsBtnId" href="/clouds/baseimages/{{ base_image.abstract_name }}"

--- a/deploy-board/deploy_board/templates/clusters/base_images.tmpl
+++ b/deploy-board/deploy_board/templates/clusters/base_images.tmpl
@@ -36,7 +36,7 @@
                 {% endif %}
                 {% if base_image.tag %}
                     <span class="label label-warning">CURRENT_GOLDEN</span>
-                {% elif golden_prod %}
+                {% elif base_image.golden_prod %}
                     <span class="label label-warning">GOLDEN</span>
                 {% endif %}
             </td>

--- a/deploy-board/deploy_board/templates/clusters/base_images.tmpl
+++ b/deploy-board/deploy_board/templates/clusters/base_images.tmpl
@@ -34,7 +34,7 @@
                 {% if base_image.golden_canary %}
                     <span class="label label-success">GOLDEN_CANARY</span>
                 {% endif %}
-                {% if base_image.tag %}
+                {% if base_image.current_golden %}
                     <span class="label label-warning">CURRENT_GOLDEN</span>
                 {% elif base_image.golden_prod %}
                     <span class="label label-warning">GOLDEN</span>

--- a/deploy-board/deploy_board/webapp/cluster_view.py
+++ b/deploy-board/deploy_board/webapp/cluster_view.py
@@ -373,6 +373,12 @@ def get_base_images(request):
     provider_list = baseimages_helper.get_all_providers(request)
     cells_list = cells_helper.get_by_provider(request, DEFAULT_PROVIDER)
     arches_list = arches_helper.get_all(request)
+    for image in base_images:
+        tags = baseimages_helper.get_image_tag_by_id(request, image['id'])
+        golden_tags = [ e['tag'] for e in tags ]
+        image['golden_latest'] = True if 'GOLDEN_LATEST' in golden_tags else False
+        image['golden_canary'] = True if 'GOLDEN_CANARY' in golden_tags else False
+        image['golden_prod'] = True if 'GOLDEN' in golden_tags else False
 
     return render(request, 'clusters/base_images.html', {
         'enable_ami_auto_update': ENABLE_AMI_AUTO_UPDATE,

--- a/deploy-board/deploy_board/webapp/cluster_view.py
+++ b/deploy-board/deploy_board/webapp/cluster_view.py
@@ -376,9 +376,9 @@ def get_base_images(request):
     for image in base_images:
         tags = baseimages_helper.get_image_tag_by_id(request, image['id'])
         golden_tags = [ e['tag'] for e in tags ]
-        image['golden_latest'] = True if 'GOLDEN_LATEST' in golden_tags else False
-        image['golden_canary'] = True if 'GOLDEN_CANARY' in golden_tags else False
-        image['golden_prod'] = True if 'GOLDEN' in golden_tags else False
+        image['golden_latest'] = 'GOLDEN_LATEST' in golden_tags
+        image['golden_canary'] = 'GOLDEN_CANARY' in golden_tags
+        image['golden_prod'] = 'GOLDEN' in golden_tags
 
     return render(request, 'clusters/base_images.html', {
         'enable_ami_auto_update': ENABLE_AMI_AUTO_UPDATE,
@@ -427,9 +427,9 @@ def get_base_image_events(request, image_id):
     update_events = sorted(update_events, key=lambda event: event['create_time'], reverse=True)
     tags = baseimages_helper.get_image_tag_by_id(request, image_id)
     golden_tags = [ e['tag'] for e in tags ]
-    golden_latest = True if 'GOLDEN_LATEST' in golden_tags else False
-    golden_canary = True if 'GOLDEN_CANARY' in golden_tags else False
-    golden_prod = True if 'GOLDEN' in golden_tags else False
+    golden_latest = 'GOLDEN_LATEST' in golden_tags
+    golden_canary = 'GOLDEN_CANARY' in golden_tags
+    golden_prod = 'GOLDEN' in golden_tags
     current_image = baseimages_helper.get_by_id(request, image_id)
     cancel = any(event['state'] == 'INIT' for event in update_events)
     latest_update_events = baseimages_helper.get_latest_image_update_events(update_events)

--- a/deploy-board/deploy_board/webapp/cluster_view.py
+++ b/deploy-board/deploy_board/webapp/cluster_view.py
@@ -406,7 +406,7 @@ def get_base_images_by_abstract_name(request, abstract_name):
     # add golden tag to images
     for image in base_images:
         if golden_images[image['cell_name']] and image['id'] == golden_images[image['cell_name']]['id']:
-            image['tag'] = 'current_golden'
+            image['current_golden'] = True
 
     return render(request, 'clusters/base_images.html', {
         'enable_ami_auto_update': ENABLE_AMI_AUTO_UPDATE,

--- a/deploy-board/deploy_board/webapp/helpers/baseimages_helper.py
+++ b/deploy-board/deploy_board/webapp/helpers/baseimages_helper.py
@@ -70,7 +70,7 @@ def get_all_with_acceptance(request, index, size):
                 golden_image = get_current_golden_image(request, name, cell)
                 golden[key] = golden_image['id'] if golden_image else None
             if img['id'] == golden[key]:
-                img['tag'] = 'current_golden'
+                img['current_golden'] = True
 
     return base_images
 


### PR DESCRIPTION
We already show all golden tags on base image event page.
Now, we add the tags on base image list UI too. ^^
Tested on dev1, looks good:
<img width="930" alt="Screenshot 2023-06-09 at 2 47 09 PM" src="https://github.com/pinterest/teletraan/assets/42289525/e005a739-7eec-45cb-ba6d-9c5c61ba9d66">
