### PR TITLE
Adding additional stage types and removing blocked deploys

### DIFF
--- a/deploy-board/deploy_board/templates/configs/env_config.tmpl
+++ b/deploy-board/deploy_board/templates/configs/env_config.tmpl
@@ -250,7 +250,7 @@
                     </label>
                     <div class ="col-xs-4">
                         <div class="input-group">
-                            <select class="form-control" name="stageType">
+                            <select class="form-control" name="stageType" id="stageTypeValueId">
                                 {% get_stage_types as stageTypes %}
                                 {% for stageType in stageTypes %}
                                 {% if env.stageType == stageType %}
@@ -377,8 +377,11 @@
                     btn.button('loading');
                 },
                 success: function (data) {
-                    if(data != null && data.success == false) {
+                    if (data != null && data.success == false) {
                         $('#errorBannerId').append(data.error);
+                        if ($('#stageTypeValueId').val() == 'DEFAULT') {
+                            $('#errorBannerId').append("<a href='//pinch/teletraan-stagetypes'>pinch/teletraan-stagetypes</a>");
+                        }
                         $('#errorBannerId').show();
                     } else {
                         $("#envConfigId").parent().html(data.html);

--- a/deploy-board/deploy_board/templates/configs/env_config.tmpl
+++ b/deploy-board/deploy_board/templates/configs/env_config.tmpl
@@ -267,8 +267,10 @@
                             </span>
                         </div>
                         <div class="col-xs-12" id="stageTypeHelpInfo" hidden="true">
+                            DEV - Used for manual testing</br>
                             LATEST - Deploy the latest available build</br>
-                            CANARY - Deploy the build after tests</br>
+                            STAGING - Deploy the latest available artifacts from master, then verify with testing (integration, stress, smoke etc)</br>
+                            CANARY - Deploy the build after tests, then verify the ACA together with the CONTROL</br>
                             CONTROL - Deploy the build as the production, used with CANARY</br>
                             PRODUCTION - Deploy the build to production
                         </div>

--- a/deploy-board/deploy_board/templates/deploys/confirm_deploy.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/confirm_deploy.tmpl
@@ -24,7 +24,8 @@
                             <strong>Notice: </strong> This build is private and should only be deployed in testing environments and not production environments
                         </div>
                         <div id="defaultStageTypeMessageId" class="alert alert-warning" role="alert" stagetype="{{env.stageType}}" hidden=true>
-                            <strong>Notice: </strong> This stage has a value of DEFAULT for the Stage Type. Please update the Stage Type to a value other than DEFAULT.
+                            <strong>Notice: </strong> This stage has a value of DEFAULT for the Stage Type. Please update the Stage Type to a value other than DEFAULT. See more details at
+                            <a href="//pinch/teletraan-stagetypes">pinch/teletraan-stagetypes</a>
                         </div>
                         <div class="form-group">
                             <label for="description"

--- a/deploy-board/deploy_board/templates/deploys/confirm_deploy.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/confirm_deploy.tmpl
@@ -81,15 +81,6 @@
 <script>
     var stageType = $('#defaultStageTypeMessageId').attr('stagetype');
     $('#deployConfirmFormlId').submit(function (e) {
-        validateInput(stageType, validStageType, $.noop, function () {
-            e.preventDefault();
-        })
-        if (e.isDefaultPrevented()) {
-            $('#defaultStageTypeMessageId').show();
-            return;
-        } else {
-            $('#defaultStageTypeMessageId').hide();
-        }
         $(this).find('button[type=submit]').prop('disabled', 'disabled');
         $(this).find('button[type=submit]').text('Creating...');
     });
@@ -111,6 +102,8 @@
         } else {
             $('#privateBuildDeployMessageId').hide();
         }
+        validateInput(stageType, validStageType, $.noop, function () {
+            $('#defaultStageTypeMessageId').show();
+        });
     });
-
 </script>

--- a/deploy-board/deploy_board/templates/environs/new_stage_modal.tmpl
+++ b/deploy-board/deploy_board/templates/environs/new_stage_modal.tmpl
@@ -47,8 +47,10 @@
                                 </span>
                             </div>
                             <div class="col-xs-12" id="newStageTypeHelpInfo" hidden="true">
