### PR TITLE
Add container health status view in deployment overview page

### DIFF
--- a/deploy-board/deploy_board/templates/deploys/_container_status.html
+++ b/deploy-board/deploy_board/templates/deploys/_container_status.html
@@ -1,0 +1,7 @@
+{% if healthStatus == "healthy" %}
+<i class="fa fa-check-circle color-green"></i>
+{% elif healthStatus == "unhealthy" %}
+<i class="fa fa-exclamation-triangle color-red"></i>
+{% else %}
+<i class="fa fa-ban"></i>
+{% endif %}

--- a/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
@@ -84,6 +84,15 @@
                 <i class="fa fa-fw {{ agentStat | agentIcon }}"></i>
                 </a>
                 {% endif %}
+                {% elif report.showMode == "containerStatus" %}
+                {% if agentStat.agent.accountId and agentStat.agent.accountId != "998131032990" and agentStat.agent.accountId != "null" %}
+                <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
+                type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
+                title="{{ agentStat | agentTip }}">
+                <small>{{ agentStat.agent.hostName }}</small>
+                {% include "deploys/_container_status.html" with healthStatus=agentStat.agent.serviceHealthStatus %}
+                </a>
+                {% endif %}
                 {% endif %}              
             {% endfor %}
         {% endif %}
@@ -129,6 +138,9 @@
                             <small>{{ agentStat.agent.hostName }}</small>
                             {% endif %}
                             <i class="fa fa-fw {{ agentStat | agentIcon }}"></i>
+                            {% if report.showMode == "containerStatus" %}
+                            {% include "deploys/_container_status.html" with healthStatus=agentStat.agent.serviceHealthStatus %}
+                            {% endif %}
                         </a>
                     {% endfor %}
                 </small>

--- a/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
@@ -36,14 +36,12 @@
         </a>
             {% endif %}
         {% elif report.showMode == "containerStatus" %}
-            {% if agentStat.agent.accountId and agentStat.agent.accountId != "998131032990" and agentStat.agent.accountId != "null" %}
         <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
         type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
         title="{{ agentStat | agentTip }}">
         <small>{{ agentStat.agent.hostName }}</small>
         {% include "deploys/_container_status.html" with healthStatus=agentStat.agent.serviceHealthStatus %}
         </a>
-            {% endif %}
         {% endif %}              
     {% endfor %}
 

--- a/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
@@ -40,6 +40,15 @@
                         <i class="fa fa-fw {{ agentStat | agentIcon }}"></i>
                         </a>
                         {% endif %}
+                        {% elif report.showMode == "containerStatus" %}
+                        {% if agentStat.agent.accountId and agentStat.agent.accountId != "998131032990" and agentStat.agent.accountId != "null" %}
+                        <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
+                        type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
+                        title="{{ agentStat | agentTip }}">
+                        <small>{{ agentStat.agent.hostName }}</small>
+                        {% include "deploys/_container_status.html" with healthStatus=agentStat.agent.serviceHealthStatus %}
+                        </a>
+                        {% endif %}
                         {% endif %}        
                     {% endif %}
                 {% endfor %}

--- a/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
@@ -11,6 +11,7 @@
             {% for tagValue, hostTags in host_tag_infos.items %}
             <div class="panel panel-default table-responsive">
                 {% for agentStat in report.agentStats %}
+                    <p>{{ agentStat }}</p>
                     {% for hostTag in hostTags %}
                         {% if agentStat.agent.hostName == hostTag.hostName %}
                             {% if report.showMode == "complete" or report.showMode == "compact" %}

--- a/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
@@ -5,107 +5,107 @@
 
 {% if report.showMode != "simple" %}
 <div class="panel panel-default">
