### PR TITLE
Update Health check alerts in Teletraan with Runbook info

### DIFF
--- a/deploy-board/deploy_board/templates/base.html
+++ b/deploy-board/deploy_board/templates/base.html
@@ -39,7 +39,7 @@
 <!-- Placed at the end of the document so the pages load faster (but it does not work ) -->
 <script src="{% static "js/jquery-1.11.1.min.js" %}"></script>
 <script src="{% static "js/bootstrap.min.js" %}"></script>
-<script src="{% static "js/deploy-board.js"%}?changedate=2022.12.06.150000"></script>
+<script src="{% static "js/deploy-board.js"%}?changedate=2023.07.26.150000"></script>
 <script src="{% static "js/fuelux.min.js" %}"></script>
 <script src="{% static "js/typeahead.bundle.min.js" %}"></script>
 <script src="{% static "js/star-rating.min.js" %}"></script>

--- a/deploy-board/deploy_board/templates/base.html
+++ b/deploy-board/deploy_board/templates/base.html
@@ -39,7 +39,7 @@
 <!-- Placed at the end of the document so the pages load faster (but it does not work ) -->
 <script src="{% static "js/jquery-1.11.1.min.js" %}"></script>
 <script src="{% static "js/bootstrap.min.js" %}"></script>
-<script src="{% static "js/deploy-board.js"%}?changedate=2023.07.26.150000"></script>
+<script src="{% static "js/deploy-board.js"%}?changedate=2022.12.06.150000"></script>
 <script src="{% static "js/fuelux.min.js" %}"></script>
 <script src="{% static "js/typeahead.bundle.min.js" %}"></script>
 <script src="{% static "js/star-rating.min.js" %}"></script>

--- a/deploy-board/deploy_board/templates/groups/group_config.tmpl
+++ b/deploy-board/deploy_board/templates/groups/group_config.tmpl
@@ -210,7 +210,7 @@
                             <input class="form-control" id="runbook_link" name="runbook_link" required="false"
                                 type="text" value="{{ config.runbookLink |default_if_none:'' }}"/>
                             <span class="input-group-btn">
-                                <button id="runbookExpressionId" class="deployToolTip btn btn-default"
+                                <button id="runbooklinkExpressionId" class="deployToolTip btn btn-default"
                                         type="button" data-toggle="tooltip"
                                         title="click for more information on the runbook link">
                                     <span class="glyphicon glyphicon-question-sign"></span>
@@ -225,6 +225,13 @@
                         <div class="col-xs-10">
                         Please enter the load balancers you would like to attach to this group seperated by commas.
                         </div>
+                </div>
+                <div class="form-group collapse" id="runbooklinkExpressionDetailsId">
+                    <div class="col-xs-8">
+                    </div>
+                    <div class="col-xs-4">
+                    Please enter the runbook link that you would like to attach to health check failure messages.
+                    </div>
                 </div>
                 <div class="form-group">
                     <label for="target_groups" class="deployToolTip control-label col-xs-2"

--- a/deploy-board/deploy_board/templates/groups/group_config.tmpl
+++ b/deploy-board/deploy_board/templates/groups/group_config.tmpl
@@ -200,6 +200,24 @@
                             </span>
                         </div>
                     </div>
+                    <label for="runbook_link" class="deployToolTip control-label col-xs-2"
+                        data-toggle="tooltip"
+                        title="Enter the link to the runbook need for any any healthcheck failure alerts">
+                        Runbook Link
+                    </label>
+                    <div class="col-xs-4">
+                        <div class="input-group">
+                            <input class="form-control" id="runbook_link" name="runbook_link" required="false"
+                                type="text" value="{{ config.runbookLink |default_if_none:'' }}"/>
+                            <span class="input-group-btn">
+                                <button id="runbookExpressionId" class="deployToolTip btn btn-default"
+                                        type="button" data-toggle="tooltip"
+                                        title="click for more information on the runbook link">
+                                    <span class="glyphicon glyphicon-question-sign"></span>
+                                </button>
+                            </span>
+                        </div>
+                    </div>
                 </div>
                 <div class="form-group collapse" id="loadbalancersExpressionDetailsId">
                         <div class="col-xs-2">
@@ -338,6 +356,9 @@
         });
         $("#targetgroupsExpressionId").click(function() {
             $("#targetgroupsExpressionDetailsId").collapse('toggle');
+        });
+        $("#runbooklinkExpressionId").click(function() {
+            $("#runbooklinkExpressionDetailsId").collapse('toggle');
         });
     });
 </script>

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -49,26 +49,26 @@ def group_landing(request):
         "disablePrevious": index <= 1,
         "disableNext": len(group_names) < DEFAULT_PAGE_SIZE,
     })
