### PR TITLE
Add spotless plugin for formatting

### DIFF
--- a/deploy-service/pom.xml
+++ b/deploy-service/pom.xml
@@ -18,6 +18,8 @@
         <micrometer.version>1.11.3</micrometer.version>
         <dropwizard.version>2.1.11</dropwizard.version>
         <junit-jupiter.version>5.10.1</junit-jupiter.version>
+        <googleJavaFormat.version>1.7</googleJavaFormat.version>
+        <spotless.version>2.30.0</spotless.version>
     </properties>
 
     <modules>
@@ -56,14 +58,16 @@
     </dependencyManagement>
 
     <dependencies>
-        <!--JUnit Jupiter Engine to depend on the JUnit5 engine and JUnit 5 API -->
+        <!--JUnit
+        Jupiter Engine to depend on the JUnit5 engine and JUnit 5 API -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <version>${junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
-        <!--JUnit Jupiter Engine to depend on the JUnit4 engine and JUnit 4 API  -->
+        <!--JUnit
+        Jupiter Engine to depend on the JUnit4 engine and JUnit 4 API  -->
         <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
@@ -129,13 +133,58 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-install-plugin</artifactId>
                     <version>3.1.1</version>
-                  </plugin>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>${spotless.version}</version>
+                <configuration>
+                    <ratchetFrom>origin/master</ratchetFrom>
+                    <java>
+                        <googleJavaFormat>
+                            <version>${googleJavaFormat.version}</version>
+                            <style>AOSP</style> <!-- AOSP is almost the same as the GOOGLE style but uses 4 spaces for indentation. -->
+                        </googleJavaFormat>
+                        <importOrder />
+                        <removeUnusedImports />
+                        <licenseHeader>
+                            <content>
+                                <![CDATA[
+/**
+ * Copyright (c) $YEAR Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ ]]>
+                            </content>
+                            <delimiter>package</delimiter>
+                        </licenseHeader>
+                    </java>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Run this command `mvn spotless:apply` to format. 
Alternatively,`-DspotlessSetLicenseHeaderYearsFromGitHistory=true` to retroactively slurp years from git history. 

Note that since ratchet is configured, so it will only format files that are changed compared to origin/master. 

**Stack**:
- #1480
- #1479


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*