### PR TITLE
[deploy-agent] Return type hints in staging & types folders

### DIFF
--- a/deploy-agent/deployd/staging/stager.py
+++ b/deploy-agent/deployd/staging/stager.py
@@ -20,6 +20,7 @@ import sys
 import shutil
 import traceback
 import logging
+from typing import Optional
 
 from deployd.common import LOG_FORMAT
 from deployd.common.caller import Caller
@@ -35,7 +36,7 @@ class Stager(object):
     _script_dirname = "teletraan"
     _template_dirname = "teletraan_template"
 
-    def __init__(self, config, build, target, env_name, transformer=None):
+    def __init__(self, config, build, target, env_name, transformer=None) -> None:
         self._build_dir = config.get_builds_directory()
         self._user_role = config.get_user_role()
         agent_dir = config.get_agent_directory()
@@ -45,7 +46,7 @@ class Stager(object):
         self._target = target
         self._env_name = env_name
 
-    def enable_package(self):
+    def enable_package(self) -> int:
         """Set the enabled build.
         """
         old_build = self.get_enabled_build()
@@ -90,7 +91,7 @@ class Stager(object):
         finally:
             return status_code
 
-    def get_enabled_build(self):
+    def get_enabled_build(self) -> Optional[str]:
         """Figure out what build is enabled by looking at symlinks."""
         if not os.path.exists(self._target):
             if (os.path.islink(self._target) and not
@@ -110,7 +111,7 @@ class Stager(object):
 
         return symlink_target.rsplit("/", 1)[-1]
 
-    def transform_script(self):
+    def transform_script(self) -> None:
         script_dir = os.path.join(self._target, self._script_dirname)
         if not os.path.exists(script_dir):
             return
@@ -125,7 +126,7 @@ class Stager(object):
                                             script_dirname=self._script_dirname)
 
 
