### PR TITLE
AgentJanitor Rework

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostAgentDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostAgentDAO.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *    
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostAgentDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostAgentDAO.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ *  
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ *    
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostAgentDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostAgentDAO.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *    
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,11 +15,10 @@
  */
 package com.pinterest.deployservice.dao;
 
-import com.pinterest.deployservice.bean.HostAgentBean;
-
-import java.util.Collection;
+import java.sql.SQLException;
 import java.util.List;
-import java.util.Set;
+
+import com.pinterest.deployservice.bean.HostAgentBean;
 
 /**
  * A collection of methods to help hosts and groups mapping
@@ -35,9 +34,11 @@ public interface HostAgentDAO {
 
     HostAgentBean getHostById(String hostId) throws Exception;
 
-    List<HostAgentBean> getStaleHosts(long after) throws Exception;
+    List<HostAgentBean> getStaleHosts(long lastUpdateBefore) throws SQLException;
 
-    List<HostAgentBean> getStaleEnvHosts(long after) throws Exception;
+    List<HostAgentBean> getStaleHosts(long lastUpdateAfter, long lastUpdateBefore) throws SQLException;
+
+    List<HostAgentBean> getStaleEnvHosts(long lastUpdateBefore) throws Exception;
 
     List<HostAgentBean> getHostsByAgent(String agentVersion, long pageIndex, int pageSize) throws Exception;
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostDAO.java
@@ -56,7 +56,7 @@ public interface HostDAO {
 
     List<HostBean> getTerminatingHosts() throws Exception;
 
-    List<String> getStaleAgentlessHostIds(long noUpdateSince, int limit) throws SQLException;
+    List<String> getStaleAgentlessHostIds(long lastUpdateBefore, int limit) throws SQLException;
 
     Collection<HostBean> getHostsByEnvId(String envId) throws Exception;
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostDAO.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *    
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,6 +17,7 @@ package com.pinterest.deployservice.dao;
 
 import com.pinterest.deployservice.bean.HostBean;
 
+import java.sql.SQLException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -54,6 +55,8 @@ public interface HostDAO {
     List<HostBean> getHostsByHostId(String hostId) throws Exception;
 
     List<HostBean> getTerminatingHosts() throws Exception;
+
+    List<String> getAgentlessHostIds(int limit) throws SQLException;
 
     Collection<HostBean> getHostsByEnvId(String envId) throws Exception;
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostDAO.java
@@ -56,7 +56,7 @@ public interface HostDAO {
 
     List<HostBean> getTerminatingHosts() throws Exception;
 
-    List<String> getAgentlessHostIds(int limit) throws SQLException;
+    List<String> getStaleAgentlessHostIds(long noUpdateSince, int limit) throws SQLException;
 
     Collection<HostBean> getHostsByEnvId(String envId) throws Exception;
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostDAOImpl.java
@@ -195,9 +195,9 @@ public class DBHostDAOImpl implements HostDAO {
     }
 
     @Override
-    public List<String> getStaleAgentlessHostIds(long noUpdateSince, int limit) throws SQLException {
+    public List<String> getStaleAgentlessHostIds(long lastUpdateBefore, int limit) throws SQLException {
         return new QueryRunner(dataSource).query(GET_STALE_AGENTLESS_HOST_IDS,
-                SingleResultSetHandlerFactory.<String>newListObjectHandler(), noUpdateSince, limit);
+                SingleResultSetHandlerFactory.<String>newListObjectHandler(), lastUpdateBefore, limit);
     }
 
     @Override

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostDAOImpl.java
@@ -52,7 +52,7 @@ public class DBHostDAOImpl implements HostDAO {
     private static final String GET_HOST_BY_HOSTID = "SELECT * FROM hosts WHERE host_id=?";
     private static final String GET_HOSTS_BY_STATES = "SELECT * FROM hosts WHERE state in (?, ?, ?) GROUP BY host_id ORDER BY last_update";
     private static final String GET_GROUP_NAMES_BY_HOST = "SELECT group_name FROM hosts WHERE host_name=?";
-    private static final String GET_AGENTLESS_HOST_IDS = "SELECT DISTINCT hosts.host_id FROM hosts LEFT JOIN hosts_and_agents ON hosts.host_id = hosts_and_agents.host_id WHERE hosts_and_agents.host_id IS NULL ORDER BY hosts.last_update LIMIT ?";
+    private static final String GET_STALE_AGENTLESS_HOST_IDS = "SELECT DISTINCT hosts.host_id FROM hosts LEFT JOIN hosts_and_agents ON hosts.host_id = hosts_and_agents.host_id WHERE last_update < ? AND hosts_and_agents.host_id IS NULL ORDER BY hosts.last_update DESC LIMIT ?";
     private static final String GET_HOST_NAMES_BY_GROUP = "SELECT host_name FROM hosts WHERE group_name=?";
     private static final String GET_HOST_IDS_BY_GROUP = "SELECT DISTINCT host_id FROM hosts WHERE group_name=?";
     private static final String GET_HOSTS_BY_ENVID = "SELECT h.* FROM hosts h INNER JOIN groups_and_envs ge ON ge.group_name = h.group_name WHERE ge.env_id=? UNION DISTINCT SELECT hs.* FROM hosts hs INNER JOIN hosts_and_envs he ON he.host_name = hs.host_name WHERE he.env_id=?";
@@ -195,9 +195,9 @@ public class DBHostDAOImpl implements HostDAO {
     }
 
     @Override
-    public List<String> getAgentlessHostIds(int limit) throws SQLException {
+    public List<String> getStaleAgentlessHostIds(long noUpdateSince, int limit) throws SQLException {
         ResultSetHandler<List<String>> h = new BeanListHandler<>(String.class);
-        return new QueryRunner(dataSource).query(GET_AGENTLESS_HOST_IDS, h, limit);
+        return new QueryRunner(dataSource).query(GET_STALE_AGENTLESS_HOST_IDS, h, noUpdateSince, limit);
     }
 
     @Override

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostDAOImpl.java
@@ -52,7 +52,7 @@ public class DBHostDAOImpl implements HostDAO {
     private static final String GET_HOST_BY_HOSTID = "SELECT * FROM hosts WHERE host_id=?";
     private static final String GET_HOSTS_BY_STATES = "SELECT * FROM hosts WHERE state in (?, ?, ?) GROUP BY host_id ORDER BY last_update";
     private static final String GET_GROUP_NAMES_BY_HOST = "SELECT group_name FROM hosts WHERE host_name=?";
-    private static final String GET_STALE_AGENTLESS_HOST_IDS = "SELECT DISTINCT hosts.host_id FROM hosts LEFT JOIN hosts_and_agents ON hosts.host_id = hosts_and_agents.host_id WHERE last_update < ? AND hosts_and_agents.host_id IS NULL ORDER BY hosts.last_update DESC LIMIT ?";
+    private static final String GET_STALE_AGENTLESS_HOST_IDS = "SELECT DISTINCT hosts.host_id FROM hosts LEFT JOIN hosts_and_agents ON hosts.host_id = hosts_and_agents.host_id WHERE hosts.last_update < ? AND hosts_and_agents.host_id IS NULL ORDER BY hosts.last_update DESC LIMIT ?";
     private static final String GET_HOST_NAMES_BY_GROUP = "SELECT host_name FROM hosts WHERE group_name=?";
     private static final String GET_HOST_IDS_BY_GROUP = "SELECT DISTINCT host_id FROM hosts WHERE group_name=?";
     private static final String GET_HOSTS_BY_ENVID = "SELECT h.* FROM hosts h INNER JOIN groups_and_envs ge ON ge.group_name = h.group_name WHERE ge.env_id=? UNION DISTINCT SELECT hs.* FROM hosts hs INNER JOIN hosts_and_envs he ON he.host_name = hs.host_name WHERE he.env_id=?";

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostDAOImpl.java
@@ -196,8 +196,8 @@ public class DBHostDAOImpl implements HostDAO {
 
     @Override
     public List<String> getStaleAgentlessHostIds(long noUpdateSince, int limit) throws SQLException {
-        ResultSetHandler<List<String>> h = new BeanListHandler<>(String.class);
-        return new QueryRunner(dataSource).query(GET_STALE_AGENTLESS_HOST_IDS, h, noUpdateSince, limit);
+        return new QueryRunner(dataSource).query(GET_STALE_AGENTLESS_HOST_IDS,
+                SingleResultSetHandlerFactory.<String>newListObjectHandler(), noUpdateSince, limit);
     }
 
     @Override

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/HostHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/HostHandler.java
@@ -1,17 +1,14 @@
 package com.pinterest.deployservice.handler;
 
 
-import com.pinterest.deployservice.ServiceContext;
-import com.pinterest.deployservice.bean.HostBean;
-import com.pinterest.deployservice.common.CommonUtils;
-import com.pinterest.deployservice.dao.AgentDAO;
-import com.pinterest.deployservice.dao.HostDAO;
-import com.pinterest.deployservice.dao.HostAgentDAO;
-import com.pinterest.deployservice.dao.HostTagDAO;
-import com.pinterest.deployservice.handler.HostHandler;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.pinterest.deployservice.ServiceContext;
+import com.pinterest.deployservice.dao.AgentDAO;
+import com.pinterest.deployservice.dao.HostAgentDAO;
+import com.pinterest.deployservice.dao.HostDAO;
+import com.pinterest.deployservice.dao.HostTagDAO;
 
 public class HostHandler {
     private static final Logger LOG = LoggerFactory.getLogger(HostHandler.class);
@@ -27,7 +24,7 @@ public class HostHandler {
         hostTagDAO = serviceContext.getHostTagDAO();
     }
 
-    public void removeHost(String hostId) throws Exception {
+    public void removeHost(String hostId) {
         try {
             hostDAO.deleteAllById(hostId);
             agentDAO.deleteAllById(hostId);

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/HostHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/HostHandler.java
@@ -30,25 +30,25 @@ public class HostHandler {
             hostDAO.deleteAllById(hostId);
         } catch (Exception e) {
             hasException = true;
-            LOG.error("Failed to remote host record " + hostId, e);
+            LOG.error("Failed to remove host record from host - " + hostId, e);
         }
         try {
             agentDAO.deleteAllById(hostId);
         } catch (Exception e) {
             hasException = true;
-            LOG.error("Failed to remote host record " + hostId, e);
+            LOG.error("Failed to remove host record from agent - " + hostId, e);
         }
         try {
             hostTagDAO.deleteByHostId(hostId);
         } catch (Exception e) {
             hasException = true;
-            LOG.error("Failed to remote host record " + hostId, e);
+            LOG.error("Failed to remove host record from hostTag - " + hostId, e);
         }
         try {
             hostAgentDAO.delete(hostId);
         } catch (Exception e) {
             hasException = true;
-            LOG.error("Failed to remote host record " + hostId, e);
+            LOG.error("Failed to remove host record from hostAgent - " + hostId, e);
         }
 
         if (!hasException) {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/HostHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/HostHandler.java
@@ -25,14 +25,35 @@ public class HostHandler {
     }
 
     public void removeHost(String hostId) {
+        boolean hasException = false;
         try {
             hostDAO.deleteAllById(hostId);
-            agentDAO.deleteAllById(hostId);
-            hostTagDAO.deleteByHostId(hostId);
-            hostAgentDAO.delete(hostId);
-            LOG.info("Removed all records for the host {}", hostId);
         } catch (Exception e) {
-            LOG.error("Failed to remove all records for the host {}, exception: {}", hostId, e);
+            hasException = true;
+            LOG.error("Failed to remote host record " + hostId, e);
+        }
+        try {
+            agentDAO.deleteAllById(hostId);
+        } catch (Exception e) {
+            hasException = true;
+            LOG.error("Failed to remote host record " + hostId, e);
+        }
+        try {
+            hostTagDAO.deleteByHostId(hostId);
+        } catch (Exception e) {
+            hasException = true;
+            LOG.error("Failed to remote host record " + hostId, e);
+        }
+        try {
+            hostAgentDAO.delete(hostId);
+        } catch (Exception e) {
+            hasException = true;
+            LOG.error("Failed to remote host record " + hostId, e);
+        }
+
+        if (!hasException) {
+            LOG.info("Removed all records for host {}", hostId);
         }
     }
+
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/HostHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/HostHandler.java
@@ -27,12 +27,6 @@ public class HostHandler {
     public void removeHost(String hostId) {
         boolean hasException = false;
         try {
-            hostDAO.deleteAllById(hostId);
-        } catch (Exception e) {
-            hasException = true;
-            LOG.error("Failed to remove host record from host - " + hostId, e);
-        }
-        try {
             agentDAO.deleteAllById(hostId);
         } catch (Exception e) {
             hasException = true;
@@ -49,6 +43,12 @@ public class HostHandler {
         } catch (Exception e) {
             hasException = true;
             LOG.error("Failed to remove host record from hostAgent - " + hostId, e);
+        }
+        try {
+            hostDAO.deleteAllById(hostId);
+        } catch (Exception e) {
+            hasException = true;
+            LOG.error("Failed to remove host record from host - " + hostId, e);
         }
 
         if (!hasException) {

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/ConfigHelper.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/ConfigHelper.java
@@ -266,7 +266,7 @@ public class ConfigHelper {
                 ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
                 int minStaleHostThreshold = MapUtils.getIntValue(properties, "minStaleHostThreshold", DEFAULT_MIN_STALE_HOST_THRESHOLD);
                 int maxStaleHostThreshold = MapUtils.getIntValue(properties, "maxStaleHostThreshold", DEFAULT_MAX_STALE_HOST_THRESHOLD);
-                int maxLaunchLatencyThreshold = MapUtils.getIntValue(properties, "maxLaunchLaencyThreshold", DEFAULT_LAUNCH_LATENCY_THRESHOLD);
+                int maxLaunchLatencyThreshold = MapUtils.getIntValue(properties, "maxLaunchLatencyThreshold", DEFAULT_LAUNCH_LATENCY_THRESHOLD);
                 Runnable worker = new AgentJanitor(serviceContext, minStaleHostThreshold, maxStaleHostThreshold, maxLaunchLatencyThreshold);
                 scheduler.scheduleAtFixedRate(worker, initDelay, period, TimeUnit.SECONDS);
                 LOG.info("Scheduled AgentJanitor.");

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/ConfigHelper.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/ConfigHelper.java
@@ -91,7 +91,7 @@ public class ConfigHelper {
     private static final int DEFAULT_PERIOD = 30;
     private static final int DEFAULT_MAX_STALE_HOST_THRESHOLD = 600; // 10 mins
     private static final int DEFAULT_MIN_STALE_HOST_THRESHOLD = 150;
-    private static final int DEFAULT_LAUNCH_LATENCY_THRESHOLD = 2 * 3600; // 2 hours
+    private static final int DEFAULT_LAUNCH_LATENCY_THRESHOLD = 600;
     private static final String DEFAULT_DEPLOY_JANITOR_SCHEDULE = "0 30 3 * * ?";
     private static final String DEFAULT_BUILD_JANITOR_SCHEDULE = "0 40 3 * * ?";
     private static final int DEFAULT_MAX_DAYS_TO_KEEP = 180;

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/ConfigHelper.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/ConfigHelper.java
@@ -89,9 +89,9 @@ import java.util.concurrent.TimeUnit;
 public class ConfigHelper {
     private static final Logger LOG = LoggerFactory.getLogger(ConfigHelper.class);
     private static final int DEFAULT_PERIOD = 30;
-    private static final int DEFAULT_MAX_STALE_HOST_THRESHOLD = 600; // 10 mins
-    private static final int DEFAULT_MIN_STALE_HOST_THRESHOLD = 150;
-    private static final int DEFAULT_LAUNCH_LATENCY_THRESHOLD = 600;
+    private static final int DEFAULT_MAX_STALE_HOST_THRESHOLD_SECONDS = 600; // 10 min
+    private static final int DEFAULT_MIN_STALE_HOST_THRESHOLD_SECONDS = 150; // 2.5 min
+    private static final int DEFAULT_LAUNCH_LATENCY_THRESHOLD_SECONDS = 600;
     private static final String DEFAULT_DEPLOY_JANITOR_SCHEDULE = "0 30 3 * * ?";
     private static final String DEFAULT_BUILD_JANITOR_SCHEDULE = "0 40 3 * * ?";
     private static final int DEFAULT_MAX_DAYS_TO_KEEP = 180;
@@ -255,8 +255,10 @@ public class ConfigHelper {
 
             if (workerName.equalsIgnoreCase(SimpleAgentJanitor.class.getSimpleName())) {
                 ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
-                int minStaleHostThreshold = MapUtils.getIntValue(properties, "minStaleHostThreshold", DEFAULT_MIN_STALE_HOST_THRESHOLD);
-                int maxStaleHostThreshold = MapUtils.getIntValue(properties, "maxStaleHostThreshold", DEFAULT_MAX_STALE_HOST_THRESHOLD);
+                int minStaleHostThreshold = MapUtils.getIntValue(properties, "minStaleHostThreshold",
+                        DEFAULT_MIN_STALE_HOST_THRESHOLD_SECONDS);
+                int maxStaleHostThreshold = MapUtils.getIntValue(properties,
+                        "maxStaleHostThreshold", DEFAULT_MAX_STALE_HOST_THRESHOLD_SECONDS);
                 Runnable worker = new SimpleAgentJanitor(serviceContext, minStaleHostThreshold, maxStaleHostThreshold);
                 scheduler.scheduleAtFixedRate(worker, initDelay, period, TimeUnit.SECONDS);
                 LOG.info("Scheduled SimpleAgentJanitor.");
@@ -264,9 +266,12 @@ public class ConfigHelper {
 
             if (workerName.equalsIgnoreCase(AgentJanitor.class.getSimpleName())) {
                 ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
-                int minStaleHostThreshold = MapUtils.getIntValue(properties, "minStaleHostThreshold", DEFAULT_MIN_STALE_HOST_THRESHOLD);
-                int maxStaleHostThreshold = MapUtils.getIntValue(properties, "maxStaleHostThreshold", DEFAULT_MAX_STALE_HOST_THRESHOLD);
-                int maxLaunchLatencyThreshold = MapUtils.getIntValue(properties, "maxLaunchLatencyThreshold", DEFAULT_LAUNCH_LATENCY_THRESHOLD);
+                int minStaleHostThreshold = MapUtils.getIntValue(properties, "minStaleHostThreshold",
+                        DEFAULT_MIN_STALE_HOST_THRESHOLD_SECONDS);
+                int maxStaleHostThreshold = MapUtils.getIntValue(properties, "maxStaleHostThreshold",
+                        DEFAULT_MAX_STALE_HOST_THRESHOLD_SECONDS);
+                int maxLaunchLatencyThreshold = MapUtils.getIntValue(properties, "maxLaunchLatencyThreshold",
+                        DEFAULT_LAUNCH_LATENCY_THRESHOLD_SECONDS);
                 Runnable worker = new AgentJanitor(serviceContext, minStaleHostThreshold, maxStaleHostThreshold, maxLaunchLatencyThreshold);
                 scheduler.scheduleAtFixedRate(worker, initDelay, period, TimeUnit.SECONDS);
                 LOG.info("Scheduled AgentJanitor.");

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/ConfigHelper.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/ConfigHelper.java
@@ -91,7 +91,7 @@ public class ConfigHelper {
     private static final int DEFAULT_PERIOD = 30;
     private static final int DEFAULT_MAX_STALE_HOST_THRESHOLD = 600; // 10 mins
     private static final int DEFAULT_MIN_STALE_HOST_THRESHOLD = 150;
-    private static final int DEFAULT_LAUNCH_LATENCY_THRESHOLD = 600;
+    private static final int DEFAULT_LAUNCH_LATENCY_THRESHOLD = 2 * 3600; // 2 hours
     private static final String DEFAULT_DEPLOY_JANITOR_SCHEDULE = "0 30 3 * * ?";
     private static final String DEFAULT_BUILD_JANITOR_SCHEDULE = "0 40 3 * * ?";
     private static final int DEFAULT_MAX_DAYS_TO_KEEP = 180;

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AgentJanitor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AgentJanitor.java
@@ -169,7 +169,7 @@ public class AgentJanitor extends SimpleAgentJanitor {
             } else {
                 HostAgentBean hostAgent = staleHostMap.get(staleId);
                 if (isHostStale(hostAgent)) {
-                    LOG.warn("Agent ({}) is stale (not Pinning Teletraan), but the host termination state is unknown.",
+                    LOG.warn("Agent ({}) is stale (not Pinning Teletraan), but might be running.",
                             hostAgent);
                 }
             }
@@ -199,7 +199,7 @@ public class AgentJanitor extends SimpleAgentJanitor {
             if (terminatedHosts.contains(hostId)) {
                 removeStaleHost(hostId);
             } else {
-                LOG.warn("Agentless host {} termination state is unknown", hostId);
+                LOG.warn("Agentless host {} is stale but might be running", hostId);
             }
         }
     }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AgentJanitor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AgentJanitor.java
@@ -43,7 +43,7 @@ public class AgentJanitor extends SimpleAgentJanitor {
     private static final Logger LOG = LoggerFactory.getLogger(AgentJanitor.class);
     private final RodimusManager rodimusManager;
     private long maxLaunchLatencyThreshold;
-    private long absoluteThreshold = 2 * 7 * 24 * 3600 * 1000; // 2 weeks
+    private long absoluteThreshold = 24 * 3600 * 1000; // 1 day
     private int agentlessHostBatchSize = 300;
 
     public AgentJanitor(ServiceContext serviceContext, int minStaleHostThreshold,
@@ -184,9 +184,11 @@ public class AgentJanitor extends SimpleAgentJanitor {
      * Hosts may stuck in this state so we should clean up here.
      */
     private void cleanUpAgentlessHosts() {
+        long current_time = System.currentTimeMillis();
+        long noUpdateSince = current_time - absoluteThreshold;
         List<String> agentlessHosts;
         try {
-            agentlessHosts = hostDAO.getAgentlessHostIds(agentlessHostBatchSize);
+            agentlessHosts = hostDAO.getStaleAgentlessHostIds(noUpdateSince, agentlessHostBatchSize);
         } catch (SQLException ex) {
             LOG.error("failed to get agentless hosts", ex);
             return;

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AgentJanitor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AgentJanitor.java
@@ -33,7 +33,7 @@ import java.util.*;
  * Housekeeping on stuck and dead agents
  * <p>
  * if an agent has not ping server for certain time, we will cross check with
- * authoritive source to confirm if the host is terminated, and handle the agent
+ * authoritative source to confirm if the host is terminated, and handle the agent
  * status accordingly
  */
 public class AgentJanitor extends SimpleAgentJanitor {

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AgentJanitor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AgentJanitor.java
@@ -168,7 +168,7 @@ public class AgentJanitor extends SimpleAgentJanitor {
             } else {
                 HostAgentBean hostAgent = staleHostMap.get(staleId);
                 if (isHostStale(hostAgent)) {
-                    LOG.warn("Agent ({}) is stale (not Pinning Teletraan), but might be running.",
+                    LOG.warn("Agent ({}) is stale (not Pinging Teletraan), but might be running.",
                             hostAgent);
                 }
             }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/SimpleAgentJanitor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/SimpleAgentJanitor.java
@@ -60,7 +60,7 @@ public class SimpleAgentJanitor implements Runnable {
 
     // remove the stale host from db
     void removeStaleHost(String id) {
-        LOG.info(String.format("Delete records of stale host {}", id));
+        LOG.info("Delete records of stale host {}", id);
         hostHandler.removeHost(id);
     }
 

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/SimpleAgentJanitor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/SimpleAgentJanitor.java
@@ -61,11 +61,7 @@ public class SimpleAgentJanitor implements Runnable {
     // remove the stale host from db
     void removeStaleHost(String id) {
         LOG.info(String.format("Delete records of stale host {}", id));
-        try {
-            hostHandler.removeHost(id);
-        } catch (Exception e) {
-            LOG.error("Failed to delete all records for host {}. exception {}", id, e);
-        }
+        hostHandler.removeHost(id);
     }
 
     void markUnreachableHost(String id) {

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/SimpleAgentJanitor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/SimpleAgentJanitor.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *    
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,29 +15,28 @@
  */
 package com.pinterest.teletraan.worker;
 
-import com.pinterest.deployservice.ServiceContext;
-import com.pinterest.deployservice.bean.AgentBean;
-import com.pinterest.deployservice.bean.AgentState;
-import com.pinterest.deployservice.bean.HostBean;
-import com.pinterest.deployservice.bean.HostAgentBean;
-import com.pinterest.deployservice.bean.HostState;
-import com.pinterest.deployservice.common.Constants;
-import com.pinterest.deployservice.dao.AgentDAO;
-import com.pinterest.deployservice.dao.GroupDAO;
-import com.pinterest.deployservice.dao.HostDAO;
-import com.pinterest.deployservice.dao.HostAgentDAO;
-import com.pinterest.deployservice.handler.HostHandler;
-import org.apache.commons.collections.CollectionUtils;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import com.pinterest.deployservice.ServiceContext;
+import com.pinterest.deployservice.bean.AgentBean;
+import com.pinterest.deployservice.bean.AgentState;
+import com.pinterest.deployservice.bean.HostAgentBean;
+import com.pinterest.deployservice.dao.AgentDAO;
+import com.pinterest.deployservice.dao.HostAgentDAO;
+import com.pinterest.deployservice.dao.HostDAO;
+import com.pinterest.deployservice.handler.HostHandler;
 
 /**
  * Housekeeping on stuck and dead agents
  * <p>
  * if an agent has not ping server for certain time, we will cross check with
- * authoritive source to confirm if the host is terminated, and set agent status
+ * authoritative source to confirm if the host is terminated, and set agent status
  * accordingly
  */
 public class SimpleAgentJanitor implements Runnable {
@@ -45,17 +44,15 @@ public class SimpleAgentJanitor implements Runnable {
     private AgentDAO agentDAO;
     protected HostDAO hostDAO;
     protected HostAgentDAO hostAgentDAO;
-    private GroupDAO groupDAO;
     private HostHandler hostHandler;
     protected long maxStaleHostThreshold;
     protected long minStaleHostThreshold;
 
     public SimpleAgentJanitor(ServiceContext serviceContext, int minStaleHostThreshold,
-        int maxStaleHostThreshold) {
+            int maxStaleHostThreshold) {
         agentDAO = serviceContext.getAgentDAO();
         hostDAO = serviceContext.getHostDAO();
         hostAgentDAO = serviceContext.getHostAgentDAO();
-        groupDAO = serviceContext.getGroupDAO();
         hostHandler = new HostHandler(serviceContext);
         this.maxStaleHostThreshold = maxStaleHostThreshold * 1000;
         this.minStaleHostThreshold = minStaleHostThreshold * 1000;
@@ -94,7 +91,7 @@ public class SimpleAgentJanitor implements Runnable {
     }
 
     void processAllHosts() throws Exception {
-        LOG.info("Process explicite capacity hosts");
+        LOG.info("Process explicit capacity hosts");
         // If a host fails to ping for longer than max stale threshold,
         // then just remove it
         long current_time = System.currentTimeMillis();
@@ -105,8 +102,8 @@ public class SimpleAgentJanitor implements Runnable {
             maxStaleHostIds.add(host.getHost_id());
         }
         if (!maxStaleHostIds.isEmpty()) {
-            LOG.info("Found the following hosts (Explicite capacity) exceeded maxStaleThreshold: ",
-                maxStaleHostIds);
+            LOG.info("Found the following hosts (Explicit capacity) exceeded maxStaleThreshold: ",
+                    maxStaleHostIds);
             processStaleHosts(maxStaleHostIds, true);
         }
 
@@ -120,8 +117,8 @@ public class SimpleAgentJanitor implements Runnable {
             minStaleHostIds.add(host.getHost_id());
         }
         if (!minStaleHostIds.isEmpty()) {
-            LOG.info("Found following hosts (Explicite capacity) excceeded minStaleThreshold: ",
-                minStaleHostIds);
+            LOG.info("Found following hosts (Explicit capacity) exceeded minStaleThreshold: ",
+                    minStaleHostIds);
             processStaleHosts(minStaleHostIds, false);
         }
     }
@@ -129,11 +126,11 @@ public class SimpleAgentJanitor implements Runnable {
     @Override
     public void run() {
         try {
-            LOG.info("Start simple agent janitor process...");
+            LOG.info("Start agent janitor process...");
             processAllHosts();
         } catch (Throwable t) {
             // Catch all throwable so that subsequent job not suppressed
-            LOG.error("SimpleAgentJanitor Failed.", t);
+            LOG.error("AgentJanitor Failed.", t);
         }
     }
 }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/SimpleAgentJanitor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/SimpleAgentJanitor.java
@@ -59,7 +59,7 @@ public class SimpleAgentJanitor implements Runnable {
     }
 
     // remove the stale host from db
-    void removeStaleHost(String id) throws Exception {
+    void removeStaleHost(String id) {
         LOG.info(String.format("Delete records of stale host {}", id));
         try {
             hostHandler.removeHost(id);
@@ -68,7 +68,7 @@ public class SimpleAgentJanitor implements Runnable {
         }
     }
 
-    void markUnreachableHost(String id) throws Exception {
+    void markUnreachableHost(String id) {
         try {
             // mark the agent as unreachable
             AgentBean updateBean = new AgentBean();


### PR DESCRIPTION
## Problems
1. AgentJanitor cleans up based on the agents_and_hosts table, but it's not complete. There are hosts that' never had an agent. So it should look at the hosts table as well. 
2. The order of processing was wrong. Stale hosts should be a subset of unreachable hosts. The current implementation processes unreachable hosts first then stale hosts. This can result in stale hosts being processed twice. 

## Improvements
Now the `AgentJanitor` does 3 things:
1. `processStaleHosts();`
2. `determineStaleHostCandidates();`
3. `cleanUpAgentlessHosts();`

The first 2 remain the same, except the order has been swapped. This resolves problem 2. The third task solves problem 1.

###  cleanUpAgentlessHosts
This method queries the DB via the new API `HostDAO:getStaleAgentlessHostIds` to get a list of host IDs without associated agents. The list is filtered by `last_update` so only stale hosts will be process. 

```SQL
SELECT DISTINCT
    hosts.host_id
FROM
    hosts
    LEFT JOIN hosts_and_agents ON hosts.host_id = hosts_and_agents.host_id
WHERE
    hosts.last_update < ?
    AND hosts_and_agents.host_id IS NULL
ORDER BY
    hosts.last_update DESC
LIMIT
    ?
```

## Tests and validations
Deployed to dev1 and manually validated the status by reviewing corresponding logs. 

CDP-6636