### PR TITLE
check if aws config is provided.

### DIFF
--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/ConfigHelper.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/ConfigHelper.java
@@ -46,8 +46,8 @@ import com.pinterest.deployservice.rodimus.DefaultRodimusManager;
 import com.pinterest.deployservice.rodimus.RodimusManagerImpl;
 import com.pinterest.deployservice.scm.SourceControlManager;
 import com.pinterest.deployservice.scm.SourceControlManagerProxy;
-import com.pinterest.teletraan.config.BuildAllowlistFactory;
 import com.pinterest.teletraan.config.AppEventFactory;
+import com.pinterest.teletraan.config.BuildAllowlistFactory;
 import com.pinterest.teletraan.config.JenkinsFactory;
 import com.pinterest.teletraan.config.RodimusFactory;
 import com.pinterest.teletraan.config.SourceControlFactory;
@@ -103,8 +103,6 @@ public class ConfigHelper {
 
         BasicDataSource dataSource = configuration.getDataSourceFactory().build();
         context.setDataSource(dataSource);
-
-        context.setBuildEventPublisher(new EventBridgePublisher(configuration.getAwsFactory().buildEventBridgeClient(), configuration.getAwsFactory().getEventBridgeEventBusName()));
 
         context.setUserRolesDAO(new DBUserRolesDAOImpl(dataSource));
         context.setGroupRolesDAO(new DBGroupRolesDAOImpl(dataSource));
@@ -200,6 +198,9 @@ public class ConfigHelper {
             context.setPingRequestValidators(validators);
         }
 
+        if (configuration.getAwsFactory() != null) {
+            context.setBuildEventPublisher(new EventBridgePublisher(configuration.getAwsFactory().buildEventBridgeClient(), configuration.getAwsFactory().getEventBridgeEventBusName()));
+        }
 
         /**
          Lastly, let us create the in-process background job executor, all transient, long


### PR DESCRIPTION
Check if AWS config is available. Worker and agent don't need to provide AWS config since Event Bridge publishing is not used in these services.

Without this check, and if no AWS config is provided, we'll get NPE. 