### PR TITLE
Allow agent state to be set as RESET by deployd like Teletraan UI does

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/AgentState.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/AgentState.java
@@ -24,6 +24,8 @@ package com.pinterest.deployservice.bean;
  *      Agent being paused by user manually
  * RESET:
  *      Agent should retry last failure
+ * REDEPLOY:
+ *      Agent should redeploy according to deployd
  * DELETE:
  *      Agent should delete its status file
  * UNREACHABLE:
@@ -37,6 +39,7 @@ public enum AgentState {
     PAUSED_BY_SYSTEM,
     PAUSED_BY_USER,
     RESET,
+    REDEPLOY,
     DELETE,
     UNREACHABLE,
     STOP

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/AgentState.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/AgentState.java
@@ -24,8 +24,8 @@ package com.pinterest.deployservice.bean;
  *      Agent being paused by user manually
  * RESET:
  *      Agent should retry last failure
- * REDEPLOY:
- *      Agent should redeploy according to deployd
+ * RESET_BY_SYSTEM:
+ *      Agent triggers redeploy 
  * DELETE:
  *      Agent should delete its status file
  * UNREACHABLE:
@@ -39,7 +39,7 @@ public enum AgentState {
     PAUSED_BY_SYSTEM,
     PAUSED_BY_USER,
     RESET,
-    REDEPLOY,
+    RESET_BY_SYSTEM,
     DELETE,
     UNREACHABLE,
     STOP

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/PingReportBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/PingReportBean.java
@@ -30,7 +30,7 @@ public class PingReportBean {
     private Map<String, String> extraInfo;
     private String deployAlias;
     private String containerHealthStatus;
-    private AgentState agentState;
+    private String agentState;
 
     public String getDeployId() {
         return deployId;
@@ -112,11 +112,11 @@ public class PingReportBean {
         this.containerHealthStatus = containerHealthStatus;
     }
 
-    public AgentState getAgentState() {
+    public String getAgentState() {
         return agentState;
     }
 
-    public void setAgentState(AgentState agentState) {
+    public void setAgentState(String agentState) {
         this.agentState = agentState;
     }
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/PingReportBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/PingReportBean.java
@@ -30,6 +30,7 @@ public class PingReportBean {
     private Map<String, String> extraInfo;
     private String deployAlias;
     private String containerHealthStatus;
+    private AgentState agentState;
 
     public String getDeployId() {
         return deployId;
@@ -109,6 +110,14 @@ public class PingReportBean {
 
     public void setContainerHealthStatus(String containerHealthStatus) {
         this.containerHealthStatus = containerHealthStatus;
+    }
+
+    public AgentState getAgentState() {
+        return agentState;
+    }
+
+    public void setAgentState(AgentState agentState) {
+        this.agentState = agentState;
     }
 
     @Override

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java
@@ -252,8 +252,8 @@ public class GoalAnalyst {
     // What the new agent state should be, if this agent is not chosen to be deploy goal
     AgentState proposeNewAgentState(PingReportBean report, AgentBean agent) {
         AgentStatus status = report.getAgentStatus();
-        if (report.getAgentState() != null && report.getAgentState().equals("REDEPLOY")) {
-            agent.setState(AgentState.REDEPLOY);
+        if (report.getAgentState() != null && report.getAgentState().equals("RESET_BY_SYSTEM")) {
+            agent.setState(AgentState.RESET_BY_SYSTEM);
         }
 
         if (agent != null && agent.getState() == AgentState.STOP) {
@@ -276,10 +276,10 @@ public class GoalAnalyst {
             return AgentState.RESET;
         }
 
-        if (agent != null && agent.getState() == AgentState.REDEPLOY) {
+        if (agent != null && agent.getState() == AgentState.RESET_BY_SYSTEM) {
             // agent has been explicitly redeployed by deployd, do not override
-            // subsequent code would have to decide if need to override REDEPLOY state
-            return AgentState.REDEPLOY;
+            // subsequent code would have to decide if need to override RESET_BY_SYSTEM state
+            return AgentState.RESET_BY_SYSTEM;
         }
 
         if (status == AgentStatus.SUCCEEDED) {
@@ -627,11 +627,11 @@ public class GoalAnalyst {
                     return;
                 }
 
-                // Special case when agent state is REDEPLOY, start from beginning
-                if (updateBean.getState() == AgentState.REDEPLOY) {
+                // Special case when agent state is RESET_BY_SYSTEM, start from beginning
+                if (updateBean.getState() == AgentState.RESET_BY_SYSTEM) {
                     installNewUpdateBean(env, report, agent);
-                    LOG.debug("GoalAnalyst case 1.0.2 - host {} work on the same deploy {}, but agent state is REDEPLOY, set env {} as a goal candidate and start from beginning.",
-                        host, env.getDeploy_id(), envId);
+                    LOG.debug("GoalAnalyst case 1.0.2 - host {} work on the same deploy {}, but agent state is {}, set env {} as a goal candidate and start from beginning.",
+                        host, env.getDeploy_id(), AgentState.RESET_BY_SYSTEM, envId);
                     return;
                 }
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java
@@ -252,6 +252,10 @@ public class GoalAnalyst {
     // What the new agent state should be, if this agent is not chosen to be deploy goal
     AgentState proposeNewAgentState(PingReportBean report, AgentBean agent) {
         AgentStatus status = report.getAgentStatus();
+        if (report.getAgnetState() == AgentState.REDEPLOY) {
+            agent.setState(AgentState.REDEPLOY)
+        }
+        
         if (agent != null && agent.getState() == AgentState.STOP) {
             // agent has been explicitly STOP, do not override
             if (agent.getDeploy_stage() == DeployStage.STOPPING && FATAL_AGENT_STATUSES.contains(status)) {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java
@@ -252,7 +252,7 @@ public class GoalAnalyst {
     // What the new agent state should be, if this agent is not chosen to be deploy goal
     AgentState proposeNewAgentState(PingReportBean report, AgentBean agent) {
         AgentStatus status = report.getAgentStatus();
-        if (report.getAgentState() != null && report.getAgentState().equals("RESET_BY_SYSTEM")) {
+        if (agent != null && report.getAgentState() != null && report.getAgentState().equals("RESET_BY_SYSTEM")) {
             agent.setState(AgentState.RESET_BY_SYSTEM);
         }
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java
@@ -251,6 +251,10 @@ public class GoalAnalyst {
 
     // What the new agent state should be, if this agent is not chosen to be deploy goal
     AgentState proposeNewAgentState(PingReportBean report, AgentBean agent) {
+        if (report.getAgentState() == AgentState.RESET) {
+            return AgentState.RESET;
+        }
+        
         AgentStatus status = report.getAgentStatus();
         if (agent != null && agent.getState() == AgentState.STOP) {
             // agent has been explicitly STOP, do not override

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java
@@ -252,7 +252,7 @@ public class GoalAnalyst {
     // What the new agent state should be, if this agent is not chosen to be deploy goal
     AgentState proposeNewAgentState(PingReportBean report, AgentBean agent) {
         AgentStatus status = report.getAgentStatus();
-        if (report.getAgnetState() == AgentState.REDEPLOY) {
+        if (report.getAgentState() == AgentState.REDEPLOY) {
             agent.setState(AgentState.REDEPLOY);
         }
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java
@@ -252,7 +252,7 @@ public class GoalAnalyst {
     // What the new agent state should be, if this agent is not chosen to be deploy goal
     AgentState proposeNewAgentState(PingReportBean report, AgentBean agent) {
         AgentStatus status = report.getAgentStatus();
-        if (report.getAgentState() == AgentState.REDEPLOY) {
+        if (report.getAgentState() != null && report.getAgentState().equals("REDEPLOY")) {
             agent.setState(AgentState.REDEPLOY);
         }
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java
@@ -253,9 +253,9 @@ public class GoalAnalyst {
     AgentState proposeNewAgentState(PingReportBean report, AgentBean agent) {
         AgentStatus status = report.getAgentStatus();
         if (report.getAgnetState() == AgentState.REDEPLOY) {
-            agent.setState(AgentState.REDEPLOY)
+            agent.setState(AgentState.REDEPLOY);
         }
-        
+
         if (agent != null && agent.getState() == AgentState.STOP) {
             // agent has been explicitly STOP, do not override
             if (agent.getDeploy_stage() == DeployStage.STOPPING && FATAL_AGENT_STATUSES.contains(status)) {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java
@@ -251,10 +251,6 @@ public class GoalAnalyst {
 
     // What the new agent state should be, if this agent is not chosen to be deploy goal
     AgentState proposeNewAgentState(PingReportBean report, AgentBean agent) {
-        if (report.getAgentState() == AgentState.RESET) {
-            return AgentState.RESET;
-        }
-        
         AgentStatus status = report.getAgentStatus();
         if (agent != null && agent.getState() == AgentState.STOP) {
             // agent has been explicitly STOP, do not override
@@ -274,6 +270,12 @@ public class GoalAnalyst {
             // agent has been explicitly reset by user, do not override
             // subsequent code would have to decide if need to override RESET state
             return AgentState.RESET;
+        }
+
+        if (agent != null && agent.getState() == AgentState.REDEPLOY) {
+            // agent has been explicitly redeployed by deployd, do not override
+            // subsequent code would have to decide if need to override REDEPLOY state
+            return AgentState.REDEPLOY;
         }
 
         if (status == AgentStatus.SUCCEEDED) {
@@ -616,7 +618,15 @@ public class GoalAnalyst {
                 // Special case when agent state is RESET, start from beginning
                 if (updateBean.getState() == AgentState.RESET) {
                     installNewUpdateBean(env, report, agent);
-                    LOG.debug("GoalAnalyst case 1.0 - host {} work on the same deploy {}, but agent state is RESET, set env {} as a goal candidate and start from beginning.",
+                    LOG.debug("GoalAnalyst case 1.0.1 - host {} work on the same deploy {}, but agent state is RESET, set env {} as a goal candidate and start from beginning.",
+                        host, env.getDeploy_id(), envId);
+                    return;
+                }
+
+                // Special case when agent state is REDEPLOY, start from beginning
+                if (updateBean.getState() == AgentState.REDEPLOY) {
+                    installNewUpdateBean(env, report, agent);
+                    LOG.debug("GoalAnalyst case 1.0.2 - host {} work on the same deploy {}, but agent state is REDEPLOY, set env {} as a goal candidate and start from beginning.",
                         host, env.getDeploy_id(), envId);
                     return;
                 }


### PR DESCRIPTION
Corresponding PR on deployd side: https://github.com/pinterest/teletraan/pull/1324 and https://github.com/pinterest/teletraan/pull/1329 