### PR TITLE
do not allow deleting build associated with deployment

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/DeployDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/DeployDAO.java
@@ -63,6 +63,8 @@ public interface DeployDAO {
     // Delete all unused deploys whose last update time is before timeThreshold
     void deleteUnusedDeploys(String envId, long timeThreshold, long numOfDeploys) throws Exception;
 
+    boolean isThereADeployWithBuildId(String buildId) throws Exception;
+
     long getDailyDeployCount() throws SQLException;
 
     long getRunningDeployCount() throws SQLException;

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBDeployDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBDeployDAOImpl.java
@@ -28,6 +28,7 @@ import org.apache.commons.dbutils.QueryRunner;
 import org.apache.commons.dbutils.ResultSetHandler;
 import org.apache.commons.dbutils.handlers.BeanHandler;
 import org.apache.commons.dbutils.handlers.BeanListHandler;
+import org.apache.commons.dbutils.handlers.ScalarHandler;
 import org.apache.commons.lang.StringUtils;
 import org.joda.time.Interval;
 
@@ -84,7 +85,7 @@ public class DBDeployDAOImpl implements DeployDAO {
     private static final String COUNT_ACTIVE_DEPLOYS =
         "SELECT COUNT(*) FROM deploys WHERE state='RUNNING'";
 
-    private BasicDataSource dataSource;
+    private final BasicDataSource dataSource;
 
     public DBDeployDAOImpl(BasicDataSource dataSource) {
         this.dataSource = dataSource;
@@ -251,6 +252,12 @@ public class DBDeployDAOImpl implements DeployDAO {
         throws Exception {
         new QueryRunner(dataSource)
             .update(DELETE_UNUSED_DEPLOYS, envId, timeThreshold, numOfDeploys);
+    }
+
+    @Override
+    public boolean isThereADeployWithBuildId(String buildId) throws Exception {
+        return new QueryRunner(dataSource).query("SELECT EXISTS(SELECT * FROM deploys WHERE build_id =?)",
+            new ScalarHandler<Integer>()) == 1;
     }
 
     @Override


### PR DESCRIPTION
## Why

A deployment is associated with a build. If there exists a deployment D for build B, this build **_should not_** be deleted. Otherwise:
1. Deployment D will then refer to a **_nonexistent_** build.
2. If D is the current deployment for an environment, or being actively deployed, this will cause problem since the build info is missing.

### DO NOT MERGE - PENDING TESTING.

