### PR TITLE
Fix too many agent updates

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java
@@ -335,7 +335,9 @@ public class GoalAnalyst {
         updateBean.setState(proposeNewAgentState(report, agent));
         updateBean.setStage_start_date(System.currentTimeMillis());
         updateBean.setDeploy_stage(report.getDeployStage());
-        if (report.getContainerHealthStatus() != null) {
+        if (report.getContainerHealthStatus() == null) {
+            updateBean.setContainer_Health_Status("");
+        } else {
             updateBean.setContainer_Health_Status(report.getContainerHealthStatus());
         }
 


### PR DESCRIPTION
## Summary
Default health status is "" so the conversion from null (in deploy agent ) to "" in agent service is needed to avoid unnecessary updates. 

## Test plan
TBU