### PR TITLE
enable private build when stage type is DEV

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironBean.java
@@ -15,7 +15,6 @@
  */
 package com.pinterest.deployservice.bean;
 
-import com.pinterest.deployservice.common.DeployInternalException;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang.builder.ReflectionToStringBuilder;
 import org.apache.commons.lang.StringEscapeUtils;
@@ -23,7 +22,6 @@ import org.hibernate.validator.constraints.NotEmpty;
 import org.hibernate.validator.constraints.Range;
 
 import java.io.Serializable;
-import javax.validation.constraints.Pattern;
 
 /**
  * Keep the bean and table in sync

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironBean.java
@@ -558,6 +558,9 @@ public class EnvironBean implements Updatable, Serializable {
 
     public void setStage_type(EnvType stage_type) {
         this.stage_type = stage_type;
+        if (this.stage_type.equals(EnvType.DEV)) {
+            this.setAllow_private_build(true);
+        }
     }
 
     public Boolean getIs_sox() {


### PR DESCRIPTION
Modify Jackson setter for stage_type to set allow_private_build flag to true if stage type is DEV.

### Testing
Tested by creating and updating stages.

#### New stage
<img width="935" alt="Screenshot 2024-02-16 at 10 18 46 AM" src="https://github.com/pinterest/teletraan/assets/104773032/29bef0f8-9151-46b1-8bf4-e59ba42772de">
<img width="742" alt="Screenshot 2024-02-16 at 10 24 02 AM" src="https://github.com/pinterest/teletraan/assets/104773032/7cf99392-bc28-4bf6-bce2-7b9c41312c59">

#### Updating default stage type to dev
<img width="747" alt="Screenshot 2024-02-16 at 10 33 27 AM" src="https://github.com/pinterest/teletraan/assets/104773032/fba3798e-5bf3-40a2-8051-b527db64e9e6">
<img width="1417" alt="Screenshot 2024-02-16 at 10 34 01 AM" src="https://github.com/pinterest/teletraan/assets/104773032/5c49921c-a10d-4adf-b7ae-7b18206b5b4a">
<img width="759" alt="Screenshot 2024-02-16 at 10 34 17 AM" src="https://github.com/pinterest/teletraan/assets/104773032/99f72442-1c6d-48fc-a819-c372c97e088b">
