### PR TITLE
Correct variable name to containerHealthStatus

### DIFF
--- a/deploy-board/deploy_board/templates/deploys/_container_status.html
+++ b/deploy-board/deploy_board/templates/deploys/_container_status.html
@@ -1,7 +1,7 @@
-{% if not healthStatus %}
-<i class="fa fa-ban"></i>
-{% elif "unhealthy" in healthStatus %}
+{% if "unhealthy" in healthStatus %}
 <i class="fa fa-exclamation-triangle color-red"></i>
-{% else %}
+{% elif "healthy" in healthStatus %}
 <i class="fa fa-check-circle color-green"></i>
+{% else %}
+<i class="fa fa-ban"></i>
 {% endif %}

--- a/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
@@ -17,10 +17,10 @@
             <small>{{ agentStat.agent.hostName }}</small>
             {% endif %}
             {% if report.showMode == "containerStatus" %}
-            {% include "deploys/_container_status.html" with healthStatus=agentStat.agent.serviceHealthStatus %}
+            {% include "deploys/_container_status.html" with healthStatus=agentStat.agent.containerHealthStatus %}
             {% else %}
             <i class="fa fa-fw {{ agentStat | agentIcon }}"></i>
-            {% endif %}  
+            {% endif %}
             {% endif %}
             </a>
         {% elif report.account == subAccount %}
@@ -32,10 +32,10 @@
             <small>{{ agentStat.agent.hostName }}</small>
             {% endif %}
             {% if report.showMode == "containerStatus" %}
-            {% include "deploys/_container_status.html" with healthStatus=agentStat.agent.serviceHealthStatus %}
+            {% include "deploys/_container_status.html" with healthStatus=agentStat.agent.containerHealthStatus %}
             {% else %}
             <i class="fa fa-fw {{ agentStat | agentIcon }}"></i>
-            {% endif %}  
+            {% endif %}
             {% endif %}
             </a>
         {% elif report.account == "others" %}
@@ -47,10 +47,10 @@
             <small>{{ agentStat.agent.hostName }}</small>
             {% endif %}
             {% if report.showMode == "containerStatus" %}
-            {% include "deploys/_container_status.html" with healthStatus=agentStat.agent.serviceHealthStatus %}
+            {% include "deploys/_container_status.html" with healthStatus=agentStat.agent.containerHealthStatus %}
             {% else %}
             <i class="fa fa-fw {{ agentStat | agentIcon }}"></i>
-            {% endif %}  
+            {% endif %}
             {% endif %}
             </a>
         {% elif report.account == "all" %}
@@ -61,10 +61,10 @@
             <small>{{ agentStat.agent.hostName }}</small>
             {% endif %}
             {% if report.showMode == "containerStatus" %}
-            {% include "deploys/_container_status.html" with healthStatus=agentStat.agent.serviceHealthStatus %}
+            {% include "deploys/_container_status.html" with healthStatus=agentStat.agent.containerHealthStatus %}
             {% else %}
             <i class="fa fa-fw {{ agentStat | agentIcon }}"></i>
-            {% endif %}  
+            {% endif %}
             </a>
         {% endif %}
     {% endfor %}
@@ -111,7 +111,7 @@
                             {% endif %}
                             <i class="fa fa-fw {{ agentStat | agentIcon }}"></i>
                             {% if report.showMode == "containerStatus" %}
-                            {% include "deploys/_container_status.html" with healthStatus=agentStat.agent.serviceHealthStatus %}
+                            {% include "deploys/_container_status.html" with healthStatus=agentStat.agent.containerHealthStatus %}
                             {% endif %}
                         </a>
                     {% endfor %}


### PR DESCRIPTION
serviceHealthStatus was a typo on the actual name returned by the Teletraan API. Also, improved the condition that renders the health icon. Here are some of the possible values it might see for containerHealthStatus:
- "service-a:healthy"
- "service-a:unhealthy"
- ""
- "service-a:healthy;service-b:healthy"
- "service-a:healthy;service-b:unhealthy"

Example:

Display Mode: Container Status
![Screenshot 2024-01-10 at 3 45 15 PM](https://github.com/pinterest/teletraan/assets/72234714/63ce4b98-b4dd-4e74-b531-4db6c85f6c2f)