### PR TITLE
fetch ec2 tags from aws instead of from facter command

### DIFF
--- a/deploy-agent/deployd/__init__.py
+++ b/deploy-agent/deployd/__init__.py
@@ -27,4 +27,4 @@ REDEPLOY_MAX_RETRY = 3
 # 2: puppet applied successfully with changes
 PUPPET_SUCCESS_EXIT_CODES = [0, 2]
 
-__version__ = '1.2.57'
+__version__ = '1.2.58'

--- a/deploy-agent/setup.py
+++ b/deploy-agent/setup.py
@@ -24,7 +24,7 @@ console_scripts = ['deploy-agent = deployd.agent:main',
                    'deploy-stager = deployd.staging.stager:main']
 
 install_requires = [
-    "requests==2.20.0",
+    "requests>=2.20.0",
     "gevent>=1.0.2,<=1.2.2; python_version < '3'",
     "gevent>=1.0.2,<=1.5.0; python_version < '3.8'",
     "gevent==20.12.0; python_version >= '3.8'",

--- a/deploy-agent/setup.py
+++ b/deploy-agent/setup.py
@@ -24,13 +24,14 @@ console_scripts = ['deploy-agent = deployd.agent:main',
                    'deploy-stager = deployd.staging.stager:main']
 
 install_requires = [
-    "requests>=2.20.0",
+    "requests==2.20.0",
     "gevent>=1.0.2,<=1.2.2; python_version < '3'",
     "gevent>=1.0.2,<=1.5.0; python_version < '3.8'",
     "gevent==20.12.0; python_version >= '3.8'",
     "lockfile==0.10.2",
     "boto>=2.39.0",
-    "boto3",
+    "botocore==1.5.34",
+    "boto3==1.4.4",
     "python-daemon==2.0.6",
     "future==0.18.2"
 ]

--- a/deploy-agent/setup.py
+++ b/deploy-agent/setup.py
@@ -30,8 +30,7 @@ install_requires = [
     "gevent==20.12.0; python_version >= '3.8'",
     "lockfile==0.10.2",
     "boto>=2.39.0",
-    "boto3>=1.12.6",
-    "urllib3<1.27,>=1.25.4",
+    "boto3",
     "python-daemon==2.0.6",
     "future==0.18.2"
 ]

--- a/deploy-agent/setup.py
+++ b/deploy-agent/setup.py
@@ -31,6 +31,7 @@ install_requires = [
     "lockfile==0.10.2",
     "boto>=2.39.0",
     "boto3>=1.12.6",
+    "urllib3<1.27,>=1.25.4",
     "python-daemon==2.0.6",
     "future==0.18.2"
 ]

--- a/deploy-agent/setup.py
+++ b/deploy-agent/setup.py
@@ -30,6 +30,7 @@ install_requires = [
     "gevent==20.12.0; python_version >= '3.8'",
     "lockfile==0.10.2",
     "boto>=2.39.0",
+    "boto3>=1.12.6",
     "python-daemon==2.0.6",
     "future==0.18.2"
 ]


### PR DESCRIPTION
If a user adds tags through the AWS console, the previous method wouldn't be able to fetch these tags using the 'facter' command.