### PR TITLE
return bad request to customers if the http response code starts with 4

### DIFF
--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/exception/GenericExceptionMapper.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/exception/GenericExceptionMapper.java
@@ -51,7 +51,7 @@ public class GenericExceptionMapper implements ExceptionMapper<Throwable> {
                 final Response response = ((WebApplicationException) t).getResponse();
                 Response.Status.Family family = response.getStatusInfo().getFamily();
                 if (family.equals(Response.Status.Family.CLIENT_ERROR)) {
-                    return Response.status(Response.Status.BAD_REQUEST).entity(sb.toString()).build();
+                    return Response.status(response.getStatus()).entity(sb.toString()).build();
                 } else {
                     return Response.serverError().entity(sb.toString()).build();
                 }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/exception/GenericExceptionMapper.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/exception/GenericExceptionMapper.java
@@ -48,7 +48,9 @@ public class GenericExceptionMapper implements ExceptionMapper<Throwable> {
                 PrintWriter pw = new PrintWriter(sw);
                 t.printStackTrace(pw);
                 sb.append("\n").append(sw.toString());
-                if (t.getMessage().contains("HTTP 4")) {
+                final Response response = ((WebApplicationException) t).getResponse();
+                Response.Status.Family family = response.getStatusInfo().getFamily();
+                if (family.equals(Response.Status.Family.CLIENT_ERROR)) {
                     return Response.status(Response.Status.BAD_REQUEST).entity(sb.toString()).build();
                 } else {
                     return Response.serverError().entity(sb.toString()).build();

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/exception/GenericExceptionMapper.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/exception/GenericExceptionMapper.java
@@ -48,7 +48,11 @@ public class GenericExceptionMapper implements ExceptionMapper<Throwable> {
                 PrintWriter pw = new PrintWriter(sw);
                 t.printStackTrace(pw);
                 sb.append("\n").append(sw.toString());
-                return Response.serverError().entity(sb.toString()).build();
+                if (t.getMessage().contains("HTTP 4")) {
+                    return Response.status(Response.Status.BAD_REQUEST).entity(sb.toString()).build();
+                } else {
+                    return Response.serverError().entity(sb.toString()).build();
+                }
             }
         } else if (t instanceof ConstraintViolationException) {
             StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
For WebApplicationException, there are exceptions caused by clients. So, we check the http code to figure out if we should return bad request to customers or internal server error to them.
In this link https://dennis-xlc.gitbooks.io/restful-java-with-jax-rs-2-0-2rd-edition/content/en/part1/chapter7/exception_handling.html, there are details:
<img width="747" alt="Screenshot 2023-07-20 at 4 54 50 PM" src="https://github.com/pinterest/teletraan/assets/42289525/1e91470b-2742-4b1d-8fab-f0a1e87f8a7f">
