### PR TITLE
Fix typo on "revoke" tooltip in UI

### DIFF
--- a/deploy-board/deploy_board/templates/users/users_config.tmpl
+++ b/deploy-board/deploy_board/templates/users/users_config.tmpl
@@ -33,7 +33,7 @@
             </select>
         </div>
         <button type="button" class="deleteBtn deployToolTip btn btn-default"
-                title="Rovoke this permission"> Revoke
+                title="Revoke this permission"> Revoke
         </button>
         {% if user_types == 'token_roles' %}
         <button type="button" class="showTokenBtn deployToolTip btn btn-default"


### PR DESCRIPTION
Was watching a walk-through and observed this typo. Its existence suggests running some kind of spellchecker on the templates might be fruitful; though questionable return on effort.