### PR TITLE
deployd: log facter exception message

### DIFF
--- a/deploy-agent/deployd/common/utils.py
+++ b/deploy-agent/deployd/common/utils.py
@@ -215,8 +215,8 @@ def get_info_from_facter(keys):
             return json.loads(output)
         else:
             return None
-    except:
-        log.error("Failed to get info from facter by keys {}".format(keys))
+    except Exception as e:
+        log.error("Failed to get info from facter by keys {}: {}".format(keys, e))
         return None
 
     


### PR DESCRIPTION
Today we sometimes see deployd errors when trying to fetch host info using facter:

```
E1019 21:03:43.646.2438106536865 MainThread /root/.pex/installed_wheels/a77ca4edb55d077339765d8ca2bec5808c937cb7fff5e7c1f439cf7d19d0ffa1/deploy_agent-1.2.46-py3-none-any.whl/deployd/common/utils.py:219] Failed to get info from facter by keys {'ec2_instance_id', 'hostname', 'deploy_service_combined', 'ec2_local_ipv4'}
```
This caused deployd to crash
```
AttributeError: 'NoneType' object has no attribute 'get'
```

This PR tries to log the exception message so we have a better understanding on why `facter` failed to fetch the info.


Not sure how this can be tested, open to suggestions. 