### PR TITLE
Improve health check display

### DIFF
--- a/deploy-board/deploy_board/templates/groups/health_check_activities.tmpl
+++ b/deploy-board/deploy_board/templates/groups/health_check_activities.tmpl
@@ -44,7 +44,11 @@
                         STATE SUCCEEDED
                     {% elif health_check.status == "QUALIFIED" %}
                         QUALIFIED (pending termination)
-                    {% elif health_check.status == "TELETRAAN_STOP_REQUESTED" and health_check.state == "COMPLETED" %}
+                    {% elif health_check.error_message and health_check.host_terminated == 1 %}
+                        FAILED (terminated)
+                    {% elif health_check.error_message %}
+                        FAILED
+                    {% elif health_check.status == "TELETRAAN_STOP_REQUESTED" and health_check.host_terminated == 1 %}
                         QUALIFIED (terminated)
                     {% elif health_check.status == "TELETRAAN_STOP_REQUESTED" %}
                         QUALIFIED (terminating)

--- a/deploy-board/deploy_board/templates/groups/health_check_activities.tmpl
+++ b/deploy-board/deploy_board/templates/groups/health_check_activities.tmpl
@@ -14,7 +14,7 @@
             <th class="col-lg-1">Details</th>
         </tr>
         {% for health_check in health_checks %}
-            <tr class="{{ health_check.status | healthCheckStatusClass }}">
+            <tr class="{{ health_check.error_message | healthCheckStatusClass }}">
                 <td>{{ health_check.start_time | convertTimestamp }}</td>
                 <td><span class="deployToolTip label label-default" data-toggle="tooltip"
                           title="Health Check was updated on {{ health_check.last_worked_on | convertTimestamp }}">

--- a/deploy-board/deploy_board/templates/groups/health_check_activities.tmpl
+++ b/deploy-board/deploy_board/templates/groups/health_check_activities.tmpl
@@ -46,8 +46,10 @@
                         QUALIFIED (pending termination)
                     {% elif health_check.error_message and health_check.host_terminated == 1 %}
                         FAILED (terminated)
+                    {% elif health_check.error_message and health_check.status == "TELETRAAN_STOP_REQUESTED" %}
+                        FAILED (terminating)
                     {% elif health_check.error_message %}
-                        FAILED
+                        FAILED (pending termination)
                     {% elif health_check.status == "TELETRAAN_STOP_REQUESTED" and health_check.host_terminated == 1 %}
                         QUALIFIED (terminated)
                     {% elif health_check.status == "TELETRAAN_STOP_REQUESTED" %}

--- a/deploy-board/deploy_board/templates/groups/health_check_details.html
+++ b/deploy-board/deploy_board/templates/groups/health_check_details.html
@@ -109,7 +109,11 @@
                         STATE SUCCEEDED
                     {% elif health_check.status == "QUALIFIED" %}
                         QUALIFIED (pending termination)
-                    {% elif health_check.status == "TELETRAAN_STOP_REQUESTED" and health_check.state == "COMPLETED" %}
+                    {% elif health_check.error_message and health_check.host_terminated == 1 %}
+                        FAILED (terminated)
+                    {% elif health_check.error_message %}
+                        FAILED
+                    {% elif health_check.status == "TELETRAAN_STOP_REQUESTED" and health_check.host_terminated == 1 %}
                         QUALIFIED (terminated)
                     {% elif health_check.status == "TELETRAAN_STOP_REQUESTED" %}
                         QUALIFIED (terminating)

--- a/deploy-board/deploy_board/templates/groups/health_check_details.html
+++ b/deploy-board/deploy_board/templates/groups/health_check_details.html
@@ -111,8 +111,10 @@
                         QUALIFIED (pending termination)
                     {% elif health_check.error_message and health_check.host_terminated == 1 %}
                         FAILED (terminated)
+                    {% elif health_check.error_message and health_check.status == "TELETRAAN_STOP_REQUESTED" %}
+                        FAILED (terminating)
                     {% elif health_check.error_message %}
-                        FAILED
+                        FAILED (pending termination)
                     {% elif health_check.status == "TELETRAAN_STOP_REQUESTED" and health_check.host_terminated == 1 %}
                         QUALIFIED (terminated)
                     {% elif health_check.status == "TELETRAAN_STOP_REQUESTED" %}

--- a/deploy-board/deploy_board/webapp/templatetags/utils.py
+++ b/deploy-board/deploy_board/webapp/templatetags/utils.py
@@ -905,13 +905,11 @@ def genImageInfo(value):
 
 
 @register.filter("healthCheckStatusClass")
-def healthCheckStatusClass(status):
-    if status == "FAILED":
+def healthCheckStatusClass(error_message):
+    if error_message:
         return "danger"
-    elif status == "TELETRAAN_STOP_REQUESTED":
+    else
         return "success"
-    else:
-        return ""
 
 
 @register.filter("healthCheckStatusIcon")

--- a/deploy-board/deploy_board/webapp/templatetags/utils.py
+++ b/deploy-board/deploy_board/webapp/templatetags/utils.py
@@ -908,7 +908,7 @@ def genImageInfo(value):
 def healthCheckStatusClass(error_message):
     if error_message:
         return "danger"
-    else
+    else:
         return "success"
 
 


### PR DESCRIPTION
There are some problems on the health check ui:

- It shows terminated when a host is still alive.
- It shows green and qualified when the check is failed and the host is terminated.