### PR TITLE
Add account id validator

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/ServiceContext.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/ServiceContext.java
@@ -16,6 +16,7 @@
 package com.pinterest.deployservice;
 
 
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -476,7 +477,7 @@ public class ServiceContext {
         return accountAllowList;
     }
 
-    public void setAccountAllowList(List<String> accountAllowList) {
+    public void setAccountAllowList(Collection<String> accountAllowList) {
         this.accountAllowList = new HashSet<String>(accountAllowList);
     }
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/ServiceContext.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/ServiceContext.java
@@ -16,6 +16,11 @@
 package com.pinterest.deployservice;
 
 
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
+import org.apache.commons.dbcp.BasicDataSource;
+
 import com.pinterest.deployservice.allowlists.Allowlist;
 import com.pinterest.deployservice.buildtags.BuildTagsManager;
 import com.pinterest.deployservice.chat.ChatManager;
@@ -48,11 +53,6 @@ import com.pinterest.deployservice.pingrequests.PingRequestValidator;
 import com.pinterest.deployservice.rodimus.RodimusManager;
 import com.pinterest.deployservice.scm.SourceControlManagerProxy;
 import com.pinterest.teletraan.universal.events.AppEventPublisher;
-
-import org.apache.commons.dbcp.BasicDataSource;
-
-import java.util.List;
-import java.util.concurrent.ExecutorService;
 
 public class ServiceContext {
     private BasicDataSource dataSource;
@@ -102,6 +102,7 @@ public class ServiceContext {
     private Long agentCountCacheTtl;
     private Long maxParallelThreshold;
     private BuildEventPublisher buildEventPublisher;
+    private List<String> accountAllowList;
 
     // Publishers & Listeners
     private AppEventPublisher appEventPublisher;
@@ -347,7 +348,6 @@ public class ServiceContext {
         this.rodimusManager = rodimusManager;
     }
 
-
     public void setBuildCacheEnabled(boolean buildCacheEnabled) {
         this.buildCacheEnabled = buildCacheEnabled;
     }
@@ -468,5 +468,13 @@ public class ServiceContext {
     public void setBuildEventPublisher(
         BuildEventPublisher buildEventPublisher) {
         this.buildEventPublisher = buildEventPublisher;
+    }
+
+    public List<String> getAccountAllowList() { 
+        return accountAllowList;
+    }
+
+    public void setAccountAllowList(List<String> accountAllowList) {
+        this.accountAllowList = accountAllowList;
     }
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/ServiceContext.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/ServiceContext.java
@@ -16,7 +16,9 @@
 package com.pinterest.deployservice;
 
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
 import org.apache.commons.dbcp.BasicDataSource;
@@ -102,7 +104,7 @@ public class ServiceContext {
     private Long agentCountCacheTtl;
     private Long maxParallelThreshold;
     private BuildEventPublisher buildEventPublisher;
-    private List<String> accountAllowList;
+    private Set<String> accountAllowList;
 
     // Publishers & Listeners
     private AppEventPublisher appEventPublisher;
@@ -470,11 +472,11 @@ public class ServiceContext {
         this.buildEventPublisher = buildEventPublisher;
     }
 
-    public List<String> getAccountAllowList() { 
+    public Set<String> getAccountAllowList() { 
         return accountAllowList;
     }
 
     public void setAccountAllowList(List<String> accountAllowList) {
-        this.accountAllowList = accountAllowList;
+        this.accountAllowList = new HashSet<String>(accountAllowList);
     }
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
@@ -15,39 +15,9 @@
  */
 package com.pinterest.deployservice.handler;
 
-import com.pinterest.deployservice.ServiceContext;
-import com.pinterest.deployservice.bean.*;
-import com.pinterest.deployservice.common.Constants;
-import com.pinterest.deployservice.common.DeployInternalException;
-import com.pinterest.deployservice.common.StateMachines;
-import com.pinterest.deployservice.dao.AgentDAO;
-import com.pinterest.deployservice.dao.AgentCountDAO;
-import com.pinterest.deployservice.dao.AgentErrorDAO;
-import com.pinterest.deployservice.dao.BuildDAO;
-import com.pinterest.deployservice.dao.DeployConstraintDAO;
-import com.pinterest.deployservice.dao.DeployDAO;
-import com.pinterest.deployservice.dao.EnvironDAO;
-import com.pinterest.deployservice.dao.GroupDAO;
-import com.pinterest.deployservice.dao.HostDAO;
-import com.pinterest.deployservice.dao.HostAgentDAO;
-import com.pinterest.deployservice.dao.HostTagDAO;
-import com.pinterest.deployservice.dao.ScheduleDAO;
-import com.pinterest.deployservice.dao.UtilDAO;
-import com.pinterest.deployservice.pingrequests.PingRequestValidator;
-
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
-import org.apache.commons.dbcp.BasicDataSource;
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.MapUtils;
-import org.apache.commons.lang.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.sql.Connection;
-import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -56,9 +26,59 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.*;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.pinterest.deployservice.ServiceContext;
+import com.pinterest.deployservice.bean.AgentBean;
+import com.pinterest.deployservice.bean.AgentCountBean;
+import com.pinterest.deployservice.bean.AgentErrorBean;
+import com.pinterest.deployservice.bean.AgentState;
+import com.pinterest.deployservice.bean.BuildBean;
+import com.pinterest.deployservice.bean.DeployBean;
+import com.pinterest.deployservice.bean.DeployConstraintBean;
+import com.pinterest.deployservice.bean.DeployConstraintType;
+import com.pinterest.deployservice.bean.DeployGoalBean;
+import com.pinterest.deployservice.bean.DeployStage;
+import com.pinterest.deployservice.bean.EnvType;
+import com.pinterest.deployservice.bean.EnvironBean;
+import com.pinterest.deployservice.bean.HostAgentBean;
+import com.pinterest.deployservice.bean.HostState;
+import com.pinterest.deployservice.bean.HostTagBean;
+import com.pinterest.deployservice.bean.OpCode;
+import com.pinterest.deployservice.bean.PingReportBean;
+import com.pinterest.deployservice.bean.PingRequestBean;
+import com.pinterest.deployservice.bean.PingResponseBean;
+import com.pinterest.deployservice.bean.PingResult;
+import com.pinterest.deployservice.bean.ScheduleBean;
+import com.pinterest.deployservice.bean.ScheduleState;
+import com.pinterest.deployservice.bean.TagSyncState;
+import com.pinterest.deployservice.common.Constants;
+import com.pinterest.deployservice.common.DeployInternalException;
+import com.pinterest.deployservice.common.StateMachines;
+import com.pinterest.deployservice.dao.AgentCountDAO;
+import com.pinterest.deployservice.dao.AgentDAO;
+import com.pinterest.deployservice.dao.AgentErrorDAO;
+import com.pinterest.deployservice.dao.BuildDAO;
+import com.pinterest.deployservice.dao.DeployConstraintDAO;
+import com.pinterest.deployservice.dao.DeployDAO;
+import com.pinterest.deployservice.dao.EnvironDAO;
+import com.pinterest.deployservice.dao.GroupDAO;
+import com.pinterest.deployservice.dao.HostAgentDAO;
+import com.pinterest.deployservice.dao.HostDAO;
+import com.pinterest.deployservice.dao.HostTagDAO;
+import com.pinterest.deployservice.dao.ScheduleDAO;
+import com.pinterest.deployservice.dao.UtilDAO;
+import com.pinterest.deployservice.pingrequests.PingRequestValidator;
 
 /**
  * This is where we handle agent ping and return deploy goal!
@@ -98,6 +118,7 @@ public class PingHandler {
     private List<PingRequestValidator> validators;
     private Long agentCountCacheTtl;
     private Long maxParallelThreshold;
+    private List<String> accountAllowList;
 
     public PingHandler(ServiceContext serviceContext) {
         agentDAO = serviceContext.getAgentDAO();
@@ -118,7 +139,8 @@ public class PingHandler {
         validators = serviceContext.getPingRequestValidators();
         agentCountCacheTtl = serviceContext.getAgentCountCacheTtl();
         maxParallelThreshold = serviceContext.getMaxParallelThreshold();
-
+        accountAllowList = serviceContext.getAccountAllowList();
+        
         if (serviceContext.isBuildCacheEnabled()) {
             buildCache = CacheBuilder.from(serviceContext.getBuildCacheSpec().replace(";", ","))
                     .build(new CacheLoader<String, BuildBean>() {
@@ -252,6 +274,7 @@ public class PingHandler {
         return true;
     }
 
+  
     /**
      * Check if we can start deploy on host for certain env. We should not allow
      * more than parallelThreshold hosts in install in the same time
@@ -593,7 +616,7 @@ public class PingHandler {
         if (validators != null) {
             // validate requests
             for (PingRequestValidator validator : validators) {
-                validator.validate(pingRequest);
+                validator.validate(pingRequest, accountAllowList);
             }
         }
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
@@ -118,7 +118,7 @@ public class PingHandler {
     private List<PingRequestValidator> validators;
     private Long agentCountCacheTtl;
     private Long maxParallelThreshold;
-    private List<String> accountAllowList;
+    private Set<String> accountAllowList;
 
     public PingHandler(ServiceContext serviceContext) {
         agentDAO = serviceContext.getAgentDAO();

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/pingrequests/Ec2InstanceValidator.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/pingrequests/Ec2InstanceValidator.java
@@ -2,7 +2,7 @@ package com.pinterest.deployservice.pingrequests;
 
 import java.util.Set;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,7 +30,7 @@ public class Ec2InstanceValidator extends PingRequestValidator {
         }
 
         String accountId = bean.getAccountId();
-        if (StringUtils.isNotBlank(accountId)) {
+        if (StringUtils.isBlank(accountId)) {
             return;
         }
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/pingrequests/Ec2InstanceValidator.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/pingrequests/Ec2InstanceValidator.java
@@ -1,6 +1,6 @@
 package com.pinterest.deployservice.pingrequests;
 
-import java.util.List;
+import java.util.Set;
 
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
@@ -15,13 +15,13 @@ public class Ec2InstanceValidator extends PingRequestValidator {
     private static final Logger LOG = LoggerFactory.getLogger(MetricsDataFactory.class);
 
     @Override
-    public void validate(PingRequestBean bean, List<String> accountAllowList) throws Exception {
+    public void validate(PingRequestBean bean, Set<String> accountAllowList) throws Exception {
         // Validate instance for ec2
         if (!StringUtils.startsWith(bean.getHostId(), "i-")) {
             LOG.warn("Ignore invalid id {} for host {}", bean.getHostId(), bean.getHostName());
             throw new DeployInternalException(
-                    String.format("Host id %s is not a valid ec2 instance id"),
-                    bean.getHostId() == null ? "null" : bean.getHostId());
+                    String.format("Host id {} is not a valid ec2 instance id"),
+                    StringUtils.defaultString(bean.getHostId()));
         }
 
         // Validate account id of EC2 instance
@@ -30,15 +30,15 @@ public class Ec2InstanceValidator extends PingRequestValidator {
         }
 
         String accountId = bean.getAccountId();
-        if (accountId == null || accountId.isEmpty()) {
+        if (StringUtils.isNotBlank(accountId)) {
             return;
         }
 
         if (!accountAllowList.contains(accountId)) {
             LOG.warn("Ignore ping request from host {} with unknown account id {}", bean.getHostName(), accountId);
             throw new DeployInternalException(
-                    String.format("Host id %s is not from the account allow list"),
-                    bean.getHostId() == null ? "null" : bean.getHostId());
+                    String.format("Host id {} is not from the account allow list"),
+                    StringUtils.defaultString(bean.getHostId()));
         }
     }
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/pingrequests/Ec2InstanceValidator.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/pingrequests/Ec2InstanceValidator.java
@@ -1,25 +1,44 @@
 package com.pinterest.deployservice.pingrequests;
 
-import com.pinterest.deployservice.bean.PingRequestBean;
-import com.pinterest.deployservice.common.DeployInternalException;
-import com.pinterest.deployservice.common.MetricsDataFactory;
+import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.pinterest.deployservice.bean.PingRequestBean;
+import com.pinterest.deployservice.common.DeployInternalException;
+import com.pinterest.deployservice.common.MetricsDataFactory;
 
 public class Ec2InstanceValidator extends PingRequestValidator {
 
     private static final Logger LOG = LoggerFactory.getLogger(MetricsDataFactory.class);
 
     @Override
-    public void validate(PingRequestBean bean) throws Exception {
-        //Validate instance for ec2
+    public void validate(PingRequestBean bean, List<String> accountAllowList) throws Exception {
+        // Validate instance for ec2
         if (!StringUtils.startsWith(bean.getHostId(), "i-")) {
             LOG.warn("Ignore invalid id {} for host {}", bean.getHostId(), bean.getHostName());
             throw new DeployInternalException(
-                String.format("Host id %s is not a valid ec2 instance id"),
-                bean.getHostId() == null ? "null" : bean.getHostId());
+                    String.format("Host id %s is not a valid ec2 instance id"),
+                    bean.getHostId() == null ? "null" : bean.getHostId());
+        }
+
+        // Validate account id of EC2 instance
+        if (accountAllowList == null) {
+            return;
+        }
+
+        String accountId = bean.getAccountId();
+        if (accountId == null || accountId.isEmpty()) {
+            return;
+        }
+
+        if (!accountAllowList.contains(accountId)) {
+            LOG.warn("Ignore ping request from host {} with unknown account id {}", bean.getHostName(), accountId);
+            throw new DeployInternalException(
+                    String.format("Host id %s is not from the account allow list"),
+                    bean.getHostId() == null ? "null" : bean.getHostId());
         }
     }
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/pingrequests/PingRequestValidator.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/pingrequests/PingRequestValidator.java
@@ -1,7 +1,9 @@
 package com.pinterest.deployservice.pingrequests;
 
+import java.util.List;
+
 import com.pinterest.deployservice.bean.PingRequestBean;
 
 public abstract class PingRequestValidator {
-    public abstract void validate(PingRequestBean bean) throws Exception;
+    public abstract void validate(PingRequestBean bean, List<String> accountAllowList) throws Exception;
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/pingrequests/PingRequestValidator.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/pingrequests/PingRequestValidator.java
@@ -1,9 +1,9 @@
 package com.pinterest.deployservice.pingrequests;
 
-import java.util.List;
+import java.util.Set;
 
 import com.pinterest.deployservice.bean.PingRequestBean;
 
 public abstract class PingRequestValidator {
-    public abstract void validate(PingRequestBean bean, List<String> accountAllowList) throws Exception;
+    public abstract void validate(PingRequestBean bean, Set<String> accountAllowList) throws Exception;
 }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/ConfigHelper.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/ConfigHelper.java
@@ -16,6 +16,30 @@
 package com.pinterest.teletraan;
 
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.TreeMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.dbcp.BasicDataSource;
+import org.quartz.CronScheduleBuilder;
+import org.quartz.CronTrigger;
+import org.quartz.JobBuilder;
+import org.quartz.JobDetail;
+import org.quartz.Scheduler;
+import org.quartz.TriggerBuilder;
+import org.quartz.impl.StdSchedulerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.pinterest.deployservice.allowlists.BuildAllowlistImpl;
 import com.pinterest.deployservice.buildtags.BuildTagsManagerImpl;
 import com.pinterest.deployservice.db.DBAgentCountDAOImpl;
@@ -63,30 +87,6 @@ import com.pinterest.teletraan.worker.HotfixStateTransitioner;
 import com.pinterest.teletraan.worker.MetricsEmitter;
 import com.pinterest.teletraan.worker.SimpleAgentJanitor;
 import com.pinterest.teletraan.worker.StateTransitioner;
-
-import org.apache.commons.collections.MapUtils;
-import org.apache.commons.dbcp.BasicDataSource;
-import org.quartz.CronScheduleBuilder;
-import org.quartz.CronTrigger;
-import org.quartz.JobBuilder;
-import org.quartz.JobDetail;
-import org.quartz.Scheduler;
-import org.quartz.TriggerBuilder;
-import org.quartz.impl.StdSchedulerFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-import java.util.TreeMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 
 public class ConfigHelper {
     private static final Logger LOG = LoggerFactory.getLogger(ConfigHelper.class);
@@ -201,6 +201,7 @@ public class ConfigHelper {
 
         if (configuration.getAwsFactory() != null) {
             context.setBuildEventPublisher(new EventBridgePublisher(configuration.getAwsFactory().buildEventBridgeClient(), configuration.getAwsFactory().getEventBridgeEventBusName()));
+            context.setAccountAllowList(configuration.getAwsFactory().getAccountAllowList());
         }
 
         /**

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanServiceConfiguration.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanServiceConfiguration.java
@@ -15,7 +15,14 @@
  */
 package com.pinterest.teletraan;
 
+import java.util.Collections;
+import java.util.List;
+
+import javax.validation.Valid;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.pinterest.teletraan.config.AnonymousAuthenticationFactory;
+import com.pinterest.teletraan.config.AppEventFactory;
 import com.pinterest.teletraan.config.AuthenticationFactory;
 import com.pinterest.teletraan.config.AuthorizationFactory;
 import com.pinterest.teletraan.config.AwsFactory;
@@ -27,7 +34,6 @@ import com.pinterest.teletraan.config.DefaultEmailFactory;
 import com.pinterest.teletraan.config.DefaultHostGroupFactory;
 import com.pinterest.teletraan.config.EmailFactory;
 import com.pinterest.teletraan.config.EmbeddedDataSourceFactory;
-import com.pinterest.teletraan.config.AppEventFactory;
 import com.pinterest.teletraan.config.ExternalAlertsConfigFactory;
 import com.pinterest.teletraan.config.HostGroupFactory;
 import com.pinterest.teletraan.config.JenkinsFactory;
@@ -38,13 +44,8 @@ import com.pinterest.teletraan.config.SourceControlFactory;
 import com.pinterest.teletraan.config.SystemFactory;
 import com.pinterest.teletraan.config.WorkerConfig;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
 import io.dropwizard.health.conf.HealthConfiguration;
-
-import java.util.Collections;
-import java.util.List;
-import javax.validation.Valid;
 
 public class TeletraanServiceConfiguration extends Configuration {
     @Valid

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanServiceConfiguration.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanServiceConfiguration.java
@@ -15,14 +15,7 @@
  */
 package com.pinterest.teletraan;
 
-import java.util.Collections;
-import java.util.List;
-
-import javax.validation.Valid;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.pinterest.teletraan.config.AnonymousAuthenticationFactory;
-import com.pinterest.teletraan.config.AppEventFactory;
 import com.pinterest.teletraan.config.AuthenticationFactory;
 import com.pinterest.teletraan.config.AuthorizationFactory;
 import com.pinterest.teletraan.config.AwsFactory;
@@ -34,6 +27,7 @@ import com.pinterest.teletraan.config.DefaultEmailFactory;
 import com.pinterest.teletraan.config.DefaultHostGroupFactory;
 import com.pinterest.teletraan.config.EmailFactory;
 import com.pinterest.teletraan.config.EmbeddedDataSourceFactory;
+import com.pinterest.teletraan.config.AppEventFactory;
 import com.pinterest.teletraan.config.ExternalAlertsConfigFactory;
 import com.pinterest.teletraan.config.HostGroupFactory;
 import com.pinterest.teletraan.config.JenkinsFactory;
@@ -44,8 +38,13 @@ import com.pinterest.teletraan.config.SourceControlFactory;
 import com.pinterest.teletraan.config.SystemFactory;
 import com.pinterest.teletraan.config.WorkerConfig;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
 import io.dropwizard.health.conf.HealthConfiguration;
+
+import java.util.Collections;
+import java.util.List;
+import javax.validation.Valid;
 
 public class TeletraanServiceConfiguration extends Configuration {
     @Valid

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/AwsFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/AwsFactory.java
@@ -1,6 +1,9 @@
 package com.pinterest.teletraan.config;
 
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.eventbridge.EventBridgeAsyncClient;
 
@@ -10,6 +13,9 @@ public class AwsFactory {
 
   private String eventBridgeEventBusName;
 
+  @JsonProperty
+  private List<String> accountAllowList;
+  
   public EventBridgeAsyncClient buildEventBridgeClient() {
     return EventBridgeAsyncClient.builder().region(Region.US_EAST_1).build();
   }
@@ -32,5 +38,13 @@ public class AwsFactory {
   @JsonProperty
   public void setEventBridgeEventBusName(String eventBridgeEventBusName) {
     this.eventBridgeEventBusName = eventBridgeEventBusName;
+  }
+
+  public List<String> getAccountAllowList() {
+    return this.accountAllowList;
+  }
+
+  public void setAccountAllowList(List<String> accountAllowList) {
+    this.accountAllowList = accountAllowList;
   }
 }


### PR DESCRIPTION
## Summary 
Added account allow list to avoid deployments in a strange account. List of allowed account will be specified in teletraanconfigs.  

## Test plan 
Deployed to dev1 and checked logs for a test deployment. 
```
{"level":"INFO","logger":"com.pinterest.deployservice.common.MetricsDataFactory","thread":"dw-21 - POST /v1/system/ping","message":"account id 998131032990 allow lists [998131032990, 562567494283]","timestamp":"2023-11-21T09:00:30.414+0000"}
```
 