### PR TITLE
Trim knox key 

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/KnoxKeyReader.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/KnoxKeyReader.java
@@ -73,6 +73,10 @@ public class KnoxKeyReader implements KeyReader {
             LOG.warn("Using default key since knoxManager is null");
             return defaultKeyContent;
         }
-        return knoxManager.getKey().trim();
+        String key = knoxManager.getKey();
+        if (key != null) {
+            return key.trim();
+        }
+        return key;
     }
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/KnoxKeyReader.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/KnoxKeyReader.java
@@ -73,6 +73,6 @@ public class KnoxKeyReader implements KeyReader {
             LOG.warn("Using default key since knoxManager is null");
             return defaultKeyContent;
         }
-        return knoxManager.getKey();
+        return knoxManager.getKey().trim();
     }
 }

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/common/KnoxKeyReaderTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/common/KnoxKeyReaderTest.java
@@ -5,33 +5,51 @@ import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import org.junit.Before;
 import org.junit.Test;
 
 public class KnoxKeyReaderTest {
+    private KnoxKeyReader sut;
+    private KnoxKeyManager mockKnoxKeyManager;
+
+    @Before
+    public void setUp() {
+        sut = new KnoxKeyReader();
+        mockKnoxKeyManager = mock(KnoxKeyManager.class);
+    }
+
     @Test
     public void testGetKey_noInit() {
-        KnoxKeyReader sut = new KnoxKeyReader();
         assertEquals("defaultKeyContent", sut.getKey());
     }
 
     @Test
     public void testGetKey_initialized() {
-        KnoxKeyReader sut = new KnoxKeyReader();
         sut.init("someRandomKey");
         assertNull(sut.getKey());
     }
 
     @Test
     public void testGetKey_cacheIsWorking() {
-        KnoxKeyReader sut = new KnoxKeyReader();
-        KnoxKeyManager mockKnoxKeyManager = mock(KnoxKeyManager.class);
-
         sut.init("someRandomKey");
         sut.setKnoxManager(mockKnoxKeyManager);
         sut.getKey();
         sut.getKey();
 
         verify(mockKnoxKeyManager, only()).getKey();
+    }
+
+    @Test
+    public void testGetKey_trimmed() {
+        String expected = "keyWith234!~@";
+        when(mockKnoxKeyManager.getKey()).thenReturn(String.format(" \n\r\t %s \n\r\t", expected));
+
+        sut.init("someRandomKey");
+        sut.setKnoxManager(mockKnoxKeyManager);
+        String trimmed = sut.getKey();
+
+        assertEquals(expected, trimmed);
     }
 }


### PR DESCRIPTION
Replace #1095

> Teletraan API and Teletraan Worker read Rodimus API keys from Knox. A newline can be inserted into a Knox key and result in a malformed authentication header. Defensive programming should avoid this mistake.