### PR TITLE
keep env_status file and add fields in the report section to do auto redeploy

### DIFF
--- a/deploy-agent/deployd/__init__.py
+++ b/deploy-agent/deployd/__init__.py
@@ -27,4 +27,4 @@ REDEPLOY_MAX_RETRY = 3
 # 2: puppet applied successfully with changes
 PUPPET_SUCCESS_EXIT_CODES = [0, 2]
 	
-__version__ = '1.2.51'
+__version__ = '1.2.52'

--- a/deploy-agent/deployd/agent.py
+++ b/deploy-agent/deployd/agent.py
@@ -133,12 +133,11 @@ class DeployAgent(object):
                         status.report.redeploy = 0
                     healthStatus = get_container_health_info(status.build_info.build_commit, status.report.envName, status.report.redeploy)
                     if healthStatus:
-                        
                         if "redeploy" in healthStatus:
                             status.report.redeploy = int(healthStatus.split("-")[1])
                             status.report.wait = 0
                             status.report.state = "RESET_BY_SYSTEM"
-                            status.report.containerHealthStatus = "unhealthy and redeploying"
+                            status.report.containerHealthStatus = None
                         else:
                             status.report.containerHealthStatus = healthStatus
                             status.report.state = None

--- a/deploy-agent/deployd/agent.py
+++ b/deploy-agent/deployd/agent.py
@@ -137,8 +137,8 @@ class DeployAgent(object):
                         if "redeploy" in healthStatus:
                             status.report.redeploy = int(healthStatus.split("-")[1])
                             status.report.wait = 0
-                            status.report.state = "REDEPLOY"
-                            status.report.containerHealthStatus = healthStatus.split("-")[0]
+                            status.report.state = "RESET_BY_SYSTEM"
+                            status.report.containerHealthStatus = "unhealthy and redeploying"
                         else:
                             status.report.containerHealthStatus = healthStatus
                             status.report.state = None

--- a/deploy-agent/deployd/agent.py
+++ b/deploy-agent/deployd/agent.py
@@ -125,7 +125,6 @@ class DeployAgent(object):
             self._executor = Executor(callback=PingServer(self), config=self._config)
         # include healthStatus info for each container
         if len(self._envs) > 0:
-            #need_to_delete = []
             for status in self._envs.values():
                 # for each service, we check the container health status
                 log.info(f"the current service is: {status.report.envName}")
@@ -134,14 +133,15 @@ class DeployAgent(object):
                         status.report.redeploy = 0
                     healthStatus = get_container_health_info(status.build_info.build_commit, status.report.envName, status.report.redeploy)
                     if healthStatus:
-                        if "reset" in healthStatus:
+                        
+                        if "redeploy" in healthStatus:
                             status.report.redeploy = int(healthStatus.split("-")[1])
                             status.report.wait = 0
-                            status.report.state = "RESET"
-                            status.report.containerHealthStatus = None
+                            status.report.state = "REDEPLOY"
+                            status.report.containerHealthStatus = healthStatus.split("-")[0]
                         else:
-                            status.report.state = None
                             status.report.containerHealthStatus = healthStatus
+                            status.report.state = None
                             if "unhealthy" not in healthStatus:
                                 if status.report.wait == None or status.report.wait > 5:
                                     status.report.redeploy = 0

--- a/deploy-agent/deployd/agent.py
+++ b/deploy-agent/deployd/agent.py
@@ -125,30 +125,37 @@ class DeployAgent(object):
             self._executor = Executor(callback=PingServer(self), config=self._config)
         # include healthStatus info for each container
         if len(self._envs) > 0:
-            need_to_delete = []
+            #need_to_delete = []
             for status in self._envs.values():
                 # for each service, we check the container health status
                 log.info(f"the current service is: {status.report.envName}")
                 try:
-                    healthStatus = get_container_health_info(status.build_info.build_commit, status.report.envName)
+                    if status.report.redeploy == None:
+                        status.report.redeploy = 0
+                    healthStatus = get_container_health_info(status.build_info.build_commit, status.report.envName, status.report.redeploy)
                     if healthStatus:
-                        if healthStatus == "delete":
-                            need_to_delete.append(status.report.envName)
+                        if "reset" in healthStatus:
+                            status.report.redeploy = int(healthStatus.split("-")[1])
+                            status.report.wait = 0
+                            status.report.state = "RESET"
+                            status.report.containerHealthStatus = None
                         else:
+                            status.report.state = None
                             status.report.containerHealthStatus = healthStatus
                             if "unhealthy" not in healthStatus:
-                                file_name = "/mnt/deployd/" + status.report.envName
-                                if os.path.exists(file_name):
-                                    with open(file_name, mode="w") as f:
-                                        f.write("0")
+                                if status.report.wait == None or status.report.wait > 5:
+                                    status.report.redeploy = 0
+                                    status.report.wait = 0
+                                else: 
+                                    status.report.wait = status.report.wait + 1
                     else:
+                        status.report.state = None
                         status.report.containerHealthStatus = None
                 except Exception:
+                    status.report.state = None
                     status.report.containerHealthStatus = None
                     log.exception('get exception while trying to check container health: {}'.format(traceback.format_exc()))
                     continue
-            for item in need_to_delete:
-                del self._envs[item]
             self._env_status.dump_envs(self._envs)
         # start to ping server to get the latest deploy goal
         self._response = self._client.send_reports(self._envs)

--- a/deploy-agent/deployd/client/client.py
+++ b/deploy-agent/deployd/client/client.py
@@ -139,7 +139,7 @@ class Client(BaseClient):
             except Exception:
                 log.warn('Host ip information does not exist.')
                 pass
