### PR TITLE
allow toggling custom fields checkbox

### DIFF
--- a/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
+++ b/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
@@ -310,7 +310,7 @@ Vue.component("aws-config-modal", {
                 this.selectedValue = "";
                 this.useCustomizedName = true;
             } else {
-                this.useCustomizedName = true;
+                this.useCustomizedName = false;
                 this.customizedName = "";
             }
             this.selectedOptionValue = null;


### PR DESCRIPTION
allow toggling of custom user data check. Currently the checkbox in the modal to add customer user data is not toggle-able once checked. 
<img width="885" alt="Screenshot 2024-03-01 at 9 49 00 AM" src="https://github.com/pinterest/teletraan/assets/104773032/f92bc9db-1f34-49fb-aa43-9555ac56f172">
