### PR TITLE
ping a user or group in slack channel

### DIFF
--- a/deploy-board/deploy_board/templates/configs/env_config.tmpl
+++ b/deploy-board/deploy_board/templates/configs/env_config.tmpl
@@ -91,6 +91,31 @@
                                type="text" value="{{ env.chatroom |default_if_none:'' }}"
                                maxlength="128"/>
                     </div>
+
+                    <label for=mentionRecipients" class="deployToolTip control-label col-xs-2"
+                        data-toggle="tooltip"
+                        title="Ping slack user or slack user group in the chat rooms (slack channels), such as user1,userGroup2">
+                        Ping User or User Group
+                    </label>
+
+                    <div class="col-xs-4">
+                        <input class="form-control" name=mention_recipients" required="false"
+                               type="text" value="{{ env.mentionRecipients |default_if_none:'' }}"/>
+                    </div>                    
+                </div>
+                <div class="form-group">
+                    <label for="chatRecipients" class="deployToolTip control-label col-xs-2"
+                        data-toggle="tooltip"
+                        title="Chat user handles to send deploy notifies to, such as user1,user2">
+                        Chat Recipients
+                    </label>
+
+                    <div class="col-xs-4">
+                        <input class="form-control" name="watch_recipients" required="false"
+                               type="text" value="{{ env.watchRecipients |default_if_none:'' }}"/>
+                    </div>
+                </div>
+                <div>
                     <label for="notify" class="deployToolTip control-label col-xs-2"
                         data-toggle="tooltip"
                         title="Whether or not to notify commiters when deploy">
@@ -103,18 +128,6 @@
                     {% else %}
                         <input class="" id="notify_author" name="notify_author" type="checkbox" value="">
                     {% endif %}
-                    </div>
-                </div>
-                <div class="form-group">
-                    <label for="chatRecipients" class="deployToolTip control-label col-xs-2"
-                        data-toggle="tooltip"
-                        title="Chat user handles to send deploy notifies to, such as user1,user2">
-                        Chat Recipients
-                    </label>
-
-                    <div class="col-xs-4">
-                        <input class="form-control" name="watch_recipients" required="false"
-                               type="text" value="{{ env.watchRecipients |default_if_none:'' }}"/>
                     </div>
 
                     <label for="emailRecipients" class="deployToolTip control-label col-xs-2"

--- a/deploy-board/deploy_board/templates/configs/env_config.tmpl
+++ b/deploy-board/deploy_board/templates/configs/env_config.tmpl
@@ -99,7 +99,7 @@
                     </label>
 
                     <div class="col-xs-4">
-                        <input class="form-control" name=mention_recipients" required="false"
+                        <input class="form-control" name="mention_recipients" required="false"
                                type="text" value="{{ env.mentionRecipients |default_if_none:'' }}"/>
                     </div>                    
                 </div>

--- a/deploy-board/deploy_board/templates/configs/env_config.tmpl
+++ b/deploy-board/deploy_board/templates/configs/env_config.tmpl
@@ -92,7 +92,7 @@
                                maxlength="128"/>
                     </div>
 
-                    <label for=mentionRecipients" class="deployToolTip control-label col-xs-2"
+                    <label for="mentionRecipients" class="deployToolTip control-label col-xs-2"
                         data-toggle="tooltip"
                         title="Ping slack user or slack user group in the chat rooms (slack channels), such as user1,userGroup2">
                         Ping User or User Group