+                                DEV - Used for manual testing</br>
                                 LATEST - Deploy the latest available build</br>
-                                CANARY - Deploy the build after tests</br>
+                                STAGING - Deploy the latest available artifacts from master, then verify with testing (integration, stress, smoke etc)</br>
+                                CANARY - Deploy the build after tests, then verify the ACA together with the CONTROL</br>
                                 CONTROL - Deploy the build as the production, used with CANARY</br>
                                 PRODUCTION - Deploy the build to production
                             </div>

--- a/deploy-board/deploy_board/templates/message_banner.tmpl
+++ b/deploy-board/deploy_board/templates/message_banner.tmpl
@@ -3,7 +3,7 @@
         {% if message.level == 40 %}
             <div class="alert alert-danger" role="alert">
                 <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                <strong>Warning!</strong> {{ message | safe}}
+                <strong>Warning!</strong> {{ message | safe}} <a href= {{message.extra_tags.link | safe}}>{{message.extra_tags.text | safe}}</a>
             </div>
         {% else %}
             <div class="alert alert-success" role="alert">

--- a/deploy-board/deploy_board/webapp/env_config_views.py
+++ b/deploy-board/deploy_board/webapp/env_config_views.py
@@ -103,7 +103,7 @@ class EnvConfigView(View):
         data["terminationLimit"] = query_dict["terminationLimit"]
 
         if data["stageType"] == "DEFAULT":
-            raise ValueError("Please update the Stage Type to a value other than DEFAULT")
+            raise ValueError("Please update the Stage Type to a value other than DEFAULT. See more details at ")
 
         environs_helper.update_env_basic_config(request, name, stage, data=data)
         return self.get(request, name, stage)

--- a/deploy-board/deploy_board/webapp/env_views.py
+++ b/deploy-board/deploy_board/webapp/env_views.py
@@ -360,7 +360,10 @@ class EnvLandingView(View):
                 break
 
         if env["stageType"] == "DEFAULT":
-            messages.add_message(request, messages.ERROR, "Please update the Stage Type to a value other than DEFAULT")
+            stageTypeWikiInfo = {}
+            stageTypeWikiInfo['link'] = "//pinch/teletraan-stagetypes"
+            stageTypeWikiInfo['text'] = "pinch/teletraan-stagetypes"
+            messages.add_message(request, messages.ERROR, "Please update the Stage Type to a value other than DEFAULT. See more details at ", stageTypeWikiInfo)
 
         if stage_with_external_id is not None and stage_with_external_id['externalId'] is not None:
             try:

--- a/deploy-board/deploy_board/webapp/helpers/environs_helper.py
+++ b/deploy-board/deploy_board/webapp/helpers/environs_helper.py
@@ -54,7 +54,7 @@ OVERRIDE_POLICY_VALUES = ['OVERRIDE', 'WARN']
 DEPLOY_CONSTRAINT_TYPES = ['GROUP_BY_GROUP', 'ALL_GROUPS_IN_PARALLEL']
 
 # Fetch from backend to avoid maintainng at multiple places?
-STAGE_TYPES = ['DEFAULT', 'LATEST', 'CANARY', 'CONTROL', 'PRODUCTION']
+STAGE_TYPES = ['DEFAULT', 'DEV', 'LATEST', 'STAGING', 'CANARY', 'CONTROL', 'PRODUCTION']
 
 deployclient = DeployClient()
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvType.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvType.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *    
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,13 +24,19 @@ package com.pinterest.deployservice.bean;
  *      Control stage type
  * CANARY:
  *      Canary stage type
-* LATEST:
+ * STAGING:
+ *    Staging stage type
+ * LATEST:
  *      LATEST stage type
+ * DEV:
+ *      DEV stage type
  */
 public enum EnvType {
     DEFAULT,
     PRODUCTION,
     CONTROL,
     CANARY,
-    LATEST;
+    STAGING,
+    LATEST,
+    DEV;
 }

