### PR TITLE
Removing reference to OldestLaunchConfiguration

### DIFF
--- a/deploy-board/deploy_board/webapp/helpers/autoscaling_groups_helper.py
+++ b/deploy-board/deploy_board/webapp/helpers/autoscaling_groups_helper.py
@@ -19,8 +19,7 @@ from deploy_board.webapp.helpers.rodimus_client import RodimusClient
 rodimus_client = RodimusClient()
 
 
-TerminationPolicy = ["Default", "OldestInstance", "NewestInstance", "OldestLaunchConfiguration",
-                     "ClosestToNextInstanceHour"]
+TerminationPolicy = ["Default", "OldestInstance", "NewestInstance", "ClosestToNextInstanceHour"]
 
 Comparator = [{"value": "GreaterThanOrEqualToThreshold", "symbol": "≥"},
               {"value": "GreaterThanThreshold", "symbol": ">"},


### PR DESCRIPTION
Since we are migrating to Launch Templates, ASGs using OldestLaunchConfiguration as the Termination Policy were migrated to use OldestInstance. This update will ensure that users will no longer be able to select OldestLaunchConfiguration.

Test:

Navigate to an ASG and confirm that `OldestLaunchConfiguration` is not selectable
<img width="2047" alt="image" src="https://github.com/pinternal/rodimus/assets/110136967/c78634e8-46f2-43ba-a0ff-23709a18ff5b">