### PR TITLE
Update downloader to read allow lists from configs

### DIFF
--- a/deploy-agent/deployd/BUILD.bazel
+++ b/deploy-agent/deployd/BUILD.bazel
@@ -19,6 +19,15 @@ py_binary(
     ],
 )
 
+py_binary(
+    name = "deploy-downloader",
+    srcs = ["download/downloader.py"],
+    main = "download/downloader.py",
+    deps = [
+       ":lib",
+    ],
+)
+
 py_library(
   name = "third_party",
   deps = [

--- a/deploy-agent/deployd/__init__.py
+++ b/deploy-agent/deployd/__init__.py
@@ -27,4 +27,4 @@ REDEPLOY_MAX_RETRY = 3
 # 2: puppet applied successfully with changes
 PUPPET_SUCCESS_EXIT_CODES = [0, 2]
 
-__version__ = '1.2.57'
+__version__ = '1.2.58'

--- a/deploy-agent/deployd/common/config.py
+++ b/deploy-agent/deployd/common/config.py
@@ -15,6 +15,8 @@ from __future__ import print_function
 
 import logging
 import os
+import json
+
 from typing import Any, List, Optional
 
 from deployd import __version__
@@ -292,8 +294,19 @@ class Config(object):
     def get_facter_account_id_key(self) -> str:
         return self.get_var('account_id_key', 'ec2_metadata.identity-credentials.ec2.info')
 
+    def _get_download_allow_list(self, key: str) -> List:
+        allow_list_str = self.get_var(key, '[]')
+        allow_list = []
+        try:
+            allow_list = json.loads(allow_list_str)
+        except json.JSONDecodeError:
+            log.error(f"Error: The string {allow_list_str} could not be converted to a list.")
+        return allow_list
+
+
     def get_http_download_allow_list(self) -> List:
-        return self.get_var('http_download_allow_list', [])
+        return self._get_download_allow_list('http_download_allow_list')
+
 
     def get_s3_download_allow_list(self) -> List:
-        return self.get_var('s3_download_allow_list', [])
+        return self._get_download_allow_list('s3_download_allow_list')

--- a/deploy-agent/deployd/download/http_download_helper.py
+++ b/deploy-agent/deployd/download/http_download_helper.py
@@ -90,4 +90,8 @@ class HTTPDownloadHelper(DownloadHelper):
 
         allow_list = self._config.get_http_download_allow_list()
 
-        return domain in allow_list if allow_list else True
+        if not allow_list or domain in allow_list:
+            return True
+        else:
+            log.error(f"{domain} is not in the allow list: {allow_list}.")
+            return False

--- a/deploy-agent/tests/unit/deploy/download/test_http_download_helper.py
+++ b/deploy-agent/tests/unit/deploy/download/test_http_download_helper.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from deployd.download.http_download_helper import HTTPDownloadHelper
+from deployd.common.config import Config
 import unittest
 from unittest import mock
 import logging
@@ -24,16 +25,17 @@ logger.level = logging.DEBUG
 class TestHttpDownloadHelper(unittest.TestCase):
 
     def setUp(self):
-        self.downloader = HTTPDownloadHelper(url="https://deploy1.com")
+        self.config = Config()
+        self.downloader = HTTPDownloadHelper(url="https://deploy1.com", config=self.config)
 
-    @mock.patch('deployd.download.http_download_helper.Config.get_http_download_allow_list')
+    @mock.patch('deployd.common.config.Config.get_http_download_allow_list')
     def test_validate_url_with_allow_list(self, mock_get_http_download_allow_list):
         mock_get_http_download_allow_list.return_value = ['deploy1.com', 'deploy2.com']
         result = self.downloader.validate_source()
         self.assertTrue(result)
         mock_get_http_download_allow_list.assert_called_once()
 
-    @mock.patch('deployd.download.http_download_helper.Config.get_http_download_allow_list')
+    @mock.patch('deployd.common.config.Config.get_http_download_allow_list')
     def test_validate_url_with_non_https(self, mock_get_http_download_allow_list):
         downloader = HTTPDownloadHelper(url="http://deploy1.com")
         mock_get_http_download_allow_list.return_value = ['deploy1', 'deploy2']
@@ -42,9 +44,9 @@ class TestHttpDownloadHelper(unittest.TestCase):
         self.assertFalse(result)
         mock_get_http_download_allow_list.assert_not_called()
 
-    @mock.patch('deployd.download.http_download_helper.Config.get_http_download_allow_list')
+    @mock.patch('deployd.common.config.Config.get_http_download_allow_list')
     def test_validate_url_without_allow_list(self, mock_get_http_download_allow_list):
-        mock_get_http_download_allow_list.return_value = None
+        mock_get_http_download_allow_list.return_value = []
         result = self.downloader.validate_source()
 
         self.assertTrue(result)

--- a/deploy-agent/tests/unit/deploy/download/test_s3_download_helper.py
+++ b/deploy-agent/tests/unit/deploy/download/test_s3_download_helper.py
@@ -16,7 +16,7 @@ from deployd.download.s3_download_helper import S3DownloadHelper
 import unittest
 from unittest import mock
 import logging
-
+from deployd.common.config import Config
 logger = logging.getLogger()
 logger.level = logging.DEBUG
 
@@ -27,9 +27,10 @@ class TestS3DownloadHelper(unittest.TestCase):
     def setUp(self, mock_aws_key, mock_aws_secret):
         mock_aws_key.return_value = "test_key"
         mock_aws_secret.return_value= "test_secret"
-        self.downloader = S3DownloadHelper(local_full_fn='', url="s3://bucket1/key1")
+        self.config = Config()
+        self.downloader = S3DownloadHelper(local_full_fn='', aws_connection=None, url="s3://bucket1/key1", config=self.config)
 
-    @mock.patch('deployd.download.s3_download_helper.Config.get_s3_download_allow_list')
+    @mock.patch('deployd.common.config.Config.get_s3_download_allow_list')
     def test_validate_url_with_allow_list(self, mock_get_s3_download_allow_list):
         mock_get_s3_download_allow_list.return_value = ['bucket1', 'bucket2', 'bucket3']
         result = self.downloader.validate_source()
@@ -40,14 +41,21 @@ class TestS3DownloadHelper(unittest.TestCase):
         result = self.downloader.validate_source()
         self.assertFalse(result)
 
-    @mock.patch('deployd.download.s3_download_helper.Config.get_s3_download_allow_list')
+    @mock.patch('deployd.common.config.Config.get_s3_download_allow_list')
     def test_validate_url_without_allow_list(self, mock_get_s3_download_allow_list):
-        mock_get_s3_download_allow_list.return_value = None
+        mock_get_s3_download_allow_list.return_value = []
         result = self.downloader.validate_source()
 
         self.assertTrue(result)
         mock_get_s3_download_allow_list.assert_called_once()
 
+    @mock.patch('deployd.common.config.Config.get_s3_download_allow_list')
+    def test_validate_url_without_allow_list(self, mock_get_s3_download_allow_list):
+        mock_get_s3_download_allow_list.return_value = []
+        result = self.downloader.validate_source()
+
+        self.assertTrue(result)
+        mock_get_s3_download_allow_list.assert_called_once()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary 
Updated download to read allow list configs from `/etc/deploy/deployagent.conf`. 
Added a bazel target for downloader 
Updated tests 

## Test plan 
UTs
```
bazel test tests/test_http_download_helper
bazel test tests/test_s3_download_helper
```

test downloader, empty config 
```
sudo bazel build deployd:deploy-downloader 
sudo bazel-bin/deployd/deploy-downloader -f /etc/deployagent.conf -v 2bhd_k2QT5GjAx0aR0G2mA_aa874a6 -u https://deployrepo.pinadmin.com/deploy-agent-pex/deploy-agent-pex-aa874a6.tar.gz -e deploy-init
2024-03-01 23:38:00,945:INFO: Start to download from url https://deployrepo.pinadmin.com/deploy-agent-pex/deploy-agent-pex-aa874a6.tar.gz to /mnt/builds/deploy-init-2bhd_k2QT5GjAx0aR0G2mA_aa874a6.tar.gz
2024-03-01 23:38:00,946:INFO: Running command: curl -o /mnt/builds/deploy-init-2bhd_k2QT5GjAx0aR0G2mA_aa874a6.tar.gz -fksS https://deployrepo.pinadmin.com/deploy-agent-pex/deploy-agent-pex-aa874a6.tar.gz
2024-03-01 23:38:01,073:INFO: Finish downloading: https://deployrepo.pinadmin.com/deploy-agent-pex/deploy-agent-pex-aa874a6.tar.gz to /mnt/builds/deploy-init-2bhd_k2QT5GjAx0aR0G2mA_aa874a6.tar.gz
2024-03-01 23:38:01,077:DEBUG: Starting new HTTPS connection (1): deployrepo.pinadmin.com:443
2024-03-01 23:38:01,107:DEBUG: https://deployrepo.pinadmin.com:443 "GET /deploy-agent-pex/deploy-agent-pex-aa874a6.tar.gz.sha1 HTTP/1.1" 404 324
2024-03-01 23:38:01,107:WARNING: Skip checksum verification. Invalid response from https://deployrepo.pinadmin.com/deploy-agent-pex/deploy-agent-pex-aa874a6.tar.gz.sha1
2024-03-01 23:38:01,108:INFO: untar files to /mnt/builds/2bhd_k2QT5GjAx0aR0G2mA_aa874a6
2024-03-01 23:38:01,317:INFO: Successfully extracted /mnt/builds/deploy-init-2bhd_k2QT5GjAx0aR0G2mA_aa874a6.tar.gz to /mnt/builds/2bhd_k2QT5GjAx0aR0G2mA_aa874a6
2024-03-01 23:38:01,317:INFO: Download succeeded.
```
Test downloader, mocking config 
```2024-03-01 23:39:16,374:INFO: Start to download the package.
2024-03-01 23:39:16,374:INFO: Start to download from url https://deployrepo.pinadmin.com/deploy-agent-pex/deploy-agent-pex-aa874a6.tar.gz to /mnt/builds/deploy-init-2bhd_k2QT5GjAx0aR0G2mA_aa874a6.tar.gz
2024-03-01 23:39:16,374:ERROR: deployrepo.pinadmin.com is not in the allow list: ['test.com'].
2024-03-01 23:39:16,374:ERROR: Invalid url: https://deployrepo.pinadmin.com/deploy-agent-pex/deploy-agent-pex-aa874a6.tar.gz. Skip downloading.
2024-03-01 23:39:16,374:ERROR: Download failed.
```