### PR TITLE
Additional step scaling validations

### DIFF
--- a/deploy-board/deploy_board/templates/groups/asg_policy.tmpl
+++ b/deploy-board/deploy_board/templates/groups/asg_policy.tmpl
@@ -489,6 +489,11 @@ aria-hidden="true">
                 var scaleDownSteps = config["scaleDownSteps"].trim();
                 var scaleDownAdjustments = config["scaleDownAdjustments"].trim();
 
+                if (scaleUpSteps.length == 0 && scaleDownSteps.length == 0) {
+                    alert("Both scale up and down steps cannot be empty!")
+                    return false;
+                }
+
                 if (scaleUpSteps.length > 0 && scaleUpAdjustments.length == 0) {
                     alert("Scale up adjustments must be provided for scale up steps!")
                     return false;


### PR DESCRIPTION
- Don't allow both steps for up and down be empty. One must be provided.
- Check if min adjustment is empty.