### PR TITLE
Show aws account id on host detail UI

### DIFF
--- a/deploy-board/deploy_board/templates/hosts/host_details.html
+++ b/deploy-board/deploy_board/templates/hosts/host_details.html
@@ -58,7 +58,8 @@
 
 <div id="hostDetailId" class="collapse in panel-body table-responsive">
 <table class="table table-striped table-bordered table-condensed table-hover">
-    <tr>
+    <tr>  
+        <th class="col-lg-1">AWS Acccount Id</th>
         <th class="col-lg-1">Host Name</th>
         <th class="col-lg-2">Host Id</th>
         <th class="col-lg-2">Host Group</th>
@@ -69,6 +70,7 @@
     </tr>
     {% for host in hosts %}
     <tr class="{{ host.state|hostStateClass}}">
+        <td>{{ host.accountId }}</td>
         <td>{{ host.hostName }}</td>
         <td>{{ host.hostId }}</td>
         <td>{{ host.groupName }}</td>


### PR DESCRIPTION
Tested on dev1:
<img width="1662" alt="Screenshot 2023-08-17 at 5 14 03 PM" src="https://github.com/pinterest/teletraan/assets/42289525/236b6242-db63-425c-b078-4f706dbc3d40">