-        IS_PINTEREST = True
+
         if IS_PINTEREST and self._use_host_info is False:
             # Read new keys from facter always
             az_key = self._config.get_facter_az_key()

--- a/deploy-agent/deployd/client/client.py
+++ b/deploy-agent/deployd/client/client.py
@@ -139,7 +139,7 @@ class Client(BaseClient):
             except Exception:
                 log.warn('Host ip information does not exist.')
                 pass
-
+        IS_PINTEREST = True
         if IS_PINTEREST and self._use_host_info is False:
             # Read new keys from facter always
             az_key = self._config.get_facter_az_key()

--- a/deploy-agent/deployd/common/utils.py
+++ b/deploy-agent/deployd/common/utils.py
@@ -251,7 +251,7 @@ def get_container_health_info(commit, service, redeploy):
                                 labels = parts[2].split(',')
                                 ret = redeploy_check(labels, service, redeploy)
                                 if ret > 0:
-                                    return "reset-" + str(ret)
+                                    return "redeploy-" + str(ret)
                             result.append(f"{name}:{status}")
                     except:
                         continue

--- a/deploy-agent/deployd/common/utils.py
+++ b/deploy-agent/deployd/common/utils.py
@@ -221,23 +221,16 @@ def get_info_from_facter(keys):
         return None
 
 
-def redeploy_check(labels, service):
+def redeploy_check(labels, service, redeploy):
     max_retry = REDEPLOY_MAX_RETRY
     for label in labels:
         if "redeploy_max_retry" in label:
             max_retry = int(label.split('=')[1])
-    retry_num = 0
-    file_name = "/mnt/deployd/" + service
-    if os.path.exists(file_name):
-        with open(file_name, mode="r") as f:
-            retry_num = int(f.readline())
-    if retry_num < max_retry:
-        with open(file_name, mode="w") as ff:
-            ff.write('%d' % (retry_num + 1))
-            return True
-    return False
+    if redeploy < max_retry:
+        return redeploy + 1
+    return 0
     
-def get_container_health_info(commit, service):
+def get_container_health_info(commit, service, redeploy):
     try:
         log.info(f"Get health info for container with commit {commit}")
         result = []
@@ -256,8 +249,9 @@ def get_container_health_info(commit, service):
                             status = status.decode().strip()
                             if status == "unhealthy" and "redeploy_when_unhealthy=enabled" in parts[2]:
                                 labels = parts[2].split(',')
-                                if redeploy_check(labels, service) == True:
-                                    return "delete"
+                                ret = redeploy_check(labels, service, redeploy)
+                                if ret > 0:
+                                    return "reset-" + str(ret)
                             result.append(f"{name}:{status}")
                     except:
                         continue

--- a/deploy-agent/deployd/types/ping_report.py
+++ b/deploy-agent/deployd/types/ping_report.py
@@ -31,6 +31,9 @@ class PingReport(object):
         self.extraInfo = None
         self.deployAlias = None
         self.containerHealthStatus = None
+        self.state = None
+        self.redeploy = 0
+        self.wait = 0
 
         if jsonValue:
             self.deployId = jsonValue.get('deployId')
@@ -53,10 +56,13 @@ class PingReport(object):
             self.extraInfo = jsonValue.get('extraInfo')
             self.deployAlias = jsonValue.get('deployAlias')
             self.containerHealthStatus = jsonValue.get('containerHealthStatus')
+            self.state = jsonValue.get('state')
+            self.redeploy = jsonValue.get('redeploy')
+            self.wait = jsonValue.get('wait')
 
     def __str__(self):
         return "PingReport(deployId={}, envId={}, deployStage={}, status={}, " \
                "errorCode={}, errorMessage={}, failCount={}, extraInfo={}, " \
-               "deployAlias={}, containerHealthStatus={})".format(self.deployId, self.envId, self.deployStage,
+               "deployAlias={}, containerHealthStatus={}, state={})".format(self.deployId, self.envId, self.deployStage,
                                         self.status, self.errorCode, self.errorMessage,
-                                        self.failCount, self.extraInfo, self.deployAlias, self.containerHealthStatus)
+                                        self.failCount, self.extraInfo, self.deployAlias, self.containerHealthStatus, self.state)

--- a/deploy-agent/deployd/types/ping_report.py
+++ b/deploy-agent/deployd/types/ping_report.py
@@ -63,6 +63,6 @@ class PingReport(object):
     def __str__(self):
         return "PingReport(deployId={}, envId={}, deployStage={}, status={}, " \
                "errorCode={}, errorMessage={}, failCount={}, extraInfo={}, " \
-               "deployAlias={}, containerHealthStatus={}, state={})".format(self.deployId, self.envId, self.deployStage,
+               "deployAlias={}, containerHealthStatus={}, agentState={})".format(self.deployId, self.envId, self.deployStage,
                                         self.status, self.errorCode, self.errorMessage,
                                         self.failCount, self.extraInfo, self.deployAlias, self.containerHealthStatus, self.state)

--- a/deploy-agent/deployd/types/ping_request.py
+++ b/deploy-agent/deployd/types/ping_request.py
@@ -72,6 +72,7 @@ class PingRequest(object):
             ping_report["failCount"] = report.failCount
             ping_report["deployAlias"] = report.deployAlias
             ping_report["containerHealthStatus"] = report.containerHealthStatus
+            ping_report["agentState"] = report.state
             
             if report.extraInfo:
                 ping_report["extraInfo"] = \


### PR DESCRIPTION
We may have trouble by deleting a service in file env_status. In this PR, on deployd side, we set RESET_BY_SYSTEM to trigger redeploy just like Teletraan UI did by clicking "Retry".