### PR TITLE
Renamed buttons for restart environments on hosts

### DIFF
--- a/deploy-board/deploy_board/templates/host_side_panel.html
+++ b/deploy-board/deploy_board/templates/host_side_panel.html
@@ -184,7 +184,7 @@
 <div class="row">
     <button id="resetAllEnvironmentsBtn" class="deployToolTip btn btn-default btn-block" data-target="#resetAllEnvironments"
             data-toggle="modal" title="Reset all environments on the host.">
-        <span class="glyphicon glyphicon-repeat"></span> Reset All Environments
+        <span class="glyphicon glyphicon-repeat"></span> Restart All Environments
     </button>
 </div>
 
@@ -194,13 +194,13 @@
             <form id="resetAllDeploysForm" class="form-horizontal" method="post" role="form"  action="/env/{{ env_name }}/{{ stage_name }}/reset_environments/{{ host_id }}">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
-                    <h4 class="modal-title">Host Reset All Environments Confirm</h4>
+                    <h4 class="modal-title">Host Restart All Environments Confirm</h4>
                 </div>
                 <div class="modal-body">
-                    <p> Are you sure to reset all environments at {{ hostname }}?</p>
+                    <p> Are you sure to restart all environments at {{ hostname }}?</p>
                 </div>
                 <div class="modal-footer">
-                    <button type="submit" class="btn btn-warning" id="resetAllDeploysBtnId">Reset All Environments</button>
+                    <button type="submit" class="btn btn-warning" id="resetAllDeploysBtnId">Restart All Environments</button>
                     <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
                 </div>
                 {% csrf_token %}

--- a/deploy-board/deploy_board/templates/hosts/host_details.tmpl
+++ b/deploy-board/deploy_board/templates/hosts/host_details.tmpl
@@ -63,8 +63,8 @@
             {% if agent|agentRetryable %}
             <button id="reset_agent_{{ env.envName }}_{{ env.stageName }}"
                     class="deployToolTip btn btn-default" data-toggle="tooltip"
-                    title="Retry the deploy on this host.">
-                <span class="glyphicon glyphicon-repeat"></span> Retry
+                    title="Restart an environment on this host.">
+                <span class="glyphicon glyphicon-repeat"></span> Restart
             </button>
             {% endif %}
             {% if agent|agentPausable %}

--- a/deploy-board/deploy_board/templates/hosts/hosts.tmpl
+++ b/deploy-board/deploy_board/templates/hosts/hosts.tmpl
@@ -18,7 +18,7 @@
           <button id="resetButton"
           class="btn btn-default btn-sm checked-hosts-btn" data-toggle="tooltip"
           title="reset selected hosts">
-          <span class="glyphicon glyphicon-repeat"></span> Reset
+          <span class="glyphicon glyphicon-repeat"></span> Restart
           </button>
           <button id="terminateButton"
           class="btn btn-default btn-sm checked-hosts-btn" data-toggle="tooltip"
@@ -88,8 +88,8 @@
     <div class="pull-left mr-1">
         <button id="reset_{{ deployId }}"
                 class="deployToolTip btn btn-primary" data-toggle="tooltip"
-                title="Retry deploys on all failed hosts.">
-            Restart current environment on all failed hosts
+                title="Restart deploy on all failed hosts.">
+            Restart current deploy on all failed hosts
         </button>
     </div>
     {% endif %}
@@ -332,13 +332,13 @@
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
-                <h4 class="modal-title">Restart current environment on all failed hosts confirmation</h4>
+                <h4 class="modal-title">Restart current deploy on all failed hosts confirmation</h4>
             </div>
             <div class="modal-body">
-                <p>Are you sure to restart the current environment on all failed hosts?</p>
+                <p>Are you sure to restart the current deploy on all failed hosts?</p>
             </div>
             <div class="modal-footer">
-                <button type="submit" class="btn btn-warning" id="resetAllFailedDeploys">Restart current environment on all failed hosts</button>
+                <button type="submit" class="btn btn-warning" id="resetAllFailedDeploys">Restart current deploy on all failed hosts</button>
                 <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
             </div>
         </div><!-- /.modal-content -->

--- a/deploy-board/deploy_board/templates/hosts/hosts.tmpl
+++ b/deploy-board/deploy_board/templates/hosts/hosts.tmpl
@@ -89,7 +89,7 @@
         <button id="reset_{{ deployId }}"
                 class="deployToolTip btn btn-primary" data-toggle="tooltip"
                 title="Retry deploys on all failed hosts.">
-            Retry current deploy on all failed hosts
+            Restart current environment on all failed hosts
         </button>
     </div>
     {% endif %}
@@ -332,13 +332,13 @@
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
-                <h4 class="modal-title">Retry current deploy on all failed hosts confirmation</h4>
+                <h4 class="modal-title">Restart current environment on all failed hosts confirmation</h4>
             </div>
             <div class="modal-body">
-                <p>Are you sure to retry the current deploy on all failed hosts?</p>
+                <p>Are you sure to restart the current environment on all failed hosts?</p>
             </div>
             <div class="modal-footer">
-                <button type="submit" class="btn btn-warning" id="resetAllFailedDeploys">Retry current deploy on all failed hosts</button>
+                <button type="submit" class="btn btn-warning" id="resetAllFailedDeploys">Restart current environment on all failed hosts</button>
                 <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
             </div>
         </div><!-- /.modal-content -->


### PR DESCRIPTION
# Context

Renamed buttons for restart environments on hosts

# Proof of Work

## Failed hosts page

<img width="1414" alt="Screenshot 2024-01-24 at 3 12 33 PM" src="https://github.com/pinterest/teletraan/assets/20383875/0d0b654b-5cb2-499b-916b-e5236ee22040">

## Failed hosts restart confirmation

<img width="622" alt="Screenshot 2024-01-24 at 3 13 00 PM" src="https://github.com/pinterest/teletraan/assets/20383875/ab5bd5e9-eff6-4ef2-aec0-b7418e47500f">

## Hosts page

<img width="1693" alt="Screenshot 2024-01-24 at 3 13 27 PM" src="https://github.com/pinterest/teletraan/assets/20383875/9d4fd6e1-5432-4635-b880-917c5ee4a2b0">

## Hosts page: restart all environments confirmation

<img width="638" alt="Screenshot 2024-01-24 at 3 13 52 PM" src="https://github.com/pinterest/teletraan/assets/20383875/3afee1a9-286f-408d-b4c8-18a632860de8">
