### PR TITLE
Implement configuration type filter in history page

### DIFF
--- a/deploy-board/deploy_board/templates/configs/config_history.tmpl
+++ b/deploy-board/deploy_board/templates/configs/config_history.tmpl
@@ -2,7 +2,7 @@
 {% load static %}
 
 
-{% regroup configs by type as configsByType %}
+{% regroup configs|dictsort:'type' by type as configsByType %}
 <div class="modal fade" id="filterConfigModalId" tabindex="-1" role="dialog" aria-labelledby="deleteClusterModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-md">
         <div class="modal-content">

--- a/deploy-board/deploy_board/templates/configs/config_history.tmpl
+++ b/deploy-board/deploy_board/templates/configs/config_history.tmpl
@@ -3,10 +3,10 @@
 
 
 {% regroup configs|dictsort:'type' by type as configsByType %}
-<div class="modal fade" id="filterConfigModalId" tabindex="-1" role="dialog" aria-labelledby="deleteClusterModalLabel" aria-hidden="true">
+<div class="modal fade" id="envFilterConfigModalId" tabindex="-1" role="dialog" aria-labelledby="deleteClusterModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-md">
         <div class="modal-content">
-            <form id="filterConfigTypesFormId">
+            <form id="envFilterConfigTypesFormId">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
                     <h4 class="modal-title">Filter Config Type</h4>
@@ -45,7 +45,7 @@
             <th class="col-lg-1">Operator</th>
             <th class="col-lg-2">
                 Type
-                <span class="fa fa-filter btn btn-xs {% if excludedTypes|length > 0 %} bg-info {% else %} btn-default {% endif %}" data-toggle="modal" data-target="#filterConfigModalId" />
+                <span class="fa fa-filter btn btn-xs {% if excludedTypes|length > 0 %} bg-info {% else %} btn-default {% endif %}" data-toggle="modal" data-target="#envFilterConfigModalId" />
             </th>
             <th class="col-lg-4">Configuration Change</th>
         </tr>
@@ -126,12 +126,12 @@
         });
     });
 