--- a/deploy-board/deploy_board/webapp/common.py
+++ b/deploy-board/deploy_board/webapp/common.py
@@ -183,6 +183,7 @@ def clone_from_stage_name(request, env_name, stage_name, from_env_name, from_sta
     new_data['emailRecipients'] = from_stage['emailRecipients']
     new_data['notifyAuthors'] = from_stage['notifyAuthors']
     new_data['watchRecipients'] = from_stage['watchRecipients']
+    new_data['mentionRecipients'] = from_stage['mentionRecipients']
     new_data['maxDeployNum'] = from_stage['maxDeployNum']
     new_data['maxDeployDay'] = from_stage['maxDeployDay']
     new_data['overridePolicy'] = from_stage['overridePolicy']

--- a/deploy-board/deploy_board/webapp/env_config_views.py
+++ b/deploy-board/deploy_board/webapp/env_config_views.py
@@ -94,6 +94,7 @@ class EnvConfigView(View):
         data["branch"] = query_dict["branch"]
         data["emailRecipients"] = query_dict["email_recipients"]
         data["watchRecipients"] = query_dict["watch_recipients"]
+        data["mentionRecipients"] = query_dict["mention_recipients"]
         data["maxDeployNum"] = int(query_dict["maxDeployNum"])
         data["maxDeployDay"] = int(query_dict["maxDeployDay"])
         data["maxParallelRp"] = int(query_dict["maxParallelRp"])

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironBean.java
@@ -144,6 +144,9 @@ public class EnvironBean implements Updatable, Serializable {
     @JsonProperty("watchRecipients")
     private String watch_recipients;
 
+    @JsonProperty("mentionRecipients")
+    private String mention_recipients;
+
     @JsonProperty("metricsConfigId")
     private String metrics_config_id;
 
@@ -418,6 +421,14 @@ public class EnvironBean implements Updatable, Serializable {
 
     public void setWatch_recipients(String watch_recipients) {
         this.watch_recipients = watch_recipients;
+    }
+
+    public String getMention_recipients() {
+        return mention_recipients;
+    }
+
+    public void setMention_recipients(String mention_recipients) {
+        this.mention_recipients = mention_recipients;
     }
 
     public String getMetrics_config_id() {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironBean.java
@@ -601,6 +601,7 @@ public class EnvironBean implements Updatable, Serializable {
         clause.addColumn("email_recipients", email_recipients);
         clause.addColumn("notify_authors", notify_authors);
         clause.addColumn("watch_recipients", watch_recipients);
+        clause.addColumn("mention_recipients", mention_recipients);
         clause.addColumn("metrics_config_id", metrics_config_id);
         clause.addColumn("alarm_config_id", alarm_config_id);
         clause.addColumn("webhooks_config_id", webhooks_config_id);

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/chat/SlackChatManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/chat/SlackChatManager.java
@@ -24,6 +24,8 @@ import com.slack.api.methods.response.users.UsersLookupByEmailResponse;
 import com.slack.api.methods.SlackApiException;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 
 public class SlackChatManager implements ChatManager {
     private static final Logger LOG = LoggerFactory.getLogger(SlackChatManager.class);

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/NotificationJob.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/NotificationJob.java
@@ -48,7 +48,7 @@ public final class NotificationJob implements Callable<Void> {
 
             if (!StringUtils.isEmpty(chatrooms)) {
                 LOG.info(String.format("Send message to %s", chatrooms));
-                commonHandler.sendChatMessage(Constants.SYSTEM_OPERATOR, chatrooms, message, "yellow");
+                commonHandler.sendChatMessage(Constants.SYSTEM_OPERATOR, chatrooms, message, "yellow", "");
             }
         } catch (Throwable t) {
             LOG.error(String.format("%s: Failed to send notifications.", subject), t);

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/CommonHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/CommonHandler.java
@@ -91,7 +91,7 @@ public class CommonHandler {
             }
 
             sendWatcherMessage(operator, envBean.getWatch_recipients(), message, color);
-            sendChatMessage(operator, envBean.getChatroom(), message, color);
+            sendChatMessage(operator, envBean.getChatroom(), message, color, envBean.getMention_recipients());
 
             if (state == DeployState.FAILING) {
                 String recipients = envBean.getEmail_recipients();
@@ -196,7 +196,7 @@ public class CommonHandler {
         }
     }
 
-    public void sendChatMessage(String from, String rooms, String message, String color) {
+    public void sendChatMessage(String from, String rooms, String message, String color, String recipients) {
         if (StringUtils.isEmpty(rooms)) {
             return;
         }
@@ -204,6 +204,12 @@ public class CommonHandler {
 
         for (String chatroom : chatrooms) {
             try {
+                if (!StringUtils.isEmpty(recipients)) {
+                    List<String> targets = Arrays.asList(recipients.split(","));
+                    for (String target : targets) {
+                        message = "<@" + target + "> " + message;
+                    }
+                }
                 chatManager.send(from, chatroom.trim(), message, color);
             } catch (Exception e) {
                 LOG.error(String.format("Failed to send message '%s' to chatroom %s", message, chatroom), e);

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
@@ -164,10 +164,10 @@ public class DeployHandler implements DeployHandlerInterface{
                     buildBean.getScm_commit_7(),
                     WebLink);
 
-                commonHandler.sendChatMessage(operator, envBean.getChatroom(), message, "yellow");
+                commonHandler.sendChatMessage(operator, envBean.getChatroom(), message, "yellow", envBean.getMention_recipients());
                 if (StringUtils.isNotEmpty(additionalMessage)) {
                     LOG.debug(String.format("Sending additional message: %s to chat", additionalMessage));
-                    commonHandler.sendChatMessage(operator, envBean.getChatroom(), additionalMessage, "yellow");
+                    commonHandler.sendChatMessage(operator, envBean.getChatroom(), additionalMessage, "yellow", envBean.getMention_recipients());
                 }
             } catch (Exception e) {
                 LOG.error("Failed to send start notification!", e);

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/HotfixStateTransitioner.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/HotfixStateTransitioner.java
@@ -230,10 +230,13 @@ public class HotfixStateTransitioner implements Runnable {
             // Send chat message
             List<EnvironBean> environBeans = environDAO.getByName(hotBean.getEnv_name());
             Set<String> chatroomSet = new HashSet<String>();
+            Set<String> mentionRecipientSet = new HashSet<String>();
             for (EnvironBean environBean : environBeans) {
                 chatroomSet.add(environBean.getChatroom());
+                mentionRecipientSet.add(environBean.getMention_recipients());
             }
             String chatrooms = StringUtils.join(chatroomSet, ",");
+            String mentionRecipients = StringUtils.join(mentionRecipientSet, ",");
             DeployBean deployBean = deployDAO.getById(hotBean.getBase_deploy());
             BuildBean buildBean = buildDAO.getById(deployBean.getBuild_id());
             String commit = buildBean.getScm_commit();
@@ -241,7 +244,7 @@ public class HotfixStateTransitioner implements Runnable {
             String branch = "hotfix_" + name;
             String message = name + " just created a hotfix in " + branch + " branch, and including commit(s) " +
                 hotBean.getCommits() + " on top of commit " + commit;
-            commonHandler.sendChatMessage(Constants.SYSTEM_OPERATOR, chatrooms, message, "yellow");
+            commonHandler.sendChatMessage(Constants.SYSTEM_OPERATOR, chatrooms, message, "yellow", mentionRecipients);
 
             LOG.info("Hotfix Id {} is finished and now in the SUCCEEDED state.", hotfixId);
         } else {


### PR DESCRIPTION
Added an UI field for this new feature.
Old UI:
<img width="1301" alt="Screenshot 2023-08-02 at 1 36 51 PM" src="https://github.com/pinterest/teletraan/assets/42289525/253a0edb-7b52-4697-81f0-2cf74383a7fe">
New UI:
<img width="1280" alt="Screenshot 2023-08-02 at 1 37 43 PM" src="https://github.com/pinterest/teletraan/assets/42289525/e18a2d34-1c0b-487b-a07e-f5768fe539fc">

Tested on dev1 ok. 
The field was saved successfully.
```
mysql> select chatroom, mention_recipients from environs where env_name="deploy-open-sentinel-dev1" and stage_name="test";
+--------------+--------------------+
| chatroom     | mention_recipients |
+--------------+--------------------+
| yaqinli_test | yaqinli            |
+--------------+--------------------+
1 row in set (0.01 sec)

mysql> 
```
<img width="1266" alt="Screenshot 2023-08-02 at 1 39 26 PM" src="https://github.com/pinterest/teletraan/assets/42289525/de12bdea-222b-45c8-a17d-c8810d4c71d4">

After restarting, the slack notification could not sent successfully since dev1 doesn't have the permission.
Checked the log, looks working:
```
yaqinli@engprod-teletraan-service-control-0a011879:/var/log/teletraan$ grep -r "slack post message" service.log
{"level":"DEBUG","logger":"com.pinterest.deployservice.chat.SlackChatManager","thread":"pool-3-thread-1","message":"slack post message: <@yaqinli> deploy-open-sentinel-dev1/test: restart of rsinha/deploy-sentinel-sleep/404da73 started. See details https://deploy-dev1.pinadmin.com/env/deploy-open-sentinel-dev1/test/deploy/. (Operated by: <@yaqinli>)","timestamp":"2023-08-02T20:22:06.282+0000"}
{"level":"DEBUG","logger":"com.pinterest.deployservice.chat.SlackChatManager","thread":"pool-3-thread-1","message":"slack post message: <@yaqinli> deploy-open-sentinel-dev1/test: restart of rsinha/deploy-sentinel-sleep/404da73 completed successfully. See details <https://deploy-dev1.pinadmin.com/env/deploy-open-sentinel-dev1/test/deploy/> (Operated by: <@yaqinli>)","timestamp":"2023-08-02T20:22:09.618+0000"}
yaqinli@engprod-teletraan-service-control-0a011879:/var/log/teletraan$ 
```

