### PR TITLE
build: Pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+repos:
+  - repo: 'https://github.com/pre-commit/pre-commit-hooks'
+    rev: v2.3.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: 'https://github.com/psf/black'
+    rev: 23.12.0
+    hooks:
+      - id: black
+        files: "^(deploy-agent|deploy-board)/.*\\.py$"
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8
+        files: "^(deploy-agent|deploy-board)/.*\\.py$"
+  - repo: https://github.com/djlint/djLint
+    rev: v1.34.1
+    hooks:
+      - id: djlint-reformat-django
+        files: "^deploy-board/.*\\.html$"
+      - id: djlint-django
+        files: "^deploy-board/.*\\.html$"
+        args: [--ignore="H031"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203, E704
+
+[testenv:black]
+description = check code format with black
+deps = black==23.12.0
+commands = black --check {posargs} deploy-board/ deploy-agent/
+
+[testenv:flake8]
+description = lint code with flake8
+deps = flake8==7.0.0
+commands = flake8 {posargs} deploy-board/ deploy-agent/
+
+[tool.djlint]
+profile = django
+ignore = H031

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,3 @@ commands = black --check {posargs} deploy-board/ deploy-agent/
 description = lint code with flake8
 deps = flake8==7.0.0
 commands = flake8 {posargs} deploy-board/ deploy-agent/
-
-[tool.djlint]
-profile = django
-ignore = H031


### PR DESCRIPTION
Pre-commit hooks are non-blocking and only run on the files with changes being commit. You can skip a pre-commit hook by specifying `SKIP=<hook_id>` before `git commit`. The reason for these changes is for having a single consistent style and avoid small mistakes through the use linters. 

Pre-commit hooks included
- Recommended general purpose hooks
- black for formatting .py files
- flake8 for linting .py files 
- djlint for formatting and linting django template files

Setup
```
pip install pre-commit tox
pre-commit install
```

Test Execution
```
pre-commit run --all-files
tox -e black
tox -e flake8
```