### PR TITLE
Update skip matching language to specify launch template.

### DIFF
--- a/deploy-board/deploy_board/templates/clusters/cluster-replacements.tmpl
+++ b/deploy-board/deploy_board/templates/clusters/cluster-replacements.tmpl
@@ -112,8 +112,8 @@
                 </div>
                 
                 <div>
-                    <label class="switch" data-toggle="tooltip" title="Whether to skip replacing instances that are already running with latest launch configurations." >
-                        Skip matching
+                    <label class="switch" data-toggle="tooltip" title="Skip replacing instances that already use the latest launch template." >
+                        Skip matching launch template
                         <input type="checkbox" id="skipMatching" name="skipMatching" checked>
                         <div class="slider round"></div>
                     </label>


### PR DESCRIPTION
Add the target "launch template" to help the customer understand the effect quickly.

Also update the language in the tooltip to properly say "launch template".

<img width="1792" alt="Screenshot 2023-09-06 at 1 02 12 PM" src="https://github.com/pinterest/teletraan/assets/1937883/aa6c6269-7893-44c4-a060-addc3f4c57eb">
