### PR TITLE
Send ec2 tags from deployd to TAS

### DIFF
--- a/deploy-agent/deployd/client/client.py
+++ b/deploy-agent/deployd/client/client.py
@@ -171,6 +171,7 @@ class Client(BaseClient):
             # so need to read ec2_tags from facter and parse Autoscaling tag to cover this case
             if not self._autoscaling_group:
                 ec2_tags = facter_data.get(ec2_tags_key)
+                self._ec2_tags = json.dumps(ec2_tags) if ec2_tags else None
                 self._autoscaling_group = ec2_tags.get(asg_tag_key) if ec2_tags else None
 
             if not self._stage_type and not self._stage_type_fetched:
@@ -185,8 +186,8 @@ class Client(BaseClient):
 
         log.info("Host information is loaded. "
                  "Host name: {}, IP: {}, host id: {}, agent_version={}, autoscaling_group: {}, "
-                 "availability_zone: {}, stage_type: {}, group: {}, account id: {}".format(self._hostname, self._ip, self._id, 
-                 self._agent_version, self._autoscaling_group, self._availability_zone, self._stage_type, self._hostgroup, self._account_id))
+                 "availability_zone: {}, ec2_tags: {}, stage_type: {}, group: {}, account id: {}".format(self._hostname, self._ip, self._id, 
+                 self._agent_version, self._autoscaling_group, self._availability_zone, self._ec2_tags, self._stage_type, self._hostgroup, self._account_id))
 
         if not self._availability_zone:
             log.error("Fail to read host info: availablity zone")
@@ -214,6 +215,7 @@ class Client(BaseClient):
                                         agentVersion=self._agent_version,
                                         autoscalingGroup=self._autoscaling_group,
                                         availabilityZone=self._availability_zone,
+                                        ec2Tags=self._ec2_tags,
                                         stageType=self._stage_type,
                                         accountId=self._account_id)
 

--- a/deploy-agent/deployd/types/ping_request.py
+++ b/deploy-agent/deployd/types/ping_request.py
@@ -20,7 +20,7 @@ from deployd.types.agent_status import AgentStatus
 class PingRequest(object):
 
     def __init__(self, hostId=None, hostName=None, hostIp=None, groups=None, reports=None,
-                agentVersion=None, autoscalingGroup=None, availabilityZone=None, stageType=None, accountId=None):
+                agentVersion=None, autoscalingGroup=None, availabilityZone=None, ec2Tags=None, stageType=None, accountId=None):
         self.hostId = hostId
         self.hostName = hostName
         self.hostIp = hostIp
@@ -29,6 +29,7 @@ class PingRequest(object):
         self.agentVersion = agentVersion
         self.autoscalingGroup = autoscalingGroup
         self.availabilityZone = availabilityZone
+        self.ec2Tags = ec2Tags
         self.stageType = stageType
         self.accountId = accountId
 
@@ -49,6 +50,8 @@ class PingRequest(object):
             ping_requests["groups"] = list(self.groups)
         if self.accountId:
             ping_requests["accountId"] = self.accountId
+        if self.ec2Tags:
+            ping_requests["ec2Tags"] = self.ec2Tags
 
         ping_requests["reports"] = []
         for report in self.reports:
@@ -83,6 +86,6 @@ class PingRequest(object):
 
     def __str__(self):
         return "PingRequest(hostId={}, hostName={}, hostIp={}, agentVersion={}, autoscalingGroup={}, " \
-            "availabilityZone={}, stageType={}, groups={}, accountId={}, reports={})".format(self.hostId, self.hostName, 
-            self.hostIp, self.agentVersion, self.autoscalingGroup, self.availabilityZone, self.stageType,
+            "availabilityZone={}, ec2Tags={}, stageType={}, groups={}, accountId={}, reports={})".format(self.hostId, self.hostName, 
+            self.hostIp, self.agentVersion, self.autoscalingGroup, self.availabilityZone, self.ec2Tags, self.stageType,
             self.groups, self.accountId, ",".join(str(v) for v in self.reports))

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/PingRequestBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/PingRequestBean.java
@@ -34,6 +34,8 @@ public class PingRequestBean {
 
     private String availabilityZone;
 
+    private String ec2Tags;
+
     private String agentVersion;
 
     private EnvType stageType;
@@ -82,6 +84,14 @@ public class PingRequestBean {
 
     public void setAvailabilityZone(String availabilityZone){
         this.availabilityZone = availabilityZone;
+    }
+
+    public String getEc2Tags() {
+        return ec2Tags;
+    }
+
+    public void setEc2Tags(String ec2Tags) {
+        this.ec2Tags = ec2Tags;
     }
 
     public String getAgentVersion() {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
@@ -58,6 +58,8 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.*;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 /**
  * This is where we handle agent ping and return deploy goal!
  */
@@ -601,6 +603,18 @@ public class PingHandler {
         String asg = pingRequest.getAutoscalingGroup();
         Set<String> groups = this.shardGroups(pingRequest);
         String accountId = pingRequest.getAccountId();
+
+        // go through ec2Tags
+        String ec2Tags = pingRequest.getEc2Tags();
+        LOG.debug("go through ec2 tags: {}", ec2Tags);
+        if (ec2Tags != null) {
+            ObjectMapper mapper = new ObjectMapper();
+            Map<String, String> tags = mapper.readValue(ec2Tags, Map.class);
+            for (Map.Entry<String, String> entry : tags.entrySet()) {
+                LOG.debug("key: {}, val: {}", entry.getKey(), entry.getValue());
+            }    
+        }
+           
         //update agent version for host
         String agentVersion = pingRequest.getAgentVersion() != null ? pingRequest.getAgentVersion() : "UNKNOWN";
 


### PR DESCRIPTION
For ec2 tags used by deployment constraint, no need to use Teletraan worker to query from CMDB. We can get them from deployd agent running on the ec2 host.