-  <div class="panel-body">
-<div class="row">
-    {% if report.sortByTag %}
-        {% for tagValue, hostTags in host_tag_infos.items %}
-        <div class="panel panel-default table-responsive">
-            {% for agentStat in report.agentStats %}
-                {% for hostTag in hostTags %}
-                    {% if agentStat.agent.hostName == hostTag.hostName %}
-                        {% if report.showMode == "complete" or report.showMode == "compact" %}
-                        <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
-                        type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
-                        title="{{ agentStat | agentTip }}">
-                        {% if report.showMode != "compact" %}
-                        <small>{{ agentStat.agent.hostName }}</small>
+<div class="panel-body">
+    <div class="row">
+        {% if report.sortByTag %}
+            {% for tagValue, hostTags in host_tag_infos.items %}
+            <div class="panel panel-default table-responsive">
+                {% for agentStat in report.agentStats %}
+                    {% for hostTag in hostTags %}
+                        {% if agentStat.agent.hostName == hostTag.hostName %}
+                            {% if report.showMode == "complete" or report.showMode == "compact" %}
+                            <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
+                            type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
+                            title="{{ agentStat | agentTip }}">
+                            {% if report.showMode != "compact" %}
+                            <small>{{ agentStat.agent.hostName }}</small>
+                            {% endif %}
+                            <i class="fa fa-fw {{ agentStat | agentIcon }}"></i>
+                            </a>
+                            {% elif report.showMode == "primaryAcct" %}
+                            {% if not agentStat.agent.accountId or agentStat.agent.accountId == "998131032990" or agentStat.agent.accountId == "null" %}
+                            <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
+                            type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
+                            title="{{ agentStat | agentTip }}">              
+                            <small>{{ agentStat.agent.hostName }}</small>
+                            <i class="fa fa-fw {{ agentStat | agentIcon }}"></i>
+                            </a>
+                            {% endif %}
+                            {% elif report.showMode == "subAcct" %}
+                            {% if agentStat.agent.accountId and agentStat.agent.accountId != "998131032990" and agentStat.agent.accountId != "null" %}
+                            <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
+                            type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
+                            title="{{ agentStat | agentTip }}">              
+                            <small>{{ agentStat.agent.hostName }}</small>
+                            <i class="fa fa-fw {{ agentStat | agentIcon }}"></i>
+                            </a>
+                            {% endif %}
+                            {% elif report.showMode == "containerStatus" %}
+                            {% if agentStat.agent.accountId and agentStat.agent.accountId != "998131032990" and agentStat.agent.accountId != "null" %}
+                            <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
+                            type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
+                            title="{{ agentStat | agentTip }}">
+                            <small>{{ agentStat.agent.hostName }}</small>
+                            {% include "deploys/_container_status.html" with healthStatus=agentStat.agent.serviceHealthStatus %}
+                            </a>
+                            {% endif %}
+                            {% endif %}        
                         {% endif %}
-                        <i class="fa fa-fw {{ agentStat | agentIcon }}"></i>
-                        </a>
-                        {% elif report.showMode == "primaryAcct" %}
-                        {% if not agentStat.agent.accountId or agentStat.agent.accountId == "998131032990" or agentStat.agent.accountId == "null" %}
-                        <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
-                        type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
-                        title="{{ agentStat | agentTip }}">              
-                        <small>{{ agentStat.agent.hostName }}</small>
-                        <i class="fa fa-fw {{ agentStat | agentIcon }}"></i>
-                        </a>
-                        {% endif %}
-                        {% elif report.showMode == "subAcct" %}
-                        {% if agentStat.agent.accountId and agentStat.agent.accountId != "998131032990" and agentStat.agent.accountId != "null" %}
-                        <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
-                        type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
-                        title="{{ agentStat | agentTip }}">              
-                        <small>{{ agentStat.agent.hostName }}</small>
-                        <i class="fa fa-fw {{ agentStat | agentIcon }}"></i>
-                        </a>
-                        {% endif %}
-                        {% elif report.showMode == "containerStatus" %}
-                        {% if agentStat.agent.accountId and agentStat.agent.accountId != "998131032990" and agentStat.agent.accountId != "null" %}
-                        <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
-                        type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
-                        title="{{ agentStat | agentTip }}">
-                        <small>{{ agentStat.agent.hostName }}</small>
-                        {% include "deploys/_container_status.html" with healthStatus=agentStat.agent.serviceHealthStatus %}
-                        </a>
-                        {% endif %}
-                        {% endif %}        
-                    {% endif %}
+                    {% endfor %}
                 {% endfor %}
+            </div>
             {% endfor %}
