### PR TITLE
only update the container health status each time at the very beginning of deploy agent starts

### DIFF
--- a/deploy-agent/deployd/__init__.py
+++ b/deploy-agent/deployd/__init__.py
@@ -26,4 +26,4 @@ STATSBOARD_URL=os.getenv('STATSBOARD_URL', "https://statsboard.pinadmin.com/api/
 # 2: puppet applied successfully with changes
 PUPPET_SUCCESS_EXIT_CODES = [0, 2]
 	
-__version__ = '1.2.46'
+__version__ = '1.2.47'

--- a/deploy-agent/deployd/agent.py
+++ b/deploy-agent/deployd/agent.py
@@ -127,7 +127,10 @@ class DeployAgent(object):
             cmd = ['docker', 'inspect', status.report.envName]
             output = subprocess.run(cmd, check=True, stdout=subprocess.PIPE).stdout
             result = json.loads(output)
-            status.report.extraInfo = result[0].get("State").get("Health")
+            if result[0].get("State"):
+                status.report.extraInfo = result[0].get("State").get("Health")
+            else:
+                status.report.extraInfo = None
         self._response = self._client.send_reports(self._envs)
 
         if self._response:

--- a/deploy-agent/deployd/agent.py
+++ b/deploy-agent/deployd/agent.py
@@ -20,6 +20,8 @@ import sys
 from random import randrange
 import time
 import traceback
+import subprocess
+import json
 
 from deployd.client.client import Client
 from deployd.client.serverless_client import ServerlessClient

--- a/deploy-agent/deployd/agent.py
+++ b/deploy-agent/deployd/agent.py
@@ -126,17 +126,10 @@ class DeployAgent(object):
             for status in self._envs.values():
                 # for each container, we check the health status
                 try:
-                    cmd = ['docker', 'inspect', status.report.envName]
-                    output = subprocess.run(cmd, check=True, stdout=subprocess.PIPE).stdout
-                    result = json.loads(output)
-                    if result[0].get("State"):
-                        healthStatus = result[0].get("State").get("Health").get("Status")
-                        status.report.extraInfo = {'serviceHealth': healthStatus}
-                    else:
-                        status.report.extraInfo = None
-                    log.info('sidecar name: {}'.format(status.report.envName))
-                    log.info('sidecar extraInfo: {}'.format(status.report.extraInfo))
+                    healthStatus = utils.get_container_health_info(status.report.envName)
+                    status.report.extraInfo = {'serviceHealth': healthStatus}
                 except Exception:
+                    status.report.extraInfo = None
                     log.exception('get exception while trying to check container health: {}'.format(traceback.format_exc()))
                     continue
         self._response = self._client.send_reports(self._envs)

--- a/deploy-agent/deployd/agent.py
+++ b/deploy-agent/deployd/agent.py
@@ -120,6 +120,12 @@ class DeployAgent(object):
         if not self._executor:
             self._executor = Executor(callback=PingServer(self), config=self._config)
         # start to ping server to get the latest deploy goal
+        for status in self._envs.values():
+            # for each container, we check the health status
+            cmd = ['docker', 'inspect', status.report.envName]
+            output = subprocess.run(cmd, check=True, stdout=subprocess.PIPE).stdout
+            result = json.loads(output)
+            status.report.extraInfo = result[0].get("State").get("Health")
         self._response = self._client.send_reports(self._envs)
 
         if self._response:

--- a/deploy-agent/deployd/agent.py
+++ b/deploy-agent/deployd/agent.py
@@ -130,13 +130,14 @@ class DeployAgent(object):
                     output = subprocess.run(cmd, check=True, stdout=subprocess.PIPE).stdout
                     result = json.loads(output)
                     if result[0].get("State"):
-                        status.report.extraInfo = result[0].get("State").get("Health")
+                        healthStatus = result[0].get("State").get("Health").get("Status")
+                        status.report.extraInfo = {'serviceHealth': healthStatus}
                     else:
                         status.report.extraInfo = None
                     log.info('sidecar name: {}'.format(status.report.envName))
                     log.info('sidecar extraInfo: {}'.format(status.report.extraInfo))
                 except Exception:
-                    log.error('get exception while trying to check container health: {}'.format(traceback.format_exc()))
+                    log.exception('get exception while trying to check container health: {}'.format(traceback.format_exc()))
                     continue
         self._response = self._client.send_reports(self._envs)
 

--- a/deploy-agent/deployd/agent.py
+++ b/deploy-agent/deployd/agent.py
@@ -20,8 +20,6 @@ import sys
 from random import randrange
 import time
 import traceback
-import subprocess
-import json
 
 from deployd.client.client import Client
 from deployd.client.serverless_client import ServerlessClient

--- a/deploy-agent/deployd/client/client.py
+++ b/deploy-agent/deployd/client/client.py
@@ -187,13 +187,13 @@ class Client(BaseClient):
                  "Host name: {}, IP: {}, host id: {}, agent_version={}, autoscaling_group: {}, "
                  "availability_zone: {}, stage_type: {}, group: {}, account id: {}".format(self._hostname, self._ip, self._id, 
                  self._agent_version, self._autoscaling_group, self._availability_zone, self._stage_type, self._hostgroup, self._account_id))
