### PR TITLE
Hotfix landing page: Fix commit link by setting the build type in the…

### DIFF
--- a/deploy-board/deploy_board/webapp/hotfix_views.py
+++ b/deploy-board/deploy_board/webapp/hotfix_views.py
@@ -114,7 +114,8 @@ class HotfixesView(View):
         index = int(request.GET.get('page_index', '1'))
         size = int(request.GET.get('page_size', DEFAULT_PAGE_SIZE))
         hotfixes = hotfixs_helper.get_all(request, name, index, size)
-        urlPattern = systems_helper.get_url_pattern(request, "")
+        build = builds_helper.get_build(request, deploy['buildId'])
+        urlPattern = systems_helper.get_url_pattern(request, build.get('type'))
         for hotfix in hotfixes:
             commits = []
             _create_commits(commits, urlPattern['template'], hotfix)


### PR DESCRIPTION
… url pattern.

The hotfixes landing page shows a list of hotfixes. For each hotfix, a
list of commits is also shown.
E.g. https://deploy.example.com/env/myproject/prod/hotfixes/

In the page, the links to commits are broken 

To Reproduce
Steps to reproduce the behavior:

    Go to 'Hotfixes'
    Click on any commits link
    If a user has specified a template, this is not considered. The link is
       broken. For example, if you switched from a old version control system
       to github, it will still use the old version.

Some more details in https://github.com/pinterest/teletraan/issues/1314