### PR TITLE
Revert "Use dropwizard health configurations and remove healthCheckController (#1247)"

### DIFF
--- a/deploy-service/teletraanservice/bin/server-no-db.yaml
+++ b/deploy-service/teletraanservice/bin/server-no-db.yaml
@@ -59,21 +59,3 @@ workers:
       period: 300
       minStaleHostThreshold: 150
       maxStaleHostThreshold: 600
-
-#
-# Health settings
-#
-health:
-  delayedShutdownHandlerEnabled: true
-  shutdownWaitPeriod: 30s
-  healthCheckUrlPaths:
-    - /healthcheck
-    - /health-check
-  healthChecks:
-    - name: generic
-      critical: true
-      schedule:
-        checkInterval: 5s
-        downtimeInterval: 10s
-        failureAttempts: 2
-        successAttempts: 1

--- a/deploy-service/teletraanservice/bin/server.yaml
+++ b/deploy-service/teletraanservice/bin/server.yaml
@@ -189,22 +189,3 @@ workers:
 # Ping Requst validators:
 # pingrequestvalidators:
 #  -  com.pinterest.deployservice.pingrequests.Ec2InstanceValidator
-
-
-#
-# Health settings
-#
-health:
-  delayedShutdownHandlerEnabled: true
-  shutdownWaitPeriod: 30s
-  healthCheckUrlPaths:
-    - /healthcheck
-    - /health-check
-  healthChecks:
-    - name: generic
-      critical: true
-      schedule:
-        checkInterval: 5s
-        downtimeInterval: 10s
-        failureAttempts: 2
-        successAttempts: 1

--- a/deploy-service/teletraanservice/pom.xml
+++ b/deploy-service/teletraanservice/pom.xml
@@ -19,7 +19,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <dropwizard.version>1.3.29</dropwizard.version>
-        <dropwizard.health.version>1.7.3</dropwizard.health.version>
     </properties>
 
     <dependencies>
@@ -48,11 +47,6 @@
                 </exclusion>
 	      </exclusions>
 	    <version>${dropwizard.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.dropwizard.modules</groupId>
-            <artifactId>dropwizard-health</artifactId>
-            <version>${dropwizard.health.version}</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanAgentService.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanAgentService.java
@@ -16,13 +16,12 @@
 package com.pinterest.teletraan;
 
 import com.pinterest.teletraan.health.GenericHealthCheck;
+import com.pinterest.teletraan.health.HealthCheckController;
 import com.pinterest.teletraan.resource.Pings;
 import io.dropwizard.Application;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
-import io.dropwizard.health.conf.HealthConfiguration;
-import io.dropwizard.health.core.HealthCheckBundle;
 import io.dropwizard.setup.Bootstrap;
 
 public class TeletraanAgentService extends Application<TeletraanServiceConfiguration> {
@@ -39,13 +38,7 @@ public class TeletraanAgentService extends Application<TeletraanServiceConfigura
                         new EnvironmentVariableSubstitutor(false)
                 )
         );
-        bootstrap.addBundle(new HealthCheckBundle<TeletraanServiceConfiguration>() {
-            @Override
-            protected HealthConfiguration getHealthConfiguration(final TeletraanServiceConfiguration configuration) {
-                return configuration.getHealthConfiguration();
-            }
-        });
-        }
+    }
 
     @Override
     public void run(TeletraanServiceConfiguration configuration, Environment environment) throws Exception {
@@ -56,6 +49,8 @@ public class TeletraanAgentService extends Application<TeletraanServiceConfigura
         environment.jersey().register(pings);
 
         environment.healthChecks().register("generic", new GenericHealthCheck(context));
+
+        environment.jersey().register(new HealthCheckController(environment.healthChecks()));
     }
 
     public static void main(String[] args) throws Exception {

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanService.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanService.java
@@ -17,13 +17,12 @@ package com.pinterest.teletraan;
 
 import com.pinterest.teletraan.exception.GenericExceptionMapper;
 import com.pinterest.teletraan.health.GenericHealthCheck;
+import com.pinterest.teletraan.health.HealthCheckController;
 import com.pinterest.teletraan.resource.*;
 
 import io.dropwizard.Application;
 import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
-import io.dropwizard.health.conf.HealthConfiguration;
-import io.dropwizard.health.core.HealthCheckBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.swagger.jaxrs.config.BeanConfig;
@@ -53,12 +52,6 @@ public class TeletraanService extends Application<TeletraanServiceConfiguration>
                 new EnvironmentVariableSubstitutor(false)
             )
         );
-        bootstrap.addBundle(new HealthCheckBundle<TeletraanServiceConfiguration>() {
-            @Override
-            protected HealthConfiguration getHealthConfiguration(final TeletraanServiceConfiguration configuration) {
-                return configuration.getHealthConfiguration();
-            }
-        });
     }
 
     @Override