-        """
+                 
         if not self._availability_zone:
             log.error("Fail to read host info: availablity zone")
             create_sc_increment(name='deploy.failed.agent.hostinfocollection',
                                 tags={'host': self._hostname, 'info': 'availability_zone'})
             return False
-        """
+
         return True
 
     def send_reports(self, env_reports=None):
@@ -216,7 +216,7 @@ class Client(BaseClient):
                                         availabilityZone=self._availability_zone,
                                         stageType=self._stage_type,
                                         accountId=self._account_id)
-                log.info('ping request: %s' % ping_request)
+
                 with create_stats_timer('deploy.agent.request.latency',
                                         tags={'host': self._hostname}):
                     ping_response = self.send_reports_internal(ping_request)

--- a/deploy-agent/deployd/client/client.py
+++ b/deploy-agent/deployd/client/client.py
@@ -187,13 +187,13 @@ class Client(BaseClient):
                  "Host name: {}, IP: {}, host id: {}, agent_version={}, autoscaling_group: {}, "
                  "availability_zone: {}, stage_type: {}, group: {}, account id: {}".format(self._hostname, self._ip, self._id, 
                  self._agent_version, self._autoscaling_group, self._availability_zone, self._stage_type, self._hostgroup, self._account_id))
-
+        """
         if not self._availability_zone:
             log.error("Fail to read host info: availablity zone")
             create_sc_increment(name='deploy.failed.agent.hostinfocollection',
                                 tags={'host': self._hostname, 'info': 'availability_zone'})
             return False
-
+        """
         return True
 
     def send_reports(self, env_reports=None):
@@ -216,7 +216,7 @@ class Client(BaseClient):
                                         availabilityZone=self._availability_zone,
                                         stageType=self._stage_type,
                                         accountId=self._account_id)
-
+                log.info('ping request: %s' % ping_request)
                 with create_stats_timer('deploy.agent.request.latency',
                                         tags={'host': self._hostname}):
                     ping_response = self.send_reports_internal(ping_request)

--- a/deploy-agent/deployd/client/client.py
+++ b/deploy-agent/deployd/client/client.py
@@ -187,7 +187,7 @@ class Client(BaseClient):
                  "Host name: {}, IP: {}, host id: {}, agent_version={}, autoscaling_group: {}, "
                  "availability_zone: {}, stage_type: {}, group: {}, account id: {}".format(self._hostname, self._ip, self._id, 
                  self._agent_version, self._autoscaling_group, self._availability_zone, self._stage_type, self._hostgroup, self._account_id))
-                 
+
         if not self._availability_zone:
             log.error("Fail to read host info: availablity zone")
             create_sc_increment(name='deploy.failed.agent.hostinfocollection',

--- a/deploy-agent/deployd/common/utils.py
+++ b/deploy-agent/deployd/common/utils.py
@@ -220,6 +220,20 @@ def get_info_from_facter(keys):
         return None
 
 
+def get_container_health_info(key):
+    try:
+        log.info(f"Get health info for container {key}")
+        cmd = ['docker', 'inspect', '-f', '{{.State.Health.Status}}', key]
+        output = subprocess.run(cmd, check=True, stdout=subprocess.PIPE).stdout
+        if output:
+            return output.decode().strip()
+        else:
+            return None
+    except:
+        log.error("Failed to get container health info for {}".format(key))
+        return None
+
+
 def check_not_none(arg, msg=None):
     if arg is None:
         raise ValueError(msg)

--- a/deploy-agent/deployd/types/ping_request.py
+++ b/deploy-agent/deployd/types/ping_request.py
@@ -71,9 +71,11 @@ class PingRequest(object):
             ping_report["errorMessage"] = report.errorMessage
             ping_report["failCount"] = report.failCount
             ping_report["deployAlias"] = report.deployAlias
+            """
             if report.extraInfo:
                 ping_report["extraInfo"] = \
                     json.dumps(report.extraInfo, ensure_ascii=False).encode('utf8')
+            """
             ping_requests["reports"].append(ping_report)
         return ping_requests
 

--- a/deploy-agent/tests/unit/deploy/server/test_agent.py
+++ b/deploy-agent/tests/unit/deploy/server/test_agent.py
@@ -163,9 +163,9 @@ class TestDeployAgent(TestCase):
         d.serve_build()
 
         calls = [mock.call(['deploy-downloader', '-f', '/etc/deployagent.conf', '-v',
-                            '123', '-u', 'https://test', '-e', 'abc']),
+                            '123', '-u', 'https://test', '-e', 'beacon']),
                  mock.call(['deploy-stager', '-f', '/etc/deployagent.conf', '-v',
-                            '123', '-t', '/tmp/tests', '-e', 'abc'])]
+                            '123', '-t', '/tmp/tests', '-e', 'beacon'])]
         self.executor.run_cmd.assert_has_calls(calls)
         self.assertEqual(len(d._envs), 0)
 
@@ -203,7 +203,7 @@ class TestDeployAgent(TestCase):
 
         deploy_goal5 = {}
         deploy_goal5['deployId'] = '234'
