### PR TITLE
Allow sustaining Instance Types for new clusters

### DIFF
--- a/deploy-board/deploy_board/templates/configs/new_capacity.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity.html
@@ -114,7 +114,7 @@ var capacitySetting = new Vue({
                 value: item.id,
                 text: item.abstract_name+" ("+item.core+" cores, "+item.mem+" GB, "+item.network+", " +item.storage+")",
                 isSelected: item.abstract_name === capacityCreationInfo.defaultHostType,
-                isDisabled: item.retired || item.blessed_status === "SUSTAINING" || item.blessed_status === "DECOMMISSIONING"
+                isDisabled: item.retired || item.blessed_status === "DECOMMISSIONING"
             }
         }),
         placements: placements.getSimpleList(false, null),

--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -147,7 +147,7 @@ var capacitySetting = new Vue({
                     value: item.id,
                     text: item.abstract_name + " (" + item.core + " cores, " + item.mem + " GB, " + item.storage + ", " + item.network + ", " + item.provider + ": " + item.provider_name + ", " + item.network + ")",
                     isSelected: item.abstract_name === info.defaultHostType,
-                    isDisabled: item.retired || item.blessed_status === "SUSTAINING" || item.blessed_status === "DECOMMISSIONING"
+                    isDisabled: item.retired || item.blessed_status === "DECOMMISSIONING"
                 }
             }),
         cellValue: info.defaultCell,
@@ -384,7 +384,7 @@ var capacitySetting = new Vue({
                                     value: item.id,
                                     text: item.abstract_name + " (" + item.core + " cores, " + item.mem + " GB, " + item.storage + ", " + item.network + ", " + item.provider + ": " + item.provider_name + ", " + item.network + ")",
                                     isSelected: item.id === data[0].id,
-                                    isDisabled: item.retired || item.blessed_status === "SUSTAINING" || item.blessed_status === "DECOMMISSIONING"
+                                    isDisabled: item.retired || item.blessed_status === "DECOMMISSIONING"
                                 }
                             });
                     capacitySetting.selectedHostTypeValue = data[0].id;


### PR DESCRIPTION
This PR is to ensure users are able to select sustaining instance types in Teletraan for new clusters

Test Plan
1. Identify the host types that are sustaining 
<img width="2518" alt="image" src="https://github.com/pinterest/teletraan/assets/69278532/c7e7c46e-0503-453d-91bb-97da76e453e7">

2. Go to the cluster creation page
3. Ensure that the Sustaining host types are not greyed out and selectable 
<img width="2581" alt="image" src="https://github.com/pinterest/teletraan/assets/69278532/8d4672b8-cfc1-4cf2-bb11-a7d7d9aff8ef">
<img width="2486" alt="image" src="https://github.com/pinterest/teletraan/assets/69278532/f538a7e4-d6a0-4a28-b9b4-a85d250e8c10">

4. Create the cluster
<img width="3000" alt="image" src="https://github.com/pinterest/teletraan/assets/69278532/20d6a160-270f-44a3-b0f2-da25454b6a20">
