### PR TITLE
Address issues on error view 

### DIFF
--- a/deploy-board/deploy_board/webapp/auth.py
+++ b/deploy-board/deploy_board/webapp/auth.py
@@ -210,7 +210,6 @@ class OAuth(object):
             data=str(body) if body else None,
             method='POST',
         )
-
         if resp.code is 401:
             # When auth.pinadmin.com returns a 401 error. remove token and redirect to / page
             raise OAuthExpiredTokenException("Expired Token")
@@ -218,7 +217,7 @@ class OAuth(object):
         if resp.code not in (200, 201):
             raise OAuthException("Invalid OAuth response")
         try:
-            resp_data = json.loads(content)
+            resp_data = json.loads(content.decode())
         except ValueError:
             raise OAuthException("Invalid OAuth response")
 
@@ -226,7 +225,7 @@ class OAuth(object):
         self.oauth_handler.token_setter(resp_data['access_token'], expires, **kwargs)
 
         try:
-            return json.loads(enc_data)
+            return json.loads(base64.b64decode(enc_data).decode())
         except ValueError:
             return None
 

--- a/deploy-board/deploy_board/webapp/cluster_view.py
+++ b/deploy-board/deploy_board/webapp/cluster_view.py
@@ -87,6 +87,7 @@ class EnvCapacityBasicCreateView(View):
 
     def post(self, request, name, stage):
         ret = 200
+        exception = None
         log.info("Post to capacity with data {0}".format(request.body))
         try:
             cluster_name = '{}-{}'.format(name, stage)
@@ -115,16 +116,18 @@ class EnvCapacityBasicCreateView(View):
         except NotAuthorizedException as e:
             log.error("Have an NotAuthorizedException error {}".format(e))
             ret = 403
+            exception = e
         except Exception as e:
             log.error("Have an error {}".format(e))
             ret = 500
+            exception = e
         finally:
             if ret == 200:
                 return HttpResponse("{}", content_type="application/json")
             else:
                 environs_helper.remove_env_capacity(
                     request, name, stage, capacity_type="GROUP", data=cluster_name)
-                return HttpResponse(e, status=ret, content_type="application/json")
+                return HttpResponse(exception, status=ret, content_type="application/json")
 
 
 class EnvCapacityAdvCreateView(View):

--- a/deploy-board/deploy_board/webapp/error_views.py
+++ b/deploy-board/deploy_board/webapp/error_views.py
@@ -32,13 +32,13 @@ class ExceptionHandlerMiddleware(object):
 
         # Error is displayed as a fragment over related feature area
         if request.is_ajax():
-            ajax_vars = {'success': False, 'error': exception.message}
+            ajax_vars = {'success': False, 'error': str(exception)}
             return HttpResponse(json.dumps(ajax_vars), content_type='application/javascript')
         else:
             # Not authorized
             if isinstance(exception, NotAuthorizedException):
                 return render(request, 'users/not_authorized.html', {
-                    "message": exception.message,
+                    "message": str(exception),
                 })
 
             elif isinstance(exception, FailedAuthenticationException):

--- a/deploy-board/deploy_board/webapp/util_views.py
+++ b/deploy-board/deploy_board/webapp/util_views.py
@@ -46,17 +46,22 @@ def _get_latest_metrics(url):
         return 0
 
     data = json.loads(data_str)
-
     # Return the first datapoint in the datapoints list
     if data:
         try:
             return [datapoint for datapoint in data['data'][0]['datapoints'] if datapoint[1] != None]
         except:
+            log.warning(f"No metrics data {data}")
             pass
 
-        # Check for TSDB response
-        if 'dps' in data[0] and len(data[0]['dps']) != 0:
-            return _convert_opentsdb_data(data[0]['dps'])
+        try:
+            # Check for TSDB response
+            if len(data) > 0 and 'dps' in data[0] and len(data[0]['dps']) != 0:
+                return _convert_opentsdb_data(data[0]['dps'])
+        except:
+            log.warning(f"No TSDB metrics data {data}")
+            pass
+
     return 0
 
 


### PR DESCRIPTION
## Summary 
cluster view doesn't show errors from aws as `UnboundLocalError: local variable 'e' is referenced before`. Created a variable for that in cluster_view.
Besides, to view the error message we need to use str(e) instead of e.message in py3. 

## Test plan 
dev1 