-        deploy_goal5['envName'] = 'beacon'
+        deploy_goal5['envName'] = 'mcrouter'
         deploy_goal5['envId'] = 'efg'
         deploy_goal5['stageName'] = 'prod'
         deploy_goal5['deployStage'] = DeployStage.PRE_DOWNLOAD
@@ -211,7 +211,7 @@ class TestDeployAgent(TestCase):
 
         deploy_goal6 = {}
         deploy_goal6['deployId'] = '234'
-        deploy_goal6['envName'] = 'beacon'
+        deploy_goal6['envName'] = 'mcrouter'
         deploy_goal6['envId'] = 'efg'
         deploy_goal6['stageName'] = 'prod'
         deploy_goal6['deployStage'] = DeployStage.DOWNLOADING
@@ -219,28 +219,28 @@ class TestDeployAgent(TestCase):
 
         deploy_goal7 = {}
         deploy_goal7['deployId'] = '234'
-        deploy_goal7['envName'] = 'beacon'
+        deploy_goal7['envName'] = 'mcrouter'
         deploy_goal7['envId'] = 'efg'
         deploy_goal7['stageName'] = 'prod'
         deploy_goal7['deployStage'] = DeployStage.STAGING
 
         deploy_goal8 = {}
         deploy_goal8['deployId'] = '234'
-        deploy_goal8['envName'] = 'beacon'
+        deploy_goal8['envName'] = 'mcrouter'
         deploy_goal8['envId'] = 'efg'
         deploy_goal8['stageName'] = 'prod'
         deploy_goal8['deployStage'] = DeployStage.RESTARTING
 
         deploy_goal9 = {}
         deploy_goal9['deployId'] = '234'
-        deploy_goal9['envName'] = 'beacon'
+        deploy_goal9['envName'] = 'mcrouter'
         deploy_goal9['envId'] = 'efg'
         deploy_goal9['stageName'] = 'prod'
         deploy_goal9['deployStage'] = DeployStage.POST_RESTART
 
         deploy_goal10 = {}
         deploy_goal10['deployId'] = '234'
-        deploy_goal10['envName'] = 'beacon'
+        deploy_goal10['envName'] = 'mcrouter'
         deploy_goal10['envId'] = 'efg'
         deploy_goal10['stageName'] = 'prod'
         deploy_goal10['deployStage'] = DeployStage.SERVING_BUILD
@@ -272,28 +272,28 @@ class TestDeployAgent(TestCase):
                         executor=self.executor, helper=self.helper)
         d.serve_build()
         calls = [mock.call(['deploy-downloader', '-f', '/etc/deployagent.conf', '-v',
-                            '123', '-u', 'https://test', '-e', 'abc']),
+                            '123', '-u', 'https://test', '-e', 'beacon']),
                  mock.call(['deploy-stager', '-f', '/etc/deployagent.conf', '-v',
-                            '123', '-t', '/tmp/tests', '-e', 'abc']),
+                            '123', '-t', '/tmp/tests', '-e', 'beacon']),
                  mock.call(['deploy-downloader', '-f', '/etc/deployagent.conf', '-v',
-                            '123', '-u', 'https://test2', '-e', 'bcd']),
+                            '123', '-u', 'https://test2', '-e', 'mcrouter']),
                  mock.call(['deploy-stager', '-f', '/etc/deployagent.conf', '-v',
-                            '123', '-t', '/tmp/tests', '-e', 'bcd'])]
+                            '123', '-t', '/tmp/tests', '-e', 'mcrouter'])]
         self.executor.run_cmd.assert_has_calls(calls)
         self.assertEqual(len(d._envs), 2)
-        self.assertEqual(d._envs['abc'].report.deployStage, DeployStage.PRE_RESTART)
-        self.assertEqual(d._envs['abc'].report.deployId, '123')
-        self.assertEqual(d._envs['abc'].report.envId, 'def')
-        self.assertEqual(d._envs['abc'].report.status, AgentStatus.SUCCEEDED)
-        self.assertEqual(d._envs['abc'].build_info.build_commit, 'abcd')
-        self.assertEqual(d._envs['abc'].build_info.build_url, 'https://test')
+        self.assertEqual(d._envs['beacon'].report.deployStage, DeployStage.PRE_RESTART)
+        self.assertEqual(d._envs['beacon'].report.deployId, '123')
+        self.assertEqual(d._envs['beacon'].report.envId, 'def')
+        self.assertEqual(d._envs['beacon'].report.status, AgentStatus.SUCCEEDED)
+        self.assertEqual(d._envs['beacon'].build_info.build_commit, 'abcd')
+        self.assertEqual(d._envs['beacon'].build_info.build_url, 'https://test')
 
