### PR TITLE
Update deploy agent logging

### DIFF
--- a/deploy-agent/deployd/common/status_code.py
+++ b/deploy-agent/deployd/common/status_code.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/deploy-agent/deployd/download/downloader.py
+++ b/deploy-agent/deployd/download/downloader.py
@@ -121,13 +121,13 @@ class Downloader(object):
             log.info("Successfully extracted {} to {}".format(local_full_fn, working_dir))
         except tarfile.TarError as e:
             status = Status.FAILED
-            log.error("Failed to extract files: {}".format(e))
+            log.exception("Failed to extract tar files")
         except OSError as e:
             status = Status.FAILED
-            log.error("Failed: {}".format(e))
+            log.exception("Failed to extract files. OSError:")
         except Exception:
             status = Status.FAILED
-            log.error(traceback.format_exc())
+            log.exception("Failed to extract files")
         finally:
             return status
 

--- a/deploy-agent/deployd/download/downloader.py
+++ b/deploy-agent/deployd/download/downloader.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -72,7 +72,7 @@ class Downloader(object):
         if extension == 'gpg':
             try:
                 log.info("gpg decrypting {}.".format(local_full_fn))
-                
+
                 # assuming we use the standard GPG toolset, it creates the following format with gpg --encrypt:
                 # input: file.extension
                 # output: file.extension.gpg
@@ -84,14 +84,14 @@ class Downloader(object):
 
                 # decrypt gpg archive
                 status = gpgHelper.decryptFile(local_full_fn, dest_full_fn)
-                
+
                 if status != Status.SUCCEEDED:
                     # die if we hit a decryption or signing error
                     return status
 
                 # remove encrypted gpg archive since it is no longer needed
                 os.remove(local_full_fn)
-                
+
                 # Rebase the extension and file path to the decrypted file
                 local_full_fn = dest_full_fn
                 extension = innerExtension

--- a/deploy-agent/deployd/download/http_download_helper.py
+++ b/deploy-agent/deployd/download/http_download_helper.py
@@ -27,7 +27,7 @@ log = logging.getLogger(__name__)
 class HTTPDownloadHelper(DownloadHelper):
 
     def _download_files(self, local_full_fn):
-        download_cmd = ['curl', '-o', local_full_fn, '-fks', self._url]
+        download_cmd = ['curl', '-o', local_full_fn, '-fksS', self._url]
         log.info('Running command: {}'.format(' '.join(download_cmd)))
         error_code = Status.SUCCEEDED
         output, error, status = Caller.call_and_log(download_cmd, cwd=os.getcwd())

--- a/deploy-agent/deployd/download/http_download_helper.py
+++ b/deploy-agent/deployd/download/http_download_helper.py
@@ -4,9 +4,9 @@ from __future__ import absolute_import
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/deploy-agent/deployd/download/http_download_helper.py
+++ b/deploy-agent/deployd/download/http_download_helper.py
@@ -51,7 +51,7 @@ class HTTPDownloadHelper(DownloadHelper):
             sha_url = '{}.sha1'.format(self._url)
             sha_r = requests.get(sha_url)
             if sha_r.status_code != 200:
-                log.error('sha1 file does not exist for {}, ignore checksum.'.format(self._url))
+                log.warning('Skip checksum verification. Invalid response from {}'.format(sha_url))
                 return status_code
 
             sha_value = sha_r.content


### PR DESCRIPTION
Contains changes to improve debuggability such as:

- Update error logging

  In case of tarball extraction failures, log the exception and stack
  trace. These exceptions could cause the host to become stuck. The stack
  trace can help with debugging.

- Update checksum verification warning

  When the sha1 reuqest for a build returns non-200, the verification is
s. kipped.

  Since this happens often and is usually expected, switch to
  `log.warning`.

  Also, update the warning message to clarify the sha1 verification is
  skipped

- Add `S` flag to curl

  From the curl documentation:

    -S, --show-error
           When used with -s, --silent, it makes curl show an error message if it fails.

  Add the flag to show the error in case of failures, which an be helpful
  for debugging

Testing done:
  Ran the downloader command locally. Verified it succeeded.
  Also tested the error case by modifying the extracted dir and re-running the downloader. Ensured stack trace was logged