### PR TITLE
Update github CI job for deploy agent

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
## Summary 
There is a error for 2.7 and we don't use python 2.7 for deploy agent for a long time. Replace it with 3.6. 
```
Warning: The support for python 2.7 will be removed on June 19. Related issue: https://github.com/actions/setup-python/issues/672
Version 2.7 was not found in the local cache
Error: Version 2.7 with arch x[6](https://github.com/pinterest/teletraan/actions/runs/5327329089/jobs/9650630779?pr=1208#step:3:7)4 not found
The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```
## Test plan
CI jobs of this PR. 