-        self.assertEqual(d._envs['bcd'].report.deployStage, DeployStage.SERVING_BUILD)
-        self.assertEqual(d._envs['bcd'].report.deployId, '234')
-        self.assertEqual(d._envs['bcd'].report.envId, 'efg')
-        self.assertEqual(d._envs['bcd'].report.status, AgentStatus.SUCCEEDED)
-        self.assertEqual(d._envs['bcd'].build_info.build_commit, 'abcd')
-        self.assertEqual(d._envs['bcd'].build_info.build_url, 'https://test2')
+        self.assertEqual(d._envs['mcrouter'].report.deployStage, DeployStage.SERVING_BUILD)
+        self.assertEqual(d._envs['mcrouter'].report.deployId, '234')
+        self.assertEqual(d._envs['mcrouter'].report.envId, 'efg')
+        self.assertEqual(d._envs['mcrouter'].report.status, AgentStatus.SUCCEEDED)
+        self.assertEqual(d._envs['mcrouter'].build_info.build_commit, 'abcd')
+        self.assertEqual(d._envs['mcrouter'].build_info.build_url, 'https://test2')
 
     def test_delete_report(self):
         status = DeployStatus()
@@ -306,7 +306,7 @@ class TestDeployAgent(TestCase):
         ping_report['status'] = AgentStatus.SUCCEEDED
         status.report = PingReport(jsonValue=ping_report)
 
-        envs = {'abc': status}
+        envs = {'beacon': status}
         client = mock.Mock()
         estatus = mock.Mock()
         estatus.load_envs = mock.Mock(return_value=envs)
@@ -514,7 +514,7 @@ class TestDeployAgent(TestCase):
                             executor=self.executor, helper=self.helper)
         agent.serve_build()
         mock_create_sc.assert_called_once_with('deployd.stats.deploy.status.sum', tags={
-                                               'first_run': False, 'deploy_stage': 'PRE_DOWNLOAD', 'env_name': 'abc', 'stage_name': 'beta', 'status_code': 'SUCCEEDED'})
+                                               'first_run': False, 'deploy_stage': 'PRE_DOWNLOAD', 'env_name': 'beacon', 'stage_name': 'beta', 'status_code': 'SUCCEEDED'})
         self.assertEqual(agent._curr_report.report.deployStage, DeployStage.PRE_DOWNLOAD)
         self.assertEqual(agent._curr_report.report.status, AgentStatus.SUCCEEDED)
 

--- a/deploy-agent/tests/unit/deploy/server/test_agent.py
+++ b/deploy-agent/tests/unit/deploy/server/test_agent.py
@@ -60,7 +60,7 @@ class TestDeployAgent(TestCase):
 
         cls.deploy_goal1 = {}
         cls.deploy_goal1['deployId'] = '123'
-        cls.deploy_goal1['envName'] = 'abc'
+        cls.deploy_goal1['envName'] = 'beacon'
         cls.deploy_goal1['envId'] = 'def'
         cls.deploy_goal1['stageName'] = 'beta'
         cls.deploy_goal1['deployStage'] = DeployStage.PRE_DOWNLOAD
@@ -68,7 +68,7 @@ class TestDeployAgent(TestCase):
 
         cls.deploy_goal2 = {}
         cls.deploy_goal2['deployId'] = '123'
-        cls.deploy_goal2['envName'] = 'abc'
+        cls.deploy_goal2['envName'] = 'beacon'
         cls.deploy_goal2['envId'] = 'def'
         cls.deploy_goal2['stageName'] = 'beta'
         cls.deploy_goal2['deployStage'] = DeployStage.DOWNLOADING
@@ -76,21 +76,21 @@ class TestDeployAgent(TestCase):
 
         cls.deploy_goal3 = {}
         cls.deploy_goal3['deployId'] = '123'
-        cls.deploy_goal3['envName'] = 'abc'
+        cls.deploy_goal3['envName'] = 'beacon'
         cls.deploy_goal3['envId'] = 'def'
         cls.deploy_goal3['stageName'] = 'beta'
         cls.deploy_goal3['deployStage'] = DeployStage.STAGING
 
         cls.deploy_goal4 = {}
         cls.deploy_goal4['deployId'] = '123'
-        cls.deploy_goal4['envName'] = 'abc'
+        cls.deploy_goal4['envName'] = 'beacon'
         cls.deploy_goal4['envId'] = 'def'
         cls.deploy_goal4['stageName'] = 'beta'
         cls.deploy_goal4['deployStage'] = DeployStage.PRE_RESTART
 
         cls.deploy_goal5 = {}
         cls.deploy_goal5['deployId'] = '123'
-        cls.deploy_goal5['envName'] = 'abc'
+        cls.deploy_goal5['envName'] = 'beacon'
         cls.deploy_goal5['envId'] = 'def'
         cls.deploy_goal5['stageName'] = 'beta'
         cls.deploy_goal5['deployId'] = '234'
@@ -99,7 +99,7 @@ class TestDeployAgent(TestCase):
 
         cls.deploy_goal6 = {}
         cls.deploy_goal6['deployId'] = '123'
-        cls.deploy_goal6['envName'] = 'abc'
+        cls.deploy_goal6['envName'] = 'beacon'
         cls.deploy_goal6['envId'] = 'def'
         cls.deploy_goal6['stageName'] = 'beta'
         cls.deploy_goal6['deployId'] = '234'