-        </div>
-        {% endfor %}
-    {% else %}
-        {% for agentStat in report.agentStats %}
-               {% if report.showMode == "complete" or report.showMode == "compact" %}
-               <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
-               type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
-               title="{{ agentStat | agentTip }}">
-               {% if report.showMode != "compact" %}
-               <small>{{ agentStat.agent.hostName }}</small>
-               {% endif %}
-               <i class="fa fa-fw {{ agentStat | agentIcon }}"></i>
-               </a>
-               {% elif report.showMode == "primaryAcct" %}
-               {% if not agentStat.agent.accountId or agentStat.agent.accountId == "998131032990" or agentStat.agent.accountId == "null" %}
-               <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
-               type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
-               title="{{ agentStat | agentTip }}">              
-               <small>{{ agentStat.agent.hostName }}</small>
-               <i class="fa fa-fw {{ agentStat | agentIcon }}"></i>
-               </a>
-               {% endif %}
-               {% elif report.showMode == "subAcct" %}
-               {% if agentStat.agent.accountId and agentStat.agent.accountId != "998131032990" and agentStat.agent.accountId != "null" %}
-               <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
-               type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
-               title="{{ agentStat | agentTip }}">              
-               <small>{{ agentStat.agent.hostName }}</small>
-               <i class="fa fa-fw {{ agentStat | agentIcon }}"></i>
-               </a>
-               {% endif %}
-               {% endif %}              
-        {% endfor %}
-    {% endif %}
+        {% else %}
+            {% for agentStat in report.agentStats %}
+                {% if report.showMode == "complete" or report.showMode == "compact" %}
+                <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
+                type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
+                title="{{ agentStat | agentTip }}">
+                {% if report.showMode != "compact" %}
+                <small>{{ agentStat.agent.hostName }}</small>
+                {% endif %}
+                <i class="fa fa-fw {{ agentStat | agentIcon }}"></i>
+                </a>
+                {% elif report.showMode == "primaryAcct" %}
+                {% if not agentStat.agent.accountId or agentStat.agent.accountId == "998131032990" or agentStat.agent.accountId == "null" %}
+                <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
+                type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
+                title="{{ agentStat | agentTip }}">              
+                <small>{{ agentStat.agent.hostName }}</small>
+                <i class="fa fa-fw {{ agentStat | agentIcon }}"></i>
+                </a>
+                {% endif %}
+                {% elif report.showMode == "subAcct" %}
+                {% if agentStat.agent.accountId and agentStat.agent.accountId != "998131032990" and agentStat.agent.accountId != "null" %}
+                <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
+                type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
+                title="{{ agentStat | agentTip }}">              
+                <small>{{ agentStat.agent.hostName }}</small>
+                <i class="fa fa-fw {{ agentStat | agentIcon }}"></i>
+                </a>
+                {% endif %}
+                {% endif %}              
+            {% endfor %}
+        {% endif %}
 
-    <br><br>
-    <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"
-       href="/env/{{ report.envName }}/{{ report.stageName }}/hosts/failed/"
-       title="Click to see the details of all failed hosts">
-       <strong>Failed Hosts</strong>
-    </a>
-    <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"
-       href="/env/{{ report.envName }}/{{ report.stageName }}/hosts/"
-       title="Click to see the details of all the hosts">
-       <strong>All Details</strong>
-    </a>
-    <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"
-       href="/env/{{ report.envName }}/{{ report.stageName }}/hosts/sub_account/"
-       title="Click to see the details of all sub account hosts">
-       <strong>Sub Account Hosts</strong>
-    </a>
+        <br><br>
+        <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"
+            href="/env/{{ report.envName }}/{{ report.stageName }}/hosts/failed/"
+            title="Click to see the details of all failed hosts">
+            <strong>Failed Hosts</strong>
+        </a>
+        <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"
+            href="/env/{{ report.envName }}/{{ report.stageName }}/hosts/"
+            title="Click to see the details of all the hosts">
+            <strong>All Details</strong>
+        </a>
+        <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"
+        href="/env/{{ report.envName }}/{{ report.stageName }}/hosts/sub_account/"
+        title="Click to see the details of all sub account hosts">
+        <strong>Sub Account Hosts</strong>
+        </a>
+    </div>
 </div>
-  </div>
 </div>
 {% endif %}
 
@@ -115,7 +115,7 @@
         <tr>
             <td class="col-lg-2">
                 <span class="deployToolTip" data-toggle="tooltip"
-                   title="New hosts being installed for the first time">
+                title="New hosts being installed for the first time">
                 <small>New Hosts</small>
                 </span>
             </td>
@@ -123,12 +123,12 @@
                 <small>
                     {% for agentStat in report.firstTimeAgentStats %}
                         <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
