### PR TITLE
Updating data sent from deploy board on host type creation

### DIFF
--- a/deploy-board/deploy_board/webapp/cluster_view.py
+++ b/deploy-board/deploy_board/webapp/cluster_view.py
@@ -570,7 +570,6 @@ def create_host_type(request):
     host_type_info['mem'] = float(params['mem']) * 1024
     host_type_info['core'] = int(params['core'])
     host_type_info['storage'] = params['storage']
-    host_type_info['blessed_status'] = hosttypes_helper.BlessedStatusValues.ONBOARDING
     hosttypes_helper.create_host_type(request, host_type_info)
     return redirect('/clouds/hosttypes/')
 
@@ -1081,7 +1080,7 @@ def start_cluster_replacement(request, name, stage):
             messages.warning(request, "Cluster replacement is already in progress.", "cluster-replacements")
         else:
             messages.warning(request, str(ex), "cluster-replacements")
-    
+
     return redirect('/env/{}/{}/cluster_replacements'.format(name, stage))
 
 def perform_cluster_replacement_action(request, name, stage, action, includeMessage=True):


### PR DESCRIPTION
Host Type creation is being blocked by invalid value sent from deploy board. This update is to allow the API to populate the default value 