### PR TITLE
Avoid too many calls to get host ec2 tags

### DIFF
--- a/deploy-board/deploy_board/webapp/agent_report.py
+++ b/deploy-board/deploy_board/webapp/agent_report.py
@@ -40,12 +40,10 @@ PROVISION_HOST_CODE = -1001
 
 
 class AgentStatistics(object):
-    def __init__(self, agent=None, isCurrent=False, isStale=False, isHostFailed=False):
+    def __init__(self, agent=None, isCurrent=False, isStale=False):
         self.agent = agent
         self.isCurrent = isCurrent
         self.isStale = isStale
-        self.isHostFailed = isHostFailed
-
 
 class DeployStatistics(object):
     def __init__(self, deploy=None, build=None, stageDistMap=None, stateDistMap=None, buildTag=None):
@@ -111,12 +109,7 @@ def addToEnvReport(request, deployStats, agent, env):
     if duration >= DEFAULT_STALE_THRESHOLD:
         isStale = True
 
-    isHostFailed = False
-    agent_ec2_tags = agents_helper.get_agent_ec2_tags(request, env['envName'], env['stageName'])
-    if agent_ec2_tags and agent_ec2_tags.get("service_mapping") == "shame":
-        isHostFailed = True
-
-    return AgentStatistics(agent, isCurrent, isStale, isHostFailed)
+    return AgentStatistics(agent, isCurrent, isStale)
 
 
 def _compare_agent_status(agentStats1, agentStats2):

--- a/deploy-board/deploy_board/webapp/helpers/agents_helper.py
+++ b/deploy-board/deploy_board/webapp/helpers/agents_helper.py
@@ -64,6 +64,3 @@ def get_agents_by_host(request, host_name):
 def get_agents_total_by_env(request, env_id):
     return deployclient.get("/agents/env/%s/total" % env_id, request.teletraan_user_id.token)
 
-def get_agent_ec2_tags(request, env_name, stage_name):
-    return deployclient.get(f"/env/{env_name}/{stage_name}/host_ec2_tags", request.teletraan_user_id.token)
-

--- a/deploy-board/deploy_board/webapp/templatetags/utils.py
+++ b/deploy-board/deploy_board/webapp/templatetags/utils.py
@@ -637,7 +637,7 @@ def agentIcon(agentStats):
     if agentStats.isCurrent:
         if agent['deployStage'] == "SERVING_BUILD":
             return 'fa-check'
-        if agentStats.isStale or agentStats.isHostFailed or (
+        if agentStats.isStale or (
                 agent['state']== "PROVISIONED" and
                 agent["ip"] is None
                 ):


### PR DESCRIPTION
# Summary

This call is expensive on environments with a lot of hosts. For detecting indefinitely spinning hosts, it should be enough with the added staleness check (15 mins) to provisioning hosts and the `ip is not None` check on provisioned/active hosts.

# Test Plan

## Verified this endpoint is not called anymore
<img width="1193" alt="image" src="https://github.com/pinterest/teletraan/assets/72234714/e940e81e-c23b-472e-bdc4-95808e23da6c">

## Verified that provisioning host shows warning if no updates in >15 mins
[within 15 mins]
<img width="1390" alt="image" src="https://github.com/pinterest/teletraan/assets/72234714/d339b1c1-02de-4959-b141-4a3e4f66a1b1">

[after 15 mins]
<img width="1444" alt="image" src="https://github.com/pinterest/teletraan/assets/72234714/523e97df-3537-4a7f-a6f1-6be960e9b2c0">