-                           type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
-                           title="{{ agentStat | agentTip }}">
-                           {% if report.showMode == "complete" %}
-                           <small>{{ agentStat.agent.hostName }}</small>
-                           {% endif %}
-                           <i class="fa fa-fw {{ agentStat | agentIcon }}"></i>
+                            type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
+                            title="{{ agentStat | agentTip }}">
+                            {% if report.showMode == "complete" %}
+                            <small>{{ agentStat.agent.hostName }}</small>
+                            {% endif %}
+                            <i class="fa fa-fw {{ agentStat | agentIcon }}"></i>
                         </a>
                     {% endfor %}
                 </small>
@@ -136,7 +136,7 @@
             <td class="col-lg-1 text-right">
                 <small>
                 <a href="hosts/show?stage=TODO" class="deployToolTip" data-toggle="tooltip"
-                   title="Click to see more details">
+                    title="Click to see more details">
                     {{ report.firstTimeAgentStats|length }}
                 </a>
                 </small>
@@ -201,12 +201,12 @@
             {% for key, value in deployStat.stageDistMap.items %}
                 {% if display_stopping_hosts == "true" or key != "STOPPING" and key != "STOPPED" %}
                 <td class="text-right">
-                  <small>
-                  <a href="/env/{{ report.envName }}/{{ report.stageName }}/{{ deployStat.deploy.id }}/hosts?hostStage={{ key }}" class="deployToolTip" data-toggle="tooltip"
-                      title="Click to see more details">
-                      {{ value }}
-                  </a>
-                  </small>
+                    <small>
+                    <a href="/env/{{ report.envName }}/{{ report.stageName }}/{{ deployStat.deploy.id }}/hosts?hostStage={{ key }}" class="deployToolTip" data-toggle="tooltip"
+                        title="Click to see more details">
+                        {{ value }}
+                    </a>
+                    </small>
                 </td>
                 {% endif %}
             {% endfor %}
@@ -217,7 +217,7 @@
                 <small>{{ deployStat.total }}</small>
                 </a>
             </td>
-         </tr>
+        </tr>
         {% endfor %}
     </table>
 </div>
@@ -228,15 +228,15 @@
         <tr>
             <td class="col-lg-2">
                 <span class="deployToolTip" data-toggle="tooltip"
-                   title="Host is new to this env.">
+                    title="Host is new to this env.">
                 <small>New Hosts</small>
                 </span>
             </td>
             <td class="col-lg-10">
                 {% for host in report.provisioningHosts %}
                 <a href="/env/{{ env.envName }}/{{ env.stageName }}/host/{{ host.hostName }}"
-                   type="button" class="deployToolTip btn btn-xs {{ host | hostButton }} host-btn"
-                   title="{{ host | hostTip }}">
+                    type="button" class="deployToolTip btn btn-xs {{ host | hostButton }} host-btn"
+                    title="{{ host | hostTip }}">
                 <small>{{ host.hostName }}</small>
                     <i class="fa fa-fw {{ host | hostIcon }}"></i>
                 </a>
@@ -244,7 +244,7 @@
             </td>
             <td class="col-lg-1 text-right">
                 <a href="/env/{{ report.envName }}/{{ report.stageName }}/hosts/provision/" class="deployToolTip" data-toggle="tooltip"
-                   title="Click to see more details">
+                    title="Click to see more details">
                 <small>{{ report.provisioningHosts | length }}</small>
                 </a>
             </td>
@@ -259,22 +259,22 @@
         <tr>
             <td class="col-lg-2">
                 <span class="deployToolTip" data-toggle="tooltip"
-                   title="Host status is unknown to this env. If the host is terminated,
-                   remove it from this env manually.">
+                    title="Host status is unknown to this env. If the host is terminated,
+                    remove it from this env manually.">
                 <small>Unknown Hosts</small>
                 </span>
             </td>
             <td class="col-lg-10">
                 {% for host in report.missingHosts %}
                 <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ host }}"
-                   type="button" class="btn btn-xs btn-warning">
+                    type="button" class="btn btn-xs btn-warning">
                 <small>{{ host }}</small>
                 </a>
                 {% endfor %}
             </td>
             <td class="col-lg-1 text-right">
                 <a href="/env/{{ report.envName }}/{{ report.stageName }}/hosts/unknowns/" class="deployToolTip" data-toggle="tooltip"
-                   title="Click to see more details">
+                    title="Click to see more details">
                 <small>{{ report.missingHosts|length }}</small>
                 </a>
             </td>
@@ -284,10 +284,10 @@
 {% endif %}
 
 <div class="row text-right">
