### PR TITLE
Remove unneccessary site metrics

### DIFF
--- a/deploy-board/deploy_board/templates/landing.html
+++ b/deploy-board/deploy_board/templates/landing.html
@@ -8,10 +8,7 @@
 {% endblock %}
 
 
-
 {% block main %}
-{% include "environs/site_health.tmpl" with metricsKind="site" %}
-
 <div class="panel panel-default">
     {% include "panel_heading.tmpl" with panel_title="Ongoing Deployments" panel_body_id="onGoingDeployId" direction="down" %}
     <div id="onGoingDeployId" class="collapse in panel-body table-responsive">


### PR DESCRIPTION
## Summary 
The old statsboard links are broken due to envoy migration. The section also doesn't bring much value. We might bring the embeded dashboard directly later on.  

## Test plan 
http://dev-anhn:8080/ 