### PR TITLE
update stage_type if it is DEFAULT and delivery_type is different with it 

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
@@ -425,7 +425,7 @@ public class DeployHandler implements DeployHandlerInterface{
         deployBean.setOperator(operator);
         
         //compare the current stage_type 
-        if(StringUtils.isEmpty(deliveryType) == false && envBean.getStage_type().toString().equals(deliveryType) == false) {
+        if(StringUtils.isNotBlank(deliveryType) && !envBean.getStage_type().toString().equals(deliveryType)) {
             if (envBean.getStage_type() != EnvType.DEFAULT) {
                 throw new Exception("The delivery type is different with the stage type, deployment is not allowed!");
             } else {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
@@ -289,12 +289,9 @@ public class DeployHandler implements DeployHandlerInterface{
         EnvironBean updateEnvBean = new EnvironBean();
         updateEnvBean.setDeploy_id(deployId);
         updateEnvBean.setDeploy_type(deployBean.getDeploy_type());
-        LOG.info("the new stage type is : {}", envBean.getStage_type());
         updateEnvBean.setStage_type(envBean.getStage_type());
-        LOG.info("the new stage type is : {}", updateEnvBean.getStage_type());
 
         statements.add(environDAO.genUpdateStatement(envBean.getEnv_id(), updateEnvBean));
-        LOG.info("the statement to update environ bean is : {}", environDAO.genUpdateStatement(envBean.getEnv_id(), updateEnvBean));
 
         // Deprecate/Obsolete the previous deploy
         DeployBean oldDeployBean = null;
@@ -428,33 +425,35 @@ public class DeployHandler implements DeployHandlerInterface{
         deployBean.setOperator(operator);
         
         //compare the current stage_type 
-        if(StringUtils.isEmpty(deliveryType) == false) {
-            EnvType type = envBean.getStage_type();
-            LOG.info("input deleivery type is : {}; stage type in database is: {}", deliveryType, type);
-            switch (deliveryType) {
-                case "PRODUCTION":
-                    type = EnvType.PRODUCTION;
-                case "CANARY":
-                    type = EnvType.CANARY;
-                case "CONTROL":
-                    type = EnvType.CONTROL;
-                case "DEV":
-                    type = EnvType.DEV;
-                case "LATEST":
-                    type = EnvType.LATEST;
-                case "STAGING":
-                    type = EnvType.STAGING;
-                default:
-                    type = envBean.getStage_type();
-            }
-            LOG.info("input deleivery type is : {}; stage type in database is: {}", deliveryType, type);
-            if (envBean.getStage_type().toString().equals(deliveryType) == false) {
-                LOG.info("stage type and delievery type are different");
-                if (envBean.getStage_type() != EnvType.DEFAULT) {
-                    throw new Exception("The delivery type is different with the stage type, deployment is not allowed!");
-                } else {
-                    envBean.setStage_type(type);
+        if(StringUtils.isEmpty(deliveryType) == false && envBean.getStage_type().toString().equals(deliveryType) == false) {
+            if (envBean.getStage_type() != EnvType.DEFAULT) {
+                throw new Exception("The delivery type is different with the stage type, deployment is not allowed!");
+            } else {
+                EnvType type = envBean.getStage_type();
+                switch (deliveryType) {
+                    case "PRODUCTION":
+                        type = EnvType.PRODUCTION;
+                        break;
+                    case "CANARY":
+                        type = EnvType.CANARY;
+                        break;
+                    case "CONTROL":
+                        type = EnvType.CONTROL;
+                        break;
+                    case "DEV":
+                        type = EnvType.DEV;
+                        break;
+                    case "LATEST":
+                        type = EnvType.LATEST;
+                        break;
+                    case "STAGING":
+                        type = EnvType.STAGING;
+                        break;
+                    default:
+                        throw new Exception("The delivery type is not a valid delivery type!");
                 }
+                envBean.setStage_type(type);
+                LOG.info("The stage type is updated from {} to {} for env {}", envBean.getStage_type(), type, envBean.getEnv_id())
             }
         }
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
@@ -453,7 +453,7 @@ public class DeployHandler implements DeployHandlerInterface{
                         throw new Exception("The delivery type is not a valid delivery type!");
                 }
                 envBean.setStage_type(type);
-                LOG.info("The stage type is updated from {} to {} for env {}", envBean.getStage_type(), type, envBean.getEnv_id())
+                LOG.info("The stage type is updated from {} to {} for env {}", envBean.getStage_type(), type, envBean.getEnv_id());
             }
         }
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
@@ -289,9 +289,12 @@ public class DeployHandler implements DeployHandlerInterface{
         EnvironBean updateEnvBean = new EnvironBean();
         updateEnvBean.setDeploy_id(deployId);
         updateEnvBean.setDeploy_type(deployBean.getDeploy_type());
+        LOG.info("the new stage type is : {}", envBean.getStage_type());
         updateEnvBean.setStage_type(envBean.getStage_type());
+        LOG.info("the new stage type is : {}", updateEnvBean.getStage_type());
 
         statements.add(environDAO.genUpdateStatement(envBean.getEnv_id(), updateEnvBean));
+        LOG.info("the statement to update environ bean is : {}", environDAO.genUpdateStatement(envBean.getEnv_id(), updateEnvBean));
 
         // Deprecate/Obsolete the previous deploy
         DeployBean oldDeployBean = null;

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
@@ -424,34 +424,14 @@ public class DeployHandler implements DeployHandlerInterface{
         deployBean.setDeploy_type(DeployType.REGULAR);
         deployBean.setOperator(operator);
         
-        //compare the current stage_type 
+        // compare the current stage_type and the delivery_type
+        // When the delivery_type is different with stage_type and stage_type is not DEFAULT, we reject the deployment API call;
+        // When the delivery_type is different with stage_type and stage_type is DEFAULT, we update the stage_type;
         if(StringUtils.isNotBlank(deliveryType) && !envBean.getStage_type().toString().equals(deliveryType)) {
             if (envBean.getStage_type() != EnvType.DEFAULT) {
                 throw new Exception("The delivery type is different with the stage type, deployment is not allowed!");
             } else {
-                EnvType type = envBean.getStage_type();
-                switch (deliveryType) {
-                    case "PRODUCTION":
-                        type = EnvType.PRODUCTION;
-                        break;
-                    case "CANARY":
-                        type = EnvType.CANARY;
-                        break;
-                    case "CONTROL":
-                        type = EnvType.CONTROL;
-                        break;
-                    case "DEV":
-                        type = EnvType.DEV;
-                        break;
-                    case "LATEST":
-                        type = EnvType.LATEST;
-                        break;
-                    case "STAGING":
-                        type = EnvType.STAGING;
-                        break;
-                    default:
-                        throw new Exception("The delivery type is not a valid delivery type!");
-                }
+                EnvType type = EnvType.valueOf(deliveryType);
                 envBean.setStage_type(type);
                 LOG.info("The stage type is updated from {} to {} for env {}", envBean.getStage_type(), type, envBean.getEnv_id());
             }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
@@ -427,6 +427,7 @@ public class DeployHandler implements DeployHandlerInterface{
         //compare the current stage_type 
         if(StringUtils.isEmpty(deliveryType) == false) {
             EnvType type = envBean.getStage_type();
+            LOG.info("input deleivery type is : {}; stage type in database is: {}", deliveryType, type);
             switch (deliveryType) {
                 case "PRODUCTION":
                     type = EnvType.PRODUCTION;
@@ -443,7 +444,9 @@ public class DeployHandler implements DeployHandlerInterface{
                 default:
                     type = envBean.getStage_type();
             }
+            LOG.info("input deleivery type is : {}; stage type in database is: {}", deliveryType, type);
             if (envBean.getStage_type().toString().equals(deliveryType) == false) {
+                LOG.info("stage type and delievery type are different");
                 if (envBean.getStage_type() != EnvType.DEFAULT) {
                     throw new Exception("The delivery type is different with the stage type, deployment is not allowed!");
                 } else {

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvDeploys.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvDeploys.java
@@ -201,12 +201,13 @@ public class EnvDeploys {
             @ApiParam(value = "Environment name", required = true)@PathParam("envName") String envName,
             @ApiParam(value = "Stage name", required = true)@PathParam("stageName") String stageName,
             @ApiParam(value = "Build id", required = true)@NotEmpty @QueryParam("buildId") String buildId,
-            @ApiParam(value = "Description", required = true)@QueryParam("description") String description) throws Exception {
+            @ApiParam(value = "Description", required = true)@QueryParam("description") String description,
+            @ApiParam(value = "Delivery type", required = false)@QueryParam("deliveryType") String deliveryType) throws Exception {
         EnvironBean envBean = Utils.getEnvStage(environDAO, envName, stageName);
         authorizer.authorize(sc, new Resource(envBean.getEnv_name(), Resource.Type.ENV), Role.OPERATOR);
         String operator = sc.getUserPrincipal().getName();
 
-        String deployId = deployHandler.deploy(envBean, buildId, description, operator);
+        String deployId = deployHandler.deploy(envBean, buildId, description, deliveryType, operator);
         LOG.info("Successfully create deploy {} for env {}/{} by {}.", deployId, envName, stageName, operator);
 
         UriBuilder ub = uriInfo.getAbsolutePathBuilder();

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AutoPromoter.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AutoPromoter.java
@@ -571,7 +571,7 @@ public class AutoPromoter implements Runnable {
                     String desc = "Auto promote build " + buildId;
                     String
                         newDeployId =
-                        deployHandler.deploy(currEnvBean, buildId, desc, AUTO_PROMOTER_NAME);
+                        deployHandler.deploy(currEnvBean, buildId, desc, null, AUTO_PROMOTER_NAME);
                     LOG.info(
                         "Auto promoted deploy {} from build {}, from stage {} to {} for env {}",
                         newDeployId, buildId, predStageName, currEnvBean.getStage_name(),


### PR DESCRIPTION
We will keep one source of truth for stage_type on Teletraan side.
When the delivery_type is different with stage_type and stage_type is not DEFAULT, we reject the deployment API call;
When the delivery_type is different with stage_type and stage_type is DEFAULT, we update the stage_type;