### PR TITLE
add telefig version in deploy agent metrics

### DIFF
--- a/deploy-agent/deployd/__init__.py
+++ b/deploy-agent/deployd/__init__.py
@@ -26,4 +26,4 @@ STATSBOARD_URL=os.getenv('STATSBOARD_URL', "https://statsboard.pinadmin.com/api/
 # 2: puppet applied successfully with changes
 PUPPET_SUCCESS_EXIT_CODES = [0, 2]
 	
-__version__ = '1.2.48'
+__version__ = '1.2.49'

--- a/deploy-agent/deployd/agent.py
+++ b/deploy-agent/deployd/agent.py
@@ -29,7 +29,8 @@ from deployd.common.helper import Helper
 from deployd.common.single_instance import SingleInstance
 from deployd.common.env_status import EnvStatus
 from deployd.common.stats import TimeElapsed, create_sc_timing, create_sc_increment
-from deployd.common import utils
+from deployd.common.utils import get_telefig_version,get_container_health_info, check_prereqs
+from deployd.common.utils import uptime as utils_uptime, listen as utils_listen
 from deployd.common.executor import Executor
 from deployd.common.types import DeployReport, PingStatus, DeployStatus, OpCode, DeployStage, AgentStatus
 from deployd import __version__, IS_PINTEREST, MAIN_LOGGER
@@ -75,6 +76,7 @@ class DeployAgent(object):
         self._env_status = estatus or EnvStatus(self._STATUS_FILE)
         # load environment deploy status file from local disk
         self.load_status_file()
+        self._telefig_version = get_telefig_version()
 
     def load_status_file(self):
         self._envs = self._env_status.load_envs()
@@ -110,7 +112,8 @@ class DeployAgent(object):
             tags['stage_name'] = self._response.deployGoal.stageName
         if deploy_report.status_code:
             tags['status_code'] = deploy_report.status_code
-            
+        if self._telefig_version: 
+            tags['telefig_version'] = self._telefig_version    
         create_sc_increment('deployd.stats.deploy.status.sum', tags=tags)
         
     def serve_build(self):
@@ -125,7 +128,7 @@ class DeployAgent(object):
             for status in self._envs.values():
                 # for each container, we check the health status
                 try:
-                    healthStatus = utils.get_container_health_info(status.report.envName)
+                    healthStatus = get_container_health_info(status.report.envName)
                     if healthStatus:
                         status.report.containerHealthStatus = healthStatus
                     else:
@@ -505,7 +508,7 @@ def main():
         logging.basicConfig(filename=log_filename, level=config.get_log_level(),
                             format='%(asctime)s %(name)s:%(lineno)d %(levelname)s %(message)s')
 
-    if not utils.check_prereqs(config): 
+    if not check_prereqs(config): 
         log.warning("Deploy agent cannot start because the prerequisites on puppet did not meet.")
         sys.exit(0)
         
@@ -520,12 +523,12 @@ def main():
         client = ServerlessClient(env_name=args.env_name, stage=args.stage, build=args.build,
                                   script_variables=args.script_variables)
 
-    uptime = utils.uptime()
+    uptime = utils_uptime()
     agent = DeployAgent(client=client, conf=config)
     create_sc_timing('deployd.stats.ec2_uptime_sec',
                      uptime,
                      tags={'first_run': agent.first_run})
-    utils.listen()
+    utils_listen()
     if args.daemon:
         logger = logging.getLogger()
         handles = []

--- a/deploy-agent/deployd/common/utils.py
+++ b/deploy-agent/deployd/common/utils.py
@@ -234,6 +234,20 @@ def get_container_health_info(key):
         return None
 
 
+def get_telefig_version():
+    if not IS_PINTEREST:
+        return None    
+    try:
+        cmd = ['configure-serviceset', '-v']
+        output = subprocess.run(cmd, check=True, stdout=subprocess.PIPE).stdout
+        if output:
+            return output.decode().strip()
+        else:
+            return None
+    except:
+        log.error("Error when fetching teletraan configure manager version")
+        return None
+
 def check_not_none(arg, msg=None):
     if arg is None:
         raise ValueError(msg)


### PR DESCRIPTION
## Summary 
Add telefig version to deploy agent metrics for monitoring deployment health per telefig version 

## Test plan 
Run locally 
Metrics were emitted 
https://statsboard.pinadmin.com/share/wrv9v