### PR TITLE
Add JsonProcessingExceptionMapper

### DIFF
--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanService.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanService.java
@@ -24,6 +24,7 @@ import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
 import io.dropwizard.health.conf.HealthConfiguration;
 import io.dropwizard.health.core.HealthCheckBundle;
+import io.dropwizard.jersey.jackson.JsonProcessingExceptionMapper;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.swagger.jaxrs.config.BeanConfig;
@@ -172,6 +173,8 @@ public class TeletraanService extends Application<TeletraanServiceConfiguration>
         environment.healthChecks().register("generic", new GenericHealthCheck(context));
 
         // Exception handler
+        // Jackson Json parsing exceptions, returns 4xx
+        environment.jersey().register(new JsonProcessingExceptionMapper());
         environment.jersey().register(new GenericExceptionMapper(configuration.getSystemFactory().getClientError()));
 
         // Swagger API docs generation related

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanService.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanService.java
@@ -173,7 +173,7 @@ public class TeletraanService extends Application<TeletraanServiceConfiguration>
         environment.healthChecks().register("generic", new GenericHealthCheck(context));
 
         // Exception handler
-        // Jackson Json parsing exceptions, returns 4xx
+        // Jackson Json parsing exceptions
         environment.jersey().register(new JsonProcessingExceptionMapper());
         environment.jersey().register(new GenericExceptionMapper(configuration.getSystemFactory().getClientError()));
 

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanService.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanService.java
@@ -174,7 +174,7 @@ public class TeletraanService extends Application<TeletraanServiceConfiguration>
 
         // Exception handler
         // Jackson Json parsing exceptions
-        environment.jersey().register(new JsonProcessingExceptionMapper());
+        environment.jersey().register(new JsonProcessingExceptionMapper(true));
         environment.jersey().register(new GenericExceptionMapper(configuration.getSystemFactory().getClientError()));
 
         // Swagger API docs generation related


### PR DESCRIPTION
Before
```bash
curl -X PUT "http://localhost:8011/v1/envs/sample-service-1/canary/promotes" \
>  -H "authorization: token None"\
>  -H "content-type: application/json" \
>  -d '{"type":"AUTO","schedule":"string","delay":0,"envId":"YA9NEGBxRZC-GNSoOyVijw","lastOperator":"Anonymous","lastUpdate":1706754119336,"predStage":"string","queueSize":1,"disablePolicy":"MANUAL","avd":"CONTINUE"}' -v
*   Trying [::1]:8011...
* Connected to localhost (::1) port 8011
> PUT /v1/envs/sample-service-1/canary/promotes HTTP/1.1
> Host: localhost:8011
> User-Agent: curl/8.4.0
> Accept: */*
> authorization: token None
> content-type: application/json
> Content-Length: 209
> 
< HTTP/1.1 500 Internal Server Error
< Date: Thu, 01 Feb 2024 23:38:59 GMT
< Content-Type: application/json
< Content-Length: 464
< 

Message: Unrecognized field "avd" (class com.pinterest.deployservice.bean.PromoteBean), not marked as ignorable (10 known properties: "failPolicy", "queueSize", "delay", "schedule", "envId", "type", "predStage", "lastUpdate", "lastOperator", "disablePolicy"])
* Connection #0 to host localhost left intact
 at [Source: (org.glassfish.jersey.message.internal.ReaderInterceptorExecutor$UnCloseableInputStream); line: 1, column: 200] (through reference chain: com.pinterest.deployservice.bean.PromoteBean["avd"])
```

After
```bash
curl -X PUT "http://localhost:8011/v1/envs/sample-service-1/canary/promotes"  -H "authorization: token None" -H "content-type: application/json"  -d '{"type":"AUTO","schedule":"string","delay":0,"envId":"YA9NEGBxRZC-GNSoOyVijw","lastOperator":"Anonymous","lastUpdate":1706754119336,"predStage":"string","queueSize":1,"disablePolicy":"MANUAL","avd":"CONTINUE"}' -v
*   Trying [::1]:8011...
* Connected to localhost (::1) port 8011
> PUT /v1/envs/sample-service-1/canary/promotes HTTP/1.1
> Host: localhost:8011
> User-Agent: curl/8.4.0
> Accept: */*
> authorization: token None
> content-type: application/json
> Content-Length: 209
> 
< HTTP/1.1 400 Bad Request
< Date: Thu, 01 Feb 2024 23:44:18 GMT
< Content-Type: application/json
< Content-Length: 164
< 
* Connection #0 to host localhost left intact
{"code":400,"message":"Unable to process JSON","details":"Unrecognized field \"avd\" (class com.pinterest.deployservice.bean.PromoteBean), not marked as ignorable"}
```