### PR TITLE
Remove commit tag to reduce metrics cardinality

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/events/DeployEvent.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/events/DeployEvent.java
@@ -13,7 +13,7 @@ public class DeployEvent extends ResourceChangedEvent {
     private final String operator;
 
     public DeployEvent(Object source, String env, String stage, String commit, String operator) {
-        super("deployed_build", operator, source, ImmutableMap.of("env", env, "stage", stage, "commit", commit));
+        super("deployed_build", operator, source, ImmutableMap.of("env", env, "stage", stage));
         this.operator = operator;
         this.env = env;
         this.stage = stage;

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/events/DeployEvent.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/events/DeployEvent.java
@@ -35,4 +35,14 @@ public class DeployEvent extends ResourceChangedEvent {
     public String getOperator() {
         return operator;
     }
+
+    @Override
+    public String toString() {
+        return "DeployEvent{" +
+                "env='" + env + '\'' +
+                ", stage='" + stage + '\'' +
+                ", commit='" + commit + '\'' +
+                ", operator='" + operator + '\'' +
+                '}';
+    }
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/events/DeployEvent.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/events/DeployEvent.java
@@ -1,5 +1,7 @@
 package com.pinterest.deployservice.events;
 
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+
 import com.google.common.collect.ImmutableMap;
 import com.pinterest.teletraan.universal.events.ResourceChangedEvent;
 
@@ -38,11 +40,6 @@ public class DeployEvent extends ResourceChangedEvent {
 
     @Override
     public String toString() {
-        return "DeployEvent{" +
-                "env='" + env + '\'' +
-                ", stage='" + stage + '\'' +
-                ", commit='" + commit + '\'' +
-                ", operator='" + operator + '\'' +
-                '}';
+        return ReflectionToStringBuilder.toString(this);
     }
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/events/DeployEvent.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/events/DeployEvent.java
@@ -1,7 +1,5 @@
 package com.pinterest.deployservice.events;
 
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
-
 import com.google.common.collect.ImmutableMap;
 import com.pinterest.teletraan.universal.events.ResourceChangedEvent;
 
@@ -36,10 +34,5 @@ public class DeployEvent extends ResourceChangedEvent {
 
     public String getOperator() {
         return operator;
-    }
-
-    @Override
-    public String toString() {
-        return ReflectionToStringBuilder.toString(this);
     }
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/CommonHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/CommonHandler.java
@@ -417,9 +417,9 @@ public class CommonHandler {
                 String commit = buildBean.getScm_commit_7();
                 String envName = environBean.getEnv_name();
                 String stageName = environBean.getStage_name();
-                String what = String.format("%s/%s deploy initiated.", envName, stageName);
-                publisher.publishEvent(new DeployEvent(this, envName, stageName, commit, newDeployBean.getOperator()));
-                LOG.info("Successfully sent deploy event. what: {}, commit: {}", what, commit);
+                DeployEvent event = new DeployEvent(this, envName, stageName, commit, newDeployBean.getOperator());
+                publisher.publishEvent(event);
+                LOG.info("Successfully sent deploy event: {}", event);
             } catch (Exception ex) {
                 LOG.error("Failed to send deploy events.", ex);
             }

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/events/AppEvent.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/events/AppEvent.java
@@ -1,6 +1,9 @@
 package com.pinterest.teletraan.universal.events;
 
 import java.util.EventObject;
+
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+
 import lombok.Getter;
 
 public abstract class AppEvent extends EventObject {
@@ -15,5 +18,10 @@ public abstract class AppEvent extends EventObject {
     protected AppEvent(Object source, long timestamp) {
         super(source);
         this.timestamp = timestamp;
+    }
+
+    @Override
+    public String toString() {
+        return ReflectionToStringBuilder.toString(this);
     }
 }

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/events/GenericEventPublisher.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/events/GenericEventPublisher.java
@@ -30,8 +30,6 @@ public class GenericEventPublisher implements ReactiveEventPublisher {
             EmitResult result = eventsSink.tryEmitNext((AppEvent) event);
             if (result.isFailure()) {
                 LOG.error("Failed to publish event, cause: " + result);
-            } else {
-                LOG.debug("Published event: " + event);
             }
         } catch (Exception ex) {
             LOG.error("Failed to publish event", ex);

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/events/GenericEventPublisher.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/events/GenericEventPublisher.java
@@ -30,6 +30,8 @@ public class GenericEventPublisher implements ReactiveEventPublisher {
             EmitResult result = eventsSink.tryEmitNext((AppEvent) event);
             if (result.isFailure()) {
                 LOG.error("Failed to publish event, cause: " + result);
+            } else {
+                LOG.debug("Published event: " + event);
             }
         } catch (Exception ex) {
             LOG.error("Failed to publish event", ex);


### PR DESCRIPTION
Log the commit instead
```
INFO  [2023-12-07 20:06:37,612] com.pinterest.deployservice.handler.CommonHandler: Successfully sent deploy event: com.pinterest.deployservice.events.DeployEvent@2862ea99[commit=7079487,env=sample-service-1,operator=<null>,stage=canary,operator=<null>,resource=deployed_build,tags={env,sample-service-1,stage,canary},timestamp=1701979597612]
```