### PR TITLE
send service health status including healthy, unhealthy, none and redeploy

### DIFF
--- a/deploy-agent/deployd/__init__.py
+++ b/deploy-agent/deployd/__init__.py
@@ -27,4 +27,4 @@ REDEPLOY_MAX_RETRY = 3
 # 2: puppet applied successfully with changes
 PUPPET_SUCCESS_EXIT_CODES = [0, 2]
 
-__version__ = '1.2.56'
+__version__ = '1.2.57'

--- a/deploy-agent/deployd/common/utils.py
+++ b/deploy-agent/deployd/common/utils.py
@@ -267,7 +267,7 @@ def get_container_health_info(commit, service, redeploy):
             else:
                 send_statsboard_metric(name='deployd.service_health_status', value=1,
                                             tags={"status": "healthy", "service": service, "commit": commit})
-            return ret
+            return returnValue
         else:
             send_statsboard_metric(name='deployd.service_health_status', value=1,
                                tags={"status": "None", "service": service, "commit": commit})

--- a/deploy-agent/deployd/common/utils.py
+++ b/deploy-agent/deployd/common/utils.py
@@ -261,7 +261,7 @@ def get_container_health_info(commit, service, redeploy):
             if returnValue == None:
                 send_statsboard_metric(name='deployd.service_health_status', value=1,
                                             tags={"status": "None", "service": service, "commit": commit})
-            else if "unhealthy" in returnValue:
+            elif "unhealthy" in returnValue:
                 send_statsboard_metric(name='deployd.service_health_status', value=1,
                                             tags={"status": "unhealthy", "service": service, "commit": commit})
             else:

--- a/deploy-agent/deployd/common/utils.py
+++ b/deploy-agent/deployd/common/utils.py
@@ -257,8 +257,11 @@ def get_container_health_info(commit, service, redeploy):
                             result.append(f"{name}:{status}")
                     except:
                         continue
-            ret = ";".join(result) if result else None
-            if "unhealthy" in ret:
+            returnValue = ";".join(result) if result else None
+            if returnValue == None:
+                send_statsboard_metric(name='deployd.service_health_status', value=1,
+                                            tags={"status": "None", "service": service, "commit": commit})
+            else if "unhealthy" in returnValue:
                 send_statsboard_metric(name='deployd.service_health_status', value=1,
                                             tags={"status": "unhealthy", "service": service, "commit": commit})
             else:

--- a/deploy-agent/deployd/common/utils.py
+++ b/deploy-agent/deployd/common/utils.py
@@ -251,15 +251,28 @@ def get_container_health_info(commit, service, redeploy):
                                 labels = parts[2].split(',')
                                 ret = redeploy_check(labels, service, redeploy)
                                 if ret > 0:
+                                    send_statsboard_metric(name='deployd.service_health_status', value=1,
+                                            tags={"status": "redeploy", "service": service, "commit": commit})
                                     return "redeploy-" + str(ret)
                             result.append(f"{name}:{status}")
                     except:
                         continue
-            return ";".join(result) if result else None
+            ret = ";".join(result) if result else None
+            if "unhealthy" in ret:
+                send_statsboard_metric(name='deployd.service_health_status', value=1,
+                                            tags={"status": "unhealthy", "service": service, "commit": commit})
+            else:
+                send_statsboard_metric(name='deployd.service_health_status', value=1,
+                                            tags={"status": "healthy", "service": service, "commit": commit})
+            return ret
         else:
+            send_statsboard_metric(name='deployd.service_health_status', value=1,
+                               tags={"status": "None", "service": service, "commit": commit})
             return None
     except:
         log.error(f"Failed to get container health info with commit {commit}")
+        send_statsboard_metric(name='deployd.service_health_status', value=1,
+                               tags={"status": "None", "service": service, "commit": commit})
         return None
 
 

--- a/deploy-agent/deployd/common/utils.py
+++ b/deploy-agent/deployd/common/utils.py
@@ -261,7 +261,7 @@ def get_container_health_info(commit, service, redeploy):
             if returnValue and "unhealthy" in returnValue:
                 send_statsboard_metric(name='deployd.service_health_status', value=1,
                                             tags={"status": "unhealthy", "service": service, "commit": commit})
-            elif returnValue and "unhealthy" not in returnValue::
+            elif returnValue and "unhealthy" not in returnValue:
                 send_statsboard_metric(name='deployd.service_health_status', value=1,
                                             tags={"status": "healthy", "service": service, "commit": commit})
             return returnValue

--- a/deploy-agent/deployd/common/utils.py
+++ b/deploy-agent/deployd/common/utils.py
@@ -258,24 +258,17 @@ def get_container_health_info(commit, service, redeploy):
                     except:
                         continue
             returnValue = ";".join(result) if result else None
-            if returnValue == None:
-                send_statsboard_metric(name='deployd.service_health_status', value=1,
-                                            tags={"status": "None", "service": service, "commit": commit})
-            elif "unhealthy" in returnValue:
+            if returnValue and "unhealthy" in returnValue:
                 send_statsboard_metric(name='deployd.service_health_status', value=1,
                                             tags={"status": "unhealthy", "service": service, "commit": commit})
-            else:
+            elif returnValue and "unhealthy" not in returnValue::
                 send_statsboard_metric(name='deployd.service_health_status', value=1,
                                             tags={"status": "healthy", "service": service, "commit": commit})
             return returnValue
         else:
-            send_statsboard_metric(name='deployd.service_health_status', value=1,
-                               tags={"status": "None", "service": service, "commit": commit})
             return None
     except:
         log.error(f"Failed to get container health info with commit {commit}")
-        send_statsboard_metric(name='deployd.service_health_status', value=1,
-                               tags={"status": "None", "service": service, "commit": commit})
         return None
 
 


### PR DESCRIPTION
Send service container health status metric to Statsboard. 
The tags include service name, commit, status and hostname.