-    
+
 
 def get_group_names(request):
     index = int(request.GET.get('page_index', '1'))
     size = int(request.GET.get('page_size', DEFAULT_PAGE_SIZE))
     group_names = autoscaling_groups_helper.get_env_group_names(request, index, size)
     return HttpResponse(json.dumps(group_names), content_type="application/json")
-    
-    
+
+
 def search_groups(request, group_name):
     index = int(request.GET.get('page_index', '1'))
     size = int(request.GET.get('page_size', DEFAULT_PAGE_SIZE))
     group_names = autoscaling_groups_helper.get_env_group_names(request, index, size, name_filter=group_name)
-    
+
     if not group_names:
         return redirect('/groups/')
 
     if len(group_names) == 1:
         return redirect('/groups/%s/' % group_names[0])
-    
+
     return render(request, 'groups/group_landing.html', {
     "group_names": group_names,
     "pageIndex": index,
@@ -76,7 +76,7 @@ def search_groups(request, group_name):
     "disablePrevious": index <= 1,
     "disableNext": len(group_names) < DEFAULT_PAGE_SIZE,
     })
-    
+
 
 def get_system_specs(request):
     instance_types = specs_helper.get_instance_types(request)
@@ -265,6 +265,7 @@ def update_group_config(request, group_name):
         groupRequest["launchLatencyTh"] = int(params["launch_latency_th"]) * 60
         groupRequest["loadBalancers"] = params.get("load_balancers")
         groupRequest["targetGroups"] = params.get("target_groups")
+        groupRequest["runbookLink"] = params.get("runbook_link")
 
         if "healthcheck_state" in params:
             groupRequest["healthcheckState"] = True
@@ -1269,9 +1270,9 @@ def disable_scaling_down_event(request, group_name):
 
 def add_scheduled_actions(request, group_name):
     params = request.POST
-    
+
     # validate scheduled capacity against ASG config minimum and maximum size
-    asg_summary = autoscaling_groups_helper.get_autoscaling_summary(request, group_name) 
+    asg_summary = autoscaling_groups_helper.get_autoscaling_summary(request, group_name)
     asg_minsize = int(asg_summary.get("minSize", -1))
     asg_maxsize = int(asg_summary.get("maxSize", -1)) # invalid value indicates no need to check
 
@@ -1286,7 +1287,7 @@ def add_scheduled_actions(request, group_name):
         schedule_action['clusterName'] = group_name
         schedule_action['schedule'] = params['schedule']
         schedule_action['capacity'] = params['capacity']
-       
+
         autoscaling_groups_helper.add_scheduled_actions(request, group_name, [schedule_action])
     except:
         log.error(traceback.format_exc())
@@ -1335,8 +1336,8 @@ def update_scheduled_actions(request, group_name):
     except:
         log.error(traceback.format_exc())
         return HttpResponse(json.dumps({'content': ""}), content_type="application/json")
-        
-        
+
+
 def get_terminating_hosts_by_group(request, group_name):
     data = groups_helper.get_terminating_by_group(request, group_name)
     return HttpResponse(json.dumps(data), content_type="application/json")


### PR DESCRIPTION
This PR is being submitted to provide a way for Teletraan operators to configure additional oncall information in the form of a runbook link for health check alerts.

Test Plan:
1. Navigate to the Group Configuration page for a cluster
2. Confirm that the group has Runbook Link blank in the UI and in the DB
<img width="2220" alt="Screenshot_2023-07-24_at_10_24_19_AM" src="https://github.com/pinterest/teletraan/assets/69278532/e3dd80ff-9e5e-409d-a689-e3eabdcfac04">
<img width="658" alt="Screenshot_2023-07-24_at_10_24_33_AM" src="https://github.com/pinterest/teletraan/assets/69278532/129cb60a-31b5-4150-b272-a97547df8421">


3. Create a health check that will eventually timeout

4. Confirm that the Email received is formatted correctly without the runbook link
<img width="1861" alt="Screenshot_2023-07-24_at_10_15_38_AM" src="https://github.com/pinterest/teletraan/assets/69278532/2b337b60-6914-4c66-a1fa-8bee798ce40d">



6. Populate the Runbook Link in the UI

7. Confirm that the Link is populated in the UI and DB
<img width="2213" alt="Screenshot_2023-07-24_at_10_22_16_AM" src="https://github.com/pinterest/teletraan/assets/69278532/37a8e223-ebda-4efc-8b2b-5b65f4ae6c34">

<img width="889" alt="Screenshot_2023-07-24_at_10_22_48_AM" src="https://github.com/pinterest/teletraan/assets/69278532/c88a4f61-a3ad-4cf0-be2e-ada759432c85">


8. Create a health check that will eventually timeout

9. Confirm that the Email received is formatted correctly without the runbook link

<img width="1852" alt="Screenshot_2023-07-24_at_10_15_50_AM" src="https://github.com/pinterest/teletraan/assets/69278532/751c1935-76f7-4538-84c5-4e6094997681">