-     <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"
-       href="/env/{{ report.envName }}/{{ report.stageName }}/hosts/all/"
-       title="Click to see more details">
-       <small>Total Hosts: {{ report|reportTotal }}</small>
+    <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"
+        href="/env/{{ report.envName }}/{{ report.stageName }}/hosts/all/"
+        title="Click to see more details">
+        <small>Total Hosts: {{ report|reportTotal }}</small>
     </a>
 </div>
 {% endwith %}

--- a/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
@@ -7,96 +7,45 @@
 <div class="panel panel-default">
 <div class="panel-body">
     <div class="row">
-        {% if report.sortByTag %}
-            {% for tagValue, hostTags in host_tag_infos.items %}
-            <div class="panel panel-default table-responsive">
-                {% for agentStat in report.agentStats %}
-                    <p>{{ agentStat }}</p>
-                    {% for hostTag in hostTags %}
-                        {% if agentStat.agent.hostName == hostTag.hostName %}
-                            {% if report.showMode == "complete" or report.showMode == "compact" %}
-                            <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
-                            type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
-                            title="{{ agentStat | agentTip }}">
-                            {% if report.showMode != "compact" %}
-                            <small>{{ agentStat.agent.hostName }}</small>
-                            {% endif %}
-                            <i class="fa fa-fw {{ agentStat | agentIcon }}"></i>
-                            </a>
-                            {% elif report.showMode == "primaryAcct" %}
-                            {% if not agentStat.agent.accountId or agentStat.agent.accountId == "998131032990" or agentStat.agent.accountId == "null" %}
-                            <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
-                            type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
-                            title="{{ agentStat | agentTip }}">              
-                            <small>{{ agentStat.agent.hostName }}</small>
-                            <i class="fa fa-fw {{ agentStat | agentIcon }}"></i>
-                            </a>
-                            {% endif %}
-                            {% elif report.showMode == "subAcct" %}
-                            {% if agentStat.agent.accountId and agentStat.agent.accountId != "998131032990" and agentStat.agent.accountId != "null" %}
-                            <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
-                            type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
-                            title="{{ agentStat | agentTip }}">              
-                            <small>{{ agentStat.agent.hostName }}</small>
-                            <i class="fa fa-fw {{ agentStat | agentIcon }}"></i>
-                            </a>
-                            {% endif %}
-                            {% elif report.showMode == "containerStatus" %}
-                            {% if agentStat.agent.accountId and agentStat.agent.accountId != "998131032990" and agentStat.agent.accountId != "null" %}
-                            <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
-                            type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
-                            title="{{ agentStat | agentTip }}">
-                            <small>{{ agentStat.agent.hostName }}</small>
-                            {% include "deploys/_container_status.html" with healthStatus=agentStat.agent.serviceHealthStatus %}
-                            </a>
-                            {% endif %}
-                            {% endif %}        
-                        {% endif %}
-                    {% endfor %}
-                {% endfor %}
-            </div>
-            {% endfor %}
-        {% else %}
-            {% for agentStat in report.agentStats %}
-                {% if report.showMode == "complete" or report.showMode == "compact" %}
-                <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
-                type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
-                title="{{ agentStat | agentTip }}">
-                {% if report.showMode != "compact" %}
-                <small>{{ agentStat.agent.hostName }}</small>
-                {% endif %}
-                <i class="fa fa-fw {{ agentStat | agentIcon }}"></i>
-                </a>
-                {% elif report.showMode == "primaryAcct" %}
-                {% if not agentStat.agent.accountId or agentStat.agent.accountId == "998131032990" or agentStat.agent.accountId == "null" %}
-                <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
-                type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
-                title="{{ agentStat | agentTip }}">              
-                <small>{{ agentStat.agent.hostName }}</small>
-                <i class="fa fa-fw {{ agentStat | agentIcon }}"></i>
-                </a>
-                {% endif %}
-                {% elif report.showMode == "subAcct" %}
-                {% if agentStat.agent.accountId and agentStat.agent.accountId != "998131032990" and agentStat.agent.accountId != "null" %}
-                <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
-                type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
-                title="{{ agentStat | agentTip }}">              
-                <small>{{ agentStat.agent.hostName }}</small>
-                <i class="fa fa-fw {{ agentStat | agentIcon }}"></i>
-                </a>
-                {% endif %}
-                {% elif report.showMode == "containerStatus" %}
-                {% if agentStat.agent.accountId and agentStat.agent.accountId != "998131032990" and agentStat.agent.accountId != "null" %}
-                <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
-                type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
-                title="{{ agentStat | agentTip }}">
-                <small>{{ agentStat.agent.hostName }}</small>
-                {% include "deploys/_container_status.html" with healthStatus=agentStat.agent.serviceHealthStatus %}
-                </a>
-                {% endif %}
-                {% endif %}              
-            {% endfor %}
+    {% for agentStat in report.agentStats %}
+        {% if report.showMode == "complete" or report.showMode == "compact" %}
+        <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
+        type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
+        title="{{ agentStat | agentTip }}">
+        {% if report.showMode != "compact" %}
+        <small>{{ agentStat.agent.hostName }}</small>
         {% endif %}
