### PR TITLE
change API cosume type to be json for external alert trigger

### DIFF
--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvAlerts.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvAlerts.java
@@ -62,7 +62,7 @@ import javax.ws.rs.core.UriInfo;
 @Path("/v1/envs/{envName : [a-zA-Z0-9\\-_]+}/{stageName : [a-zA-Z0-9\\-_]+}/alerts")
 @Api("ExternalAlerts")
 @Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+@Consumes(MediaType.APPLICATION_JSON)
 public class EnvAlerts {
 
   private static final Logger LOG = LoggerFactory.getLogger(EnvWebHooks.class);


### PR DESCRIPTION
I am not sure why there is an exception in an API in this file which is consuming media type APPLICATION_FORM_URLENCODED. I checked all consume media types in this repo, they are all APPLICATION_JSON.
So, updated the type to be json.
Related Jira ticket: https://jira.pinadmin.com/browse/CDP-6820 