### PR TITLE
Fix keyError on Teletaan UI

### DIFF
--- a/deploy-board/deploy_board/webapp/cluster_view.py
+++ b/deploy-board/deploy_board/webapp/cluster_view.py
@@ -426,7 +426,7 @@ def get_base_images_by_abstract_name(request, abstract_name):
         cell_name = cell['name']
         golden_images[cell_name] = baseimages_helper.get_current_golden_image(request, abstract_name, cell_name)
     for image in base_images:
-        if golden_images[image['cell_name']] and image['id'] == golden_images[image['cell_name']]['id']:
+        if golden_images.get(image['cell_name']) and image['id'] == golden_images[image['cell_name']]['id']:
             image['current_golden'] = True
 
     return render(request, 'clusters/base_images.html', {


### PR DESCRIPTION
Usually, we don't have this error:
<img width="1669" alt="Screenshot 2024-02-02 at 5 20 08 PM" src="https://github.com/pinterest/teletraan/assets/42289525/8def5aaf-7eb6-434f-93f5-5bc1cf033acc">

But if someone call the API to add an AMI and the cell is not in the list, we could encounter this error.
<img width="1665" alt="Screenshot 2024-02-02 at 5 21 26 PM" src="https://github.com/pinterest/teletraan/assets/42289525/1a337d60-7ee4-4efa-9423-1be0ec9224a9">