+        <i class="fa fa-fw {{ agentStat | agentIcon }}"></i>
+        </a>
+        {% elif report.showMode == "primaryAcct" %}
+        {% if not agentStat.agent.accountId or agentStat.agent.accountId == "998131032990" or agentStat.agent.accountId == "null" %}
+        <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
+        type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
+        title="{{ agentStat | agentTip }}">              
+        <small>{{ agentStat.agent.hostName }}</small>
+        <i class="fa fa-fw {{ agentStat | agentIcon }}"></i>
+        </a>
+        {% endif %}
+        {% elif report.showMode == "subAcct" %}
+        {% if agentStat.agent.accountId and agentStat.agent.accountId != "998131032990" and agentStat.agent.accountId != "null" %}
+        <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
+        type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
+        title="{{ agentStat | agentTip }}">              
+        <small>{{ agentStat.agent.hostName }}</small>
+        <i class="fa fa-fw {{ agentStat | agentIcon }}"></i>
+        </a>
+        {% endif %}
+        {% elif report.showMode == "containerStatus" %}
+        {% if agentStat.agent.accountId and agentStat.agent.accountId != "998131032990" and agentStat.agent.accountId != "null" %}
+        <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
+        type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
+        title="{{ agentStat | agentTip }}">
+        <small>{{ agentStat.agent.hostName }}</small>
+        {% include "deploys/_container_status.html" with healthStatus=agentStat.agent.serviceHealthStatus %}
+        </a>
+        {% endif %}
+        {% endif %}              
+    {% endfor %}
 
         <br><br>
         <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"

--- a/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
@@ -12,38 +12,38 @@
         <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
         type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
         title="{{ agentStat | agentTip }}">
-        {% if report.showMode != "compact" %}
+            {% if report.showMode != "compact" %}
         <small>{{ agentStat.agent.hostName }}</small>
-        {% endif %}
+            {% endif %}
         <i class="fa fa-fw {{ agentStat | agentIcon }}"></i>
         </a>
         {% elif report.showMode == "primaryAcct" %}
-        {% if not agentStat.agent.accountId or agentStat.agent.accountId == "998131032990" or agentStat.agent.accountId == "null" %}
+            {% if not agentStat.agent.accountId or agentStat.agent.accountId == "998131032990" or agentStat.agent.accountId == "null" %}
         <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
         type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
         title="{{ agentStat | agentTip }}">              
         <small>{{ agentStat.agent.hostName }}</small>
         <i class="fa fa-fw {{ agentStat | agentIcon }}"></i>
         </a>
-        {% endif %}
+            {% endif %}
         {% elif report.showMode == "subAcct" %}
-        {% if agentStat.agent.accountId and agentStat.agent.accountId != "998131032990" and agentStat.agent.accountId != "null" %}
+            {% if agentStat.agent.accountId and agentStat.agent.accountId != "998131032990" and agentStat.agent.accountId != "null" %}
         <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
         type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
         title="{{ agentStat | agentTip }}">              
         <small>{{ agentStat.agent.hostName }}</small>
         <i class="fa fa-fw {{ agentStat | agentIcon }}"></i>
         </a>
-        {% endif %}
+            {% endif %}
         {% elif report.showMode == "containerStatus" %}
-        {% if agentStat.agent.accountId and agentStat.agent.accountId != "998131032990" and agentStat.agent.accountId != "null" %}
+            {% if agentStat.agent.accountId and agentStat.agent.accountId != "998131032990" and agentStat.agent.accountId != "null" %}
         <a href="/env/{{env.envName}}/{{env.stageName}}/host/{{ agentStat.agent.hostName }}"
         type="button" class="deployToolTip btn btn-xs {{ agentStat | agentButton }} host-btn"
         title="{{ agentStat | agentTip }}">
         <small>{{ agentStat.agent.hostName }}</small>
         {% include "deploys/_container_status.html" with healthStatus=agentStat.agent.serviceHealthStatus %}
         </a>
