### PR TITLE
Use knox directly 

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/RodimusManagerImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/RodimusManagerImpl.java
@@ -27,6 +27,9 @@ import com.pinterest.deployservice.common.HTTPClient;
 import com.pinterest.deployservice.common.KnoxKeyManager;
 import com.pinterest.deployservice.common.KnoxKeyReader;
 
+import io.netty.util.internal.StringUtil;
+
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,11 +74,11 @@ public class RodimusManagerImpl implements RodimusManager {
             this.httpClient = new HTTPClient();
         }
 
+        knoxKeyReader = new KnoxKeyReader();
         if (knoxKey != null) {
-            knoxKeyReader = new KnoxKeyReader();
             knoxKeyReader.init(knoxKey);
         } else {
-            throw new NullPointerException("Knox key is null");
+            LOG.warn("Rodimus Knox key is null, this is only acceptable in test environment.");
         }
         this.gson = new GsonBuilder().addSerializationExclusionStrategy(new CustomExclusionStrategy()).create();
     }
@@ -94,6 +97,9 @@ public class RodimusManagerImpl implements RodimusManager {
 
     private void setAuthorization() throws Exception {
         String knoxKey = knoxKeyReader.getKey();
+        if (knoxKey == null) {
+            throw new IllegalStateException("Rodimus knoxKey is null");
+        }
         this.headers.put("Authorization", String.format("token %s", knoxKey));
     }
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/RodimusManagerImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/RodimusManagerImpl.java
@@ -24,10 +24,7 @@ import com.google.gson.JsonPrimitive;
 import com.google.gson.reflect.TypeToken;
 
 import com.pinterest.deployservice.common.HTTPClient;
-import com.pinterest.deployservice.common.KnoxKeyManager;
 import com.pinterest.deployservice.common.KnoxKeyReader;
-
-import io.netty.util.internal.StringUtil;
 
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -43,7 +40,7 @@ public class RodimusManagerImpl implements RodimusManager {
     private static final Logger LOG = LoggerFactory.getLogger(RodimusManagerImpl.class);
     private static final int RETRIES = 3;
 
-    private static enum Verb {
+    protected static enum Verb {
         GET, POST, DELETE
     };
 
@@ -74,11 +71,10 @@ public class RodimusManagerImpl implements RodimusManager {
             this.httpClient = new HTTPClient();
         }
 
-        knoxKeyReader = new KnoxKeyReader();
-        if (knoxKey != null) {
+        if (StringUtils.isNotBlank(knoxKey)) {
             knoxKeyReader.init(knoxKey);
         } else {
-            LOG.warn("Rodimus Knox key is null, this is only acceptable in test environment.");
+            LOG.warn("Rodimus Knox key is blank, this is only acceptable in test environment.");
         }
         this.gson = new GsonBuilder().addSerializationExclusionStrategy(new CustomExclusionStrategy()).create();
     }
@@ -121,7 +117,7 @@ public class RodimusManagerImpl implements RodimusManager {
         return res;
     }
 
-    private String callHttpClient(Verb verb, String url, String payload) throws Exception {
+    protected String callHttpClient(Verb verb, String url, String payload) throws Exception {
         setAuthorization();
         return switchHttpClient(verb, url, payload);
     }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/RodimusManagerImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/RodimusManagerImpl.java
@@ -24,8 +24,8 @@ import com.google.gson.JsonPrimitive;
 import com.google.gson.reflect.TypeToken;
 
 import com.pinterest.deployservice.common.HTTPClient;
-import com.pinterest.deployservice.knox.FileSystemKnox;
-import com.pinterest.deployservice.knox.Knox;
+import com.pinterest.deployservice.common.KnoxKeyManager;
+import com.pinterest.deployservice.common.KnoxKeyReader;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,7 +48,7 @@ public class RodimusManagerImpl implements RodimusManager {
     private HTTPClient httpClient;
     private Map<String, String> headers;
     private Gson gson;
-    private Knox fsKnox = null;
+    private KnoxKeyReader knoxKeyReader = new KnoxKeyReader();
 
     public RodimusManagerImpl(String rodimusUrl, String knoxKey, boolean useProxy, String httpProxyAddr,
             String httpProxyPort) throws Exception {
@@ -72,7 +72,8 @@ public class RodimusManagerImpl implements RodimusManager {
         }
 
         if (knoxKey != null) {
-            this.fsKnox = new FileSystemKnox(knoxKey);
+            knoxKeyReader = new KnoxKeyReader();
+            knoxKeyReader.init(knoxKey);
         } else {
             throw new NullPointerException("Knox key is null");
         }
@@ -92,7 +93,7 @@ public class RodimusManagerImpl implements RodimusManager {
     }
 
     private void setAuthorization() throws Exception {
-        String knoxKey = new String(this.fsKnox.getPrimaryKey());
+        String knoxKey = knoxKeyReader.getKey();
         this.headers.put("Authorization", String.format("token %s", knoxKey));
     }
 

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/common/KnoxKeyTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/common/KnoxKeyTest.java
@@ -39,7 +39,6 @@ import org.junit.Assert;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 
-
 @SuppressWarnings("unchecked")
 public class KnoxKeyTest {
 
@@ -76,6 +75,25 @@ public class KnoxKeyTest {
         // Allocate answerList
         answerList = new ArrayList<Answer>();
         mockClasses(rodimusManager, mockKnox, mockHttpClient);
+
+        when(this.mockHttpClient.get(
+                Mockito.any(String.class),
+                Mockito.any(String.class),
+                Mockito.anyMap(),
+                Mockito.anyMap(),
+                Mockito.any(Integer.class))).thenAnswer(invocation -> this.getAnswer(invocation));
+
+        when(mockHttpClient.post(
+                Mockito.any(String.class),
+                Mockito.any(String.class),
+                Mockito.anyMap(),
+                Mockito.any(Integer.class))).thenAnswer(invocation -> this.postAnswer(invocation));
+
+        when(this.mockHttpClient.delete(
+                Mockito.any(String.class),
+                Mockito.any(String.class),
+                Mockito.anyMap(),
+                Mockito.any(Integer.class))).thenAnswer(invocation -> this.deleteAnswer(invocation));
     }
 
     // ### terminateHostsByClusterName tests ###
@@ -83,15 +101,7 @@ public class KnoxKeyTest {
     @Test
     public void terminateHostsByClusterName_Ok() throws Exception {
         // All working as expected
-
         when(this.mockKnox.getPrimaryKey()).thenReturn(this.testKey[1]);
-
-        when(this.mockHttpClient.delete(
-                Mockito.any(String.class),
-                Mockito.any(String.class),
-                Mockito.anyMap(),
-                Mockito.any(Integer.class)))
-            .thenAnswer(invocation -> this.deleteAnswer(invocation));
 
         try {
             this.rodimusManager.terminateHostsByClusterName("cluster", Collections.singletonList("i-001"));
@@ -106,14 +116,7 @@ public class KnoxKeyTest {
     @Test
     public void terminateHostsByClusterName_ErrorOk() throws Exception {
         // Token does not work, refresh and retry, second try works
-
         when(this.mockKnox.getPrimaryKey()).thenReturn(this.testKey[0], this.testKey[1]);
-
-        when(this.mockHttpClient.delete(
-                Mockito.any(String.class),
-                Mockito.any(String.class),
-                Mockito.anyMap(),
-                Mockito.any(Integer.class))).thenAnswer(invocation -> this.deleteAnswer(invocation));
 
         Exception exception = Assert.assertThrows(DeployInternalException.class, () -> {
             this.rodimusManager.terminateHostsByClusterName("cluster", Collections.singletonList("i-001"));
@@ -133,14 +136,7 @@ public class KnoxKeyTest {
     @Test
     public void terminateHostsByClusterName_MultipleError() throws Exception {
         // Token does not work, refresh does not offer new token
-
         when(this.mockKnox.getPrimaryKey()).thenReturn(this.testKey[0], this.testKey[0]);
-
-        when(this.mockHttpClient.delete(
-                Mockito.any(String.class),
-                Mockito.any(String.class),
-                Mockito.anyMap(),
-                Mockito.any(Integer.class))).thenAnswer(invocation -> this.deleteAnswer(invocation));
 
         for (int i = 1; i <= 2; i++) {
             Exception exception = Assert.assertThrows(DeployInternalException.class, () -> {
@@ -159,15 +155,7 @@ public class KnoxKeyTest {
     @Test
     public void getTerminatedHosts_Ok() throws Exception {
         // All working as expected
-
         when(this.mockKnox.getPrimaryKey()).thenReturn(this.testKey[1]);
-
-        when(this.mockHttpClient.post(
-                Mockito.any(String.class),
-                Mockito.any(String.class),
-                Mockito.anyMap(),
-                Mockito.any(Integer.class))).thenAnswer(invocation -> this.postAnswer(invocation));
-
         this.postAnswerReturn = postAnswerArray;
 
         try {
@@ -185,13 +173,6 @@ public class KnoxKeyTest {
         // Token does not work, refresh and retry, second try works
 
         when(this.mockKnox.getPrimaryKey()).thenReturn(this.testKey[0], this.testKey[1]);
-
-        when(this.mockHttpClient.post(
-                Mockito.any(String.class),
-                Mockito.any(String.class),
-                Mockito.anyMap(),
-                Mockito.any(Integer.class))).thenAnswer(invocation -> this.postAnswer(invocation));
-
         this.postAnswerReturn = postAnswerArray;
 
         Exception exception = Assert.assertThrows(DeployInternalException.class, () -> {
@@ -212,15 +193,7 @@ public class KnoxKeyTest {
     @Test
     public void getTerminatedHosts_MultipleError() throws Exception {
         // Token does not work, refresh does not offer new token
-
         when(this.mockKnox.getPrimaryKey()).thenReturn(this.testKey[0], this.testKey[0]);
-
-        when(this.mockHttpClient.post(
-                Mockito.any(String.class),
-                Mockito.any(String.class),
-                Mockito.anyMap(),
-                Mockito.any(Integer.class))).thenAnswer(invocation -> this.postAnswer(invocation));
-
         this.postAnswerReturn = postAnswerArray;
 
         for (int i = 1; i <= 2; i++) {
@@ -240,16 +213,7 @@ public class KnoxKeyTest {
     @Test
     public void getClusterInstanceLaunchGracePeriod_Ok() throws Exception {
         // All working as expected
-
         when(this.mockKnox.getPrimaryKey()).thenReturn(this.testKey[1]);
-
-        when(this.mockHttpClient.get(
-                Mockito.any(String.class),
-                Mockito.any(String.class),
-                Mockito.anyMap(),
-                Mockito.anyMap(),
-                Mockito.any(Integer.class))).thenAnswer(invocation -> this.getAnswer(invocation));
-
         long res = 0;
         try {
             res = this.rodimusManager.getClusterInstanceLaunchGracePeriod("cluster");
@@ -264,18 +228,8 @@ public class KnoxKeyTest {
 
     @Test
     public void getClusterInstanceLaunchGracePeriod_test() throws Exception {
-        // getClusterInstanceLaunchGracePeriod
         // Token does not work, refresh and retry, second try works
-
         when(this.mockKnox.getPrimaryKey()).thenReturn(this.testKey[0], this.testKey[1]);
-
-        when(this.mockHttpClient.get(
-                Mockito.any(String.class),
-                Mockito.any(String.class),
-                Mockito.anyMap(),
-                Mockito.anyMap(),
-                Mockito.any(Integer.class))).thenAnswer(invocation -> this.getAnswer(invocation));
-
         this.postAnswerReturn = postAnswerArray;
 
         Exception exception = Assert.assertThrows(DeployInternalException.class, () -> {
@@ -295,17 +249,8 @@ public class KnoxKeyTest {
 
     @Test
     public void getClusterInstanceLaunchGracePeriod_MultipleError() throws Exception {
-        // getClusterInstanceLaunchGracePeriod
         // Token does not work, refresh does not offer new token
-
         when(this.mockKnox.getPrimaryKey()).thenReturn(this.testKey[0], this.testKey[0]);
-
-        when(this.mockHttpClient.get(
-                Mockito.any(String.class),
-                Mockito.any(String.class),
-                Mockito.anyMap(),
-                Mockito.anyMap(),
-                Mockito.any(Integer.class))).thenAnswer(invocation -> this.getAnswer(invocation));
 
         for (int i = 1; i <= 2; i++) {
             Exception exception = Assert.assertThrows(DeployInternalException.class, () -> {
@@ -326,13 +271,6 @@ public class KnoxKeyTest {
         // All working as expected
 
         when(this.mockKnox.getPrimaryKey()).thenReturn(this.testKey[1]);
-
-        when(this.mockHttpClient.post(
-                Mockito.any(String.class),
-                Mockito.any(String.class),
-                Mockito.anyMap(),
-                Mockito.any(Integer.class))).thenAnswer(invocation -> this.postAnswer(invocation));
-
         this.postAnswerReturn = postAnswerTag;
 
         try {
@@ -348,15 +286,7 @@ public class KnoxKeyTest {
     @Test
     public void getEC2Tags_ErrorOk() throws Exception {
         // Token does not work, refresh and retry, second try works
-
         when(this.mockKnox.getPrimaryKey()).thenReturn(this.testKey[0], this.testKey[1]);
-
-        when(this.mockHttpClient.post(
-                Mockito.any(String.class),
-                Mockito.any(String.class),
-                Mockito.anyMap(),
-                Mockito.any(Integer.class))).thenAnswer(invocation -> this.postAnswer(invocation));
-
         this.postAnswerReturn = postAnswerTag;
 
         Exception exception = Assert.assertThrows(DeployInternalException.class, () -> {
@@ -377,15 +307,7 @@ public class KnoxKeyTest {
     @Test
     public void getEC2Tags_MultipleError() throws Exception {
         // Token does not work, refresh does not offer new token
-
         when(this.mockKnox.getPrimaryKey()).thenReturn(this.testKey[0], this.testKey[0]);
-
-        when(this.mockHttpClient.post(
-                Mockito.any(String.class),
-                Mockito.any(String.class),
-                Mockito.anyMap(),
-                Mockito.any(Integer.class))).thenAnswer(invocation -> this.postAnswer(invocation));
-
         this.postAnswerReturn = postAnswerTag;
 
         for (int i = 1; i <= 2; i++) {
@@ -400,25 +322,9 @@ public class KnoxKeyTest {
         assertArrayEquals(expected, answerList.toArray());
     }
 
-    // =======================================================
-    // to test: methods: terminateHostsByClusterName         1
-    //                   getTerminatedHosts                  2
-    //                   getClusterInstanceLaunchGracePeriod 3
-    //                   getEc2Tags                          4
-    //          actions: token ok                                        1234
-    //                     (everyday operation)
-    //                   token error and retry ok                        1234
-    //                     (expected behaviour when token changes)
-    //                   token error and no new token given              1234
-    //                     (do not try more than once with same token)
-    //                   token error and new token does not work neither 1234
-    //                     (do not try indefinitely)
-    // =======================================================
-
     // ### HELPER METHODS ###
 
     private void mockClasses(RodimusManager rodimusMngr, Knox mokKnox, HTTPClient mokHttpClient) throws Exception {
-
         // Modify fsKnox to use our mock
         Field classKnox = rodimusMngr.getClass().getDeclaredField("fsKnox");
         classKnox.setAccessible(true);
@@ -434,10 +340,7 @@ public class KnoxKeyTest {
 
     private String getToken(Map<String, String> headers) {
         // Get token out of Map of headers
-
         for (Map.Entry<String, String> entry : headers.entrySet()) {
-            // DEBUG System.out.println("headers-> " + entry.getKey() + ":" +
-            // entry.getValue());
             if (entry.getKey() == "Authorization")
                 return entry.getValue();
         }

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/common/KnoxKeyTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/common/KnoxKeyTest.java
@@ -134,7 +134,7 @@ public class KnoxKeyTest {
 
     @Test
     public void terminateHostsByClusterName_MultipleError() throws Exception {
-        // Token does not work, refresh does not offer new token
+        // Token does not work
         when(this.mockKnoxKeyReader.getKey()).thenReturn(this.testKey[0], this.testKey[0]);
 
         for (int i = 1; i <= 2; i++) {
@@ -170,7 +170,6 @@ public class KnoxKeyTest {
     @Test
     public void getTerminatedHosts_ErrorOk() throws Exception {
         // Token does not work, refresh and retry, second try works
-
         when(this.mockKnoxKeyReader.getKey()).thenReturn(this.testKey[0], this.testKey[1]);
         this.postAnswerReturn = postAnswerArray;
 

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/common/KnoxKeyTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/common/KnoxKeyTest.java
@@ -20,6 +20,7 @@ import com.pinterest.deployservice.rodimus.RodimusManager;
 import com.pinterest.deployservice.rodimus.RodimusManagerImpl;
 import com.pinterest.deployservice.knox.Knox;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
 
@@ -93,19 +94,15 @@ public class KnoxKeyTest {
             Assert.assertTrue("Unexpected exception: " + e, false);
         }
 
-        final ArrayList<Answer> cmpArray = new ArrayList<Answer>() {
-            {
-                add(Answer.NULL);
-            }
-        };
-        Assert.assertArrayEquals(this.answerList.toArray(), cmpArray.toArray());
+        final Answer[] expected = {Answer.NULL};
+        assertArrayEquals(expected, answerList.toArray());
     }
 
     @Test
     public void terminateHostsByClusterName_ErrorOk() throws Exception {
         // Token does not work, refresh and retry, second try works
 
-        when(this.mockKnox.getPrimaryKey()).thenReturn(this.testKey[0], this.testKey[1], this.testKey[2], this.testKey[3]);
+        when(this.mockKnox.getPrimaryKey()).thenReturn(this.testKey[0], this.testKey[1]);
 
         when(this.mockHttpClient.delete(
                 Mockito.any(String.class),
@@ -126,8 +123,8 @@ public class KnoxKeyTest {
             fail("Unexpected exception: " + e);
         }
 
-        final List<Answer> cmpArray = Arrays.asList(Answer.EXCEPTION, Answer.NULL);
-        Assert.assertArrayEquals(cmpArray.toArray(), answerList.toArray());
+        final List<Answer> expected = Arrays.asList(Answer.EXCEPTION, Answer.NULL);
+        assertArrayEquals(expected.toArray(), answerList.toArray());
     }
 
     @Test
@@ -152,8 +149,8 @@ public class KnoxKeyTest {
             Assert.assertTrue(exception.getMessage().contains(msgUnauthException));
         }
 
-        final List<Answer> cmpArray = Arrays.asList(Answer.EXCEPTION, Answer.EXCEPTION);
-        Assert.assertArrayEquals( cmpArray.toArray(), answerList.toArray());
+        final List<Answer> expected = Arrays.asList(Answer.EXCEPTION, Answer.EXCEPTION);
+        assertArrayEquals( expected.toArray(), answerList.toArray());
     }
 
     // ### getTerminatedHosts tests ###
@@ -174,20 +171,14 @@ public class KnoxKeyTest {
 
         this.postAnswerReturn = this.postAnswerArray;
 
-        Collection<String> res = null;
         try {
-            res = this.rodimusManager.getTerminatedHosts(Arrays.asList("i-001", "i-002"));
+            this.rodimusManager.getTerminatedHosts(Arrays.asList("i-001", "i-002"));
         } catch (Exception e) {
             Assert.assertTrue("Unexpected exception: " + e, false);
         }
 
-        final ArrayList<Answer> cmpArray = new ArrayList<Answer>() {
-            {
-                add(Answer.ARRAY);
-            }
-        };
-
-        Assert.assertArrayEquals(this.answerList.toArray(), cmpArray.toArray());
+        final Answer[] expected = {Answer.ARRAY};
+        assertArrayEquals(expected, answerList.toArray());
     }
 
     @Test
@@ -206,26 +197,19 @@ public class KnoxKeyTest {
 
         this.postAnswerReturn = this.postAnswerArray;
 
-        Collection<String> res = null;
-
         Exception exception = Assert.assertThrows(DeployInternalException.class, () -> {
             this.rodimusManager.getTerminatedHosts(Arrays.asList("i-001", "i-002"));
         });
         Assert.assertTrue(exception.getMessage().contains(msgUnauthException));
 
         try {
-            res = this.rodimusManager.getTerminatedHosts(Arrays.asList("i-001", "i-002"));
+            this.rodimusManager.getTerminatedHosts(Arrays.asList("i-001", "i-002"));
         } catch (Exception e) {
             Assert.assertTrue("Unexpected exception: " + e, false);
         }
 
-        final ArrayList<Answer> cmpArray = new ArrayList<Answer>() {
-            {
-                add(Answer.EXCEPTION);
-                add(Answer.ARRAY);
-            }
-        };
-        Assert.assertArrayEquals(this.answerList.toArray(), cmpArray.toArray());
+        final Answer[] expected = {Answer.EXCEPTION, Answer.ARRAY};
+        assertArrayEquals(expected, answerList.toArray());
     }
 
     @Test
@@ -252,13 +236,8 @@ public class KnoxKeyTest {
             Assert.assertTrue(exception.getMessage().contains(msgUnauthException));
         }
 
-        final ArrayList<Answer> cmpArray = new ArrayList<Answer>() {
-            {
-                add(Answer.EXCEPTION);
-                add(Answer.EXCEPTION);
-            }
-        };
-        Assert.assertArrayEquals(this.answerList.toArray(), cmpArray.toArray());
+        final Answer[] expected = {Answer.EXCEPTION, Answer.EXCEPTION};
+        assertArrayEquals(expected, answerList.toArray());
     }
 
     // ### getClusterInstanceLaunchGracePeriod tests
@@ -281,18 +260,13 @@ public class KnoxKeyTest {
         long res = 0;
         try {
             res = this.rodimusManager.getClusterInstanceLaunchGracePeriod("cluster");
+            Assert.assertEquals(res, (long) 10);
         } catch (Exception e) {
-            Assert.assertTrue("Unexpected exception: " + e, false);
+            fail("Unexpected exception: " + e);
         }
 
-        final ArrayList<Answer> cmpArray = new ArrayList<Answer>() {
-            {
-                add(Answer.LATENCY);
-            }
-        };
-
-        Assert.assertArrayEquals(this.answerList.toArray(), cmpArray.toArray());
-        Assert.assertEquals(res, (long) 10);
+        final Answer[] expected = {Answer.LATENCY};
+        assertArrayEquals(expected, answerList.toArray());
     }
 
     @Test
@@ -313,26 +287,19 @@ public class KnoxKeyTest {
 
         this.postAnswerReturn = this.postAnswerArray;
 
-        long res = 0;
-
         Exception exception = Assert.assertThrows(DeployInternalException.class, () -> {
             this.rodimusManager.getClusterInstanceLaunchGracePeriod("cluster");
         });
         Assert.assertTrue(exception.getMessage().contains("HTTP request failed, status"));
 
         try {
-            res = this.rodimusManager.getClusterInstanceLaunchGracePeriod("cluster");
+            this.rodimusManager.getClusterInstanceLaunchGracePeriod("cluster");
         } catch (Exception e) {
-            Assert.assertTrue("Unexpected exception: " + e, false);
+            fail("Unexpected exception: " + e);
         }
 
-        final ArrayList<Answer> cmpArray = new ArrayList<Answer>() {
-            {
-                add(Answer.EXCEPTION);
-                add(Answer.LATENCY);
-            }
-        };
-        Assert.assertArrayEquals(this.answerList.toArray(), cmpArray.toArray());
+        final Answer[] expected = {Answer.EXCEPTION, Answer.LATENCY};
+        assertArrayEquals(expected, answerList.toArray());
     }
 
     @Test
@@ -359,13 +326,8 @@ public class KnoxKeyTest {
             Assert.assertTrue(exception.getMessage().contains("HTTP request failed, status"));
         }
 
-        final ArrayList<Answer> cmpArray = new ArrayList<Answer>() {
-            {
-                add(Answer.EXCEPTION);
-                add(Answer.EXCEPTION);
-            }
-        };
-        Assert.assertArrayEquals(this.answerList.toArray(), cmpArray.toArray());
+        final Answer[] expected = {Answer.EXCEPTION, Answer.EXCEPTION};
+        assertArrayEquals(expected, answerList.toArray());
     }
 
     // ### getEC2Tags tests ###
@@ -386,19 +348,14 @@ public class KnoxKeyTest {
 
         this.postAnswerReturn = this.postAnswerTag;
 
-        Map<String, Map<String, String>> res = null;
         try {
-            res = this.rodimusManager.getEc2Tags(Arrays.asList("i-001", "i-002"));
+            rodimusManager.getEc2Tags(Arrays.asList("i-001", "i-002"));
         } catch (Exception e) {
-            Assert.assertTrue("Unexpected exception: " + e, false);
+            fail("Unexpected exception: " + e);
         }
 
-        final ArrayList<Answer> cmpArray = new ArrayList<Answer>() {
-            {
-                add(Answer.ARRAY);
-            }
-        };
-        Assert.assertArrayEquals(this.answerList.toArray(), cmpArray.toArray());
+        final Answer[] expected = {Answer.ARRAY};
+        assertArrayEquals(expected, answerList.toArray());
     }
 
     @Test
@@ -430,19 +387,12 @@ public class KnoxKeyTest {
             Assert.assertTrue("Unexpected exception: " + e, false);
         }
 
-        final ArrayList<Answer> cmpArray = new ArrayList<Answer>() {
-            {
-                add(Answer.EXCEPTION);
-                add(Answer.ARRAY);
-            }
-        };
-        Assert.assertArrayEquals(this.answerList.toArray(), cmpArray.toArray());
-
+        final Answer[] expected = {Answer.EXCEPTION, Answer.ARRAY};
+        assertArrayEquals(expected, answerList.toArray());
     }
 
     @Test
     public void getEC2Tags_MultipleError() throws Exception {
-        // getEC2Tags
         // Token does not work, refresh does not offer new token
 
         when(this.mockKnox.getPrimaryKey()).thenReturn(this.testKey[0], this.testKey[0]);
@@ -465,30 +415,23 @@ public class KnoxKeyTest {
             Assert.assertTrue(exception.getMessage().contains("HTTP request failed, status"));
         }
 
-        final ArrayList<Answer> cmpArray = new ArrayList<Answer>() {
-            {
-                add(Answer.EXCEPTION);
-                add(Answer.EXCEPTION);
-            }
-        };
-        Assert.assertArrayEquals(this.answerList.toArray(), cmpArray.toArray());
+        final Answer[] expected = {Answer.EXCEPTION, Answer.EXCEPTION};
+        assertArrayEquals(expected, answerList.toArray());
     }
 
     // =======================================================
-
-// to test: methods: terminateHostsByClusterName         1
-//                   getTerminatedHosts                  2
-//                   getClusterInstanceLaunchGracePeriod 3
-//                   getEc2Tags                          4
-//          actions: token ok                                        1234
-//                     (everyday operation)
-//                   token error and retry ok                        1234
-//                     (expected behaviour when token changes)
-//                   token error and no new token given              1234
-//                     (do not try more than once with same token)
-//                   token error and new token does not work neither 1234
-//                     (do not try indefinitely)
-
+    // to test: methods: terminateHostsByClusterName         1
+    //                   getTerminatedHosts                  2
+    //                   getClusterInstanceLaunchGracePeriod 3
+    //                   getEc2Tags                          4
+    //          actions: token ok                                        1234
+    //                     (everyday operation)
+    //                   token error and retry ok                        1234
+    //                     (expected behaviour when token changes)
+    //                   token error and no new token given              1234
+    //                     (do not try more than once with same token)
+    //                   token error and new token does not work neither 1234
+    //                     (do not try indefinitely)
     // =======================================================
 
     // ### HELPER METHODS ###

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/common/KnoxKeyTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/common/KnoxKeyTest.java
@@ -25,6 +25,12 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -33,7 +39,6 @@ import org.junit.Assert;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 
-import java.util.*;
 
 @SuppressWarnings("unchecked")
 public class KnoxKeyTest {
@@ -42,10 +47,10 @@ public class KnoxKeyTest {
         NULL, EXCEPTION, ARRAY, LATENCY
     };
 
-    private static String msgUnauthException = "HTTP request failed, status = 401, content = Unauthorized";
-    private static String postAnswerTag = "{\"i-001\":{\"Name\": \"devapp-example1\"},\"i-002\":{\"Name\": \"devrestricted-example2\"}}";
-    private static String postAnswerArray = "[\"i-001\",\"i-002\"]";
-    private static String getAnswerValue = "{\"launchLatencyTh\": 10}";
+    private static final String msgUnauthException = "HTTP request failed, status = 401, content = Unauthorized";
+    private static final String postAnswerTag = "{\"i-001\":{\"Name\": \"devapp-example1\"},\"i-002\":{\"Name\": \"devrestricted-example2\"}}";
+    private static final String postAnswerArray = "[\"i-001\",\"i-002\"]";
+    private static final String getAnswerValue = "{\"launchLatencyTh\": 10}";
 
     private RodimusManager rodimusManager = null;
     private Knox mockKnox;
@@ -70,6 +75,7 @@ public class KnoxKeyTest {
 
         // Allocate answerList
         answerList = new ArrayList<Answer>();
+        mockClasses(rodimusManager, mockKnox, mockHttpClient);
     }
 
     // ### terminateHostsByClusterName tests ###
@@ -86,8 +92,6 @@ public class KnoxKeyTest {
                 Mockito.anyMap(),
                 Mockito.any(Integer.class)))
             .thenAnswer(invocation -> this.deleteAnswer(invocation));
-
-        this.mockClasses(this.rodimusManager, this.mockKnox, this.mockHttpClient);
 
         try {
             this.rodimusManager.terminateHostsByClusterName("cluster", Collections.singletonList("i-001"));
@@ -111,8 +115,6 @@ public class KnoxKeyTest {
                 Mockito.anyMap(),
                 Mockito.any(Integer.class))).thenAnswer(invocation -> this.deleteAnswer(invocation));
 
-        this.mockClasses(this.rodimusManager, this.mockKnox, this.mockHttpClient);
-
         Exception exception = Assert.assertThrows(DeployInternalException.class, () -> {
             this.rodimusManager.terminateHostsByClusterName("cluster", Collections.singletonList("i-001"));
         });
@@ -124,8 +126,8 @@ public class KnoxKeyTest {
             fail("Unexpected exception: " + e);
         }
 
-        final List<Answer> expected = Arrays.asList(Answer.EXCEPTION, Answer.NULL);
-        assertArrayEquals(expected.toArray(), answerList.toArray());
+        final Answer[] expected = {Answer.EXCEPTION, Answer.NULL};
+        assertArrayEquals(expected, answerList.toArray());
     }
 
     @Test
@@ -140,8 +142,6 @@ public class KnoxKeyTest {
                 Mockito.anyMap(),
                 Mockito.any(Integer.class))).thenAnswer(invocation -> this.deleteAnswer(invocation));
 
-        this.mockClasses(this.rodimusManager, this.mockKnox, this.mockHttpClient);
-
         for (int i = 1; i <= 2; i++) {
             Exception exception = Assert.assertThrows(DeployInternalException.class, () -> {
                 this.rodimusManager.terminateHostsByClusterName("cluster", Collections.singletonList("i-001"));
@@ -150,8 +150,8 @@ public class KnoxKeyTest {
             Assert.assertTrue(exception.getMessage().contains(msgUnauthException));
         }
 
-        final List<Answer> expected = Arrays.asList(Answer.EXCEPTION, Answer.EXCEPTION);
-        assertArrayEquals( expected.toArray(), answerList.toArray());
+        final Answer[] expected = {Answer.EXCEPTION, Answer.EXCEPTION};
+        assertArrayEquals(expected, answerList.toArray());
     }
 
     // ### getTerminatedHosts tests ###
@@ -168,9 +168,7 @@ public class KnoxKeyTest {
                 Mockito.anyMap(),
                 Mockito.any(Integer.class))).thenAnswer(invocation -> this.postAnswer(invocation));
 
-        this.mockClasses(this.rodimusManager, this.mockKnox, this.mockHttpClient);
-
-        this.postAnswerReturn = KnoxKeyTest.postAnswerArray;
+        this.postAnswerReturn = postAnswerArray;
 
         try {
             this.rodimusManager.getTerminatedHosts(Arrays.asList("i-001", "i-002"));
@@ -194,9 +192,7 @@ public class KnoxKeyTest {
                 Mockito.anyMap(),
                 Mockito.any(Integer.class))).thenAnswer(invocation -> this.postAnswer(invocation));
 
-        this.mockClasses(this.rodimusManager, this.mockKnox, this.mockHttpClient);
-
-        this.postAnswerReturn = KnoxKeyTest.postAnswerArray;
+        this.postAnswerReturn = postAnswerArray;
 
         Exception exception = Assert.assertThrows(DeployInternalException.class, () -> {
             this.rodimusManager.getTerminatedHosts(Arrays.asList("i-001", "i-002"));
@@ -225,9 +221,7 @@ public class KnoxKeyTest {
                 Mockito.anyMap(),
                 Mockito.any(Integer.class))).thenAnswer(invocation -> this.postAnswer(invocation));
 
-        this.mockClasses(this.rodimusManager, this.mockKnox, this.mockHttpClient);
-
-        this.postAnswerReturn = KnoxKeyTest.postAnswerArray;
+        this.postAnswerReturn = postAnswerArray;
 
         for (int i = 1; i <= 2; i++) {
             Exception exception = Assert.assertThrows(DeployInternalException.class, () -> {
@@ -256,8 +250,6 @@ public class KnoxKeyTest {
                 Mockito.anyMap(),
                 Mockito.any(Integer.class))).thenAnswer(invocation -> this.getAnswer(invocation));
 
-        this.mockClasses(this.rodimusManager, this.mockKnox, this.mockHttpClient);
-
         long res = 0;
         try {
             res = this.rodimusManager.getClusterInstanceLaunchGracePeriod("cluster");
@@ -284,9 +276,7 @@ public class KnoxKeyTest {
                 Mockito.anyMap(),
                 Mockito.any(Integer.class))).thenAnswer(invocation -> this.getAnswer(invocation));
 
-        this.mockClasses(this.rodimusManager, this.mockKnox, this.mockHttpClient);
-
-        this.postAnswerReturn = KnoxKeyTest.postAnswerArray;
+        this.postAnswerReturn = postAnswerArray;
 
         Exception exception = Assert.assertThrows(DeployInternalException.class, () -> {
             this.rodimusManager.getClusterInstanceLaunchGracePeriod("cluster");
@@ -317,8 +307,6 @@ public class KnoxKeyTest {
                 Mockito.anyMap(),
                 Mockito.any(Integer.class))).thenAnswer(invocation -> this.getAnswer(invocation));
 
-        this.mockClasses(this.rodimusManager, this.mockKnox, this.mockHttpClient);
-
         for (int i = 1; i <= 2; i++) {
             Exception exception = Assert.assertThrows(DeployInternalException.class, () -> {
                 this.rodimusManager.getClusterInstanceLaunchGracePeriod("cluster");
@@ -345,9 +333,7 @@ public class KnoxKeyTest {
                 Mockito.anyMap(),
                 Mockito.any(Integer.class))).thenAnswer(invocation -> this.postAnswer(invocation));
 
-        this.mockClasses(this.rodimusManager, this.mockKnox, this.mockHttpClient);
-
-        this.postAnswerReturn = KnoxKeyTest.postAnswerTag;
+        this.postAnswerReturn = postAnswerTag;
 
         try {
             rodimusManager.getEc2Tags(Arrays.asList("i-001", "i-002"));
@@ -371,9 +357,7 @@ public class KnoxKeyTest {
                 Mockito.anyMap(),
                 Mockito.any(Integer.class))).thenAnswer(invocation -> this.postAnswer(invocation));
 
-        this.mockClasses(this.rodimusManager, this.mockKnox, this.mockHttpClient);
-
-        this.postAnswerReturn = KnoxKeyTest.postAnswerTag;
+        this.postAnswerReturn = postAnswerTag;
 
         Exception exception = Assert.assertThrows(DeployInternalException.class, () -> {
             this.rodimusManager.getEc2Tags(Arrays.asList("i-001", "i-002"));
@@ -402,9 +386,7 @@ public class KnoxKeyTest {
                 Mockito.anyMap(),
                 Mockito.any(Integer.class))).thenAnswer(invocation -> this.postAnswer(invocation));
 
-        this.mockClasses(this.rodimusManager, this.mockKnox, this.mockHttpClient);
-
-        this.postAnswerReturn = KnoxKeyTest.postAnswerTag;
+        this.postAnswerReturn = postAnswerTag;
 
         for (int i = 1; i <= 2; i++) {
             Exception exception = Assert.assertThrows(DeployInternalException.class, () -> {
@@ -474,7 +456,7 @@ public class KnoxKeyTest {
             return null;
         } else {
             this.answerList.add(Answer.EXCEPTION);
-            throw new DeployInternalException(KnoxKeyTest.msgUnauthException);
+            throw new DeployInternalException(msgUnauthException);
         }
     }
 
@@ -490,7 +472,7 @@ public class KnoxKeyTest {
             return this.postAnswerReturn;
         } else {
             this.answerList.add(Answer.EXCEPTION);
-            throw new DeployInternalException(KnoxKeyTest.msgUnauthException);
+            throw new DeployInternalException(msgUnauthException);
         }
     }
 
@@ -503,10 +485,10 @@ public class KnoxKeyTest {
 
         if (Objects.equals(token, "token bbb")) {
             this.answerList.add(Answer.LATENCY);
-            return KnoxKeyTest.getAnswerValue;
+            return getAnswerValue;
         } else {
             this.answerList.add(Answer.EXCEPTION);
-            throw new DeployInternalException(KnoxKeyTest.msgUnauthException);
+            throw new DeployInternalException(msgUnauthException);
         }
     }
 

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/common/KnoxKeyTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/common/KnoxKeyTest.java
@@ -35,6 +35,7 @@ import org.mockito.invocation.InvocationOnMock;
 
 import java.util.*;
 
+@SuppressWarnings("unchecked")
 public class KnoxKeyTest {
 
     private static enum Answer {
@@ -82,7 +83,7 @@ public class KnoxKeyTest {
         when(this.mockHttpClient.delete(
                 Mockito.any(String.class),
                 Mockito.any(String.class),
-                Mockito.any(Map.class),
+                Mockito.anyMap(),
                 Mockito.any(Integer.class)))
             .thenAnswer(invocation -> this.deleteAnswer(invocation));
 
@@ -91,7 +92,7 @@ public class KnoxKeyTest {
         try {
             this.rodimusManager.terminateHostsByClusterName("cluster", Collections.singletonList("i-001"));
         } catch (Exception e) {
-            Assert.assertTrue("Unexpected exception: " + e, false);
+            fail("Unexpected exception: " + e);
         }
 
         final Answer[] expected = {Answer.NULL};
@@ -107,7 +108,7 @@ public class KnoxKeyTest {
         when(this.mockHttpClient.delete(
                 Mockito.any(String.class),
                 Mockito.any(String.class),
-                Mockito.any(Map.class),
+                Mockito.anyMap(),
                 Mockito.any(Integer.class))).thenAnswer(invocation -> this.deleteAnswer(invocation));
 
         this.mockClasses(this.rodimusManager, this.mockKnox, this.mockHttpClient);
@@ -136,7 +137,7 @@ public class KnoxKeyTest {
         when(this.mockHttpClient.delete(
                 Mockito.any(String.class),
                 Mockito.any(String.class),
-                Mockito.any(Map.class),
+                Mockito.anyMap(),
                 Mockito.any(Integer.class))).thenAnswer(invocation -> this.deleteAnswer(invocation));
 
         this.mockClasses(this.rodimusManager, this.mockKnox, this.mockHttpClient);
@@ -164,17 +165,17 @@ public class KnoxKeyTest {
         when(this.mockHttpClient.post(
                 Mockito.any(String.class),
                 Mockito.any(String.class),
-                Mockito.any(Map.class),
+                Mockito.anyMap(),
                 Mockito.any(Integer.class))).thenAnswer(invocation -> this.postAnswer(invocation));
 
         this.mockClasses(this.rodimusManager, this.mockKnox, this.mockHttpClient);
 
-        this.postAnswerReturn = this.postAnswerArray;
+        this.postAnswerReturn = KnoxKeyTest.postAnswerArray;
 
         try {
             this.rodimusManager.getTerminatedHosts(Arrays.asList("i-001", "i-002"));
         } catch (Exception e) {
-            Assert.assertTrue("Unexpected exception: " + e, false);
+            fail("Unexpected exception: " + e);
         }
 
         final Answer[] expected = {Answer.ARRAY};
@@ -190,12 +191,12 @@ public class KnoxKeyTest {
         when(this.mockHttpClient.post(
                 Mockito.any(String.class),
                 Mockito.any(String.class),
-                Mockito.any(Map.class),
+                Mockito.anyMap(),
                 Mockito.any(Integer.class))).thenAnswer(invocation -> this.postAnswer(invocation));
 
         this.mockClasses(this.rodimusManager, this.mockKnox, this.mockHttpClient);
 
-        this.postAnswerReturn = this.postAnswerArray;
+        this.postAnswerReturn = KnoxKeyTest.postAnswerArray;
 
         Exception exception = Assert.assertThrows(DeployInternalException.class, () -> {
             this.rodimusManager.getTerminatedHosts(Arrays.asList("i-001", "i-002"));
@@ -205,7 +206,7 @@ public class KnoxKeyTest {
         try {
             this.rodimusManager.getTerminatedHosts(Arrays.asList("i-001", "i-002"));
         } catch (Exception e) {
-            Assert.assertTrue("Unexpected exception: " + e, false);
+            fail("Unexpected exception: " + e);
         }
 
         final Answer[] expected = {Answer.EXCEPTION, Answer.ARRAY};
@@ -221,12 +222,12 @@ public class KnoxKeyTest {
         when(this.mockHttpClient.post(
                 Mockito.any(String.class),
                 Mockito.any(String.class),
-                Mockito.any(Map.class),
+                Mockito.anyMap(),
                 Mockito.any(Integer.class))).thenAnswer(invocation -> this.postAnswer(invocation));
 
         this.mockClasses(this.rodimusManager, this.mockKnox, this.mockHttpClient);
 
-        this.postAnswerReturn = this.postAnswerArray;
+        this.postAnswerReturn = KnoxKeyTest.postAnswerArray;
 
         for (int i = 1; i <= 2; i++) {
             Exception exception = Assert.assertThrows(DeployInternalException.class, () -> {
@@ -251,8 +252,8 @@ public class KnoxKeyTest {
         when(this.mockHttpClient.get(
                 Mockito.any(String.class),
                 Mockito.any(String.class),
-                Mockito.any(Map.class),
-                Mockito.any(Map.class),
+                Mockito.anyMap(),
+                Mockito.anyMap(),
                 Mockito.any(Integer.class))).thenAnswer(invocation -> this.getAnswer(invocation));
 
         this.mockClasses(this.rodimusManager, this.mockKnox, this.mockHttpClient);
@@ -279,13 +280,13 @@ public class KnoxKeyTest {
         when(this.mockHttpClient.get(
                 Mockito.any(String.class),
                 Mockito.any(String.class),
-                Mockito.any(Map.class),
-                Mockito.any(Map.class),
+                Mockito.anyMap(),
+                Mockito.anyMap(),
                 Mockito.any(Integer.class))).thenAnswer(invocation -> this.getAnswer(invocation));
 
         this.mockClasses(this.rodimusManager, this.mockKnox, this.mockHttpClient);
 
-        this.postAnswerReturn = this.postAnswerArray;
+        this.postAnswerReturn = KnoxKeyTest.postAnswerArray;
 
         Exception exception = Assert.assertThrows(DeployInternalException.class, () -> {
             this.rodimusManager.getClusterInstanceLaunchGracePeriod("cluster");
@@ -312,8 +313,8 @@ public class KnoxKeyTest {
         when(this.mockHttpClient.get(
                 Mockito.any(String.class),
                 Mockito.any(String.class),
-                Mockito.any(Map.class),
-                Mockito.any(Map.class),
+                Mockito.anyMap(),
+                Mockito.anyMap(),
                 Mockito.any(Integer.class))).thenAnswer(invocation -> this.getAnswer(invocation));
 
         this.mockClasses(this.rodimusManager, this.mockKnox, this.mockHttpClient);
@@ -341,12 +342,12 @@ public class KnoxKeyTest {
         when(this.mockHttpClient.post(
                 Mockito.any(String.class),
                 Mockito.any(String.class),
-                Mockito.any(Map.class),
+                Mockito.anyMap(),
                 Mockito.any(Integer.class))).thenAnswer(invocation -> this.postAnswer(invocation));
 
         this.mockClasses(this.rodimusManager, this.mockKnox, this.mockHttpClient);
 
-        this.postAnswerReturn = this.postAnswerTag;
+        this.postAnswerReturn = KnoxKeyTest.postAnswerTag;
 
         try {
             rodimusManager.getEc2Tags(Arrays.asList("i-001", "i-002"));
@@ -367,14 +368,12 @@ public class KnoxKeyTest {
         when(this.mockHttpClient.post(
                 Mockito.any(String.class),
                 Mockito.any(String.class),
-                Mockito.any(Map.class),
+                Mockito.anyMap(),
                 Mockito.any(Integer.class))).thenAnswer(invocation -> this.postAnswer(invocation));
 
         this.mockClasses(this.rodimusManager, this.mockKnox, this.mockHttpClient);
 
-        this.postAnswerReturn = this.postAnswerTag;
-
-        Map<String, Map<String, String>> res = null;
+        this.postAnswerReturn = KnoxKeyTest.postAnswerTag;
 
         Exception exception = Assert.assertThrows(DeployInternalException.class, () -> {
             this.rodimusManager.getEc2Tags(Arrays.asList("i-001", "i-002"));
@@ -382,9 +381,9 @@ public class KnoxKeyTest {
         Assert.assertTrue(exception.getMessage().contains("HTTP request failed, status"));
 
         try {
-            res = this.rodimusManager.getEc2Tags(Arrays.asList("i-001", "i-002"));
+            this.rodimusManager.getEc2Tags(Arrays.asList("i-001", "i-002"));
         } catch (Exception e) {
-            Assert.assertTrue("Unexpected exception: " + e, false);
+            fail("Unexpected exception: " + e);
         }
 
         final Answer[] expected = {Answer.EXCEPTION, Answer.ARRAY};
@@ -400,12 +399,12 @@ public class KnoxKeyTest {
         when(this.mockHttpClient.post(
                 Mockito.any(String.class),
                 Mockito.any(String.class),
-                Mockito.any(Map.class),
+                Mockito.anyMap(),
                 Mockito.any(Integer.class))).thenAnswer(invocation -> this.postAnswer(invocation));
 
         this.mockClasses(this.rodimusManager, this.mockKnox, this.mockHttpClient);
 
-        this.postAnswerReturn = this.postAnswerTag;
+        this.postAnswerReturn = KnoxKeyTest.postAnswerTag;
 
         for (int i = 1; i <= 2; i++) {
             Exception exception = Assert.assertThrows(DeployInternalException.class, () -> {
@@ -475,7 +474,7 @@ public class KnoxKeyTest {
             return null;
         } else {
             this.answerList.add(Answer.EXCEPTION);
-            throw new DeployInternalException(this.msgUnauthException);
+            throw new DeployInternalException(KnoxKeyTest.msgUnauthException);
         }
     }
 
@@ -491,7 +490,7 @@ public class KnoxKeyTest {
             return this.postAnswerReturn;
         } else {
             this.answerList.add(Answer.EXCEPTION);
-            throw new DeployInternalException(this.msgUnauthException);
+            throw new DeployInternalException(KnoxKeyTest.msgUnauthException);
         }
     }
 
@@ -504,10 +503,10 @@ public class KnoxKeyTest {
 
         if (Objects.equals(token, "token bbb")) {
             this.answerList.add(Answer.LATENCY);
-            return this.getAnswerValue;
+            return KnoxKeyTest.getAnswerValue;
         } else {
             this.answerList.add(Answer.EXCEPTION);
-            throw new DeployInternalException(this.msgUnauthException);
+            throw new DeployInternalException(KnoxKeyTest.msgUnauthException);
         }
     }
 

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/rodimus/RodimusManagerImplTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/rodimus/RodimusManagerImplTest.java
@@ -1,0 +1,54 @@
+package com.pinterest.deployservice.rodimus;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import com.pinterest.deployservice.common.HTTPClient;
+import com.pinterest.deployservice.rodimus.RodimusManagerImpl.Verb;
+
+public class RodimusManagerImplTest {
+    private RodimusManagerImpl sut;
+    private HTTPClient mockHttpClient;
+    private String TEST_URL = "testUrl";
+
+    @Before
+    public void setUp() throws Exception {
+        sut = new RodimusManagerImpl("http://localhost", null, false, "", "");
+
+        mockHttpClient = Mockito.mock(HTTPClient.class);
+        Field classHttpClient = sut.getClass().getDeclaredField("httpClient");
+        classHttpClient.setAccessible(true);
+        classHttpClient.set(sut, mockHttpClient);
+        classHttpClient.setAccessible(false);
+    }
+
+    @Test
+    public void nullKnoxKey_defaultKeyIsUsed() throws Exception {
+        sut.callHttpClient(Verb.DELETE, TEST_URL, null);
+
+        ArgumentCaptor<Map<String, String>> argument = ArgumentCaptor
+                .forClass((Class<Map<String, String>>) (Class) Map.class);
+        verify(mockHttpClient).delete(eq(TEST_URL), eq(null), argument.capture(), eq(3));
+
+        Map<String, String> headers = argument.getValue();
+        assertTrue(headers.containsKey("Authorization"));
+        assertEquals("token key", headers.get("Authorization"));
+    }
+
+    @Test
+    public void invalidKnoxKey_exceptionThrown() throws Exception {
+        RodimusManagerImpl sut = new RodimusManagerImpl("http://localhost", "invalidRodimusKnoxKey", false, "", "");
+        assertThrows(IllegalStateException.class, () -> sut.callHttpClient(Verb.DELETE, TEST_URL, null));
+    }
+}


### PR DESCRIPTION
Knox provides caching now, so we don't need to cache it in the app. The current implementation is problematic because it doesn't handle key refreshes. 

This will supersedes #1094 