### PR TITLE
Short in-memory cache for Knox

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/KnoxKeyReader.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/KnoxKeyReader.java
@@ -31,6 +31,7 @@ public class KnoxKeyReader implements KeyReader {
 
     private String knoxKeyId;
     private KnoxKeyManager knoxManager;
+
     private final LoadingCache<String, Optional<String>> knoxCache;
 
     public KnoxKeyReader() {
@@ -44,6 +45,10 @@ public class KnoxKeyReader implements KeyReader {
                                 return Optional.fromNullable(getKeyInternal());
                             }
                         });
+    }
+
+    void setKnoxManager(KnoxKeyManager knoxManager) {
+        this.knoxManager = knoxManager;
     }
 
     public void init(String keyID) {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/KnoxKeyReader.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/KnoxKeyReader.java
@@ -15,36 +15,59 @@
  */
 package com.pinterest.deployservice.common;
 
+import java.util.concurrent.TimeUnit;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Optional;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 
 public class KnoxKeyReader implements KeyReader {
-
     private static final Logger LOG = LoggerFactory.getLogger(KnoxKeyReader.class);
+    private static final String defaultKeyContent = "defaultKeyContent";
 
-    private String testKey = "key";
-
+    private String knoxKeyId;
     private KnoxKeyManager knoxManager;
+    private final LoadingCache<String, Optional<String>> knoxCache;
 
-    public void init(String key) {
+    public KnoxKeyReader() {
+        knoxCache = CacheBuilder.newBuilder()
+                .maximumSize(1)
+                .expireAfterWrite(1, TimeUnit.MINUTES)
+                .build(
+                        new CacheLoader<String, Optional<String>>() {
+                            @Override
+                            public Optional<String> load(String key) throws Exception {
+                                return Optional.fromNullable(getKeyInternal());
+                            }
+                        });
+    }
+
+    public void init(String keyID) {
         if (knoxManager == null) {
             knoxManager = new KnoxKeyManager();
-            knoxManager.init(key);
+            knoxManager.init(keyID);
+            knoxKeyId = keyID;
         }
     }
 
     public String getKey() {
-        if (knoxManager == null) {
-            LOG.error("Using default key since knoxManager is null");
-            return testKey;
-        }
         try {
-            String knoxKey = knoxManager.getKey();
-            return knoxKey;
+            return knoxCache.get(knoxKeyId).orNull();
         } catch (Exception e) {
-            LOG.error("Using default key due to exception :" + e.getMessage());
-            return testKey;
+            LOG.warn("Using default key due to exception", e);
+            return defaultKeyContent;
         }
+    }
+
+    private String getKeyInternal() {
+        if (knoxManager == null) {
+            LOG.warn("Using default key since knoxManager is null");
+            return defaultKeyContent;
+        }
+        return knoxManager.getKey();
     }
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/RodimusManagerImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/RodimusManagerImpl.java
@@ -24,6 +24,7 @@ import com.google.gson.JsonPrimitive;
 import com.google.gson.reflect.TypeToken;
 
 import com.pinterest.deployservice.common.HTTPClient;
+import com.pinterest.deployservice.common.KeyReader;
 import com.pinterest.deployservice.common.KnoxKeyReader;
 
 import org.apache.commons.lang3.StringUtils;
@@ -48,7 +49,7 @@ public class RodimusManagerImpl implements RodimusManager {
     private HTTPClient httpClient;
     private Map<String, String> headers;
     private Gson gson;
-    private KnoxKeyReader knoxKeyReader = new KnoxKeyReader();
+    private KeyReader knoxKeyReader = new KnoxKeyReader();
 
     public RodimusManagerImpl(String rodimusUrl, String knoxKey, boolean useProxy, String httpProxyAddr,
             String httpProxyPort) throws Exception {

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/common/KnoxKeyReaderTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/common/KnoxKeyReaderTest.java
@@ -1,0 +1,21 @@
+package com.pinterest.deployservice.common;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+public class KnoxKeyReaderTest {
+    @Test
+    public void testGetKey_noInit() {
+        KnoxKeyReader sut = new KnoxKeyReader();
+        assertEquals("defaultKeyContent", sut.getKey());
+    }
+
+    @Test
+    public void testGetKey_initialized() {
+        KnoxKeyReader sut = new KnoxKeyReader();
+        sut.init("someRandomKey");
+        assertNull(sut.getKey());
+    }
+}

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/common/KnoxKeyReaderTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/common/KnoxKeyReaderTest.java
@@ -2,6 +2,9 @@ package com.pinterest.deployservice.common;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.only;
+import static org.mockito.Mockito.verify;
 
 import org.junit.Test;
 
@@ -17,5 +20,18 @@ public class KnoxKeyReaderTest {
         KnoxKeyReader sut = new KnoxKeyReader();
         sut.init("someRandomKey");
         assertNull(sut.getKey());
+    }
+
+    @Test
+    public void testGetKey_cacheIsWorking() {
+        KnoxKeyReader sut = new KnoxKeyReader();
+        KnoxKeyManager mockKnoxKeyManager = mock(KnoxKeyManager.class);
+
+        sut.init("someRandomKey");
+        sut.setKnoxManager(mockKnoxKeyManager);
+        sut.getKey();
+        sut.getKey();
+
+        verify(mockKnoxKeyManager, only()).getKey();
     }
 }

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/rodimus/RodimusManagerImplTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/rodimus/RodimusManagerImplTest.java
@@ -43,7 +43,7 @@ public class RodimusManagerImplTest {
 
         Map<String, String> headers = argument.getValue();
         assertTrue(headers.containsKey("Authorization"));
-        assertEquals("token key", headers.get("Authorization"));
+        assertEquals("token defaultKeyContent", headers.get("Authorization"));
     }
 
     @Test


### PR DESCRIPTION
Add short 1-minute in-memory cache for Knox key. This will remove most disk access for key read yet to ensure key replacement doesn't require a restart of the application. 