@@ -203,7 +203,7 @@ class TestDeployAgent(TestCase):
 
         deploy_goal5 = {}
         deploy_goal5['deployId'] = '234'
-        deploy_goal5['envName'] = 'bcd'
+        deploy_goal5['envName'] = 'beacon'
         deploy_goal5['envId'] = 'efg'
         deploy_goal5['stageName'] = 'prod'
         deploy_goal5['deployStage'] = DeployStage.PRE_DOWNLOAD
@@ -211,7 +211,7 @@ class TestDeployAgent(TestCase):
 
         deploy_goal6 = {}
         deploy_goal6['deployId'] = '234'
-        deploy_goal6['envName'] = 'bcd'
+        deploy_goal6['envName'] = 'beacon'
         deploy_goal6['envId'] = 'efg'
         deploy_goal6['stageName'] = 'prod'
         deploy_goal6['deployStage'] = DeployStage.DOWNLOADING
@@ -219,28 +219,28 @@ class TestDeployAgent(TestCase):
 
         deploy_goal7 = {}
         deploy_goal7['deployId'] = '234'
-        deploy_goal7['envName'] = 'bcd'
+        deploy_goal7['envName'] = 'beacon'
         deploy_goal7['envId'] = 'efg'
         deploy_goal7['stageName'] = 'prod'
         deploy_goal7['deployStage'] = DeployStage.STAGING
 
         deploy_goal8 = {}
         deploy_goal8['deployId'] = '234'
-        deploy_goal8['envName'] = 'bcd'
+        deploy_goal8['envName'] = 'beacon'
         deploy_goal8['envId'] = 'efg'
         deploy_goal8['stageName'] = 'prod'
         deploy_goal8['deployStage'] = DeployStage.RESTARTING
 
         deploy_goal9 = {}
         deploy_goal9['deployId'] = '234'
-        deploy_goal9['envName'] = 'bcd'
+        deploy_goal9['envName'] = 'beacon'
         deploy_goal9['envId'] = 'efg'
         deploy_goal9['stageName'] = 'prod'
         deploy_goal9['deployStage'] = DeployStage.POST_RESTART
 
         deploy_goal10 = {}
         deploy_goal10['deployId'] = '234'
-        deploy_goal10['envName'] = 'bcd'
+        deploy_goal10['envName'] = 'beacon'
         deploy_goal10['envId'] = 'efg'
         deploy_goal10['stageName'] = 'prod'
         deploy_goal10['deployStage'] = DeployStage.SERVING_BUILD
@@ -300,7 +300,7 @@ class TestDeployAgent(TestCase):
         ping_report = {}
         ping_report['deployId'] = '123'
         ping_report['envId'] = '234'
-        ping_report['envName'] = 'abc'
+        ping_report['envName'] = 'beacon'
         ping_report['stageName'] = 'beta'
         ping_report['deployStage'] = DeployStage.SERVING_BUILD
         ping_report['status'] = AgentStatus.SUCCEEDED
@@ -313,7 +313,7 @@ class TestDeployAgent(TestCase):
         deploy_goal = {}
         deploy_goal['deployId'] = '123'
         deploy_goal['envId'] = '234'
-        deploy_goal['envName'] = 'abc'
+        deploy_goal['envName'] = 'beacon'
         deploy_goal['stageName'] = 'beta'
         ping_response = {'deployGoal': deploy_goal, 'opCode': OpCode.DELETE}
 
@@ -347,7 +347,7 @@ class TestDeployAgent(TestCase):
         ping_report = {}
         ping_report['deployId'] = '123'
         ping_report['envId'] = '234'
-        ping_report['envName'] = 'abc'
+        ping_report['envName'] = 'beacon'
         ping_report['stageName'] = 'beta'
         ping_report['deployStage'] = DeployStage.SERVING_BUILD
         ping_report['status'] = AgentStatus.SUCCEEDED
@@ -377,7 +377,7 @@ class TestDeployAgent(TestCase):
         client = mock.Mock()
         deploy_goal = {}
         deploy_goal['deployId'] = '123'
-        deploy_goal['envName'] = '456'
+        deploy_goal['envName'] = 'beacon'
         deploy_goal['envId'] = '789'
         deploy_goal['stageName'] = 'beta'
         deploy_goal['deployStage'] = DeployStage.PRE_DOWNLOAD
@@ -416,21 +416,21 @@ class TestDeployAgent(TestCase):
 
         deploy_goal5 = {}
         deploy_goal5['deployId'] = '123'
-        deploy_goal5['envName'] = 'abc'
+        deploy_goal5['envName'] = 'beacon'
         deploy_goal5['envId'] = 'def'
         deploy_goal5['stageName'] = 'beta'
         deploy_goal5['deployStage'] = DeployStage.RESTARTING
 
         deploy_goal6 = {}
         deploy_goal6['deployId'] = '123'
-        deploy_goal6['envName'] = 'abc'
+        deploy_goal6['envName'] = 'beacon'
         deploy_goal6['envId'] = 'def'
         deploy_goal6['stageName'] = 'beta'
         deploy_goal6['deployStage'] = DeployStage.POST_RESTART
 
         deploy_goal7 = {}
         deploy_goal7['deployId'] = '123'
