### PR TITLE
fix scaling action type bug

### DIFF
--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -567,8 +567,9 @@ def _parse_metrics_configs(request, group_name):
         if key.startswith('TELETRAAN_'):
             alarm_info = {}
             alarm_info["scalingPolicies"] = []
-            action_type = params["asgActionType"]
+            
             alarm_id = key[len('TELETRAAN_'):]
+            action_type = params["actionType_{}".format(alarm_id)]
 
             if page_data["fromAwsMetric_{}".format(alarm_id)][0] == "True":
                 alarm_info["fromAwsMetric"] = True
@@ -591,7 +592,7 @@ def _parse_metrics_configs(request, group_name):
                 policy_type = "simple-scaling"
 
             if policy_type == "simple-scaling":
-                if action_type == "grow":
+                if action_type == "GROW":
                     if policies["scaleupPolicies"] != None:
                         for i in policies["scaleupPolicies"]:
                             alarm_info["scalingPolicies"].append(i)


### PR DESCRIPTION
Action type (GROW or SHRINK) associated with an alarm was incorrectly retrieved. They are encoded as `actionType_ALARM_ID` prop in the form, so they need to be retrieved with proper key.

Tested and confirmed in dev1 that the bug is fixed.

Testing steps:
1. Create a simple scaling policy for both grow and shrink
2. Create a GROW alarm and SHRINK alarm and associated with this simple scaling policy.
3. Update and save the alarms (e.g. change threshold, etc.)
4. In AWS Console, verify the alarms are correctly associated with the scaling policy: the SHRINK alarm will be associated with Scale Down policy, and GROW alarm will be associated with Scale Up policy.
5. Repeat step 3 and 4 and confirm the behavior is still correct.