### PR TITLE
Prevent alarm created without scaling policy

### DIFF
--- a/deploy-board/deploy_board/templates/groups/asg_config.html
+++ b/deploy-board/deploy_board/templates/groups/asg_config.html
@@ -16,7 +16,6 @@
 {% include "groups/group_side_panel.html" %}
 </div>
 
-
 {% endblock %}
 
 {% block new-builds-panel %}
@@ -26,7 +25,14 @@
 
 {% block main %}
 
-
+{% if storage %}
+    {% for message in storage %}
+        <div class="alert alert-warning" role="alert">
+            <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            <strong>Warning!</strong> {{ message | safe}}
+        </div>
+    {% endfor %}
+{% endif %}
 
 {% if not is_cmp %}
 <div id="launchConfigPid" class="panel panel-default">

--- a/deploy-board/deploy_board/templates/groups/asg_metrics.tmpl
+++ b/deploy-board/deploy_board/templates/groups/asg_metrics.tmpl
@@ -1,12 +1,3 @@
-{% if messages %}
-    {% for message in messages %}
-    <div class="alert alert-warning" role="alert">
-        <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        <strong>Warning!</strong> {{ message | safe }}
-    </div>
-    {% endfor %}
-{% endif %}
-
 {% load utils %}
 {% include "panel_heading.tmpl" with panel_title="Scaling Alarms" panel_body_id="asMetricsId" direction="down" %}
 <div id="asMetricsId" class="collapse in panel-body">

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -20,6 +20,7 @@ from django.views.generic import View
 from django.template.loader import render_to_string
 from django.http import HttpResponse
 from django.contrib import messages
+from django.contrib.messages import get_messages
 import json
 import logging
 import traceback
@@ -739,7 +740,7 @@ def add_alarms(request, group_name):
         # Technically, an alarm can be created without an action (e.g. scaling policy)
         # However, in the current context, an alarm must have an associated scaling policy.
         # In this case, there is no scaling policy, so refuse to create new alarm.
-        messages.add_message(request, messages.ERROR, 'Alarm could not be created because there was no scaling policy. Create scaling policy first.')
+        messages.add_message(request, messages.ERROR, 'Alarm could not be created because there was no {} policy.'.format(policy_type))
         return redirect("/groups/{}/config/".format(group_name))
 
     autoscaling_groups_helper.add_alarm(request, group_name, [alarm_info])
@@ -1128,6 +1129,7 @@ class GroupConfigView(View):
             "pas_config": pas_config,
             "is_cmp": is_cmp,
             "disallow_autoscaling": _disallow_autoscaling(curr_image),
+            "storage": get_messages(request)
         })
 
 


### PR DESCRIPTION
Prevent alarm creation if selected scaling policy is not existent.

![image](https://github.com/pinterest/teletraan/assets/63071572/c274e272-95f0-4d23-81fd-8fac421ca5a6)
