### PR TITLE
Consider the situation that accountId is string null

### DIFF
--- a/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
@@ -23,7 +23,7 @@
                         <i class="fa fa-fw {{ agentStat | agentIcon }}"></i>
                         </a>
                         {% elif report.showMode == "primaryAcct" %}
-                        {% if not agentStat.agent.accountId or agentStat.agent.accountId == "998131032990" %}
+                        {% if not agentStat.agent.accountId or agentStat.agent.accountId == "998131032990" or agentStat.agent.accountId == "null" %}
                         <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
                         type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
                         title="{{ agentStat | agentTip }}">              
@@ -32,7 +32,7 @@
                         </a>
                         {% endif %}
                         {% elif report.showMode == "subAcct" %}
-                        {% if agentStat.agent.accountId and agentStat.agent.accountId != "998131032990" %}
+                        {% if agentStat.agent.accountId and agentStat.agent.accountId != "998131032990" and agentStat.agent.accountId != "null" %}
                         <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
                         type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
                         title="{{ agentStat | agentTip }}">              

--- a/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
@@ -58,7 +58,7 @@
                <i class="fa fa-fw {{ agentStat | agentIcon }}"></i>
                </a>
                {% elif report.showMode == "primaryAcct" %}
-               {% if not agentStat.agent.accountId or agentStat.agent.accountId == "998131032990" %}
+               {% if not agentStat.agent.accountId or agentStat.agent.accountId == "998131032990" or agentStat.agent.accountId == "null" %}
                <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
                type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
                title="{{ agentStat | agentTip }}">              
@@ -67,7 +67,7 @@
                </a>
                {% endif %}
                {% elif report.showMode == "subAcct" %}
-               {% if agentStat.agent.accountId and agentStat.agent.accountId != "998131032990" %}
+               {% if agentStat.agent.accountId and agentStat.agent.accountId != "998131032990" and agentStat.agent.accountId != "null" %}
                <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
                type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
                title="{{ agentStat | agentTip }}">              

--- a/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
@@ -23,7 +23,7 @@
                         <i class="fa fa-fw {{ agentStat | agentIcon }}"></i>
                         </a>
                         {% elif report.showMode == "primaryAcct" %}
-                        {% if not agentStat.agent.accountId or agentStat.agent.accountId == "998131032990" or agentStat.agent.accountId == "null" %}
+                        {% if not agentStat.agent.accountId or agentStat.agent.accountId == "998131032990" %}
                         <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
                         type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
                         title="{{ agentStat | agentTip }}">              
@@ -32,7 +32,7 @@
                         </a>
                         {% endif %}
                         {% elif report.showMode == "subAcct" %}
-                        {% if agentStat.agent.accountId and agentStat.agent.accountId != "998131032990" and agentStat.agent.accountId != "null" %}
+                        {% if agentStat.agent.accountId and agentStat.agent.accountId != "998131032990" %}
                         <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
                         type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
                         title="{{ agentStat | agentTip }}">              
@@ -58,7 +58,7 @@
                <i class="fa fa-fw {{ agentStat | agentIcon }}"></i>
                </a>
                {% elif report.showMode == "primaryAcct" %}
-               {% if not agentStat.agent.accountId or agentStat.agent.accountId == "998131032990" or agentStat.agent.accountId == "null" %}
+               {% if not agentStat.agent.accountId or agentStat.agent.accountId == "998131032990" %}
                <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
                type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
                title="{{ agentStat | agentTip }}">              
@@ -67,7 +67,7 @@
                </a>
                {% endif %}
                {% elif report.showMode == "subAcct" %}
-               {% if agentStat.agent.accountId and agentStat.agent.accountId != "998131032990" and agentStat.agent.accountId != "null" %}
+               {% if agentStat.agent.accountId and agentStat.agent.accountId != "998131032990" %}
                <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
                type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
                title="{{ agentStat | agentTip }}">              

--- a/deploy-board/deploy_board/templates/hosts/host_details.html
+++ b/deploy-board/deploy_board/templates/hosts/host_details.html
@@ -59,7 +59,7 @@
 <div id="hostDetailId" class="collapse in panel-body table-responsive">
 <table class="table table-striped table-bordered table-condensed table-hover">
     <tr>  
-        {% if account_id and account_id!="null" %}
+        {% if account_id and account_id != "null" %}
         <th class="col-lg-1">Acccount Id</th>
         {% endif %}
         <th class="col-lg-1">Host Name</th>
@@ -72,7 +72,7 @@
     </tr>
     {% for host in hosts %}
     <tr class="{{ host.state|hostStateClass}}">
-        {% if account_id and account_id!="null" %}
+        {% if account_id and account_id != "null" %}
         <td>{{ host.accountId }}</td>
         {% endif %}
         <td>{{ host.hostName }}</td>

--- a/deploy-board/deploy_board/templates/hosts/host_details.html
+++ b/deploy-board/deploy_board/templates/hosts/host_details.html
@@ -59,7 +59,7 @@
 <div id="hostDetailId" class="collapse in panel-body table-responsive">
 <table class="table table-striped table-bordered table-condensed table-hover">
     <tr>  
-        {% if account_id %}
+        {% if account_id and account_id!="null" %}
         <th class="col-lg-1">Acccount Id</th>
         {% endif %}
         <th class="col-lg-1">Host Name</th>
@@ -72,7 +72,7 @@
     </tr>
     {% for host in hosts %}
     <tr class="{{ host.state|hostStateClass}}">
-        {% if account_id %}
+        {% if account_id and account_id!="null" %}
         <td>{{ host.accountId }}</td>
         {% endif %}
         <td>{{ host.hostName }}</td>

--- a/deploy-board/deploy_board/webapp/agent_report.py
+++ b/deploy-board/deploy_board/webapp/agent_report.py
@@ -154,7 +154,7 @@ def gen_report(request, env, progress, sortByStatus="false"):
         accountIdMap[host['hostId']] = host['accountId']
 
     for agent in progress["agents"]:
-        agent['accountId'] = accountIdMap.get(agent['hostId'], "null")
+        agent['accountId'] = accountIdMap.get(agent['hostId'])
         if agent["firstDeploy"]:
             firstTimeAgentStats.append(addToEnvReport(request, deployStats, agent, env))
         else:

--- a/deploy-board/deploy_board/webapp/agent_report.py
+++ b/deploy-board/deploy_board/webapp/agent_report.py
@@ -154,7 +154,7 @@ def gen_report(request, env, progress, sortByStatus="false"):
         accountIdMap[host['hostId']] = host['accountId']
 
     for agent in progress["agents"]:
-        agent['accountId'] = accountIdMap[agent['hostId']]
+        agent['accountId'] = accountIdMap.get(agent['hostId'], "null")
         if agent["firstDeploy"]:
             firstTimeAgentStats.append(addToEnvReport(request, deployStats, agent, env))
         else:


### PR DESCRIPTION
The account id is default to be NULL in the database. When a new host is up, if the account is not a sub account, it will be updated as string "null".
This PR fixed two issues:
if a new host is updated the account_id as “null” , it still shows the column on UI;
if a host in the agents table but not in hosts table, we got error on UI.