### PR TITLE
Add logging for when hosts become stale

### DIFF
--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AgentJanitor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AgentJanitor.java
@@ -122,7 +122,7 @@ public class AgentJanitor extends SimpleAgentJanitor {
         }
 
         if (janitorStartTime - hostAgentBean.getLast_update() >= absoluteThreshold) {
-            LOG.info("exceeded absolute stale threshold ({}) for host ({})", absoluteThreshold, hostAgentBean)
+            LOG.info("exceeded absolute stale threshold ({}) for host ({})", absoluteThreshold, hostAgentBean);
             return true;
         }
 
@@ -139,12 +139,12 @@ public class AgentJanitor extends SimpleAgentJanitor {
         Long launchGracePeriod = getInstanceLaunchGracePeriod(hostAgentBean.getAuto_scaling_group());
         if ((hostBean.getState() == HostState.PROVISIONED)
                 && (janitorStartTime - hostAgentBean.getLast_update() >= launchGracePeriod)) {
-            LOG.info("exceeded launch grace period ({}) for provisioned host ({})", launchGracePeriod, hostAgentBean)
+            LOG.info("exceeded launch grace period ({}) for provisioned host ({})", launchGracePeriod, hostAgentBean);
             return true;
         }
         if (hostBean.getState() != HostState.TERMINATING && !hostBean.isPendingTerminate() &&
                 (janitorStartTime - hostAgentBean.getLast_update() >= maxStaleHostThreshold)) {
-            LOG.info("exceeded max stale threshold ({}) for host ({})", maxStaleHostThreshold, hostAgentBean)
+            LOG.info("exceeded max stale threshold ({}) for host ({})", maxStaleHostThreshold, hostAgentBean);
             return true;
         }
         return false;

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AgentJanitor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AgentJanitor.java
@@ -122,7 +122,7 @@ public class AgentJanitor extends SimpleAgentJanitor {
         }
 
         if (janitorStartTime - hostAgentBean.getLast_update() >= absoluteThreshold) {
-            LOG.info("exceeded absolute stale threshold ({}) for host ({})", absoluteThreshold, hostAgentBean);
+            LOG.debug("exceeded absolute stale threshold ({}) for host ({})", absoluteThreshold, hostAgentBean);
             return true;
         }
 
@@ -139,12 +139,12 @@ public class AgentJanitor extends SimpleAgentJanitor {
         Long launchGracePeriod = getInstanceLaunchGracePeriod(hostAgentBean.getAuto_scaling_group());
         if ((hostBean.getState() == HostState.PROVISIONED)
                 && (janitorStartTime - hostAgentBean.getLast_update() >= launchGracePeriod)) {
-            LOG.info("exceeded launch grace period ({}) for provisioned host ({})", launchGracePeriod, hostAgentBean);
+            LOG.debug("exceeded launch grace period ({}) for provisioned host ({})", launchGracePeriod, hostAgentBean);
             return true;
         }
         if (hostBean.getState() != HostState.TERMINATING && !hostBean.isPendingTerminate() &&
                 (janitorStartTime - hostAgentBean.getLast_update() >= maxStaleHostThreshold)) {
-            LOG.info("exceeded max stale threshold ({}) for host ({})", maxStaleHostThreshold, hostAgentBean);
+            LOG.debug("exceeded max stale threshold ({}) for host ({})", maxStaleHostThreshold, hostAgentBean);
             return true;
         }
         return false;

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AgentJanitor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AgentJanitor.java
@@ -122,6 +122,7 @@ public class AgentJanitor extends SimpleAgentJanitor {
         }
 
         if (janitorStartTime - hostAgentBean.getLast_update() >= absoluteThreshold) {
+            LOG.info("exceeded absolute stale threshold ({}) for host ({})", absoluteThreshold, hostAgentBean)
             return true;
         }
 
@@ -138,10 +139,12 @@ public class AgentJanitor extends SimpleAgentJanitor {
         Long launchGracePeriod = getInstanceLaunchGracePeriod(hostAgentBean.getAuto_scaling_group());
         if ((hostBean.getState() == HostState.PROVISIONED)
                 && (janitorStartTime - hostAgentBean.getLast_update() >= launchGracePeriod)) {
+            LOG.info("exceeded launch grace period ({}) for provisioned host ({})", launchGracePeriod, hostAgentBean)
             return true;
         }
         if (hostBean.getState() != HostState.TERMINATING && !hostBean.isPendingTerminate() &&
                 (janitorStartTime - hostAgentBean.getLast_update() >= maxStaleHostThreshold)) {
+            LOG.info("exceeded max stale threshold ({}) for host ({})", maxStaleHostThreshold, hostAgentBean)
             return true;
         }
         return false;


### PR DESCRIPTION
This will help detect whenever a host is stuck in PROVISIONED state indefinitely and become stale.

Tested on dev1

https://search-visibility-es4-yzk3lo6prv6qkda3oetn7zcm5a.us-east-1.es.amazonaws.com/_plugin/kibana/goto/b08969e95892ec6f141b5b047308af24?security_tenant=global