--- a/docs/api/definitions.md
+++ b/docs/api/definitions.md
@@ -233,7 +233,7 @@
 |**scheduleId**  <br>*optional*||string|
 |**scriptConfigId**  <br>*optional*||string|
 |**stageName**  <br>*optional*||string|
-|**stageType**  <br>*optional*||enum (DEFAULT, PRODUCTION, CONTROL, CANARY, LATEST)|
+|**stageType**  <br>*optional*||enum (DEFAULT, PRODUCTION, CONTROL, CANARY, STAGING, LATEST, DEV)|
 |**state**  <br>*optional*||enum (NORMAL, DISABLED)|
 |**stuckThreshold**  <br>*optional*||integer (int32)|
 |**successThreshold**  <br>*optional*||integer (int32)|
@@ -417,7 +417,7 @@
 
   Copyright 2016 Pinterest, Inc.
 
- 
+
 
   Licensed under the Apache License, Version 2.0 (the "License");
 
@@ -425,11 +425,11 @@
 
   You may obtain a copy of the License at
 
- 
+
 
       http://www.apache.org/licenses/LICENSE-2.0
 
- 
+
 
   Unless required by applicable law or agreed to in writing, software
 
@@ -445,7 +445,7 @@
 
   Copyright 2016 Pinterest, Inc.
 
- 
+
 
   Licensed under the Apache License, Version 2.0 (the "License");
 
@@ -453,11 +453,11 @@
 
   You may obtain a copy of the License at
 
-   
+
 
       http://www.apache.org/licenses/LICENSE-2.0
 
-     
+
 
   Unless required by applicable law or agreed to in writing, software
 
@@ -475,7 +475,7 @@
 
   Copyright 2016 Pinterest, Inc.
 
- 
+
 
   Licensed under the Apache License, Version 2.0 (the "License");
 
@@ -483,11 +483,11 @@
 
   You may obtain a copy of the License at
 
- 
+
 
       http://www.apache.org/licenses/LICENSE-2.0
 
- 
+
 
   Unless required by applicable law or agreed to in writing, software
 
@@ -503,7 +503,7 @@
 
   Copyright 2016 Pinterest, Inc.
 
- 
+
 
   Licensed under the Apache License, Version 2.0 (the "License");
 
@@ -511,11 +511,11 @@
 
   You may obtain a copy of the License at
 
-   
+
 
       http://www.apache.org/licenses/LICENSE-2.0
 
-     
+
 
   Unless required by applicable law or agreed to in writing, software
 
@@ -531,7 +531,7 @@
 
   Copyright 2016 Pinterest, Inc.
 
- 
+
 
   Licensed under the Apache License, Version 2.0 (the "License");
 
@@ -539,11 +539,11 @@
 
   You may obtain a copy of the License at
 
-   
+
 
       http://www.apache.org/licenses/LICENSE-2.0
 
-     
+
 
   Unless required by applicable law or agreed to in writing, software
 
@@ -559,7 +559,7 @@
 
   Copyright 2016 Pinterest, Inc.
 
- 
+
 
   Licensed under the Apache License, Version 2.0 (the "License");
 
@@ -567,11 +567,11 @@
 
   You may obtain a copy of the License at
 
-   
+
 
       http://www.apache.org/licenses/LICENSE-2.0
 
-     
+
 
   Unless required by applicable law or agreed to in writing, software
 
@@ -587,7 +587,7 @@
 
   Copyright 2016 Pinterest, Inc.
 
- 
+
 
   Licensed under the Apache License, Version 2.0 (the "License");
 
@@ -595,11 +595,11 @@
 
   You may obtain a copy of the License at
 
-   
+
 
       http://www.apache.org/licenses/LICENSE-2.0
 
-     
+
 
   Unless required by applicable law or agreed to in writing, software
 
@@ -615,7 +615,7 @@
 
   Copyright 2016 Pinterest, Inc.
 
- 
+
 
   Licensed under the Apache License, Version 2.0 (the "License");
 
@@ -623,11 +623,11 @@
 
   You may obtain a copy of the License at
 
-   
+
 
       http://www.apache.org/licenses/LICENSE-2.0
 
