### PR TITLE
remove max parallel replacement from UI

### DIFF
--- a/deploy-board/deploy_board/templates/configs/env_config.tmpl
+++ b/deploy-board/deploy_board/templates/configs/env_config.tmpl
@@ -210,18 +210,6 @@
                             {% endfor %}
                         </select>
                     </div>
-
-                    <label for="maxParallelRp" class="deployToolTip control-label col-xs-2"
-                        data-toggle="tooltip"
-                        title="Maximum number of hosts are allowed to be replaced at the same time
-                        when doing cluster upgrading">
-                        Maximum Replaceable Host
-                    </label>
-
-                    <div class="col-xs-4">
-                        <input class="form-control" name="maxParallelRp" required="true"
-                               type="text" value="{{ env.maxParallelRp }}"/>
-                    </div>
                 </div>
                 <div class="form-group">
                     <label for="overridePolicy" class="deployToolTip control-label col-xs-2"

--- a/deploy-board/deploy_board/webapp/env_config_views.py
+++ b/deploy-board/deploy_board/webapp/env_config_views.py
@@ -97,7 +97,6 @@ class EnvConfigView(View):
         data["groupMentionRecipients"] = query_dict["group_mention_recipients"]
         data["maxDeployNum"] = int(query_dict["maxDeployNum"])
         data["maxDeployDay"] = int(query_dict["maxDeployDay"])
-        data["maxParallelRp"] = int(query_dict["maxParallelRp"])
         data["overridePolicy"] = query_dict["overridePolicy"]
         data["stageType"] = query_dict["stageType"]
         data["terminationLimit"] = query_dict["terminationLimit"]


### PR DESCRIPTION
The max parallel replacement field is no longer needed in new replacement feature. Remove to avoid confusion