### PR TITLE
Allow custom metrics name

### DIFF
--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AutoPromoter.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AutoPromoter.java
@@ -15,6 +15,8 @@
  */
 package com.pinterest.teletraan.worker;
 
+import static com.pinterest.teletraan.universal.metrics.micrometer.PinStatsNamingConvention.CUSTOM_NAME_PREFIX;
+
 import com.pinterest.deployservice.ServiceContext;
 import com.pinterest.deployservice.bean.*;
 import com.pinterest.deployservice.buildtags.BuildTagsManager;
@@ -28,7 +30,9 @@ import com.pinterest.deployservice.dao.PromoteDAO;
 import com.pinterest.deployservice.dao.UtilDAO;
 import com.pinterest.deployservice.handler.DeployHandler;
 
+
 import com.google.common.base.Preconditions;
+import io.micrometer.core.instrument.Metrics;
 import org.apache.commons.lang.StringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
@@ -573,6 +577,7 @@ public class AutoPromoter implements Runnable {
         try {
             LOG.info("Start AutoPromoter process...");
             processBatch();
+            Metrics.counter(CUSTOM_NAME_PREFIX + "failed").increment();
         } catch (Throwable t) {
             // Catch all throwable so that subsequent job not suppressed
             LOG.error("Failed to call AutoPromoter.", t);

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AutoPromoter.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AutoPromoter.java
@@ -15,8 +15,6 @@
  */
 package com.pinterest.teletraan.worker;
 
-import static com.pinterest.teletraan.universal.metrics.micrometer.PinStatsNamingConvention.CUSTOM_NAME_PREFIX;
-
 import com.pinterest.deployservice.ServiceContext;
 import com.pinterest.deployservice.bean.*;
 import com.pinterest.deployservice.buildtags.BuildTagsManager;
@@ -30,9 +28,7 @@ import com.pinterest.deployservice.dao.PromoteDAO;
 import com.pinterest.deployservice.dao.UtilDAO;
 import com.pinterest.deployservice.handler.DeployHandler;
 
-
 import com.google.common.base.Preconditions;
-import io.micrometer.core.instrument.Metrics;
 import org.apache.commons.lang.StringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
@@ -577,7 +573,6 @@ public class AutoPromoter implements Runnable {
         try {
             LOG.info("Start AutoPromoter process...");
             processBatch();
-            Metrics.counter(CUSTOM_NAME_PREFIX + "failed").increment();
         } catch (Throwable t) {
             // Catch all throwable so that subsequent job not suppressed
             LOG.error("Failed to call AutoPromoter.", t);

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/metrics/micrometer/PinStatsNamingConvention.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/metrics/micrometer/PinStatsNamingConvention.java
@@ -9,7 +9,7 @@ import io.micrometer.core.instrument.Meter.Type;
 import io.micrometer.opentsdb.OpenTSDBNamingConvention;
 
 public class PinStatsNamingConvention extends OpenTSDBNamingConvention {
-
+  public final static String CUSTOM_NAME_PREFIX = "custom.";
   private String prefix = "mm.";
 
   public PinStatsNamingConvention() {
@@ -28,6 +28,10 @@ public class PinStatsNamingConvention extends OpenTSDBNamingConvention {
 
   @Override
   public String name(String name, Type type, String baseUnit) {
+    if (name.startsWith(CUSTOM_NAME_PREFIX)) {
+      return name.replaceFirst(CUSTOM_NAME_PREFIX, "");
+    }
+
     String sanitized = super.name(name, type, baseUnit);
     switch (type) {
       case COUNTER:

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/metrics/micrometer/PinStatsNamingConventionTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/metrics/micrometer/PinStatsNamingConventionTest.java
@@ -37,4 +37,11 @@ public class PinStatsNamingConventionTest {
     assertEquals("m_0tag_key", convention.tagKey("0tag.key"));
     assertEquals("m__tag_key", convention.tagKey("*tag.key"));
   }
+
+  @Test
+  void testCustomName() {
+    String customName = "abcDEF.123-xyZ";
+    assertEquals(customName,
+        convention.name(PinStatsNamingConvention.CUSTOM_NAME_PREFIX + customName, Meter.Type.COUNTER));
+  }
 }


### PR DESCRIPTION
Update the naming convention so when a metric name starts with `custom.`, no naming convention will be applied. 