@@ -170,6 +163,7 @@ public class TeletraanService extends Application<TeletraanServiceConfiguration>
         ConfigHelper.scheduleWorkers(configuration, context);
 
         environment.healthChecks().register("generic", new GenericHealthCheck(context));
+        environment.jersey().register(new HealthCheckController(environment.healthChecks()));
 
         // Exception handler
         environment.jersey().register(new GenericExceptionMapper(configuration.getSystemFactory().getClientError()));

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanServiceConfiguration.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanServiceConfiguration.java
@@ -39,7 +39,6 @@ import com.pinterest.teletraan.config.WorkerConfig;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
-import io.dropwizard.health.conf.HealthConfiguration;
 
 import java.util.Collections;
 import java.util.List;
@@ -114,10 +113,6 @@ public class TeletraanServiceConfiguration extends Configuration {
     @Valid
     @JsonProperty("pingrequestvalidators")
     private List<String> pingRequestValidators;
-
-    @Valid
-    @JsonProperty("health")
-    private HealthConfiguration healthConfiguration = new HealthConfiguration();
 
     public DataSourceFactory getDataSourceFactory() {
         if (dataSourceFactory == null) {
@@ -280,14 +275,6 @@ public class TeletraanServiceConfiguration extends Configuration {
 
     public void setDefaultScmTypeName(String defaultScmTypeName) {
         this.defaultScmTypeName = defaultScmTypeName;
-    }
-
-    public HealthConfiguration getHealthConfiguration() {
-        return healthConfiguration;
-    }
-
-    public void setHealthConfiguration(final HealthConfiguration healthConfiguration) {
-        this.healthConfiguration = healthConfiguration;
     }
 
     public AwsFactory getAwsFactory() {

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanWorker.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanWorker.java
@@ -15,13 +15,12 @@
  */
 package com.pinterest.teletraan;
 
+import com.pinterest.teletraan.health.HealthCheckController;
 import com.pinterest.teletraan.health.WorkerHealthCheck;
 import io.dropwizard.Application;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
-import io.dropwizard.health.conf.HealthConfiguration;
-import io.dropwizard.health.core.HealthCheckBundle;
 import io.dropwizard.setup.Bootstrap;
 
 public class TeletraanWorker extends Application<TeletraanServiceConfiguration> {
@@ -38,12 +37,6 @@ public class TeletraanWorker extends Application<TeletraanServiceConfiguration> 
                         new EnvironmentVariableSubstitutor(false)
                 )
         );
-        bootstrap.addBundle(new HealthCheckBundle<TeletraanServiceConfiguration>() {
-            @Override
-            protected HealthConfiguration getHealthConfiguration(final TeletraanServiceConfiguration configuration) {
-                return configuration.getHealthConfiguration();
-            }
-        });
     }
 
     @Override
@@ -51,6 +44,8 @@ public class TeletraanWorker extends Application<TeletraanServiceConfiguration> 
         TeletraanServiceContext context = ConfigHelper.setupContext(configuration);
         ConfigHelper.scheduleWorkers(configuration, context);
         environment.healthChecks().register("generic", new WorkerHealthCheck(context));
+
+        environment.jersey().register(new HealthCheckController(environment.healthChecks()));
     }
 
     public static void main(String[] args) throws Exception {

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/health/GenericHealthCheck.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/health/GenericHealthCheck.java
@@ -22,10 +22,13 @@ import com.pinterest.deployservice.bean.DeployQueryResultBean;
 import com.pinterest.deployservice.dao.DeployDAO;
 import com.pinterest.deployservice.db.DeployQueryFilter;
 import com.pinterest.teletraan.TeletraanServiceContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
 public class GenericHealthCheck extends HealthCheck {
+    private static final Logger LOG = LoggerFactory.getLogger(GenericHealthCheck.class);
     private final static int DEFAULT_SIZE = 2;
     private DeployDAO deployDAO;
 

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/health/HealthCheckController.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/health/HealthCheckController.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2016 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *    
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.health;
+import com.codahale.metrics.health.HealthCheck;
+import com.codahale.metrics.health.HealthCheckRegistry;
+import io.swagger.annotations.Api;
+
+import java.util.Map.Entry;
+import java.util.Set;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/healthcheck")
+@Api(tags = "healthcheck")
+@Produces(MediaType.APPLICATION_JSON)
+public class HealthCheckController {
+    private HealthCheckRegistry registry;
+
+    public HealthCheckController(HealthCheckRegistry registry) {
+        this.registry = registry;
+    }
+
+    @GET
+    public Set<Entry<String, HealthCheck.Result>> getStatus() throws Exception {
+        return registry.runHealthChecks().entrySet();
+    }
+}


### PR DESCRIPTION
Revert "Use dropwizard health configurations and remove healthCheckController (#1247)"

This reverts commit b825e5ae5ff57f5fd06c69294d4c08bb32d856d9.