### PR TITLE
Add GitHub action for auto-labeling PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,12 @@
+deploy-agent:
+  - changed-files:
+    - any-glob-to-any-file: deploy-agent/**
+deploy-board:
+  - changed-files:
+    - any-glob-to-any-file: deploy-board/**
+deploy-sentinel:
+  - changed-files:
+    - any-glob-to-any-file: deploy-sentinel/**
+deploy-service:
+  - changed-files:
+    - any-glob-to-any-file: deploy-service/**

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,16 @@
+name: "Pull Request Labeler"
+
+on:
+  - pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        sync-labels: true


### PR DESCRIPTION
At deployment time, we don't have a way within Teletraan to differentiate which commits are relevant to that service. With this GHA, we will be able to look at the diff in GitHub and filter by labels depending on which service we are deploying.

https://github.com/actions/labeler