### PR TITLE
Ensure `delivery_type` / `stage_type` are in sync

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/exception/TeletaanInternalException.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/exception/TeletaanInternalException.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *    
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
@@ -433,8 +433,11 @@ public class DeployHandler implements DeployHandlerInterface{
         // When the delivery_type is different with stage_type and stage_type is DEFAULT, we update the stage_type;
         if (StringUtils.isNotBlank(deliveryType) && !envBean.getStage_type().toString().equals(deliveryType)) {
             if (envBean.getStage_type() != EnvType.DEFAULT) {
-                LOG.error("The delivery type {} is different with the stage type {} for {}/{}",
+                String errorMessage = String.format(
+                        "The delivery type %s is different with the stage type %s for %s/%s",
                         deliveryType, envBean.getStage_type(), envBean.getEnv_name(), envBean.getStage_name());
+                LOG.error(errorMessage);
+                throw new TeletaanInternalException(Response.Status.CONFLICT, errorMessage);
             } else {
                 EnvType type = EnvType.valueOf(deliveryType);
                 envBean.setStage_type(type);


### PR DESCRIPTION
**Summary**

Enforce that the `delivery_type` (value passed in by deployment pipeline) needs to be in sync with the `stage_type`.

If they are not in sync, throw an error so that users can take action and resolve the inconsistency.

**Caveats**

In case the `delivery_type` / `stage_type` is out of sync, this could cause deployment failures.

These failures should not happen frequently and are currently expected to be resolved manually.

**Test Plan**

Verified there have been no inconsistencies in the last week and a half.