### PR TITLE
highlight sidecars with matching host environment

### DIFF
--- a/deploy-board/deploy_board/templates/hosts/host_details.html
+++ b/deploy-board/deploy_board/templates/hosts/host_details.html
@@ -45,7 +45,7 @@
     {% if has_host_env_sidecar_agents %}
     {% include "panel_heading.tmpl" with panel_title="Sidecar Agent Details" panel_body_id="sidecarAgentDetailsId" direction="down" copy_host_name_button=True %}
     <div id="sidecarAgentDetailsId" class="collapse in panel-body">
-        <span>This host has relevant sidecars in it's environment. These have been marked with <span class="bg-success">green backgrounds</span> for visibility.</span>
+        <span>This is a sidecar deployment on the host. The relevant sidecar has been marked with a <span class="bg-info">blue background</span> for visibility.</span>
     {% else %}
     {% include "panel_heading.tmpl" with panel_title="Sidecar Agent Details" panel_body_id="sidecarAgentDetailsId" direction="right" copy_host_name_button=True %}
     <div id="sidecarAgentDetailsId" class="collapse panel-body">

--- a/deploy-board/deploy_board/templates/hosts/host_details.html
+++ b/deploy-board/deploy_board/templates/hosts/host_details.html
@@ -42,11 +42,21 @@
 
 {% if agent_wrappers %}
 <div class="panel panel-default">
+    {% if has_host_env_sidecar_agents %}
+    {% include "panel_heading.tmpl" with panel_title="Sidecar Agent Details" panel_body_id="sidecarAgentDetailsId" direction="down" copy_host_name_button=True %}
+    <div id="sidecarAgentDetailsId" class="collapse in panel-body">
+        <span>This host has relevant sidecars in it's environment. These have been marked with <span class="bg-success">green backgrounds</span> for visibility.</span>
+    {% else %}
     {% include "panel_heading.tmpl" with panel_title="Sidecar Agent Details" panel_body_id="sidecarAgentDetailsId" direction="right" copy_host_name_button=True %}
     <div id="sidecarAgentDetailsId" class="collapse panel-body">
+    {% endif %}
         {% for agent_wrapper in agent_wrappers.sidecars %}
         {% with env=agent_wrapper.env agent=agent_wrapper.agent hostdetailsvalue=host_details|getValue:"Phobos Link" %}
+        {% if env and env_name == env.envName and stage_name == env.stageName %}
+        {% include "hosts/host_details.tmpl" with agent=agent env=env hostdetailsvalue=hostdetailsvalue host_related_sidecar=1%}
+        {% else %}
         {% include "hosts/host_details.tmpl" with agent=agent env=env hostdetailsvalue=hostdetailsvalue%}
+        {% endif %}
         {% endwith %}
         {% endfor %}
     </div>

--- a/deploy-board/deploy_board/templates/hosts/host_details.tmpl
+++ b/deploy-board/deploy_board/templates/hosts/host_details.tmpl
@@ -1,6 +1,10 @@
 {% load utils %}
 <div id="hostInfo" class="panel panel-default">
+    {% if host_related_sidecar %}
+    <div class="panel-heading host-related-sidecar">
+    {% else %}
     <div class="panel-heading">
+    {% endif %}
         <strong>Environment:</strong><a href="/env/{{ env.envName }}/{{ env.stageName }}"> {{ env.envName }}/{{ env.stageName }}</a>
         <strong>Deploy:</strong><a href="/deploy/{{ agent.deployId }}"> {{ agent.deployId }}</a>
     </div>
@@ -83,6 +87,12 @@
         </div>
     </div>
 </div>
+<style>
+    #hostInfo>.panel-heading.host-related-sidecar {
+        background-image: none;
+        background-color: #dff0d8;
+    }
+</style>
 <script>
     $(function () {
         $('.deployToolTip').tooltip();

--- a/deploy-board/deploy_board/templates/hosts/host_details.tmpl
+++ b/deploy-board/deploy_board/templates/hosts/host_details.tmpl
@@ -90,7 +90,8 @@
 <style>
     #hostInfo>.panel-heading.host-related-sidecar {
         background-image: none;
-        background-color: #dff0d8;
+        background-color: #d9edf7;
+        font-weight: bold;
     }
 </style>
 <script>

--- a/deploy-board/deploy_board/webapp/host_views.py
+++ b/deploy-board/deploy_board/webapp/host_views.py
@@ -189,11 +189,11 @@ class HostDetailView(View):
 
         agent_wrappers, is_unreachable = get_agent_wrapper(request, hostname)
         has_host_env_sidecar_agents = any(
-            x for x in agent_wrappers['sidecars']
-            if x['env'] and x['env']['envName'] and
-            x['env']['stageName'] and
-            x['env']['envName'] == name and
-            x['env']['stageName'] == stage
+            agent for agent in agent_wrappers['sidecars']
+            if agent['env'] and agent['env']['envName'] and
+            agent['env']['stageName'] and
+            agent['env']['envName'] == name and
+            agent['env']['stageName'] == stage
         )
         
         host_details = get_host_details(host_id)

--- a/deploy-board/deploy_board/webapp/host_views.py
+++ b/deploy-board/deploy_board/webapp/host_views.py
@@ -188,6 +188,14 @@ class HostDetailView(View):
             is_protected = autoscaling_groups_helper.is_hosts_protected(request, asg, [host_id])
 
         agent_wrappers, is_unreachable = get_agent_wrapper(request, hostname)
+        has_host_env_sidecar_agents = any(
+            x for x in agent_wrappers['sidecars']
+            if x['env'] and x['env']['envName'] and
+            x['env']['stageName'] and
+            x['env']['envName'] == name and
+            x['env']['stageName'] == stage
+        )
+        
         host_details = get_host_details(host_id)
 
         termination_limit = environs_helper.get_env_by_stage(request, name, stage).get('terminationLimit')
@@ -212,6 +220,7 @@ class HostDetailView(View):
             'host_details': host_details,
             'duplicate_stage': duplicate_stage,
             'termination_limit': termination_limit,
+            'has_host_env_sidecar_agents': has_host_env_sidecar_agents,
         })
 
 


### PR DESCRIPTION
If a sidecar agent has the same environment as the host environment, then the sidecar should be highlighted for ease of discovery, and the sidecars tab should not be folded.

#### Example of host with highlighted sidecars
<img width="960" alt="Screenshot 2024-03-04 at 9 37 32 PM" src="https://github.com/pinterest/teletraan/assets/104773032/ffda7119-5f26-43fe-9d39-9a234f56f38a">
<img width="947" alt="Screenshot 2024-03-04 at 9 32 49 PM" src="https://github.com/pinterest/teletraan/assets/104773032/352621b9-1131-4d63-a3e0-542d694207e5">

