### PR TITLE
Rename stage type env var

### DIFF
--- a/deploy-agent/deployd/common/config.py
+++ b/deploy-agent/deployd/common/config.py
@@ -105,7 +105,7 @@ class Config(object):
         if deploy_status.report.stageName:
             self._environ['STAGE_NAME'] = deploy_status.report.stageName
         if deploy_status.report.stageType:
-            self._environ['COMPUTE_STAGE_TYPE'] = deploy_status.report.stageType
+            self._environ['COMPUTE_ENV_TYPE'] = deploy_status.report.stageType
         if deploy_status.first_deploy:
             self._environ['FIRST_DEPLOY'] = str(deploy_status.first_deploy)
         if deploy_status.is_docker:

--- a/deploy-agent/deployd/common/config.py
+++ b/deploy-agent/deployd/common/config.py
@@ -4,9 +4,9 @@ from __future__ import print_function
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -246,7 +246,7 @@ class Config(object):
 
     def get_daemon_sleep_time(self):
         return self.get_intvar("daemon_sleep_time", 30)
-    
+
     def get_init_sleep_time(self):
         return self.get_intvar("init_sleep_time", 50)
 
@@ -269,7 +269,7 @@ class Config(object):
 
     def get_facter_group_key(self):
         return self.get_var('agent_group_key', None)
-    
+
     def get_verify_https_certificate(self):
         return self.get_var('verify_https_certificate', 'False')
 

--- a/deploy-agent/tests/unit/deploy/common/test_config.py
+++ b/deploy-agent/tests/unit/deploy/common/test_config.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/deploy-agent/tests/unit/deploy/common/test_config.py
+++ b/deploy-agent/tests/unit/deploy/common/test_config.py
@@ -55,7 +55,7 @@ class TestConfigFunctions(tests.TestCase):
         self.assertEqual(os.environ['DEPLOY_ID'], '123')
         self.assertEqual(os.environ['ENV_NAME'], 'pinboard')
         self.assertEqual(os.environ['STAGE_NAME'], 'beta')
-        self.assertEqual(os.environ['COMPUTE_STAGE_TYPE'], 'DEFAULT')
+        self.assertEqual(os.environ['COMPUTE_ENV_TYPE'], 'DEFAULT')
         self.assertEqual(self.config.get_target(), '/tmp/pinboard')
 
 

--- a/deploy-sentinel/teletraan/POST_RESTART
+++ b/deploy-sentinel/teletraan/POST_RESTART
@@ -8,7 +8,7 @@ echo $PORT
 # Built in Environment Variables
 echo $ENV_NAME
 echo $STAGE_NAME
-echo $COMPUTE_STAGE_TYPE
+echo $COMPUTE_ENV_TYPE
 echo $DEPLOY_ID
 echo $DEPLOY_STEP
 echo $OPCODE

--- a/deploy-sentinel/teletraan/POST_RESTART
+++ b/deploy-sentinel/teletraan/POST_RESTART
@@ -5,7 +5,7 @@ echo Running POST_RESTART script.
 # Environment Variable defined in DeployBoard Script Config
 echo $PORT
 
-# Built in Environment Variables 
+# Built in Environment Variables
 echo $ENV_NAME
 echo $STAGE_NAME
 echo $COMPUTE_STAGE_TYPE


### PR DESCRIPTION
The Teletraan stage type is now exposed as an environment variable to
the host.

Rename the env var to match the expected name