### PR TITLE
Better handling site metrics

### DIFF
--- a/deploy-board/deploy_board/webapp/util_views.py
+++ b/deploy-board/deploy_board/webapp/util_views.py
@@ -46,17 +46,22 @@ def _get_latest_metrics(url):
         return 0
 
     data = json.loads(data_str)
-
     # Return the first datapoint in the datapoints list
     if data:
         try:
             return [datapoint for datapoint in data['data'][0]['datapoints'] if datapoint[1] != None]
         except:
+            log.warning(f"No metrics data {data}")
             pass
 
-        # Check for TSDB response
-        if 'dps' in data[0] and len(data[0]['dps']) != 0:
-            return _convert_opentsdb_data(data[0]['dps'])
+        try:
+            # Check for TSDB response
+            if len(data) > 0 and 'dps' in data[0] and len(data[0]['dps']) != 0:
+                return _convert_opentsdb_data(data[0]['dps'])
+        except:
+            log.warning(f"No TSDB metrics data {data}")
+            pass
+
     return 0
 
 


### PR DESCRIPTION
## Summary 
The metrics urls needs to be updated. Currently it just return empty data and caused errors in prod like 
```
Traceback (most recent call last): File "/usr/local/lib/python2.7/dist-packages/django/core/handlers/base.py", line 185, in _get_response response = wrapped_callback(request, *callback_args, **callback_kwargs) File "/opt/deploy_board/deploy_board/webapp/util_views.py", line 70, in get_site_health_metrics data[metric['title']] = _get_latest_metrics(metric['url']) File "/opt/deploy_board/deploy_board/webapp/util_views.py", line 54, in _get_latest_metrics if 'dps' in data[0] and len(data[0]['dps']) != 0: KeyError: 0
```
sample output for metric urls: 
```
{"data":[],"tags":{},"metadata":{"detailed_fetch":{"m0":{"fetch_data":[5.098104476928711],"to_dataframe":[0.946044921875],"goku_ms":[null]}},"execution_time":[["total_time",6.889892578125],["initialization",0.269775390625],["fetch_data_and_to_dataframe",6.260986328125],["tscript_and_to_tsd",0.359130859375]],"num_points":{"downsampled":0,"raw":0},"reducer":{"values":{"m0":[60,"max"]},"aggregator_defined":false,"interval_defined":false,"rollup_metrics":[],"end_timestamp":1697842199,"end_modifier":60}},"alert":{},"warnings":[]}
```

Add exception handling for the empty data, they all show 0s now. Follow up would be update the metrics urls. 

## Test plan 
local and dev1 
No more `Failed to get metrics` in console. 
log
```
{"asctime": "2023-10-20 23:14:28,763", "created": "1697843668.7634304", "exc_info": "None", "exc_text": "None", "filename": "util_views.py", "funcName": "_get_latest_metrics", "levelname": "WARNING", "levelno": "30", "lineno": "54", "message": "No metrics data {'data': [], 'tags': {}, 'metadata': {'detailed_fetch': {'m0': {'fetch_data': [5.014657974243164], 'to_dataframe': [0.8754730224609375], 'goku_ms': [None]}}, 'execution_time': [['total_time', 6.721435546875], ['initialization', 0.269775390625], ['fetch_data_and_to_dataframe', 6.116943359375], ['tscript_and_to_tsd', 0.334716796875]], 'num_points': {'downsampled': 0, 'raw': 0}, 'reducer': {'values': {'m0': [60, 'sum']}, 'aggregator_defined': False, 'interval_defined': False, 'rollup_metrics': [], 'end_timestamp': 1697843639, 'end_modifier': 60}}, 'alert': {}, 'warnings': []}", "module": "util_views", "msecs": "763.4303569793701", "msg": "No metrics data {'data': [], 'tags': {}, 'metadata': {'detailed_fetch': {'m0': {'fetch_data': [5.014657974243164], 'to_dataframe': [0.8754730224609375], 'goku_ms': [None]}}, 'execution_time': [['total_time', 6.721435546875], ['initialization', 0.269775390625], ['fetch_data_and_to_dataframe', 6.116943359375], ['tscript_and_to_tsd', 0.334716796875]], 'num_points': {'downsampled': 0, 'raw': 0}, 'reducer': {'values': {'m0': [60, 'sum']}, 'aggregator_defined': False, 'interval_defined': False, 'rollup_metrics': [], 'end_timestamp': 1697843639, 'end_modifier': 60}}, 'alert': {}, 'warnings': []}", "name": "deploy_board.webapp.util_views", "pathname": "/opt/deploy-board/deploy_board/webapp/util_views.py", "process": "13500", "processName": "MainProcess", "relativeCreated": "111667.71626472473", "thread": "140582531894096", "threadName": "Thread-44"}
```