-        deploy_goal7['envName'] = 'abc'
+        deploy_goal7['envName'] = 'beacon'
         deploy_goal7['envId'] = 'def'
         deploy_goal7['stageName'] = 'beta'
         deploy_goal7['deployStage'] = DeployStage.SERVING_BUILD
@@ -460,7 +460,7 @@ class TestDeployAgent(TestCase):
         self.executor.execute_command.assert_has_calls(calls)
         self.assertEqual(len(d._envs), 1)
         self.assertEqual(d._curr_report.report.envId, 'def')
-        self.assertEqual(d._curr_report.report.envName, 'abc')
+        self.assertEqual(d._curr_report.report.envName, 'beacon')
         self.assertEqual(d._curr_report.report.deployId, '123')
         self.assertEqual(d._curr_report.report.stageName, 'beta')
         self.assertEqual(d._curr_report.report.deployStage, DeployStage.SERVING_BUILD)

--- a/deploy-agent/tests/unit/deploy/server/test_agent.py
+++ b/deploy-agent/tests/unit/deploy/server/test_agent.py
@@ -60,7 +60,7 @@ class TestDeployAgent(TestCase):
 
         cls.deploy_goal1 = {}
         cls.deploy_goal1['deployId'] = '123'
-        cls.deploy_goal1['envName'] = 'beacon'
+        cls.deploy_goal1['envName'] = 'abc'
         cls.deploy_goal1['envId'] = 'def'
         cls.deploy_goal1['stageName'] = 'beta'
         cls.deploy_goal1['deployStage'] = DeployStage.PRE_DOWNLOAD
@@ -68,7 +68,7 @@ class TestDeployAgent(TestCase):
 
         cls.deploy_goal2 = {}
         cls.deploy_goal2['deployId'] = '123'
-        cls.deploy_goal2['envName'] = 'beacon'
+        cls.deploy_goal2['envName'] = 'abc'
         cls.deploy_goal2['envId'] = 'def'
         cls.deploy_goal2['stageName'] = 'beta'
         cls.deploy_goal2['deployStage'] = DeployStage.DOWNLOADING
@@ -76,21 +76,21 @@ class TestDeployAgent(TestCase):
 
         cls.deploy_goal3 = {}
         cls.deploy_goal3['deployId'] = '123'
-        cls.deploy_goal3['envName'] = 'beacon'
+        cls.deploy_goal3['envName'] = 'abc'
         cls.deploy_goal3['envId'] = 'def'
         cls.deploy_goal3['stageName'] = 'beta'
         cls.deploy_goal3['deployStage'] = DeployStage.STAGING
 
         cls.deploy_goal4 = {}
         cls.deploy_goal4['deployId'] = '123'
-        cls.deploy_goal4['envName'] = 'beacon'
+        cls.deploy_goal4['envName'] = 'abc'
         cls.deploy_goal4['envId'] = 'def'
         cls.deploy_goal4['stageName'] = 'beta'
         cls.deploy_goal4['deployStage'] = DeployStage.PRE_RESTART
 
         cls.deploy_goal5 = {}
         cls.deploy_goal5['deployId'] = '123'
-        cls.deploy_goal5['envName'] = 'beacon'
+        cls.deploy_goal5['envName'] = 'abc'
         cls.deploy_goal5['envId'] = 'def'
         cls.deploy_goal5['stageName'] = 'beta'
         cls.deploy_goal5['deployId'] = '234'
@@ -99,7 +99,7 @@ class TestDeployAgent(TestCase):
 
         cls.deploy_goal6 = {}
         cls.deploy_goal6['deployId'] = '123'
-        cls.deploy_goal6['envName'] = 'beacon'
+        cls.deploy_goal6['envName'] = 'abc'
         cls.deploy_goal6['envId'] = 'def'
         cls.deploy_goal6['stageName'] = 'beta'
         cls.deploy_goal6['deployId'] = '234'
@@ -163,9 +163,9 @@ class TestDeployAgent(TestCase):
         d.serve_build()
 
         calls = [mock.call(['deploy-downloader', '-f', '/etc/deployagent.conf', '-v',
-                            '123', '-u', 'https://test', '-e', 'beacon']),
+                            '123', '-u', 'https://test', '-e', 'abc']),
                  mock.call(['deploy-stager', '-f', '/etc/deployagent.conf', '-v',
-                            '123', '-t', '/tmp/tests', '-e', 'beacon'])]
+                            '123', '-t', '/tmp/tests', '-e', 'abc'])]
         self.executor.run_cmd.assert_has_calls(calls)
         self.assertEqual(len(d._envs), 0)
 
@@ -203,7 +203,7 @@ class TestDeployAgent(TestCase):
 
         deploy_goal5 = {}
         deploy_goal5['deployId'] = '234'
-        deploy_goal5['envName'] = 'mcrouter'
+        deploy_goal5['envName'] = 'bcd'
         deploy_goal5['envId'] = 'efg'
         deploy_goal5['stageName'] = 'prod'
         deploy_goal5['deployStage'] = DeployStage.PRE_DOWNLOAD
