### PR TITLE
map dev and staging to stage type latest

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvType.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvType.java
@@ -32,5 +32,7 @@ public enum EnvType {
     PRODUCTION,
     CONTROL,
     CANARY,
-    LATEST;
+    LATEST,
+    DEV,
+    STAGING
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
@@ -602,6 +602,8 @@ public class PingHandler {
     private Set<String> shardGroups(PingRequestBean pingRequest) throws Exception {
         List<String> shards = new ArrayList<>();
         EnvType stageType = populateStageType(pingRequest);
+        // A tmp solution to map dev and staging to latest.
+        // This way sidecar deployments will work without sidecar owners to update their env/stage setup and spinnaker pipelines, which might take a long time.
         stageType = stageTypeMapping(stageType);
         shards.add(stageType.toString().toLowerCase());
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
@@ -568,6 +568,14 @@ public class PingHandler {
         return envBean;
     }
 
+    private EnvType stageTypeMapping(EnvType type) {
+        if (type == EnvType.DEV || type == EnvType.STAGING) {
+            return EnvType.LATEST;
+        } else {
+            return type;
+        }
+    }
+
     private EnvType populateStageType(PingRequestBean pingRequest) throws Exception {
         if (pingRequest.getStageType() != null) {
             return pingRequest.getStageType();
@@ -594,6 +602,7 @@ public class PingHandler {
     private Set<String> shardGroups(PingRequestBean pingRequest) throws Exception {
         List<String> shards = new ArrayList<>();
         EnvType stageType = populateStageType(pingRequest);
+        stageType = stageTypeMapping(stageType);
         shards.add(stageType.toString().toLowerCase());
 
         String availabilityZone = pingRequest.getAvailabilityZone();


### PR DESCRIPTION
A temporary solution to map stage_type DEV and STAGING to LATEST. This way sidecar deployments will work without sidecar owners to update their env/stage setup and spinnaker pipelines, which might take a long time.