### PR TITLE
reset agent state in env_status file after sending pingRequest

### DIFF
--- a/deploy-agent/deployd/__init__.py
+++ b/deploy-agent/deployd/__init__.py
@@ -27,4 +27,4 @@ REDEPLOY_MAX_RETRY = 3
 # 2: puppet applied successfully with changes
 PUPPET_SUCCESS_EXIT_CODES = [0, 2]
 	
-__version__ = '1.2.52'
+__version__ = '1.2.53'

--- a/deploy-agent/deployd/agent.py
+++ b/deploy-agent/deployd/agent.py
@@ -158,6 +158,12 @@ class DeployAgent(object):
             self._env_status.dump_envs(self._envs)
         # start to ping server to get the latest deploy goal
         self._response = self._client.send_reports(self._envs)
+        # we only need to send RESET once in one deploy-agent run 
+        if len(self._envs) > 0:
+            for status in self._envs.values():
+                if status.report.state == "RESET_BY_SYSTEM":
+                    status.report.state = None
+            self._env_status.dump_envs(self._envs)
 
         if self._response:
             report = self._update_internal_deploy_goal(self._response)


### PR DESCRIPTION
Need to reset agent state otherwise TAS could not go outside of PRE_DOWNLOAD deploy stage.
Tested with https://github.com/pinterest/teletraan/pull/1325 for these cases:
1. with deploy-agent-pex current version 1.2.46, tested these UI operations: reset, restart, deploy and launch a new host;
2. with deploy-agent-pex latest version 1.2.52, tested: reset, restart and deploy;
3. with deploy-agent-pex latest version 1.2.52, tested: auto redeploy
everything looks good.