@@ -211,7 +211,7 @@ class TestDeployAgent(TestCase):
 
         deploy_goal6 = {}
         deploy_goal6['deployId'] = '234'
-        deploy_goal6['envName'] = 'mcrouter'
+        deploy_goal6['envName'] = 'bcd'
         deploy_goal6['envId'] = 'efg'
         deploy_goal6['stageName'] = 'prod'
         deploy_goal6['deployStage'] = DeployStage.DOWNLOADING
@@ -219,28 +219,28 @@ class TestDeployAgent(TestCase):
 
         deploy_goal7 = {}
         deploy_goal7['deployId'] = '234'
-        deploy_goal7['envName'] = 'mcrouter'
+        deploy_goal7['envName'] = 'bcd'
         deploy_goal7['envId'] = 'efg'
         deploy_goal7['stageName'] = 'prod'
         deploy_goal7['deployStage'] = DeployStage.STAGING
 
         deploy_goal8 = {}
         deploy_goal8['deployId'] = '234'
-        deploy_goal8['envName'] = 'mcrouter'
+        deploy_goal8['envName'] = 'bcd'
         deploy_goal8['envId'] = 'efg'
         deploy_goal8['stageName'] = 'prod'
         deploy_goal8['deployStage'] = DeployStage.RESTARTING
 
         deploy_goal9 = {}
         deploy_goal9['deployId'] = '234'
-        deploy_goal9['envName'] = 'mcrouter'
+        deploy_goal9['envName'] = 'bcd'
         deploy_goal9['envId'] = 'efg'
         deploy_goal9['stageName'] = 'prod'
         deploy_goal9['deployStage'] = DeployStage.POST_RESTART
 
         deploy_goal10 = {}
         deploy_goal10['deployId'] = '234'
-        deploy_goal10['envName'] = 'mcrouter'
+        deploy_goal10['envName'] = 'bcd'
         deploy_goal10['envId'] = 'efg'
         deploy_goal10['stageName'] = 'prod'
         deploy_goal10['deployStage'] = DeployStage.SERVING_BUILD
@@ -272,48 +272,48 @@ class TestDeployAgent(TestCase):
                         executor=self.executor, helper=self.helper)
         d.serve_build()
         calls = [mock.call(['deploy-downloader', '-f', '/etc/deployagent.conf', '-v',
-                            '123', '-u', 'https://test', '-e', 'beacon']),
+                            '123', '-u', 'https://test', '-e', 'abc']),
                  mock.call(['deploy-stager', '-f', '/etc/deployagent.conf', '-v',
-                            '123', '-t', '/tmp/tests', '-e', 'beacon']),
+                            '123', '-t', '/tmp/tests', '-e', 'abc']),
                  mock.call(['deploy-downloader', '-f', '/etc/deployagent.conf', '-v',
-                            '123', '-u', 'https://test2', '-e', 'mcrouter']),
+                            '123', '-u', 'https://test2', '-e', 'bcd']),
                  mock.call(['deploy-stager', '-f', '/etc/deployagent.conf', '-v',
-                            '123', '-t', '/tmp/tests', '-e', 'mcrouter'])]
+                            '123', '-t', '/tmp/tests', '-e', 'bcd'])]
         self.executor.run_cmd.assert_has_calls(calls)
         self.assertEqual(len(d._envs), 2)
-        self.assertEqual(d._envs['beacon'].report.deployStage, DeployStage.PRE_RESTART)
-        self.assertEqual(d._envs['beacon'].report.deployId, '123')
-        self.assertEqual(d._envs['beacon'].report.envId, 'def')
-        self.assertEqual(d._envs['beacon'].report.status, AgentStatus.SUCCEEDED)
-        self.assertEqual(d._envs['beacon'].build_info.build_commit, 'abcd')
-        self.assertEqual(d._envs['beacon'].build_info.build_url, 'https://test')
+        self.assertEqual(d._envs['abc'].report.deployStage, DeployStage.PRE_RESTART)
+        self.assertEqual(d._envs['abc'].report.deployId, '123')
+        self.assertEqual(d._envs['abc'].report.envId, 'def')
+        self.assertEqual(d._envs['abc'].report.status, AgentStatus.SUCCEEDED)
+        self.assertEqual(d._envs['abc'].build_info.build_commit, 'abcd')
+        self.assertEqual(d._envs['abc'].build_info.build_url, 'https://test')
 
-        self.assertEqual(d._envs['mcrouter'].report.deployStage, DeployStage.SERVING_BUILD)
-        self.assertEqual(d._envs['mcrouter'].report.deployId, '234')
-        self.assertEqual(d._envs['mcrouter'].report.envId, 'efg')
-        self.assertEqual(d._envs['mcrouter'].report.status, AgentStatus.SUCCEEDED)
-        self.assertEqual(d._envs['mcrouter'].build_info.build_commit, 'abcd')
-        self.assertEqual(d._envs['mcrouter'].build_info.build_url, 'https://test2')
+        self.assertEqual(d._envs['bcd'].report.deployStage, DeployStage.SERVING_BUILD)
+        self.assertEqual(d._envs['bcd'].report.deployId, '234')
+        self.assertEqual(d._envs['bcd'].report.envId, 'efg')
+        self.assertEqual(d._envs['bcd'].report.status, AgentStatus.SUCCEEDED)
+        self.assertEqual(d._envs['bcd'].build_info.build_commit, 'abcd')
+        self.assertEqual(d._envs['bcd'].build_info.build_url, 'https://test2')
 
     def test_delete_report(self):
         status = DeployStatus()
         ping_report = {}
         ping_report['deployId'] = '123'
         ping_report['envId'] = '234'