-    $("#filterConfigTypesFormId").submit(function (e) {
+    $("#envFilterConfigTypesFormId").submit(function (e) {
         e.preventDefault()
         e.stopPropagation() 
 
         const filteredOutTypes = [];
-        $('#filterConfigTypesFormId input[type="checkbox"]:not(:checked)').each(function(a){
+        $('#envFilterConfigTypesFormId input[type="checkbox"]:not(:checked)').each(function(a){
             filteredOutTypes.push($(this).val());
         });
         
@@ -140,8 +140,8 @@
         window.location=url;
     });
 
-    $("#filterConfigModalId").on('hide.bs.modal', function(){
-        $("#filterConfigTypesFormId").trigger('reset');
+    $("#envFilterConfigModalId").on('hide.bs.modal', function(){
+        $("#envFilterConfigTypesFormId").trigger('reset');
     });
 
 </script>

--- a/deploy-board/deploy_board/templates/configs/config_history.tmpl
+++ b/deploy-board/deploy_board/templates/configs/config_history.tmpl
@@ -2,7 +2,7 @@
 {% load static %}
 
 
-{% regroup configs2 by type as configsByType %}
+{% regroup configs by type as configsByType %}
 <div class="modal fade" id="filterConfigModalId" tabindex="-1" role="dialog" aria-labelledby="deleteClusterModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-md">
         <div class="modal-content">
@@ -20,7 +20,6 @@
                         <input class="form-check-input" type="checkbox" name="exclude" value="{{ config.grouper }}" id="{{ config.grouper }}"
                         {% if config.grouper not in excludedTypes %} checked {% else %} '' {% endif %}>
                         <label class="form-check-label" for="{{ config.grouper }}">
-                                
                             {{config.grouper}}
                         </label>
                     </div>
@@ -53,6 +52,7 @@
         <tbody>
 
         {% for config in configs %}
+        {% if config.type not in excludedTypes %}
         <tr>
             <td>
                 <input type="checkbox" value="{{ config.type }}_{{ config.replaced_config }}" name="chkbox_{{ config.changeId }}">
@@ -78,6 +78,7 @@
             {% endwith %}
             </td>
         </tr>
+        {% endif %}
         {% endfor %}
     </tbody>
 
@@ -90,7 +91,7 @@
 
     jQuery(function(){
         var maxCheckedAllowed = 2;
-        var checkboxes = $('env_config_history_list', 'input[type="checkbox"]');
+        var checkboxes = $('#envConfigHistoryTableId input[type="checkbox"]');
             checkboxes.change(function(){
                 var numChecked = checkboxes.filter(':checked').length;
                 checkboxes.filter(':not(:checked)').prop('disabled', numChecked >= maxCheckedAllowed);
@@ -130,7 +131,7 @@
         e.stopPropagation() 
 
         const filteredOutTypes = [];
-        $('input[type="checkbox"]:not(:checked)').each(function(){
+        $('#filterConfigTypesFormId input[type="checkbox"]:not(:checked)').each(function(a){
             filteredOutTypes.push($(this).val());
         });
         

--- a/deploy-board/deploy_board/templates/configs/config_history.tmpl
+++ b/deploy-board/deploy_board/templates/configs/config_history.tmpl
@@ -3,10 +3,10 @@
 
 
 {% regroup configs|dictsort:'type' by type as configsByType %}
-<div class="modal fade" id="envFilterConfigModalId" tabindex="-1" role="dialog" aria-labelledby="deleteClusterModalLabel" aria-hidden="true">
+<div class="modal fade" id="filterConfigModalId" tabindex="-1" role="dialog" aria-labelledby="deleteClusterModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-md">
         <div class="modal-content">
-            <form id="envFilterConfigTypesFormId">
+            <form id="filterConfigTypesFormId">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
                     <h4 class="modal-title">Filter Config Type</h4>
@@ -45,7 +45,7 @@
             <th class="col-lg-1">Operator</th>
             <th class="col-lg-2">
                 Type
-                <span class="fa fa-filter btn btn-xs {% if excludedTypes|length > 0 %} bg-info {% else %} btn-default {% endif %}" data-toggle="modal" data-target="#envFilterConfigModalId" />
+                <span class="fa fa-filter btn btn-xs {% if excludedTypes|length > 0 %} bg-info {% else %} btn-default {% endif %}" data-toggle="modal" data-target="#filterConfigModalId" />
             </th>
             <th class="col-lg-4">Configuration Change</th>
         </tr>
@@ -126,12 +126,12 @@
         });
     });
 
-    $("#envFilterConfigTypesFormId").submit(function (e) {
+    $("#filterConfigTypesFormId").submit(function (e) {
         e.preventDefault()
         e.stopPropagation() 
 
         const filteredOutTypes = [];
-        $('#envFilterConfigTypesFormId input[type="checkbox"]:not(:checked)').each(function(a){
+        $('#filterConfigTypesFormId input[type="checkbox"]:not(:checked)').each(function(a){
             filteredOutTypes.push($(this).val());
         });
         
@@ -140,8 +140,8 @@
         window.location=url;
     });
 
-    $("#envFilterConfigModalId").on('hide.bs.modal', function(){
-        $("#envFilterConfigTypesFormId").trigger('reset');
+    $("#filterConfigModalId").on('hide.bs.modal', function(){
+        $("#filterConfigTypesFormId").trigger('reset');
     });
 
 </script>

--- a/deploy-board/deploy_board/templates/configs/config_history.tmpl
+++ b/deploy-board/deploy_board/templates/configs/config_history.tmpl
@@ -1,17 +1,57 @@
 {% load utils %}
 {% load static %}
 
+
+{% regroup configs2 by type as configsByType %}
+<div class="modal fade" id="filterConfigModalId" tabindex="-1" role="dialog" aria-labelledby="deleteClusterModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-md">
+        <div class="modal-content">
+            <form id="filterConfigTypesFormId">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+                    <h4 class="modal-title">Filter Config Type</h4>
+                </div>
+
+                <div class="modal-body" id="newMetricModal">
+                    <p>Select which config types to display</p>
+
+                    {% for config in configsByType %}
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" name="exclude" value="{{ config.grouper }}" id="{{ config.grouper }}"
+                        {% if config.grouper not in excludedTypes %} checked {% else %} '' {% endif %}>
+                        <label class="form-check-label" for="{{ config.grouper }}">
+                                
+                            {{config.grouper}}
+                        </label>
+                    </div>
+                    {% endfor %}
+                    
+                </div>
+
+                <div class="modal-footer">
+                    <button id="addMetricBtnId" type="submit" class="btn btn-primary">Save</button>
+                    <button id="modalCloseBtnId" type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                </div>
+                {% csrf_token %}
+            <form> 
+        </div>
+    </div>
+</div>
+
 <form name="env_config_history_list">
-    <table id="envConfigHistoryTableId" class="table table-condensed table-striped table-hover sortable">
-        <thead>
-        <tr>
+    <table id="envConfigHistoryTableId" class="table table-condensed table-striped table-hover">
+        <tr class="align-middle">
             <th class="col-sm-1"></th>
             <th class="col-lg-2">Time</th>
             <th class="col-lg-1">Operator</th>
-            <th class="col-lg-2">Type</th>
+            <th class="col-lg-2">
+                Type
+                <span class="fa fa-filter btn btn-xs {% if excludedTypes|length > 0 %} bg-info {% else %} btn-default {% endif %}" data-toggle="modal" data-target="#filterConfigModalId" />
+            </th>
             <th class="col-lg-4">Configuration Change</th>
         </tr>
-        </thead>
+        <tbody>
+
         {% for config in configs %}
         <tr>
             <td>
@@ -39,6 +79,8 @@
             </td>
         </tr>
         {% endfor %}
+    </tbody>
+
     </table>
     <button type="button" id="compareConfigsBtn" class="btn btn-default">Compare configs in new tab</button>
 </form>
@@ -48,7 +90,7 @@
 
     jQuery(function(){
         var maxCheckedAllowed = 2;
-        var checkboxes = $('input[type="checkbox"]');
+        var checkboxes = $('env_config_history_list', 'input[type="checkbox"]');
             checkboxes.change(function(){
                 var numChecked = checkboxes.filter(':checked').length;
                 checkboxes.filter(':not(:checked)').prop('disabled', numChecked >= maxCheckedAllowed);
@@ -82,4 +124,23 @@
             }
         });
     });
+
+    $("#filterConfigTypesFormId").submit(function (e) {
+        e.preventDefault()
+        e.stopPropagation() 
+
+        const filteredOutTypes = [];
+        $('input[type="checkbox"]:not(:checked)').each(function(){
+            filteredOutTypes.push($(this).val());
+        });
+        
+        const queryString = `exclude=${filteredOutTypes.join()}`
+        const url = '/env/{{ envName }}/{{ stageName }}/config_history/?' + queryString
+        window.location=url;
+    });
+
+    $("#filterConfigModalId").on('hide.bs.modal', function(){
+        $("#filterConfigTypesFormId").trigger('reset');
+    });
+
 </script>

--- a/deploy-board/deploy_board/templates/groups/group_config_history.tmpl
+++ b/deploy-board/deploy_board/templates/groups/group_config_history.tmpl
@@ -2,10 +2,10 @@
 {% load static %}
 
 {% regroup configs|dictsort:'type' by type as configsByType %}
-<div class="modal fade" id="groupFilterConfigModalId" tabindex="-1" role="dialog" aria-labelledby="deleteClusterModalLabel" aria-hidden="true">
+<div class="modal fade" id="filterConfigModalId" tabindex="-1" role="dialog" aria-labelledby="deleteClusterModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-md">
         <div class="modal-content">
-            <form id="groupfilterConfigTypesFormId">
+            <form id="filterConfigTypesFormId">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
                     <h4 class="modal-title">Filter Config Type</h4>
@@ -44,7 +44,7 @@
             <th class="col-lg-1">Operator</th>
             <th class="col-lg-2">
                 Type
-                <span class="fa fa-filter btn btn-xs {% if excludedTypes|length > 0 %} bg-info {% else %} btn-default {% endif %}" data-toggle="modal" data-target="#groupfilterConfigModalId" />
+                <span class="fa fa-filter btn btn-xs {% if excludedTypes|length > 0 %} bg-info {% else %} btn-default {% endif %}" data-toggle="modal" data-target="#filterConfigModalId" />
             </th>
             <th class="col-lg-4">Configuration Change</th>
         </tr>
@@ -128,12 +128,12 @@
             $('#' + currentId + 'Toggler').toggleClass('glyphicon-chevron-right glyphicon-chevron-down', 100);
         });
 
-    $("#groupfilterConfigTypesFormId").submit(function (e) {
+    $("#filterConfigTypesFormId").submit(function (e) {
         e.preventDefault()
         e.stopPropagation() 
 
         const filteredOutTypes = [];
-        $('#groupfilterConfigTypesFormId input[type="checkbox"]:not(:checked)').each(function(a){
+        $('#filterConfigTypesFormId input[type="checkbox"]:not(:checked)').each(function(a){
             filteredOutTypes.push($(this).val());
         });
 
@@ -142,7 +142,7 @@
         window.location=url;
     });
 
-    $("#groupfilterConfigModalId").on('hide.bs.modal', function(){
-        $("#groupfilterConfigTypesFormId").trigger('reset');
+    $("#filterConfigModalId").on('hide.bs.modal', function(){
+        $("#filterConfigTypesFormId").trigger('reset');
     });
 </script>

--- a/deploy-board/deploy_board/templates/groups/group_config_history.tmpl
+++ b/deploy-board/deploy_board/templates/groups/group_config_history.tmpl
@@ -1,16 +1,55 @@
 {% load utils %}
 {% load static %}
 
+{% regroup configs|dictsort:'type' by type as configsByType %}
+<div class="modal fade" id="filterConfigModalId" tabindex="-1" role="dialog" aria-labelledby="deleteClusterModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-md">
+        <div class="modal-content">
+            <form id="filterConfigTypesFormId">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+                    <h4 class="modal-title">Filter Config Type</h4>
+                </div>
+
+                <div class="modal-body" id="newMetricModal">
+                    <p>Select which config types to display</p>
+
+                    {% for config in configsByType %}
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" name="exclude" value="{{ config.grouper }}" id="{{ config.grouper }}"
+                        {% if config.grouper not in excludedTypes %} checked {% else %} '' {% endif %}>
+                        <label class="form-check-label" for="{{ config.grouper }}">
+                            {{config.grouper}}
+                        </label>
+                    </div>
+                    {% endfor %}
+
+                </div>
+
+                <div class="modal-footer">
+                    <button id="addMetricBtnId" type="submit" class="btn btn-primary">Save</button>
+                    <button id="modalCloseBtnId" type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                </div>
+                {% csrf_token %}
+            <form> 
+        </div>
+    </div>
+</div>
+
 <form name="asg_config_history_list">
     <table id="asgConfigHistoryTableId" class="table table-condensed table-striped table-hover">
         <tr>
             <th class="col-sm-1"></th>
             <th class="col-lg-2">Time</th>
             <th class="col-lg-1">Operator</th>
-            <th class="col-lg-2">Type</th>
+            <th class="col-lg-2">
+                Type
+                <span class="fa fa-filter btn btn-xs {% if excludedTypes|length > 0 %} bg-info {% else %} btn-default {% endif %}" data-toggle="modal" data-target="#filterConfigModalId" />
+            </th>
             <th class="col-lg-4">Configuration Change</th>
         </tr>
         {% for config in configs %}
+        {% if config.type not in excludedTypes %}
         <tr>
             <td>
                 <input type="checkbox" value="{{ config.type }}_{{ config.replaced_config }}" name="chkbox_{{ config.changeId }}">
@@ -38,6 +77,7 @@
                 </div>
             </td>
         </tr>
+        {% endif %}
         {% endfor %}
     </table>
      <button type="button" id="compareConfigsBtn" class="btn btn-default">Compare configs in new tab</button>
@@ -48,7 +88,7 @@
 
     jQuery(function(){
         var maxCheckedAllowed = 2;
-        var checkboxes = $('input[type="checkbox"]');
+        var checkboxes = $('#asgConfigHistoryTableId input[type="checkbox"]');
             checkboxes.change(function(){
                 var numChecked = checkboxes.filter(':checked').length;
                 checkboxes.filter(':not(:checked)').prop('disabled', numChecked >= maxCheckedAllowed);
@@ -87,4 +127,22 @@
             var currentId = $(this).attr('id');
             $('#' + currentId + 'Toggler').toggleClass('glyphicon-chevron-right glyphicon-chevron-down', 100);
         });
+
+    $("#filterConfigTypesFormId").submit(function (e) {
+        e.preventDefault()
+        e.stopPropagation() 
+
+        const filteredOutTypes = [];
+        $('#filterConfigTypesFormId input[type="checkbox"]:not(:checked)').each(function(a){
+            filteredOutTypes.push($(this).val());
+        });
+
+        const queryString = `exclude=${filteredOutTypes.join()}`
+        const url = '/groups/{{ envName }}-{{ stageName }}/config_history/?' + queryString
+        window.location=url;
+    });
+
+    $("#filterConfigModalId").on('hide.bs.modal', function(){
+        $("#filterConfigTypesFormId").trigger('reset');
+    });
 </script>

--- a/deploy-board/deploy_board/templates/groups/group_config_history.tmpl
+++ b/deploy-board/deploy_board/templates/groups/group_config_history.tmpl
@@ -138,7 +138,7 @@
         });
 
         const queryString = `exclude=${filteredOutTypes.join()}`
-        const url = '/groups/{{ envName }}-{{ stageName }}/config_history/?' + queryString
+        const url = '/groups/{{ group_name }}/config_history/?' + queryString
         window.location=url;
     });
 

--- a/deploy-board/deploy_board/templates/groups/group_config_history.tmpl
+++ b/deploy-board/deploy_board/templates/groups/group_config_history.tmpl
@@ -2,10 +2,10 @@
 {% load static %}
 
 {% regroup configs|dictsort:'type' by type as configsByType %}
-<div class="modal fade" id="filterConfigModalId" tabindex="-1" role="dialog" aria-labelledby="deleteClusterModalLabel" aria-hidden="true">
+<div class="modal fade" id="groupFilterConfigModalId" tabindex="-1" role="dialog" aria-labelledby="deleteClusterModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-md">
         <div class="modal-content">
-            <form id="filterConfigTypesFormId">
+            <form id="groupfilterConfigTypesFormId">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
                     <h4 class="modal-title">Filter Config Type</h4>
@@ -44,7 +44,7 @@
             <th class="col-lg-1">Operator</th>
             <th class="col-lg-2">
                 Type
-                <span class="fa fa-filter btn btn-xs {% if excludedTypes|length > 0 %} bg-info {% else %} btn-default {% endif %}" data-toggle="modal" data-target="#filterConfigModalId" />
+                <span class="fa fa-filter btn btn-xs {% if excludedTypes|length > 0 %} bg-info {% else %} btn-default {% endif %}" data-toggle="modal" data-target="#groupfilterConfigModalId" />
             </th>
             <th class="col-lg-4">Configuration Change</th>
         </tr>
@@ -128,12 +128,12 @@
             $('#' + currentId + 'Toggler').toggleClass('glyphicon-chevron-right glyphicon-chevron-down', 100);
         });
 
-    $("#filterConfigTypesFormId").submit(function (e) {
+    $("#groupfilterConfigTypesFormId").submit(function (e) {
         e.preventDefault()
         e.stopPropagation() 
 
         const filteredOutTypes = [];
-        $('#filterConfigTypesFormId input[type="checkbox"]:not(:checked)').each(function(a){
+        $('#groupfilterConfigTypesFormId input[type="checkbox"]:not(:checked)').each(function(a){
             filteredOutTypes.push($(this).val());
         });
 
@@ -142,7 +142,7 @@
         window.location=url;
     });
 
-    $("#filterConfigModalId").on('hide.bs.modal', function(){
-        $("#filterConfigTypesFormId").trigger('reset');
+    $("#groupfilterConfigModalId").on('hide.bs.modal', function(){
+        $("#groupfilterConfigTypesFormId").trigger('reset');
     });
 </script>

--- a/deploy-board/deploy_board/templates/groups/group_config_history.tmpl
+++ b/deploy-board/deploy_board/templates/groups/group_config_history.tmpl
@@ -138,7 +138,7 @@
         });
 
         const queryString = `exclude=${filteredOutTypes.join()}`
-        const url = '/groups/{{ group_name }}/config_history/?' + queryString
+        const url = '/groups/{{ envName }}-{{ stageName }}/config_history/?' + queryString
         window.location=url;
     });
 

--- a/deploy-board/deploy_board/webapp/env_views.py
+++ b/deploy-board/deploy_board/webapp/env_views.py
@@ -1495,7 +1495,8 @@ def get_env_config_history(request, name, stage):
         replaced_config = config["configChange"].replace(",", ", ").replace("#", "%23").replace("\"", "%22")\
             .replace("{", "%7B").replace("}", "%7D").replace("_", "%5F")
         config["replaced_config"] = replaced_config
-        excludedTypes = list(filter(None, request.GET.get("exclude", '').replace("%20", " ").split(",")))
+    
+    excludedTypes = list(filter(None, request.GET.get("exclude", '').replace("%20", " ").split(",")))
 
     return render(request, 'configs/config_history.html', {
         "envName": name,

--- a/deploy-board/deploy_board/webapp/env_views.py
+++ b/deploy-board/deploy_board/webapp/env_views.py
@@ -1496,6 +1496,49 @@ def get_env_config_history(request, name, stage):
             .replace("{", "%7B").replace("}", "%7D").replace("_", "%5F")
         config["replaced_config"] = replaced_config
 
+    
+    # CONFIG_TYPES = [
+    #     "Host Action",
+    #     "Cluster Action",
+    #     "Cluster Deletion",
+    #     "Cluster Config",
+    #     "Cluster Clone",
+    #     "Cluster Creation",
+    #     "Host Action",
+    #     "Asg General Config",
+    #     "ASG Config Change",
+    #     "Asg Pas Config",
+    #     "Asg ALARM Action",
+    #     "Asg Scheduled Action",
+    #     "Asg Scaling Alarm",
+    #     "Asg Scaling Policy",
+    #     "Asg Scaling Action",
+    #     "Asg Scaling Group",
+    #     "Asg Launch Config",
+    # ]
+
+    configs2 = [
+        {"type": "Host Action", "name": "Ian1"},
+        {"type": "Cluster Action", "name": "Ian2"},
+        {"type": "Cluster Deletion", "name": "Ian1"},
+        {"type": "Cluster Config", "name": "Ian1"},
+        {"type": "Cluster Clone", "name": "Ian1"},
+        {"type": "Cluster Creation", "name": "Ian1"},
+        {"type": "Host Action", "name": "Ian1"},
+        {"type": "Asg General Config", "name": "Ian1"},
+        {"type": "ASG Config Change", "name": "Ian1"},
+        {"type": "Asg Pas Config", "name": "Ian1"},
+        {"type": "Asg ALARM Action", "name": "Ian1"},
+        {"type": "Asg Scheduled Action", "name": "Ian1"},
+        {"type": "Asg Scaling Alarm", "name": "Ian1"},
+        {"type": "Asg Scaling Policy", "name": "Ian1"},
+        {"type": "Asg Scaling Action", "name": "Ian1"},
+        {"type": "Asg Scaling Group", "name": "Ian1"},
+        {"type": "Asg Launch Config", "name": "Ian1"},
+    ]
+    excludedTypes = list(filter(None, request.GET.get("exclude", '').replace("%20", " ").split(",")))
+    
+
     return render(request, 'configs/config_history.html', {
         "envName": name,
         "stageName": stage,
@@ -1505,6 +1548,8 @@ def get_env_config_history(request, name, stage):
         "pageSize": DEFAULT_PAGE_SIZE,
         "disablePrevious": index <= 1,
         "disableNext": len(configs) < DEFAULT_PAGE_SIZE,
+        "configs2": configs2,
+        "excludedTypes": excludedTypes 
     })
 
 

--- a/deploy-board/deploy_board/webapp/env_views.py
+++ b/deploy-board/deploy_board/webapp/env_views.py
@@ -1495,49 +1495,7 @@ def get_env_config_history(request, name, stage):
         replaced_config = config["configChange"].replace(",", ", ").replace("#", "%23").replace("\"", "%22")\
             .replace("{", "%7B").replace("}", "%7D").replace("_", "%5F")
         config["replaced_config"] = replaced_config
-
-    
-    # CONFIG_TYPES = [
-    #     "Host Action",
-    #     "Cluster Action",
-    #     "Cluster Deletion",
-    #     "Cluster Config",
-    #     "Cluster Clone",
-    #     "Cluster Creation",
-    #     "Host Action",
-    #     "Asg General Config",
-    #     "ASG Config Change",
-    #     "Asg Pas Config",
-    #     "Asg ALARM Action",
-    #     "Asg Scheduled Action",
-    #     "Asg Scaling Alarm",
-    #     "Asg Scaling Policy",
-    #     "Asg Scaling Action",
-    #     "Asg Scaling Group",
-    #     "Asg Launch Config",
-    # ]
-
-    configs2 = [
-        {"type": "Host Action", "name": "Ian1"},
-        {"type": "Cluster Action", "name": "Ian2"},
-        {"type": "Cluster Deletion", "name": "Ian1"},
-        {"type": "Cluster Config", "name": "Ian1"},
-        {"type": "Cluster Clone", "name": "Ian1"},
-        {"type": "Cluster Creation", "name": "Ian1"},
-        {"type": "Host Action", "name": "Ian1"},
-        {"type": "Asg General Config", "name": "Ian1"},
-        {"type": "ASG Config Change", "name": "Ian1"},
-        {"type": "Asg Pas Config", "name": "Ian1"},
-        {"type": "Asg ALARM Action", "name": "Ian1"},
-        {"type": "Asg Scheduled Action", "name": "Ian1"},
-        {"type": "Asg Scaling Alarm", "name": "Ian1"},
-        {"type": "Asg Scaling Policy", "name": "Ian1"},
-        {"type": "Asg Scaling Action", "name": "Ian1"},
-        {"type": "Asg Scaling Group", "name": "Ian1"},
-        {"type": "Asg Launch Config", "name": "Ian1"},
-    ]
-    excludedTypes = list(filter(None, request.GET.get("exclude", '').replace("%20", " ").split(",")))
-    
+        excludedTypes = list(filter(None, request.GET.get("exclude", '').replace("%20", " ").split(",")))
 
     return render(request, 'configs/config_history.html', {
         "envName": name,
@@ -1548,7 +1506,6 @@ def get_env_config_history(request, name, stage):
         "pageSize": DEFAULT_PAGE_SIZE,
         "disablePrevious": index <= 1,
         "disableNext": len(configs) < DEFAULT_PAGE_SIZE,
-        "configs2": configs2,
         "excludedTypes": excludedTypes 
     })
 

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -800,6 +800,7 @@ def get_config_history(request, group_name):
         replaced_config = config["configChange"].replace(",", ", ").replace("#", "%23").replace("\"", "%22")\
             .replace("{", "%7B").replace("}", "%7D").replace("_", "%5F")
         config["replaced_config"] = replaced_config
+    excludedTypes = list(filter(None, request.GET.get("exclude", '').replace("%20", " ").split(",")))
 
     return render(request, 'groups/group_config_history.html', {
         "group_name": group_name,
@@ -808,6 +809,7 @@ def get_config_history(request, group_name):
         "pageSize": DEFAULT_PAGE_SIZE,
         "disablePrevious": index <= 1,
         "disableNext": len(configs) < DEFAULT_PAGE_SIZE,
+        "excludedTypes": excludedTypes
     })
 
 


### PR DESCRIPTION
Why is this change necessary?
- The configuration can become really busy depending on config changes
- A more narrow focus on configuration changes can improve visibility and clarity

How does this PR address the issue?
- It adds a filter functionality based on different configuration change types currently in view 
- Implementation in both the environment and the ASG configuration history pages

What effects does this change have?
- Add a filter button next to the column header "Type"
- On click, display a modal that shows all distinct config types in the current page as a checklist
- When a type is unchecked and the modal is saved, the URL adds a "exclude=" (comma-separated for multiple) argument with the unchecked type name
- Config types in the "exclude=" argument are not rendered

Test Plan:
- No types excluded
  - All configs are shown
- Some types excluded
  - Unchecked config types are not shown, filter button is highlighted
- All types excluded
  - No configs are shown, filter button is highlighted

JIRA Ticket(s): [CDP-6711](https://jira.pinadmin.com/browse/CDP-6711)