### PR TITLE
Added possibility to restart all failed hosts without checking any

### DIFF
--- a/deploy-board/deploy_board/static/css/deploy-board.css
+++ b/deploy-board/deploy_board/static/css/deploy-board.css
@@ -342,3 +342,11 @@ body {
   vertical-align: middle;
   margin-top: 3px;
 }
+
+.mr-1 {
+  margin-right: 5px;
+}
+
+.ml-1 {
+  margin-left: 5px;
+}

--- a/deploy-board/deploy_board/templates/hosts/hosts.tmpl
+++ b/deploy-board/deploy_board/templates/hosts/hosts.tmpl
@@ -6,27 +6,27 @@
       <strong>Deploy:</strong><a href="/deploy/{{ deployId }}"> {{ deployId }}</a>
        <div class="btn-toolbar pull-right">
           <button id="pauseButton"
-          class="btn btn-default btn-sm" data-toggle="tooltip"
+          class="btn btn-default btn-sm checked-hosts-btn" data-toggle="tooltip"
           title="Pause selected hosts">
           <span class="glyphicon glyphicon-pause"></span> Pause
           </button>
           <button id="resumeButton"
-          class="btn btn-default btn-sm" data-toggle="tooltip"
+          class="btn btn-default btn-sm checked-hosts-btn" data-toggle="tooltip"
           title="Resume selected hosts">
           <span class="glyphicon glyphicon-play"></span> Resume
           </button>
           <button id="resetButton"
-          class="btn btn-default btn-sm" data-toggle="tooltip"
+          class="btn btn-default btn-sm checked-hosts-btn" data-toggle="tooltip"
           title="reset selected hosts">
           <span class="glyphicon glyphicon-repeat"></span> Reset
           </button>
           <button id="terminateButton"
-          class="btn btn-default btn-sm" data-toggle="tooltip"
+          class="btn btn-default btn-sm checked-hosts-btn" data-toggle="tooltip"
           title="Soft terminate selected hosts">
           <span class="glyphicon glyphicon-off"></span> Terminate
           </button>
           <button id="forceTerminateButton"
-          class="btn btn-default btn-sm" data-toggle="tooltip"
+          class="btn btn-default btn-sm checked-hosts-btn" data-toggle="tooltip"
           title="Soft terminate selected hosts">
           <span class="glyphicon glyphicon-remove"></span> Force Terminate
           </button>
@@ -128,6 +128,12 @@
     });
 
     $('#hostTable input[type="checkbox"]').click(function(){
+        if ($("#hostTable input:checkbox:checked").length <= 0) {
+            $(".checked-hosts-btn").prop("disabled", true);
+        } else {
+            $(".checked-hosts-btn").prop("disabled", false);
+        }
+
         if ($(this).is(":checked")) {
           checkedHosts.push($(this).val());
         } else {
@@ -144,6 +150,12 @@
                 checkedHosts.push($(this).val());
             }
         });