-        ping_report['envName'] = 'beacon'
+        ping_report['envName'] = 'abc'
         ping_report['stageName'] = 'beta'
         ping_report['deployStage'] = DeployStage.SERVING_BUILD
         ping_report['status'] = AgentStatus.SUCCEEDED
         status.report = PingReport(jsonValue=ping_report)
 
-        envs = {'beacon': status}
+        envs = {'abc': status}
         client = mock.Mock()
         estatus = mock.Mock()
         estatus.load_envs = mock.Mock(return_value=envs)
         deploy_goal = {}
         deploy_goal['deployId'] = '123'
         deploy_goal['envId'] = '234'
-        deploy_goal['envName'] = 'beacon'
+        deploy_goal['envName'] = 'abc'
         deploy_goal['stageName'] = 'beta'
         ping_response = {'deployGoal': deploy_goal, 'opCode': OpCode.DELETE}
 
@@ -347,7 +347,7 @@ class TestDeployAgent(TestCase):
         ping_report = {}
         ping_report['deployId'] = '123'
         ping_report['envId'] = '234'
-        ping_report['envName'] = 'beacon'
+        ping_report['envName'] = 'abc'
         ping_report['stageName'] = 'beta'
         ping_report['deployStage'] = DeployStage.SERVING_BUILD
         ping_report['status'] = AgentStatus.SUCCEEDED
@@ -377,7 +377,7 @@ class TestDeployAgent(TestCase):
         client = mock.Mock()
         deploy_goal = {}
         deploy_goal['deployId'] = '123'
-        deploy_goal['envName'] = 'beacon'
+        deploy_goal['envName'] = '456'
         deploy_goal['envId'] = '789'
         deploy_goal['stageName'] = 'beta'
         deploy_goal['deployStage'] = DeployStage.PRE_DOWNLOAD
@@ -416,21 +416,21 @@ class TestDeployAgent(TestCase):
 
         deploy_goal5 = {}
         deploy_goal5['deployId'] = '123'
-        deploy_goal5['envName'] = 'beacon'
+        deploy_goal5['envName'] = 'abc'
         deploy_goal5['envId'] = 'def'
         deploy_goal5['stageName'] = 'beta'
         deploy_goal5['deployStage'] = DeployStage.RESTARTING
 
         deploy_goal6 = {}
         deploy_goal6['deployId'] = '123'
-        deploy_goal6['envName'] = 'beacon'
+        deploy_goal6['envName'] = 'abc'
         deploy_goal6['envId'] = 'def'
         deploy_goal6['stageName'] = 'beta'
         deploy_goal6['deployStage'] = DeployStage.POST_RESTART
 
         deploy_goal7 = {}
         deploy_goal7['deployId'] = '123'
-        deploy_goal7['envName'] = 'beacon'
+        deploy_goal7['envName'] = 'abc'
         deploy_goal7['envId'] = 'def'
         deploy_goal7['stageName'] = 'beta'
         deploy_goal7['deployStage'] = DeployStage.SERVING_BUILD
@@ -460,7 +460,7 @@ class TestDeployAgent(TestCase):
         self.executor.execute_command.assert_has_calls(calls)
         self.assertEqual(len(d._envs), 1)
         self.assertEqual(d._curr_report.report.envId, 'def')
-        self.assertEqual(d._curr_report.report.envName, 'beacon')
+        self.assertEqual(d._curr_report.report.envName, 'abc')
         self.assertEqual(d._curr_report.report.deployId, '123')
         self.assertEqual(d._curr_report.report.stageName, 'beta')
         self.assertEqual(d._curr_report.report.deployStage, DeployStage.SERVING_BUILD)
@@ -514,7 +514,7 @@ class TestDeployAgent(TestCase):
                             executor=self.executor, helper=self.helper)
         agent.serve_build()
         mock_create_sc.assert_called_once_with('deployd.stats.deploy.status.sum', tags={
-                                               'first_run': False, 'deploy_stage': 'PRE_DOWNLOAD', 'env_name': 'beacon', 'stage_name': 'beta', 'status_code': 'SUCCEEDED'})
+                                               'first_run': False, 'deploy_stage': 'PRE_DOWNLOAD', 'env_name': 'abc', 'stage_name': 'beta', 'status_code': 'SUCCEEDED'})
         self.assertEqual(agent._curr_report.report.deployStage, DeployStage.PRE_DOWNLOAD)
         self.assertEqual(agent._curr_report.report.status, AgentStatus.SUCCEEDED)
 


### PR DESCRIPTION
We need to send container health status to agent server so that Teletraan UI page can expose the container health status.