### PR TITLE
Default auto update when there is a golden image for GA

### DIFF
--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -124,9 +124,8 @@ var capacitySetting = new Vue({
         baseImageHelpData: [],
         baseImages: mapBaseImagesToOptions(baseImagesSorted),
         baseImageValue: defaultImageId,
-        // Default to Pin image if there is a golden image before GA
-        // After GA, default to Auto Update.
-        pinImage: getPinImageValue(goldenImage, false),
+        // Default to Auto Update if there is a golden image.
+        pinImage: getPinImageValue(goldenImage, true),
         pinImageEnabled: isPinImageEnabled(goldenImage),
         configOptions: Object.keys(info.configList).map(
             function (key) {
@@ -418,9 +417,8 @@ var capacitySetting = new Vue({
                     const defaultImageId = goldenImage ? goldenImage.id : getDefaultBaseImageId(baseImageSorted);
                     capacitySetting.baseImages = mapBaseImagesToOptions(baseImageSorted);
                     capacitySetting.baseImageValue = defaultImageId;
-                    // Default not auto update if there is a golden image before GA
-                    // Default auto update if there is a golden image after GA
-                    capacitySetting.pinImage = getPinImageValue(goldenImage, false);
+                    // Default auto update if there is a golden image
+                    capacitySetting.pinImage = getPinImageValue(goldenImage, true);
                     capacitySetting.pinImageEnabled = isPinImageEnabled(goldenImage);
                 },
                 error: function (data) {


### PR DESCRIPTION
## Summary 
Default to auto update on deploy board when there is a golden image for GA 
## Test plan 
Tested on dev 1 with a golden image. Verified that auto update is enabled by default. 
<img width="1227" alt="Screenshot 2023-07-11 at 1 14 15 AM" src="https://github.com/pinterest/teletraan/assets/50259686/9216de19-4ad0-46a4-b592-9ce90a40491f">