+
+        if ($("#hostTable input:checkbox:checked").length <= 0) {
+            $(".checked-hosts-btn").prop("disabled", true);
+        } else {
+            $(".checked-hosts-btn").prop("disabled", false);
+        }
     });
 
     $("#pauseButton").on("click", function() {

--- a/deploy-board/deploy_board/templates/hosts/hosts.tmpl
+++ b/deploy-board/deploy_board/templates/hosts/hosts.tmpl
@@ -89,7 +89,7 @@
         <button id="reset_{{ deployId }}"
                 class="deployToolTip btn btn-primary" data-toggle="tooltip"
                 title="Retry deploys on all failed hosts.">
-            Retry deploys on all failed hosts
+            Retry current deploy on all failed hosts
         </button>
     </div>
     {% endif %}
@@ -332,13 +332,13 @@
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
-                <h4 class="modal-title">Retry deploys on all failed hosts confirmation</h4>
+                <h4 class="modal-title">Retry current deploy on all failed hosts confirmation</h4>
             </div>
             <div class="modal-body">
-                <p> Are you sure to retry deploys on all failed hosts?</p>
+                <p>Are you sure to retry the current deploy on all failed hosts?</p>
             </div>
             <div class="modal-footer">
-                <button type="submit" class="btn btn-warning" id="resetAllFailedDeploys">Retry deploys on all failed hosts</button>
+                <button type="submit" class="btn btn-warning" id="resetAllFailedDeploys">Retry current deploy on all failed hosts</button>
                 <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
             </div>
         </div><!-- /.modal-content -->

--- a/deploy-board/deploy_board/templates/hosts/hosts.tmpl
+++ b/deploy-board/deploy_board/templates/hosts/hosts.tmpl
@@ -85,7 +85,7 @@
 
 <div class="panel-footer clearfix">
     {% if is_retryable and host_ids %}
-    <div class="pull-left">
+    <div class="pull-left mr-1">
         <button id="reset_{{ deployId }}"
                 class="deployToolTip btn btn-primary" data-toggle="tooltip"
                 title="Retry deploys on all failed hosts.">
@@ -95,7 +95,7 @@
     {% endif %}
 
     {% if pinterest and host_ids %}
-    <div class="pull-left">
+    <div class="pull-left ml-1">
         <button class="deployToolTip btn btn-default btn-block checked-hosts-btn" data-target="#terminateHost"
             data-toggle="modal" title="Terminate all failed hosts">
         <span class="glyphicon glyphicon-remove"></span> Terminate failed hosts
@@ -108,7 +108,12 @@
 
     $(function () {
         $('.deployToolTip').tooltip();
-        $('#reset_{{ deployId }}').click(function () {
+
+        $("#reset_{{ deployId }}").on("click", function() {
+            $('#resetAllFailedDeploysModal').modal();
+        });
+
+        $('#resetAllFailedDeploys').click(function () {
             $.ajax({
                 type: 'POST',
                 url: '/env/{{ env.envName }}/{{ env.stageName }}/reset_failed_hosts/{{ deployId }}/',
@@ -318,6 +323,24 @@
                 </div>
                 {% csrf_token %}
             </form>
+        </div><!-- /.modal-content -->
+    </div><!-- /.modal-dialog -->
+</div><!-- /.modal -->
+
+<div class="modal fade" id="resetAllFailedDeploysModal" tabindex="-1" role="dialog" aria-labelledby="newEntryModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+                <h4 class="modal-title">Retry deploys on all failed hosts confirmation</h4>
+            </div>
+            <div class="modal-body">
+                <p> Are you sure to retry deploys on all failed hosts?</p>
+            </div>
+            <div class="modal-footer">
+                <button type="submit" class="btn btn-warning" id="resetAllFailedDeploys">Retry deploys on all failed hosts</button>
+                <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+            </div>
         </div><!-- /.modal-content -->
     </div><!-- /.modal-dialog -->
 </div><!-- /.modal -->

--- a/deploy-board/deploy_board/templates/hosts/hosts.tmpl
+++ b/deploy-board/deploy_board/templates/hosts/hosts.tmpl
@@ -96,7 +96,7 @@
 
     {% if pinterest and host_ids %}
     <div class="pull-left ml-1">
-        <button class="deployToolTip btn btn-default btn-block checked-hosts-btn" data-target="#terminateHost"
+        <button class="deployToolTip btn btn-default btn-block" data-target="#terminateHost"
             data-toggle="modal" title="Terminate all failed hosts">
         <span class="glyphicon glyphicon-remove"></span> Terminate failed hosts
         </button>
@@ -128,12 +128,6 @@
     });
 
     $('#hostTable input[type="checkbox"]').click(function(){
-        if ($("#hostTable input:checkbox:checked").length <= 0) {
-          $(".checked-hosts-btn").prop("disabled", true);
-        } else {
-          $(".checked-hosts-btn").prop("disabled", false);
-        }
-
         if ($(this).is(":checked")) {
           checkedHosts.push($(this).val());
         } else {
@@ -150,12 +144,6 @@
                 checkedHosts.push($(this).val());
             }
         });
-
-        if ($("#hostTable input:checkbox:checked").length <= 0) {
-            $(".checked-hosts-btn").prop("disabled", true);
-        } else {
-            $(".checked-hosts-btn").prop("disabled", false);
-        }
     });
 
     $("#pauseButton").on("click", function() {

--- a/deploy-board/deploy_board/templates/hosts/hosts.tmpl
+++ b/deploy-board/deploy_board/templates/hosts/hosts.tmpl
@@ -88,15 +88,15 @@
     <div class="pull-left">
         <button id="reset_{{ deployId }}"
                 class="deployToolTip btn btn-primary" data-toggle="tooltip"
-                title="Retry the current deploy step on this host.">
-            Retry deploy on all hosts
+                title="Retry deploys on all failed hosts.">
+            Retry deploys on all failed hosts
         </button>
     </div>
     {% endif %}
 
     {% if pinterest and host_ids %}
     <div class="pull-left">
-        <button class="deployToolTip btn btn-default btn-block" data-target="#terminateHost"
+        <button class="deployToolTip btn btn-default btn-block checked-hosts-btn" data-target="#terminateHost"
             data-toggle="modal" title="Terminate all failed hosts">
         <span class="glyphicon glyphicon-remove"></span> Terminate failed hosts
         </button>
@@ -124,9 +124,9 @@
 
     $('#hostTable input[type="checkbox"]').click(function(){
         if ($("#hostTable input:checkbox:checked").length <= 0) {
-          $(".btn").prop("disabled", true);
+          $(".checked-hosts-btn").prop("disabled", true);
         } else {
-          $(".btn").prop("disabled", false);
+          $(".checked-hosts-btn").prop("disabled", false);
         }
 
         if ($(this).is(":checked")) {
@@ -147,9 +147,9 @@
         });
 
         if ($("#hostTable input:checkbox:checked").length <= 0) {
-            $(".btn").prop("disabled", true);
+            $(".checked-hosts-btn").prop("disabled", true);
         } else {
-            $(".btn").prop("disabled", false);
+            $(".checked-hosts-btn").prop("disabled", false);
         }
     });
 


### PR DESCRIPTION
# Context

Made button to restart failed deployment on all failed hosts available without checking any hosts.

# Proof of Work

## Failed hosts for current deployment
<img width="1425" alt="Screenshot 2024-01-19 at 10 45 26 AM" src="https://github.com/pinterest/teletraan/assets/20383875/80aac6fb-6e2d-4647-84cd-b82e70fd06dd">

## Confirmation of retrying deployment

<img width="1501" alt="Screenshot 2024-01-19 at 10 56 07 AM" src="https://github.com/pinterest/teletraan/assets/20383875/74e9d9a4-e9c7-4fe3-b73d-b6134e64f71d">


## Active button without selected hosts
<img width="1403" alt="Screenshot 2024-01-19 at 10 46 34 AM" src="https://github.com/pinterest/teletraan/assets/20383875/8d06fc30-fdfd-45ad-9a5e-54821e7f3400">

## Button works without selected hosts

<img width="393" alt="Screenshot 2024-01-18 at 7 04 46 PM" src="https://github.com/pinterest/teletraan/assets/20383875/a03ac3b8-d640-4a29-a713-43596303efa9">