-def main():
+def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('-f', '--config-file', dest='config_file', default=None,
                         help="the deploy agent conf file filename path. If none, "

--- a/deploy-agent/deployd/staging/transformer.py
+++ b/deploy-agent/deployd/staging/transformer.py
@@ -17,6 +17,7 @@ import traceback
 from string import Template
 import re
 import logging
+from typing import List
 from deployd import IS_PINTEREST
 
 log = logging.getLogger(__name__)
@@ -73,7 +74,7 @@ class Transformer(object):
             log.error('Fail to translate script {}, stacktrace: {}'.format(from_path,
                                                                            traceback.format_exc()))
 
-    def transform_scripts(self, script_dir, template_dirname, script_dirname) -> list:
+    def transform_scripts(self, script_dir, template_dirname, script_dirname) -> List:
         scripts = []
         suffix = ".tmpl"
         try:

--- a/deploy-agent/deployd/staging/transformer.py
+++ b/deploy-agent/deployd/staging/transformer.py
@@ -29,12 +29,12 @@ class TeletraanTemplate(Template):
 
 class Transformer(object):
 
-    def __init__(self, agent_dir, env_name, dict_fn=None):
+    def __init__(self, agent_dir, env_name, dict_fn=None) -> None:
         self._agent_dir = agent_dir
         self._env_name = env_name
         self._load_config(dict_fn)
 
-    def _load_config(self, fn):
+    def _load_config(self, fn) -> None:
         if not fn:
             fn = os.path.join(self._agent_dir, "{}_SCRIPT_CONFIG".format(self._env_name))
 
@@ -45,10 +45,10 @@ class Transformer(object):
         with open(fn, 'r') as f:
             self._dictionary = dict((n.strip('\"\n\' ') for n in line.split("=", 1)) for line in f)
 
-    def dict_size(self):
+    def dict_size(self) -> int:
         return len(self._dictionary)
 
-    def _translate(self, from_path, to_path):
+    def _translate(self, from_path, to_path) -> None:
         try:
             with open(from_path, 'r') as f:
                 res = f.read()
@@ -73,7 +73,7 @@ class Transformer(object):
             log.error('Fail to translate script {}, stacktrace: {}'.format(from_path,
                                                                            traceback.format_exc()))
 
-    def transform_scripts(self, script_dir, template_dirname, script_dirname):
+    def transform_scripts(self, script_dir, template_dirname, script_dirname) -> list:
         scripts = []
         suffix = ".tmpl"
         try:

--- a/deploy-agent/deployd/types/build.py
+++ b/deploy-agent/deployd/types/build.py
@@ -15,7 +15,7 @@
 
 class Build(object):
 
-    def __init__(self, jsonValue=None):
+    def __init__(self, jsonValue=None) -> None:
         self.buildId = None
         self.buildName = None
         self.buildVersion = None
@@ -43,7 +43,7 @@ class Build(object):
             self.publishInfo = jsonValue.get('publishInfo')
             self.publishDate = jsonValue.get('publishDate')
 
-    def __key(self):
+    def __key(self) -> tuple:
         return (self.buildId,
                 self.buildName,
                 self.buildVersion,
@@ -57,20 +57,20 @@ class Build(object):
                 self.publishInfo,
                 self.publishDate)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(self.__key())
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         """ compare Builds """
         return isinstance(other, Build) \
             and self.__key() == other.__key()
 
-    def __ne__(self, other):
+    def __ne__(self, other) -> bool:
         """ compare Builds """
         return not (isinstance(other, Build)
                     and self.__key() == other.__key())
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "Build(buildId={}, buildName={}, buildVersion={}, artifactUrl={}, scm={}, " \
                "scmRepo={}, scmBranch={}, scmCommit={}, scmInfo={}, commitDate={}, publishInfo={}, " \
                "publishDate={})".format(self.buildId, self.buildName, self.buildVersion,

--- a/deploy-agent/deployd/types/build.py
+++ b/deploy-agent/deployd/types/build.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 
+from typing import Tuple
+
+
 class Build(object):
 
     def __init__(self, jsonValue=None) -> None:
@@ -43,7 +46,7 @@ class Build(object):
             self.publishInfo = jsonValue.get('publishInfo')
             self.publishDate = jsonValue.get('publishDate')
 
-    def __key(self) -> tuple:
+    def __key(self) -> Tuple:
         return (self.buildId,
                 self.buildName,
                 self.buildVersion,

--- a/deploy-agent/deployd/types/deploy_goal.py
+++ b/deploy-agent/deployd/types/deploy_goal.py
@@ -51,7 +51,7 @@ class DeployGoal(object):
             self.firstDeploy = jsonValue.get('firstDeploy')
             self.isDocker = jsonValue.get('isDocker')
 
-    def __key(self) -> tuple:
+    def __key(self) -> Tuple:
         return (self.deployId,
                 self.envId,
                 self.envName,

--- a/deploy-agent/deployd/types/deploy_goal.py
+++ b/deploy-agent/deployd/types/deploy_goal.py
@@ -16,7 +16,7 @@ from deployd.types.build import Build
 from deployd.types.deploy_stage import DeployStage
 
 class DeployGoal(object):
-    def __init__(self, jsonValue=None):
+    def __init__(self, jsonValue=None) -> None:
         self.deployId = None
         self.envId = None
         self.envName = None
@@ -51,7 +51,7 @@ class DeployGoal(object):
             self.firstDeploy = jsonValue.get('firstDeploy')
             self.isDocker = jsonValue.get('isDocker')
 
-    def __key(self):
+    def __key(self) -> tuple:
         return (self.deployId,
                 self.envId,
                 self.envName,
@@ -65,20 +65,20 @@ class DeployGoal(object):
                 self.firstDeploy,
                 self.isDocker)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(self.__key())
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         """ compare DeployGoals """
         return isinstance(other, DeployGoal) \
             and self.__key() == other.__key()
 
-    def __ne__(self, other):
+    def __ne__(self, other) -> bool:
         """ compare DeployGoals """
         return not (isinstance(other, DeployGoal)
                     and self.__key() == other.__key())
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "DeployGoal(deployId={}, envId={}, envName={}, stageName={}, stageType={}, " \
                "deployStage={}, build={}, deployAlias={}, agentConfig={}," \
                "scriptVariables={}, firstDeploy={}, isDocker={})".format(self.deployId, self.envId, self.envName,

--- a/deploy-agent/deployd/types/deploy_goal.py
+++ b/deploy-agent/deployd/types/deploy_goal.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Tuple
 from deployd.types.build import Build
 from deployd.types.deploy_stage import DeployStage
 

--- a/deploy-agent/deployd/types/ping_report.py
+++ b/deploy-agent/deployd/types/ping_report.py
@@ -18,7 +18,7 @@ from deployd.types.agent_status import AgentStatus
 
 class PingReport(object):
 
-    def __init__(self, jsonValue=None):
+    def __init__(self, jsonValue=None) -> None:
         self.deployId = None
         self.envId = None
         self.envName = None
@@ -62,7 +62,7 @@ class PingReport(object):
             self.redeploy = jsonValue.get('redeploy')
             self.wait = jsonValue.get('wait')
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "PingReport(deployId={}, envId={}, deployStage={}, status={}, " \
                "errorCode={}, errorMessage={}, failCount={}, extraInfo={}, " \
                "deployAlias={}, containerHealthStatus={}, agentState={})".format(self.deployId, self.envId, self.deployStage,

--- a/deploy-agent/deployd/types/ping_response.py
+++ b/deploy-agent/deployd/types/ping_response.py
@@ -18,7 +18,7 @@ from deployd.common.types import OpCode
 
 
 class PingResponse(object):
-    def __init__(self, jsonValue=None):
+    def __init__(self, jsonValue=None) -> None:
         self.opCode = OpCode.NOOP
         self.deployGoal = None
 
@@ -32,5 +32,5 @@ class PingResponse(object):
             if jsonValue.get('deployGoal'):
                 self.deployGoal = DeployGoal(jsonValue=jsonValue.get('deployGoal'))
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "PingResponse(opCode={}, deployGoal={})".format(self.opCode, self.deployGoal)


### PR DESCRIPTION
Improve readability for low risk:

> The Python runtime does not enforce function and variable type annotations.