### PR TITLE
Use the old deploy status metric

### DIFF
--- a/deploy-agent/deployd/agent.py
+++ b/deploy-agent/deployd/agent.py
@@ -112,7 +112,7 @@ class DeployAgent(object):
         if deploy_report.status_code:
             tags['status_code'] = deploy_report.status_code
             
-        create_sc_increment('deployd.stats.deploy.status', tags=tags)
+        create_sc_increment('deployd.stats.deploy.status.sum', tags=tags)
         
     def serve_build(self):
         """This is the main function of the ``DeployAgent``.

--- a/deploy-agent/tests/unit/deploy/server/test_agent.py
+++ b/deploy-agent/tests/unit/deploy/server/test_agent.py
@@ -513,7 +513,7 @@ class TestDeployAgent(TestCase):
         agent = DeployAgent(client=client, estatus=estatus, conf=self.config,
                             executor=self.executor, helper=self.helper)
         agent.serve_build()
-        mock_create_sc.assert_called_once_with('deployd.stats.deploy.status', tags={
+        mock_create_sc.assert_called_once_with('deployd.stats.deploy.status.sum', tags={
                                                'first_run': False, 'deploy_stage': 'PRE_DOWNLOAD', 'env_name': 'abc', 'stage_name': 'beta', 'status_code': 'SUCCEEDED'})
         self.assertEqual(agent._curr_report.report.deployStage, DeployStage.PRE_DOWNLOAD)
         self.assertEqual(agent._curr_report.report.status, AgentStatus.SUCCEEDED)

--- a/deploy-agent/tox.ini
+++ b/deploy-agent/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py36,py37,py38,py39
+envlist=py36,py38
 recreate=True
 
 [flake8]
@@ -13,6 +13,5 @@ commands=py.test --cov=deployd {posargs}
 [gh-actions]
 python =
     3.6: py36
-    3.7: py37
     3.8: py38
-    3.9: py39
+    


### PR DESCRIPTION
### Summary
Added the postfix `.sum` which was mistakenly removed before so that we can monitor errors across versions in a single dashboard. 
### Test plan 
https://statsboard.pinadmin.com/share/633tq
