### PR TITLE
Add account id validator

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/ServiceContext.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/ServiceContext.java
@@ -16,6 +16,14 @@
 package com.pinterest.deployservice;
 
 
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+
+import org.apache.commons.dbcp.BasicDataSource;
+
 import com.pinterest.deployservice.allowlists.Allowlist;
 import com.pinterest.deployservice.buildtags.BuildTagsManager;
 import com.pinterest.deployservice.chat.ChatManager;
@@ -48,11 +56,6 @@ import com.pinterest.deployservice.pingrequests.PingRequestValidator;
 import com.pinterest.deployservice.rodimus.RodimusManager;
 import com.pinterest.deployservice.scm.SourceControlManagerProxy;
 import com.pinterest.teletraan.universal.events.AppEventPublisher;
-
-import org.apache.commons.dbcp.BasicDataSource;
-
-import java.util.List;
-import java.util.concurrent.ExecutorService;
 
 public class ServiceContext {
     private BasicDataSource dataSource;
@@ -102,6 +105,7 @@ public class ServiceContext {
     private Long agentCountCacheTtl;
     private Long maxParallelThreshold;
     private BuildEventPublisher buildEventPublisher;
+    private Set<String> accountAllowList;
 
     // Publishers & Listeners
     private AppEventPublisher appEventPublisher;
@@ -347,7 +351,6 @@ public class ServiceContext {
         this.rodimusManager = rodimusManager;
     }
 
-
     public void setBuildCacheEnabled(boolean buildCacheEnabled) {
         this.buildCacheEnabled = buildCacheEnabled;
     }
@@ -468,5 +471,13 @@ public class ServiceContext {
     public void setBuildEventPublisher(
         BuildEventPublisher buildEventPublisher) {
         this.buildEventPublisher = buildEventPublisher;
+    }
+
+    public Set<String> getAccountAllowList() { 
+        return accountAllowList;
+    }
+
+    public void setAccountAllowList(Collection<String> accountAllowList) {
+        this.accountAllowList = new HashSet<String>(accountAllowList);
     }
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
@@ -118,6 +118,7 @@ public class PingHandler {
     private List<PingRequestValidator> validators;
     private Long agentCountCacheTtl;
     private Long maxParallelThreshold;
+    private Set<String> accountAllowList;
 
     public PingHandler(ServiceContext serviceContext) {
         agentDAO = serviceContext.getAgentDAO();
@@ -138,7 +139,8 @@ public class PingHandler {
         validators = serviceContext.getPingRequestValidators();
         agentCountCacheTtl = serviceContext.getAgentCountCacheTtl();
         maxParallelThreshold = serviceContext.getMaxParallelThreshold();
-
+        accountAllowList = serviceContext.getAccountAllowList();
+        
         if (serviceContext.isBuildCacheEnabled()) {
             buildCache = CacheBuilder.from(serviceContext.getBuildCacheSpec().replace(";", ","))
                     .build(new CacheLoader<String, BuildBean>() {
@@ -272,6 +274,7 @@ public class PingHandler {
         return true;
     }
 
+  
     /**
      * Check if we can start deploy on host for certain env. We should not allow
      * more than parallelThreshold hosts in install in the same time
@@ -632,7 +635,7 @@ public class PingHandler {
         if (validators != null) {
             // validate requests
             for (PingRequestValidator validator : validators) {
-                validator.validate(pingRequest);
+                validator.validate(pingRequest, accountAllowList);
             }
         }
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/pingrequests/Ec2InstanceValidator.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/pingrequests/Ec2InstanceValidator.java
@@ -1,25 +1,44 @@
 package com.pinterest.deployservice.pingrequests;
 
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.pinterest.deployservice.bean.PingRequestBean;
 import com.pinterest.deployservice.common.DeployInternalException;
 import com.pinterest.deployservice.common.MetricsDataFactory;
-
-import org.apache.commons.lang.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class Ec2InstanceValidator extends PingRequestValidator {
 
     private static final Logger LOG = LoggerFactory.getLogger(MetricsDataFactory.class);
 
     @Override
-    public void validate(PingRequestBean bean) throws Exception {
-        //Validate instance for ec2
+    public void validate(PingRequestBean bean, Set<String> accountAllowList) throws Exception {
+        // Validate instance for ec2
         if (!StringUtils.startsWith(bean.getHostId(), "i-")) {
             LOG.warn("Ignore invalid id {} for host {}", bean.getHostId(), bean.getHostName());
             throw new DeployInternalException(
-                String.format("Host id %s is not a valid ec2 instance id"),
-                bean.getHostId() == null ? "null" : bean.getHostId());
+                    String.format("Host id {} is not a valid ec2 instance id"),
+                    StringUtils.defaultString(bean.getHostId()));
+        }
+
+        // Validate account id of EC2 instance
+        if (accountAllowList == null) {
+            return;
+        }
+
+        String accountId = bean.getAccountId();
+        if (StringUtils.isBlank(accountId)) {
+            return;
+        }
+
+        if (!accountAllowList.contains(accountId)) {
+            LOG.warn("Ignore ping request from host {} with unknown account id {}", bean.getHostName(), accountId);
+            throw new DeployInternalException(
+                    String.format("Host id {} is not from an AWS account in the allow list"),
+                    StringUtils.defaultString(bean.getHostId()));
         }
     }
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/pingrequests/Ec2InstanceValidator.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/pingrequests/Ec2InstanceValidator.java
@@ -35,7 +35,7 @@ public class Ec2InstanceValidator extends PingRequestValidator {
         }
 
         if (!accountAllowList.contains(accountId)) {
-            LOG.warn("Ignore ping request from host {} with unknown account id {}", bean.getHostName(), accountId);
+            LOG.warn("Ignore ping request from host {} with unknown account id: {}", bean.getHostName(), accountId);
             throw new DeployInternalException(
                     String.format("Host id {} is from an disallowed AWS account: {}"),
                     StringUtils.defaultString(bean.getHostId()), accountId);

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/pingrequests/Ec2InstanceValidator.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/pingrequests/Ec2InstanceValidator.java
@@ -37,8 +37,8 @@ public class Ec2InstanceValidator extends PingRequestValidator {
         if (!accountAllowList.contains(accountId)) {
             LOG.warn("Ignore ping request from host {} with unknown account id {}", bean.getHostName(), accountId);
             throw new DeployInternalException(
-                    String.format("Host id {} is not from an AWS account in the allow list"),
-                    StringUtils.defaultString(bean.getHostId()));
+                    String.format("Host id {} is from an disallowed AWS account: {}"),
+                    StringUtils.defaultString(bean.getHostId()), accountId);
         }
     }
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/pingrequests/PingRequestValidator.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/pingrequests/PingRequestValidator.java
@@ -1,7 +1,9 @@
 package com.pinterest.deployservice.pingrequests;
 
+import java.util.Set;
+
 import com.pinterest.deployservice.bean.PingRequestBean;
 
 public abstract class PingRequestValidator {
-    public abstract void validate(PingRequestBean bean) throws Exception;
+    public abstract void validate(PingRequestBean bean, Set<String> accountAllowList) throws Exception;
 }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/ConfigHelper.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/ConfigHelper.java
@@ -16,6 +16,30 @@
 package com.pinterest.teletraan;
 
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.TreeMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.dbcp.BasicDataSource;
+import org.quartz.CronScheduleBuilder;
+import org.quartz.CronTrigger;
+import org.quartz.JobBuilder;
+import org.quartz.JobDetail;
+import org.quartz.Scheduler;
+import org.quartz.TriggerBuilder;
+import org.quartz.impl.StdSchedulerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.pinterest.deployservice.allowlists.BuildAllowlistImpl;
 import com.pinterest.deployservice.buildtags.BuildTagsManagerImpl;
 import com.pinterest.deployservice.db.DBAgentCountDAOImpl;
@@ -63,30 +87,6 @@ import com.pinterest.teletraan.worker.HotfixStateTransitioner;
 import com.pinterest.teletraan.worker.MetricsEmitter;
 import com.pinterest.teletraan.worker.SimpleAgentJanitor;
 import com.pinterest.teletraan.worker.StateTransitioner;
-
-import org.apache.commons.collections.MapUtils;
-import org.apache.commons.dbcp.BasicDataSource;
-import org.quartz.CronScheduleBuilder;
-import org.quartz.CronTrigger;
-import org.quartz.JobBuilder;
-import org.quartz.JobDetail;
-import org.quartz.Scheduler;
-import org.quartz.TriggerBuilder;
-import org.quartz.impl.StdSchedulerFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-import java.util.TreeMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 
 public class ConfigHelper {
     private static final Logger LOG = LoggerFactory.getLogger(ConfigHelper.class);
@@ -201,6 +201,11 @@ public class ConfigHelper {
 
         if (configuration.getAwsFactory() != null) {
             context.setBuildEventPublisher(new EventBridgePublisher(configuration.getAwsFactory().buildEventBridgeClient(), configuration.getAwsFactory().getEventBridgeEventBusName()));
+            
+        }
+
+        if (configuration.getAccountAllowList() != null) {
+            context.setAccountAllowList(configuration.getAccountAllowList());
         }
 
         /**

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanServiceConfiguration.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanServiceConfiguration.java
@@ -123,6 +123,10 @@ public class TeletraanServiceConfiguration extends Configuration {
     @Valid
     private MicrometerMetricsFactory metricsFactory = new MicrometerMetricsFactory();
 
+    @Valid
+    @JsonProperty("accountAllowList")
+    private List<String> accountAllowList;
+
     public DataSourceFactory getDataSourceFactory() {
         if (dataSourceFactory == null) {
             return new EmbeddedDataSourceFactory();
@@ -310,5 +314,9 @@ public class TeletraanServiceConfiguration extends Configuration {
     @JsonProperty("metrics")
     public void setMetricsFactory(MicrometerMetricsFactory metrics) {
         this.metricsFactory = metrics;
+    }
+
+    public List<String> getAccountAllowList() {
+        return accountAllowList;
     }
 }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/AwsFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/AwsFactory.java
@@ -1,6 +1,9 @@
 package com.pinterest.teletraan.config;
 
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.eventbridge.EventBridgeAsyncClient;
 
@@ -10,6 +13,9 @@ public class AwsFactory {
 
   private String eventBridgeEventBusName;
 
+  @JsonProperty
+  private List<String> accountAllowList;
+  
   public EventBridgeAsyncClient buildEventBridgeClient() {
     return EventBridgeAsyncClient.builder().region(Region.US_EAST_1).build();
   }
@@ -32,5 +38,13 @@ public class AwsFactory {
   @JsonProperty
   public void setEventBridgeEventBusName(String eventBridgeEventBusName) {
     this.eventBridgeEventBusName = eventBridgeEventBusName;
+  }
+
+  public List<String> getAccountAllowList() {
+    return this.accountAllowList;
+  }
+
+  public void setAccountAllowList(List<String> accountAllowList) {
+    this.accountAllowList = accountAllowList;
   }
 }


### PR DESCRIPTION
## Summary 
Added account allow list to avoid deployments in a strange account. List of allowed account will be specified in teletraanconfigs. Rework this PR using a separate config as the last one under aws seems to have an issue. 

## Test plan
Deployed to dev1 and checked logs for a test deployment.
1. No allow list. deployment works as before. 

2. Random acc id in the allow list: the deployment was ignored 
[removed photo]
3. Primary and sub moka acc are in the list. Deployment was performed successfully. 
[removed photo]
