### PR TITLE
backfill account id for existing hosts

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostDAO.java
@@ -75,4 +75,6 @@ public interface HostDAO {
     Collection<String> getFailedHostIdsByGroup(String groupName) throws Exception;
 
     Collection<String> getTerminatingHostIdsByGroup(String groupName) throws Exception;
+
+    String getAccountIdByHost(String hostName) throws Exception;
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostDAOImpl.java
@@ -70,6 +70,7 @@ public class DBHostDAOImpl implements HostDAO {
             "GROUP BY x.host_id HAVING count(*) = (SELECT count(*) FROM agents y WHERE y.host_id = x.host_id) ORDER BY host_id";
     private static final String GET_NEW_HOSTIDS_BY_GROUP = "SELECT DISTINCT host_id FROM hosts WHERE can_retire=0 AND group_name=? AND state not in (?,?,?)";
     private static final String GET_TERMINATING_HOST_IDS_BY_GROUP = "SELECT DISTINCT host_id FROM hosts WHERE state in (?, ?, ?) AND group_name=?";
+    private static final String GET_ACCOUNTID_BY_HOSTNAME = "SELECT DISTINCT account_id FROM hosts WHERE host_name=?";
 
     private BasicDataSource dataSource;
 
@@ -286,5 +287,11 @@ public class DBHostDAOImpl implements HostDAO {
         return new QueryRunner(dataSource).query(GET_TERMINATING_HOST_IDS_BY_GROUP,
         SingleResultSetHandlerFactory.<String>newListObjectHandler(), HostState.PENDING_TERMINATE.toString(),
                 HostState.TERMINATING.toString(), HostState.PENDING_TERMINATE_NO_REPLACE.toString(), groupName);
+    }
+
+    @Override
+    public String getAccountIdByHost(String hostName) throws Exception {
+        return new QueryRunner(dataSource).query(GET_ACCOUNTID_BY_HOSTNAME,
+                SingleResultSetHandlerFactory.<String>newObjectHandler(), hostName);
     }
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostDAOImpl.java
@@ -39,7 +39,7 @@ public class DBHostDAOImpl implements HostDAO {
             "LEFT JOIN agent_errors ON agents.host_name=agent_errors.host_name WHERE hosts.host_id=?";
     private static final String UPDATE_HOST_BY_ID = "UPDATE hosts SET %s WHERE host_id=?";
     private static final String INSERT_HOST_TEMPLATE = "INSERT INTO hosts SET %s ON DUPLICATE KEY UPDATE %s";
-    private static final String INSERT_UPDATE_TEMPLATE = "INSERT INTO hosts %s VALUES %s ON DUPLICATE KEY UPDATE ip=?, last_update=?, " +
+    private static final String INSERT_UPDATE_TEMPLATE = "INSERT INTO hosts %s VALUES %s ON DUPLICATE KEY UPDATE ip=?, last_update=?, account_id=?, " +
             "state=IF(state!='%s' AND state!='%s' AND state!='%s', VALUES(state), state), " +
             "host_name=CASE WHEN host_name IS NULL THEN ? WHEN host_name=host_id THEN ? ELSE host_name END, " +
             "ip=CASE WHEN ip IS NULL THEN ? ELSE ip END";
@@ -154,7 +154,7 @@ public class DBHostDAOImpl implements HostDAO {
         sb.setLength(sb.length() - 1);
         new QueryRunner(dataSource).update(String.format(INSERT_UPDATE_TEMPLATE, names, sb.toString(),
                 HostState.PENDING_TERMINATE.toString(), HostState.TERMINATING.toString(),
-                HostState.PENDING_TERMINATE_NO_REPLACE.toString()), ip, now, hostName, hostName, ip);
+                HostState.PENDING_TERMINATE_NO_REPLACE.toString()), ip, now, accountId, hostName, hostName, ip);
     }
 
     @Override

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
@@ -160,7 +160,10 @@ public class PingHandler {
             LOG.info("accountId:{}", accountId);
         }
         
-        if (groupsToAdd.size() > 0 || accountId != null && !accountId.equals(recordedAccountId)) {
+        if (groupsToAdd.size() > 0 || (accountId != null && (!accountId.equals(recordedAccountId)))) {
+            if (hostName.equals("engprod-teletraan-service-dev1-0a01dab5")) {
+                LOG.info("yaqin-test");
+            }
             hostDAO.insertOrUpdate(hostName, hostIp, hostId, HostState.ACTIVE.toString(), groups, accountId);
         }
         

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
@@ -145,7 +145,7 @@ public class PingHandler {
     // Keep host and group membership in sync
     void updateHosts(String hostName, String hostIp, String hostId, Set<String> groups, String accountId) throws Exception {
         Set<String> recordedGroups = new HashSet<String>(hostDAO.getGroupNamesByHost(hostName));
-        String recordedAccountId = new String(hostDAO.getAccountIdByHost(hostName));
+        String recordedAccountId = hostDAO.getAccountIdByHost(hostName);
 
         Set<String> groupsToAdd = new HashSet<String>();
         // Insert if not recorded

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
@@ -155,6 +155,11 @@ public class PingHandler {
                 groupsToAdd.add(group);
             }
         }
+        if (hostName.equals("engprod-teletraan-service-dev1-0a01dab5")) {
+            LOG.info("recordedAccountId:{}", recordedAccountId);
+            LOG.info("accountId:{}", accountId);
+        }
+        
         if (groupsToAdd.size() > 0 || accountId != null && !accountId.equals(recordedAccountId)) {
             hostDAO.insertOrUpdate(hostName, hostIp, hostId, HostState.ACTIVE.toString(), groups, accountId);
         }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
@@ -157,6 +157,8 @@ public class PingHandler {
             }
         }
         
+        // if it is the main account, don't update it to avoid huge updates for existing hosts
+        // only update sub account id for existing hosts
         if (groupsToAdd.size() > 0 || accountId != null && !accountId.equals(PINTEREST_MAIN_AWS_ACCOUNT) && !accountId.equals(recordedAccountId)) {
             hostDAO.insertOrUpdate(hostName, hostIp, hostId, HostState.ACTIVE.toString(), groups, accountId);
         }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
@@ -155,15 +155,8 @@ public class PingHandler {
                 groupsToAdd.add(group);
             }
         }
-        if (hostName.equals("engprod-teletraan-service-dev1-0a01dab5")) {
-            LOG.info("recordedAccountId:{}", recordedAccountId);
-            LOG.info("accountId:{}", accountId);
-        }
         
         if (groupsToAdd.size() > 0 || accountId != null && !accountId.equals(recordedAccountId)) {
-            if (hostName.equals("engprod-teletraan-service-dev1-0a01dab5")) {
-                LOG.info("yaqin-test");
-            }
             hostDAO.insertOrUpdate(hostName, hostIp, hostId, HostState.ACTIVE.toString(), groups, accountId);
         }
         

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
@@ -65,6 +65,7 @@ public class PingHandler {
     private static final Logger LOG = LoggerFactory.getLogger(PingHandler.class);
     private static final PingResponseBean NOOP;
     private static final Set<String> EMPTY_GROUPS;
+    private static final String PINTEREST_MAIN_AWS_ACCOUNT = "998131032990";
     //private static final long AGENT_COUNT_CACHE_TTL = 5 * 1000;
 
     static {
@@ -156,7 +157,7 @@ public class PingHandler {
             }
         }
         
-        if (groupsToAdd.size() > 0 || accountId != null && !accountId.equals(recordedAccountId)) {
+        if (groupsToAdd.size() > 0 || accountId != null && !accountId.equals(PINTEREST_MAIN_AWS_ACCOUNT) && !accountId.equals(recordedAccountId)) {
             hostDAO.insertOrUpdate(hostName, hostIp, hostId, HostState.ACTIVE.toString(), groups, accountId);
         }
         

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
@@ -145,6 +145,7 @@ public class PingHandler {
     // Keep host and group membership in sync
     void updateHosts(String hostName, String hostIp, String hostId, Set<String> groups, String accountId) throws Exception {
         Set<String> recordedGroups = new HashSet<String>(hostDAO.getGroupNamesByHost(hostName));
+        String recordedAccountId = new String(hostDAO.getAccountIdByHost(hostName));
 
         Set<String> groupsToAdd = new HashSet<String>();
         // Insert if not recorded
@@ -154,7 +155,7 @@ public class PingHandler {
                 groupsToAdd.add(group);
             }
         }
-        if (groupsToAdd.size() > 0) {
+        if (groupsToAdd.size() > 0 || accountId != null && !accountId.equals(recordedAccountId)) {
             hostDAO.insertOrUpdate(hostName, hostIp, hostId, HostState.ACTIVE.toString(), groups, accountId);
         }
         

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
@@ -160,7 +160,7 @@ public class PingHandler {
             LOG.info("accountId:{}", accountId);
         }
         
-        if (groupsToAdd.size() > 0 || (accountId != null && (!accountId.equals(recordedAccountId)))) {
+        if (groupsToAdd.size() > 0 || accountId != null && !accountId.equals(recordedAccountId)) {
             if (hostName.equals("engprod-teletraan-service-dev1-0a01dab5")) {
                 LOG.info("yaqin-test");
             }


### PR DESCRIPTION
Tested on dev1.
At the beginning, the host doesn't have any account info:
```
mysql> select * from hosts where host_name="engprod-teletraan-service-dev1-0a01dab5";
+-----------------------------------------+------------------------------------------------------+--------------+---------------+---------------+--------+---------------------+------------+------------+
| host_name                               | group_name                                           | ip           | create_date   | last_update   | state  | host_id             | can_retire | account_id |
+-----------------------------------------+------------------------------------------------------+--------------+---------------+---------------+--------+---------------------+------------+------------+
| engprod-teletraan-service-dev1-0a01dab5 | deploy-open-sentinel-dev1-test                       | 10.1.218.181 | 1691182995335 | 1692402457133 | ACTIVE | i-0ce811ae17e6c1b78 |          0 | NULL       |
| engprod-teletraan-service-dev1-0a01dab5 | deploy-open-sentinel-dev1-test-production-us-east-1e | 10.1.218.181 | 1691183562888 | 1692402457133 | ACTIVE | i-0ce811ae17e6c1b78 |          0 | NULL       |
| engprod-teletraan-service-dev1-0a01dab5 | envoy-sidecar                                        | 10.1.218.181 | 1691183562888 | 1692402457133 | ACTIVE | i-0ce811ae17e6c1b78 |          0 | NULL       |
| engprod-teletraan-service-dev1-0a01dab5 | envoy-sidecar-production-us-east-1e                  | 10.1.218.181 | 1691183562888 | 1692402457133 | ACTIVE | i-0ce811ae17e6c1b78 |          0 | NULL       |
| engprod-teletraan-service-dev1-0a01dab5 | mcrouter-prod-sidecar                                | 10.1.218.181 | 1691183562888 | 1692402457133 | ACTIVE | i-0ce811ae17e6c1b78 |          0 | NULL       |
| engprod-teletraan-service-dev1-0a01dab5 | mcrouter-prod-sidecar-production-us-east-1e          | 10.1.218.181 | 1691183562888 | 1692402457133 | ACTIVE | i-0ce811ae17e6c1b78 |          0 | NULL       |
| engprod-teletraan-service-dev1-0a01dab5 | metrics-agent-prod-sidecar                           | 10.1.218.181 | 1691183562888 | 1692402457133 | ACTIVE | i-0ce811ae17e6c1b78 |          0 | NULL       |
| engprod-teletraan-service-dev1-0a01dab5 | metrics-agent-prod-sidecar-production-us-east-1e     | 10.1.218.181 | 1691183562888 | 1692402457133 | ACTIVE | i-0ce811ae17e6c1b78 |          0 | NULL       |
| engprod-teletraan-service-dev1-0a01dab5 | singer-prod-sidecar                                  | 10.1.218.181 | 1691183562888 | 1692402457133 | ACTIVE | i-0ce811ae17e6c1b78 |          0 | NULL       |
| engprod-teletraan-service-dev1-0a01dab5 | singer-prod-sidecar-production-us-east-1e            | 10.1.218.181 | 1691183562888 | 1692402457133 | ACTIVE | i-0ce811ae17e6c1b78 |          0 | NULL       |
| engprod-teletraan-service-dev1-0a01dab5 | tcollector-prod-sidecar                              | 10.1.218.181 | 1691183562888 | 1692402457133 | ACTIVE | i-0ce811ae17e6c1b78 |          0 | NULL       |
| engprod-teletraan-service-dev1-0a01dab5 | tcollector-prod-sidecar-production-us-east-1e        | 10.1.218.181 | 1691183562888 | 1692402457133 | ACTIVE | i-0ce811ae17e6c1b78 |          0 | NULL       |
| engprod-teletraan-service-dev1-0a01dab5 | zk_update_monitor-prod-sidecar                       | 10.1.218.181 | 1691183562888 | 1692402457133 | ACTIVE | i-0ce811ae17e6c1b78 |          0 | NULL       |
| engprod-teletraan-service-dev1-0a01dab5 | zk_update_monitor-prod-sidecar-production-us-east-1e | 10.1.218.181 | 1691183562888 | 1692402457133 | ACTIVE | i-0ce811ae17e6c1b78 |          0 | NULL       |
+-----------------------------------------+------------------------------------------------------+--------------+---------------+---------------+--------+---------------------+------------+------------+
14 rows in set (0.00 sec)
```
And then I installed the latest deploy-agent on it:
```
yaqinli@engprod-teletraan-service-dev1-0a01dab5:~$ dpkg -l | grep deploy-agent-pex
ii  deploy-agent-pex                            1.2.40-pinterest-1.0.2                          amd64        Teletraan deploy-agent, built with PEX
yaqinli@engprod-teletraan-service-dev1-0a01dab5:~$ sudo apt-get install deploy-agent-pex
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following packages were automatically installed and are no longer required:
  bc libntfs-3g88 libopts25 pastebinit python3-attr python3-automat python3-click python3-constantly python3-httplib2 python3-hyperlink python3-incremental python3-newt python3-pam python3-problem-report
  python3-pyasn1-modules python3-requests-unixsocket python3-service-identity python3-systemd python3-twisted python3-twisted-bin python3-zope.interface run-one sntp
Use 'sudo apt autoremove' to remove them.
The following packages will be upgraded:
  deploy-agent-pex
1 upgraded, 0 newly installed, 0 to remove and 160 not upgraded.
Need to get 21.4 MB of archives.
After this operation, 1221 kB of additional disk space will be used.
Get:1 https://artifacts-deploy-prod-use1.pinadmin.com/artifactory/ubuntu-deb-apt-prod-local bionic/main amd64 deploy-agent-pex amd64 1.2.45-pinterest-1.0.2 [21.4 MB]
Fetched 21.4 MB in 0s (68.3 MB/s)     
(Reading database ... 143159 files and directories currently installed.)
Preparing to unpack .../deploy-agent-pex_1.2.45-pinterest-1.0.2_amd64.deb ...
Unpacking deploy-agent-pex (1.2.45-pinterest-1.0.2) over (1.2.40-pinterest-1.0.2) ...
Setting up deploy-agent-pex (1.2.45-pinterest-1.0.2) ...
yaqinli@engprod-teletraan-service-dev1-0a01dab5:~$ sudo pwrapper --disable 1d:test
pwrapper start: 2023-08-18 22:39:17 +0000
Creating disable file for pwrapper: /var/lock/pwrapper.disabled
metric agent error in posting operations.puppet_exit_status metric: Connection refused - connect(2) for "localhost" port 18126
metric agent error in posting operations.pwrapper.success_rate metric: Connection refused - connect(2) for "localhost" port 18126
metric agent error in posting operations.pwrapper.exit_code_by_repo_version metric: Connection refused - connect(2) for "localhost" port 18126
metric agent error in posting operations.pwrapper.ami_id metric: Connection refused - connect(2) for "localhost" port 18126
metric agent error in posting operations.pwrapper.cloud_init_pinterest_version metric: Connection refused - connect(2) for "localhost" port 18126
pwrapper disabled until 1692484757 (2023-08-19 22:39:17 +0000):
test

The pwrapper script is disabled from running, aborted.
yaqinli@engprod-teletraan-service-dev1-0a01dab5:~$
```
Finally, the account id is backfilled:
```
mysql> select * from hosts where host_name="engprod-teletraan-service-dev1-0a01dab5";
+-----------------------------------------+------------------------------------------------------+--------------+---------------+---------------+--------+---------------------+------------+--------------+
| host_name                               | group_name                                           | ip           | create_date   | last_update   | state  | host_id             | can_retire | account_id   |
+-----------------------------------------+------------------------------------------------------+--------------+---------------+---------------+--------+---------------------+------------+--------------+
| engprod-teletraan-service-dev1-0a01dab5 | deploy-open-sentinel-dev1-test                       | 10.1.218.181 | 1691182995335 | 1692402534855 | ACTIVE | i-0ce811ae17e6c1b78 |          0 | 998131032990 |
| engprod-teletraan-service-dev1-0a01dab5 | deploy-open-sentinel-dev1-test-production-us-east-1e | 10.1.218.181 | 1691183562888 | 1692402534855 | ACTIVE | i-0ce811ae17e6c1b78 |          0 | 998131032990 |
| engprod-teletraan-service-dev1-0a01dab5 | envoy-sidecar                                        | 10.1.218.181 | 1691183562888 | 1692402534855 | ACTIVE | i-0ce811ae17e6c1b78 |          0 | 998131032990 |
| engprod-teletraan-service-dev1-0a01dab5 | envoy-sidecar-production-us-east-1e                  | 10.1.218.181 | 1691183562888 | 1692402534855 | ACTIVE | i-0ce811ae17e6c1b78 |          0 | 998131032990 |
| engprod-teletraan-service-dev1-0a01dab5 | mcrouter-prod-sidecar                                | 10.1.218.181 | 1691183562888 | 1692402534855 | ACTIVE | i-0ce811ae17e6c1b78 |          0 | 998131032990 |
| engprod-teletraan-service-dev1-0a01dab5 | mcrouter-prod-sidecar-production-us-east-1e          | 10.1.218.181 | 1691183562888 | 1692402534855 | ACTIVE | i-0ce811ae17e6c1b78 |          0 | 998131032990 |
| engprod-teletraan-service-dev1-0a01dab5 | metrics-agent-prod-sidecar                           | 10.1.218.181 | 1691183562888 | 1692402534855 | ACTIVE | i-0ce811ae17e6c1b78 |          0 | 998131032990 |
| engprod-teletraan-service-dev1-0a01dab5 | metrics-agent-prod-sidecar-production-us-east-1e     | 10.1.218.181 | 1691183562888 | 1692402534855 | ACTIVE | i-0ce811ae17e6c1b78 |          0 | 998131032990 |
| engprod-teletraan-service-dev1-0a01dab5 | singer-prod-sidecar                                  | 10.1.218.181 | 1691183562888 | 1692402534855 | ACTIVE | i-0ce811ae17e6c1b78 |          0 | 998131032990 |
| engprod-teletraan-service-dev1-0a01dab5 | singer-prod-sidecar-production-us-east-1e            | 10.1.218.181 | 1691183562888 | 1692402534855 | ACTIVE | i-0ce811ae17e6c1b78 |          0 | 998131032990 |
| engprod-teletraan-service-dev1-0a01dab5 | tcollector-prod-sidecar                              | 10.1.218.181 | 1691183562888 | 1692402534855 | ACTIVE | i-0ce811ae17e6c1b78 |          0 | 998131032990 |
| engprod-teletraan-service-dev1-0a01dab5 | tcollector-prod-sidecar-production-us-east-1e        | 10.1.218.181 | 1691183562888 | 1692402534855 | ACTIVE | i-0ce811ae17e6c1b78 |          0 | 998131032990 |
| engprod-teletraan-service-dev1-0a01dab5 | zk_update_monitor-prod-sidecar                       | 10.1.218.181 | 1691183562888 | 1692402534855 | ACTIVE | i-0ce811ae17e6c1b78 |          0 | 998131032990 |
| engprod-teletraan-service-dev1-0a01dab5 | zk_update_monitor-prod-sidecar-production-us-east-1e | 10.1.218.181 | 1691183562888 | 1692402534855 | ACTIVE | i-0ce811ae17e6c1b78 |          0 | 998131032990 |
+-----------------------------------------+------------------------------------------------------+--------------+---------------+---------------+--------+---------------------+------------+--------------+
14 rows in set (0.00 sec)

```