-     
+
 
   Unless required by applicable law or agreed to in writing, software
 
@@ -645,7 +645,7 @@
 
   Copyright 2016 Pinterest, Inc.
 
- 
+
 
   Licensed under the Apache License, Version 2.0 (the "License");
 
@@ -653,11 +653,11 @@
 
   You may obtain a copy of the License at
 
- 
+
 
       http://www.apache.org/licenses/LICENSE-2.0
 
- 
+
 
   Unless required by applicable law or agreed to in writing, software
 
@@ -673,7 +673,7 @@
 
   Copyright 2016 Pinterest, Inc.
 
- 
+
 
   Licensed under the Apache License, Version 2.0 (the "License");
 
@@ -681,11 +681,11 @@
 
   You may obtain a copy of the License at
 
-   
+
 
       http://www.apache.org/licenses/LICENSE-2.0
 
-     
+
 
   Unless required by applicable law or agreed to in writing, software
 
@@ -701,7 +701,7 @@
 
   Copyright 2016 Pinterest, Inc.
 
- 
+
 
   Licensed under the Apache License, Version 2.0 (the "License");
 
@@ -709,11 +709,11 @@
 
   You may obtain a copy of the License at
 
-   
+
 
       http://www.apache.org/licenses/LICENSE-2.0
 
-     
+
 
   Unless required by applicable law or agreed to in writing, software
 
@@ -731,7 +731,7 @@
 
   Copyright 2016 Pinterest, Inc.
 
- 
+
 
   Licensed under the Apache License, Version 2.0 (the "License");
 
@@ -739,11 +739,11 @@
 
   You may obtain a copy of the License at
 
- 
+
 
        http://www.apache.org/licenses/LICENSE-2.0
 
- 
+
 
   Unless required by applicable law or agreed to in writing, software
 
@@ -777,7 +777,7 @@
 
   Copyright 2016 Pinterest, Inc.
 
- 
+
 
   Licensed under the Apache License, Version 2.0 (the "License");
 
@@ -785,11 +785,11 @@
 
   You may obtain a copy of the License at
 
-   
+
 
       http://www.apache.org/licenses/LICENSE-2.0
 
-     
+
 
   Unless required by applicable law or agreed to in writing, software
 
@@ -805,7 +805,7 @@
 
   Copyright 2016 Pinterest, Inc.
 
- 
+
 
   Licensed under the Apache License, Version 2.0 (the "License");
 
@@ -813,11 +813,11 @@
 
   You may obtain a copy of the License at
 
-   
+
 
       http://www.apache.org/licenses/LICENSE-2.0
 
-     
+
 
   Unless required by applicable law or agreed to in writing, software
 
@@ -833,7 +833,7 @@
 
   Copyright 2016 Pinterest, Inc.
 
- 
+
 
   Licensed under the Apache License, Version 2.0 (the "License");
 
@@ -841,11 +841,11 @@
 
   You may obtain a copy of the License at
 
-   
+
 
       http://www.apache.org/licenses/LICENSE-2.0
 
-     
+
 
   Unless required by applicable law or agreed to in writing, software
 
@@ -861,7 +861,7 @@
 
   Copyright 2016 Pinterest, Inc.
 
- 
+
 
   Licensed under the Apache License, Version 2.0 (the "License");
 
@@ -869,11 +869,11 @@
 
   You may obtain a copy of the License at
 
-   
+
 
       http://www.apache.org/licenses/LICENSE-2.0
 
-     
+
 
   Unless required by applicable law or agreed to in writing, software
 
@@ -889,7 +889,7 @@
 
   Copyright 2016 Pinterest, Inc.
 
- 
+
 
   Licensed under the Apache License, Version 2.0 (the "License");
 
@@ -897,11 +897,11 @@
 
   You may obtain a copy of the License at
 
-   
+
 
       http://www.apache.org/licenses/LICENSE-2.0
 
-     
+
 
   Unless required by applicable law or agreed to in writing, software
 
@@ -917,7 +917,7 @@
 
   Copyright 2016 Pinterest, Inc.
 