-        {% endif %}
+            {% endif %}
         {% endif %}              
     {% endfor %}
 

--- a/deploy-board/deploy_board/templates/environs/env_host_tags.html
+++ b/deploy-board/deploy_board/templates/environs/env_host_tags.html
@@ -61,7 +61,7 @@
     <script>
         $(function () {
             $('#envDeployWithTagBtn').click(function () {
-                window.location = "/env/{{ env.envName }}/{{ env.stageName }}/deploy?sortByTag={{ tag_name }}";
+                window.location = "/env/{{ env.envName }}/{{ env.stageName }}/deploy";
             });
 
             $('#viewDeployConstraintModalId').on('shown.bs.modal', function() {

--- a/deploy-board/deploy_board/templates/environs/env_landing.html
+++ b/deploy-board/deploy_board/templates/environs/env_landing.html
@@ -483,7 +483,7 @@ $('#privateBldUploadBtnId button').click(function () {
             if(new Date().getTime() - startTime > 3600000) {
                 clearInterval(interval);
             }
-            $('#activeDeployId').load('/env/{{ env.envName }}/{{ env.stageName }}/update_deploy_progress/?showMode={{ report.showMode }}&sortByStatus={{ report.sortByStatus }}&sortByTag={{ report.sortByTag }}');
+            $('#activeDeployId').load('/env/{{ env.envName }}/{{ env.stageName }}/update_deploy_progress/?showMode={{ report.showMode }}&sortByStatus={{ report.sortByStatus }}');
         }, 30000);
 
         $(".dropdown-menu li").click(function() {

--- a/deploy-board/deploy_board/templates/environs/env_landing.html
+++ b/deploy-board/deploy_board/templates/environs/env_landing.html
@@ -432,6 +432,15 @@ $('#privateBldUploadBtnId button').click(function () {
                         > Sub Account
                         </label></div>
                     </li>
+                    <li>
+                        <div class="radio"><label>&nbsp;
+                        <input type="radio" name="showMode" value="containerStatus"
+                        {% if report.showMode == "containerStatus" %}
+                        checked
+                        {% endif %}
+                        > Container Status
+                        </label></div>
+                    </li>
                     <li role="presentation" class="divider"></li>
                     <li>
                         <div class="checkbox"><label>&nbsp;

--- a/deploy-board/deploy_board/webapp/env_views.py
+++ b/deploy-board/deploy_board/webapp/env_views.py
@@ -210,11 +210,6 @@ def update_deploy_progress(request, name, stage):
         "display_stopping_hosts": DISPLAY_STOPPING_HOSTS,
         "pinterest": IS_PINTEREST
     }
-    sortByTag = _fetch_param_with_cookie(
-        request, 'sortByTag', MODE_COOKIE_NAME, None)
-    if sortByTag:
-        report.sortByTag = sortByTag
-        context["host_tag_infos"] = environ_hosts_helper.get_host_tags(request, name, stage, sortByTag)
 
     html = render_to_string('deploys/deploy_progress.tmpl', context)
 
@@ -489,10 +484,6 @@ class EnvLandingView(View):
                 "project_info": project_info,
                 "remaining_capacity": json.dumps(remaining_capacity),
             }
-            sortByTag = request.GET.get('sortByTag', None)
-            if sortByTag:
-                report.sortByTag = sortByTag
-                context["host_tag_infos"] = environ_hosts_helper.get_host_tags(request, name, stage, sortByTag)
             response = render(request, 'environs/env_landing.html', context)
 
         # save preferences


### PR DESCRIPTION
Add a new Display Mode option, "Container Status", that outputs the all of the host's names next to their configured healthcheck status. Status can be one of "healthy", "unhealthy", or "N/A" (not configured). 

![image](https://github.com/pinterest/teletraan/assets/72234714/69ead070-b158-4a0d-a54f-ce64aa336f10)
![image](https://github.com/pinterest/teletraan/assets/72234714/aa38dc31-23c4-4c8d-9685-da4e6af3d2ee)

[CDP-6936](https://jira.pinadmin.com/browse/CDP-6936)

