### PR TITLE
auto redeploy the service if the container is unhealthy and auto redeploy is enabled

### DIFF
--- a/deploy-agent/deployd/__init__.py
+++ b/deploy-agent/deployd/__init__.py
@@ -21,6 +21,7 @@ METRIC_CACHE_PATH = os.getenv('METRIC_CACHE_PATH', None)
 TELEFIG_BINARY = os.getenv('TELEFIG_BINARY', None)
 MAIN_LOGGER = "deployd"
 STATSBOARD_URL=os.getenv('STATSBOARD_URL', "https://statsboard.pinadmin.com/api/v1/")
+REDEPLOY_RETRY_TIMES = 10
 
 # 0: puppet applied successfully with no changes
 # 2: puppet applied successfully with changes

--- a/deploy-agent/deployd/__init__.py
+++ b/deploy-agent/deployd/__init__.py
@@ -21,10 +21,10 @@ METRIC_CACHE_PATH = os.getenv('METRIC_CACHE_PATH', None)
 TELEFIG_BINARY = os.getenv('TELEFIG_BINARY', None)
 MAIN_LOGGER = "deployd"
 STATSBOARD_URL=os.getenv('STATSBOARD_URL', "https://statsboard.pinadmin.com/api/v1/")
-REDEPLOY_RETRY_TIMES = 10
+REDEPLOY_MAX_RETRY = 3
 
 # 0: puppet applied successfully with no changes
 # 2: puppet applied successfully with changes
 PUPPET_SUCCESS_EXIT_CODES = [0, 2]
 	
-__version__ = '1.2.50'
+__version__ = '1.2.51'

--- a/deploy-agent/deployd/agent.py
+++ b/deploy-agent/deployd/agent.py
@@ -137,11 +137,10 @@ class DeployAgent(object):
                         else:
                             status.report.containerHealthStatus = healthStatus
                             if "unhealthy" not in healthStatus:
-                                fileName = "/mnt/deployd/" + status.report.envName
-                                if os.path.exists(fileName):
-                                    f=open(fileName,"w")
-                                    f.write("0")
-                                    f.close()
+                                file_name = "/mnt/deployd/" + status.report.envName
+                                if os.path.exists(file_name):
+                                    with open(file_name, mode="w") as f:
+                                        f.write("0")
                     else:
                         status.report.containerHealthStatus = None
                 except Exception:

--- a/deploy-agent/deployd/agent.py
+++ b/deploy-agent/deployd/agent.py
@@ -130,7 +130,27 @@ class DeployAgent(object):
                 try:
                     healthStatus = get_container_health_info(status.build_info.build_commit)
                     if healthStatus:
-                        status.report.containerHealthStatus = healthStatus
+                        if healthStatus == "delete":
+                            log.info(f"the current service is: {status}")
+                            fileName = "/mnt/deployd/" + status
+                            if os.path.exists(fileName):
+                                f=open(fileName,"r")
+                                retryNum = f.readline()
+                                f.close()
+                                if int(retryNum) < 10:
+                                    del self._envs[status]
+                                    ff=open(fileName,"w")
+                                    ff.write('%d' % int(retryNum))
+                                    ff.close()
+                            else:
+                                del self._envs[status]
+                        else:
+                            status.report.containerHealthStatus = healthStatus
+                            fileName = "/mnt/deployd/" + status
+                            if os.path.exists(fileName):
+                                f=open(fileName,"w")
+                                f.write("0")
+                                f.close()
                     else:
                         status.report.containerHealthStatus = None
                 except Exception:

--- a/deploy-agent/deployd/common/utils.py
+++ b/deploy-agent/deployd/common/utils.py
@@ -26,7 +26,7 @@ import yaml
 
 
 import json
-from deployd import IS_PINTEREST, PUPPET_SUCCESS_EXIT_CODES, REDEPLOY_RETRY_TIMES
+from deployd import IS_PINTEREST, PUPPET_SUCCESS_EXIT_CODES, REDEPLOY_MAX_RETRY
 from deployd.common.stats import TimeElapsed, create_sc_increment, create_sc_timing, send_statsboard_metric
 
 log = logging.getLogger(__name__)
@@ -220,6 +220,22 @@ def get_info_from_facter(keys):
         log.exception("Failed to get info from facter by keys {}".format(keys))
         return None
 
+
+def redeploy_check(labels, service):
+    max_retry = REDEPLOY_MAX_RETRY
+    for label in labels:
+        if "redeploy_max_retry" in label:
+            max_retry = int(label.split('=')[1])
+    retry_num = 0
+    file_name = "/mnt/deployd/" + service
+    if os.path.exists(file_name):
+        with open(file_name, mode="r") as f:
+            retry_num = int(f.readline())
+    if retry_num < max_retry:
+        with open(file_name, mode="w") as ff:
+            ff.write('%d' % (retry_num + 1))
+            return True
+    return False
     
 def get_container_health_info(commit, service):
     try:
@@ -240,20 +256,7 @@ def get_container_health_info(commit, service):
                             status = status.decode().strip()
                             if status == "unhealthy" and "redeploy_when_unhealthy=enabled" in parts[2]:
                                 labels = parts[2].split(',')
-                                max_retry = REDEPLOY_RETRY_TIMES
-                                for label in labels:
-                                    if "redeploy_retry_times" in label:
-                                        max_retry = int(label.split('=')[1])
-                                retry_num = 0
-                                file_name = "/mnt/deployd/" + service
-                                if os.path.exists(file_name):
-                                    f=open(file_name,"r")
-                                    retry_num = int(f.readline())
-                                    f.close()
-                                if retry_num < max_retry:
-                                    ff=open(file_name,"w")
-                                    ff.write('%d' % (retry_num + 1))
-                                    ff.close()
+                                if redeploy_check(labels, service) == True:
                                     return "delete"
                             result.append(f"{name}:{status}")
                     except:

--- a/deploy-agent/deployd/common/utils.py
+++ b/deploy-agent/deployd/common/utils.py
@@ -232,7 +232,6 @@ def get_container_health_info(commit, service):
             for line in lines:
                 if commit in line:
                     parts = line.split(';')
-                    log.info(f"parts[0]: {parts[0]}; parts[1]: {parts[1]}; parts[2]: {parts[2]}")
                     name = parts[1]
                     try:
                         command = ['docker', 'inspect', '-f', '{{.State.Health.Status}}', name]
@@ -251,11 +250,7 @@ def get_container_health_info(commit, service):
                                     f=open(file_name,"r")
                                     retry_num = int(f.readline())
                                     f.close()
-                                log.info(f"retry num: {retry_num}")
-                                log.info(f"max retry: {max_retry}")
                                 if retry_num < max_retry:
-                                    log.info(f"yaqin-test")
-                                    log.info(f"write to file: {file_name}")
                                     ff=open(file_name,"w")
                                     ff.write('%d' % (retry_num + 1))
                                     ff.close()


### PR DESCRIPTION
Option for auto restart in serviceset config/ healthcheck
In deploy agent, restart the required times when deployment fails.
Related PRs: 
https://github.com/pinternal/teletraan-config-manager/pull/95 
https://github.com/pinternal/teletraan-config-manager/pull/101 