- 
+
 
   Licensed under the Apache License, Version 2.0 (the "License");
 
@@ -925,11 +925,11 @@
 
   You may obtain a copy of the License at
 
-   
+
 
       http://www.apache.org/licenses/LICENSE-2.0
 
-     
+
 
   Unless required by applicable law or agreed to in writing, software
 
@@ -945,7 +945,7 @@
 
   Copyright 2020 Pinterest, Inc.
 
- 
+
 
   Licensed under the Apache License, Version 2.0 (the "License");
 
@@ -953,11 +953,11 @@
 
   You may obtain a copy of the License at
 
-   
+
 
       http://www.apache.org/licenses/LICENSE-2.0
 
-     
+
 
   Unless required by applicable law or agreed to in writing, software
 
@@ -973,7 +973,7 @@
 
   Copyright 2016 Pinterest, Inc.
 
- 
+
 
   Licensed under the Apache License, Version 2.0 (the "License");
 
@@ -981,11 +981,11 @@
 
   You may obtain a copy of the License at
 
-   
+
 
       http://www.apache.org/licenses/LICENSE-2.0
 
-     
+
 
   Unless required by applicable law or agreed to in writing, software
 
@@ -1001,7 +1001,7 @@
 
   Copyright 2016 Pinterest, Inc.
 
- 
+
 
   Licensed under the Apache License, Version 2.0 (the "License");
 
@@ -1009,11 +1009,11 @@
 
   You may obtain a copy of the License at
 
-   
+
 
       http://www.apache.org/licenses/LICENSE-2.0
 
-     
+
 
   Unless required by applicable law or agreed to in writing, software
 
@@ -1041,7 +1041,7 @@
 
   Copyright 2016 Pinterest, Inc.
 
- 
+
 
   Licensed under the Apache License, Version 2.0 (the "License");
 
@@ -1049,11 +1049,11 @@
 
   You may obtain a copy of the License at
 
-   
+
 
       http://www.apache.org/licenses/LICENSE-2.0
 
-     
+
 
   Unless required by applicable law or agreed to in writing, software
 
@@ -1069,7 +1069,7 @@
 
   Copyright 2016 Pinterest, Inc.
 
- 
+
 
   Licensed under the Apache License, Version 2.0 (the "License");
 
@@ -1077,11 +1077,11 @@
 
   You may obtain a copy of the License at
 
-   
+
 
       http://www.apache.org/licenses/LICENSE-2.0
 
-     
+
 
   Unless required by applicable law or agreed to in writing, software
 


### PR DESCRIPTION
### Summary:

This PR contains the following changes
-Removal of blocking deploys for DEFAULT stage type
-Addition of DEV and STAGING stage types
-Addition of pinch links to error messages to stage type wiki 

### Test Plan:

**Updated Stage Type Dropdown + tool type for env config**
<img width="801" alt="image" src="https://github.com/pinterest/teletraan/assets/69278532/d28fb06c-7a10-45fa-b8ff-2dc3e69fd3d1">
<img width="760" alt="image" src="https://github.com/pinterest/teletraan/assets/69278532/0d0b628a-d05c-411d-b7e0-5260b44d4f86">

**Updated error banner for env config**
<img width="1524" alt="image" src="https://github.com/pinterest/teletraan/assets/69278532/cdd8f907-99ea-425c-92c0-97552e72eef3">

**Updated error banner for confirm deploy**
<img width="906" alt="image" src="https://github.com/pinterest/teletraan/assets/69278532/52ae08ae-fed8-4849-a79e-50b5284a5d9f">


**Updated Stage Type Dropdown + tool type for stage create**
<img width="916" alt="image" src="https://github.com/pinterest/teletraan/assets/69278532/895af4cc-80a1-4c42-bbc1-de659251556e">
<img width="965" alt="image" src="https://github.com/pinterest/teletraan/assets/69278532/fe35881b-717f-411b-8de4-c9eef52d97af">

**Updates Env landing error banner**
<img width="1407" alt="image" src="https://github.com/pinterest/teletraan/assets/69278532/10fcd188-6d75-47ac-a8fc-51f6c004b6c4">
