### PR TITLE
[deploy-agent] Return type hints in client folder and agent 

### DIFF
--- a/deploy-agent/deployd/client/client.py
+++ b/deploy-agent/deployd/client/client.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional
 import lockfile
 import logging
 import os
@@ -26,6 +27,7 @@ from deployd.common.stats import create_stats_timer, create_sc_increment
 from deployd.common import utils
 from deployd.types.ping_request import PingRequest
 from deployd import IS_PINTEREST
+from deployd.types.ping_response import PingResponse
 
 
 log = logging.getLogger(__name__)
@@ -33,7 +35,7 @@ log = logging.getLogger(__name__)
 
 class Client(BaseClient):
     def __init__(self, config=None, hostname=None, ip=None, hostgroup=None, 
-                host_id=None, use_facter=None, use_host_info=False):
+                host_id=None, use_facter=None, use_host_info=False) -> None:
         self._hostname = hostname
         self._ip = ip
         self._hostgroup = hostgroup
@@ -50,7 +52,7 @@ class Client(BaseClient):
         self._stage_type_fetched = False
         self._account_id = None
 
-    def _read_host_info(self):
+    def _read_host_info(self) -> bool:
         if self._use_facter:
             log.info("Use facter to get host info")
             name_key = self._config.get_facter_name_key()
@@ -199,7 +201,7 @@ class Client(BaseClient):
 
         return True
 
-    def send_reports(self, env_reports=None):
+    def send_reports(self, env_reports=None) -> Optional[PingResponse]:
         try:
             if self._read_host_info():
                 reports = [status.report for status in env_reports.values()]
@@ -238,7 +240,7 @@ class Client(BaseClient):
             return None
 
     @retry(ExceptionToCheck=Exception, delay=1, tries=3)
-    def send_reports_internal(self, request):
+    def send_reports_internal(self, request) -> PingResponse:
         ping_service = RestfulClient(self._config)
         response = ping_service.ping(request)
         return response

--- a/deploy-agent/deployd/client/restfulclient.py
+++ b/deploy-agent/deployd/client/restfulclient.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Callable, Optional
 import requests
 import logging
 
@@ -26,7 +27,7 @@ log = logging.getLogger(__name__)
 
 @singleton
 class RestfulClient(object):
-    def __init__(self, config):
+    def __init__(self, config) -> None:
         self.config = config
         self.url_prefix = config.get_restful_service_url()
         self.url_version = config.get_restful_service_version()
@@ -35,13 +36,13 @@ class RestfulClient(object):
         self.default_timeout = 30
 
     @staticmethod
-    def sc_fail(reason):
+    def sc_fail(reason) -> None:
         """ send RestfulClient failure metrics """
         create_sc_increment(name='deploy.agent.rest.failure',
                             tags={'reason': reason})
 
-    def __call(self, method):
-        def api(path, params=None, data=None):
+    def __call(self, method) -> Callable:
+        def api(path, params=None, data=None) -> Optional[dict]:
             url = '%s/%s%s' % (self.url_prefix, self.url_version, path)
             if self.token:
                 headers = {'Authorization': 'token %s' % self.token, 'Content-type': 'application/json'}
@@ -74,10 +75,10 @@ class RestfulClient(object):
 
         return api
 
-    def _ping_internal(self, ping_request):
+    def _ping_internal(self, ping_request) -> Optional[dict]:
         return self.__call('post')("/system/ping", data=ping_request)
 
-    def ping(self, ping_request):
+    def ping(self, ping_request) -> PingResponse:
         # python object -> json
         response = self._ping_internal(ping_request.to_json())
 


### PR DESCRIPTION
Improve readability for low risk:

> The Python runtime does not enforce function and variable type annotations.