### PR TITLE
Use old lock file if it exists

### DIFF
--- a/deploy-agent/deployd/__init__.py
+++ b/deploy-agent/deployd/__init__.py
@@ -26,4 +26,4 @@ STATSBOARD_URL=os.getenv('STATSBOARD_URL', "https://statsboard.pinadmin.com/api/
 # 2: puppet applied successfully with changes
 PUPPET_SUCCESS_EXIT_CODES = [0, 2]
 	
-__version__ = '1.2.43'
+__version__ = '1.2.44'

--- a/deploy-agent/deployd/common/single_instance.py
+++ b/deploy-agent/deployd/common/single_instance.py
@@ -21,7 +21,7 @@ import errno
 import fcntl
 from . import utils
 from future.utils import PY3
-
+import tempfile
 log = logging.getLogger(__name__)
 LOCKFILE_DIR = '/var/lock'
 
@@ -32,7 +32,13 @@ class SingleInstance(object):
         appname = 'deploy-agent'
         lockfile_name = '.{}.lock'.format(appname)
         self._create_lock_dir()
-        lockfile_path = os.path.join(LOCKFILE_DIR, lockfile_name)
+        # Backward compatibility as old deploy agent versions use lock file in /tmp. 
+        # Use the old lock file if it exists 
+        tmp_lockfile_path = os.path.join(tempfile.gettempdir(), lockfile_name)
+        if os.path.exists(tmp_lockfile_path):
+            lockfile_path = tmp_lockfile_path
+        else: 
+            lockfile_path = os.path.join(LOCKFILE_DIR, lockfile_name)
         lockfile_flags = os.O_WRONLY | os.O_CREAT
         # This is 0o222, i.e. 146, --w--w--w-
         lockfile_mode = stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH
@@ -49,7 +55,7 @@ class SingleInstance(object):
             fcntl.lockf(lockfile_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
         except IOError:
             log.error(('Error: {0} may already be running. Only one instance of it '
-                   'can run at a time.').format(appname))
+                       'can run at a time.').format(appname))
             # noinspection PyTypeChecker
             os.close(lockfile_fd)
             utils.exit_abruptly(1)


### PR DESCRIPTION
## Summary 
Previous versions of deploy agent used /tmp/ as the lock dir and recently we changed to /var/lock. We need an additional logic for use the existing lock file in old hosts. New hosts will use the new lock file in /var/lock instead. The old file will be removed entirely when all hosts will be using new AMIs. 

## Test Plan 
Run locally when there is lock file in /tmp 
```
INFO: Running command line: bazel-bin/deployd/deploy-agent
/tmp/.deploy-agent.lock
anhn@dev-anhn ~/code/teletraan/deploy-agent (anhn/keep-same-lock) $bazel run deployd/deploy-agent 
INFO: Analyzed target //deployd:deploy-agent (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //deployd:deploy-agent up-to-date:
  bazel-bin/deployd/deploy-agent
INFO: Elapsed time: 0.150s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/deployd/deploy-agent
/tmp/.deploy-agent.lock
Error: deploy-agent may already be running. Only one instance of it can run at a time.
```
When there is no lock file in /tmp 
```
NFO: Found 1 target...
Target //deployd:deploy-agent up-to-date:
  bazel-bin/deployd/deploy-agent
INFO: Elapsed time: 0.066s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/deployd/deploy-agent
/var/lock/.deploy-agent.lock
Error: deploy-agent may already be running. Only one instance of it can run at a time.
```
