### PR TITLE
Introduce universal/security library for AuthN and AuthZ

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,8 +39,22 @@ jobs:
         languages: ${{ matrix.language }}
         config-file: ./.github/codeql-config.yml
 
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+    - if: matrix.language == 'python'
+      name: Autobuild
+      uses: github/codeql-action/autobuild@v3
+
+    - if: matrix.language == 'java'
+      name: Set up JDK 1.8
+      uses: actions/setup-java@v4
+      with:
+        distribution: corretto
+        java-version: 8
+        cache: 'maven'
+    - if: matrix.language == 'java'
+      name: Build with Maven
+      working-directory: deploy-service
+      run: |
+          mvn clean package --file pom.xml -P-pinterest-dependenies,exclude-pinterest-only-classes -B -V -e -Dfindbugs.skip -Dcheckstyle.skip -Dpmd.skip=true -Dspotbugs.skip -Denforcer.skip -Dmaven.javadoc.skip -DskipTests -Dmaven.test.skip.exec -Dlicense.skip=true -Drat.skip=true -Dspotless.check.skip=true
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -4,22 +4,29 @@ on:
   push:
     branches:
     - master
+    paths:
+    - 'deploy-service/**'
+    - '.github/workflows/maven.yml'
   pull_request:
     branches:
     - master
+    paths:
+    - 'deploy-service/**'
+    - '.github/workflows/maven.yml'
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
-        java-version: 1.8
+        distribution: corretto
+        java-version: 8
+        cache: 'maven'
     - name: Build with Maven
+      working-directory: deploy-service
       run: |
-        cd deploy-service
-        mvn package --file pom.xml
+        mvn clean package --file pom.xml -P-pinterest-dependenies,exclude-pinterest-only-classes

--- a/deploy-service/pom.xml
+++ b/deploy-service/pom.xml
@@ -38,7 +38,7 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
-                <version>2022.0.9</version>
+                <version>2023.0.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/deploy-service/universal/pom.xml
+++ b/deploy-service/universal/pom.xml
@@ -21,6 +21,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <micrometer.version>1.11.3</micrometer.version>
+    <pinterest.commons.version>0.1-20220908.230942-22097</pinterest.commons.version>
   </properties>
 
   <dependencyManagement>
@@ -28,7 +29,7 @@
       <dependency>
         <groupId>io.projectreactor</groupId>
         <artifactId>reactor-bom</artifactId>
-        <version>2022.0.9</version>
+        <version>2023.0.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -60,6 +61,10 @@
       <artifactId>reactor-netty-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.projectreactor.netty</groupId>
+      <artifactId>reactor-netty-http</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <version>1.18.28</version>
@@ -73,7 +78,33 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>2.0.9</version>
+      <version>1.7.36</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>32.1.2-jre</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>javax.ws.rs-api</artifactId>
+      <version>2.1</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.3.2</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.dropwizard</groupId>
+      <artifactId>dropwizard-auth</artifactId>
+      <version>${dropwizard.version}</version>
     </dependency>
 
     <!-- Test dependencies -->
@@ -96,15 +127,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <version>1.7.32</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>32.1.2-jre</version>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <version>4.12.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -115,14 +140,14 @@
       <plugins>
         <plugin>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>2.8.2</version>
-          <configuration>  
-            <skip>true</skip>  
+          <version>3.1.1</version>
+          <configuration>
+            <skip>true</skip>
           </configuration>
         </plugin>
         <plugin>
           <artifactId>maven-project-info-reports-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.5.0</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -141,10 +166,11 @@
       </plugin>
       <plugin>
         <!-- This is Pinterest deployment specific. -->
-        <!-- For non-Pinterest deployments, remove this block and use the maven-deploy-plugin instead. -->
+        <!-- For non-Pinterest deployments, remove this block and use the maven-deploy-plugin
+        instead. -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>  
+        <version>3.0.0</version>
         <executions>
           <execution>
             <id>artifactory-push-deploy</id>
@@ -181,4 +207,109 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>pinterest-dependenies</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <repositories>
+        <repository>
+          <!-- Single end point to fetch all maven artifacts.  -->
+          <id>maven-virtual</id>
+          <name>maven-virtual</name>
+          <url>https://artifacts-prod-use1.pinadmin.com/artifactory/maven-virtual/</url>
+        </repository>
+        <repository>
+          <id>artifactory-thirdparty-prod</id>
+          <name>artifactory-thirdparty-prod</name>
+          <url>https://artifacts-prod-use1.pinadmin.com/artifactory/maven_thirdparty-jar-bazel-prod-local</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+        <repository>
+          <id>artifactory-legacy-prod</id>
+          <name>artifactory-legacy-prod</name>
+          <url>https://artifacts-prod-use1.pinadmin.com/artifactory/maven_legacy-jar-bazel-prod-local</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+        <repository>
+          <id>artifactory-private-snapshots-prod</id>
+          <name>artifactory-private-snapshots-prod</name>
+          <url>https://artifacts-prod-use1.pinadmin.com/artifactory/maven_private_snapshots-jar-bazel-prod-local</url>
+          <releases>
+            <enabled>false</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <dependencies>
+        <dependency>
+          <groupId>com.pinterest.optimus.commons</groupId>
+          <artifactId>pinterest-commons</artifactId>
+          <version>${pinterest.commons.version}</version>
+          <exclusions>
+            <exclusion>
+              <groupId>org.slf4j</groupId>
+              <artifactId>*</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>com.amazonaws</groupId>
+              <artifactId>*</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>com.pinterest.schemas</groupId>
+              <artifactId>schemas_jdk18</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>com.pinterest</groupId>
+              <artifactId>libjava_fbs</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>com.google.flatbuffers</groupId>
+              <artifactId>flatbuffers-java</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>com.pinterest.psc</groupId>
+              <artifactId>psc-internal-shaded</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+      </dependencies>
+    </profile>
+
+    <profile>
+      <!-- If you are outside Pinterest, use this profile instead -->
+      <!-- i.e. mvn clean package -P-pinterest-dependenies,exclude-pinterest-only-classes -->
+      <id>exclude-pinterest-only-classes</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <excludes>
+                <exclude>**/BasePastisAuthorizer.java</exclude>
+              </excludes>
+              <testExcludes>
+                <testExclude>**/BasePastisAuthorizerTest.java</testExclude>
+              </testExcludes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/AnonymousAuthFilter.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/AnonymousAuthFilter.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.universal.security;
+
+import com.pinterest.teletraan.universal.security.bean.AnonymousUser;
+import java.io.IOException;
+import java.security.Principal;
+import javax.annotation.Priority;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * A filter for authenticating and authorizing any request as an anonymous user. For development use
+ * only.
+ */
+@Provider
+@Priority(Priorities.AUTHENTICATION)
+public class AnonymousAuthFilter implements ContainerRequestFilter {
+    public static final AnonymousUser USER = new AnonymousUser();
+    private SecurityContext securityContext;
+
+    public AnonymousAuthFilter() {
+        securityContext =
+                new SecurityContext() {
+
+                    @Override
+                    public Principal getUserPrincipal() {
+                        return AnonymousAuthFilter.USER;
+                    }
+
+                    @Override
+                    public boolean isUserInRole(String s) {
+                        return true;
+                    }
+
+                    @Override
+                    public boolean isSecure() {
+                        return false;
+                    }
+
+                    @Override
+                    public String getAuthenticationScheme() {
+                        return "Anonymous";
+                    }
+                };
+    }
+
+    @Override
+    public void filter(ContainerRequestContext containerRequestContext) throws IOException {
+        containerRequestContext.setSecurityContext(securityContext);
+    }
+}

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/AuditLoggingFilter.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/AuditLoggingFilter.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.universal.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Priority;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * A filter for logging audit information for each request. Should be configured differently than
+ * regular application logs.
+ */
+@Priority(Integer.MIN_VALUE)
+@Slf4j
+public class AuditLoggingFilter implements ContainerResponseFilter {
+    private static final String PRINCIPAL = "principal";
+    private static final String RESOURCE = "resource";
+    private static final String METHOD = "method";
+    private static final String STATUS = "status";
+
+    @Override
+    public void filter(
+            ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+            throws IOException {
+        if (requestContext.getSecurityContext() == null
+                || requestContext.getSecurityContext().getUserPrincipal() == null) {
+            return;
+        }
+        Map<String, Object> attributes = new HashMap<>();
+        try {
+            attributes.put(
+                    PRINCIPAL, requestContext.getSecurityContext().getUserPrincipal().getName());
+            attributes.put(RESOURCE, requestContext.getUriInfo().getRequestUri().toString());
+            attributes.put(METHOD, requestContext.getMethod());
+            attributes.put(STATUS, responseContext.getStatus());
+
+            String json = new ObjectMapper().writeValueAsString(attributes);
+            log.info(json);
+        } catch (Exception ex) {
+            log.error("Failed to generate audit log for: {}", attributes, ex);
+        }
+    }
+}

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/AuthZResourceExtractor.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/AuthZResourceExtractor.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.universal.security;
+
+import com.pinterest.teletraan.universal.security.bean.AuthZResource;
+import javax.ws.rs.container.ContainerRequestContext;
+
+public interface AuthZResourceExtractor {
+    /**
+     * Extracts AuthZResource from the requestContext.
+     *
+     * @param requestContext
+     * @return
+     * @throws ExtractionException if no resource can be extracted
+     */
+    AuthZResource extractResource(ContainerRequestContext requestContext)
+            throws ExtractionException;
+
+    /**
+     * Extracts AuthZResource from the requestContext.
+     *
+     * @param requestContext
+     * @param beanClass is the class of the expected resource bean
+     * @return
+     * @throws ExtractionException if no resource can be extracted
+     */
+    default AuthZResource extractResource(
+            ContainerRequestContext requestContext, Class<?> beanClass) throws ExtractionException {
+        return extractResource(requestContext);
+    }
+
+    interface Factory {
+        AuthZResourceExtractor create(ResourceAuthZInfo authZInfo);
+    }
+
+    class ExtractionException extends Exception {
+        public ExtractionException(String message, Throwable cause) {
+            super(message, cause);
+        }
+
+        public ExtractionException(String message) {
+            super(message);
+        }
+    }
+}

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/BaseAuthorizer.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/BaseAuthorizer.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.universal.security;
+
+import com.pinterest.teletraan.universal.security.AuthZResourceExtractor.ExtractionException;
+import com.pinterest.teletraan.universal.security.bean.AuthZResource;
+import com.pinterest.teletraan.universal.security.bean.TeletraanPrincipal;
+import io.dropwizard.auth.Authorizer;
+import javax.annotation.Nullable;
+import javax.ws.rs.container.ContainerRequestContext;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * A base class for authorizers. Every Teletraan authorizer should extend this class.
+ *
+ * @param <P> the principal type
+ */
+@AllArgsConstructor
+@Slf4j
+public abstract class BaseAuthorizer<P extends TeletraanPrincipal> implements Authorizer<P> {
+    protected final AuthZResourceExtractor.Factory extractorFactory;
+
+    @Override
+    public boolean authorize(P principal, String role) {
+        throw new UnsupportedOperationException(
+                "ContainerRequestContext is required for authorization");
+    }
+
+    @Override
+    public boolean authorize(P principal, String role, @Nullable ContainerRequestContext context) {
+        log.debug("Authorizing...");
+
+        if (context == null) {
+            log.warn("ContainerRequestContext is required for authorization");
+            return false;
+        }
+
+        Object authZInfo = context.getProperty(ResourceAuthZInfo.class.getName());
+        if (authZInfo == null) {
+            log.warn("ResourceAuthZInfo is required for authorization");
+            return false;
+        }
+
+        if (!(authZInfo instanceof ResourceAuthZInfo)) {
+            log.warn("authZInfo type not supported");
+            return false;
+        }
+
+        ResourceAuthZInfo safeAuthZInfo = (ResourceAuthZInfo) authZInfo;
+
+        AuthZResource requestedResource;
+        try {
+            requestedResource =
+                    extractorFactory
+                            .create(safeAuthZInfo)
+                            .extractResource(context, safeAuthZInfo.beanClass());
+        } catch (ExtractionException ex) {
+            log.warn(
+                    "Failed to extract resource. Did you forget to annotate the resource with @ResourceAuthZInfo?",
+                    ex);
+            return false;
+        }
+
+        return authorize(principal, role, requestedResource, context);
+    }
+
+    public abstract boolean authorize(
+            P principal,
+            String role,
+            AuthZResource requestedResource,
+            @Nullable ContainerRequestContext context);
+}

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/BasePastisAuthorizer.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/BasePastisAuthorizer.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.universal.security;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pinterest.commons.pastis.PastisAuthorizer;
+import com.pinterest.teletraan.universal.security.bean.AuthZResource;
+import com.pinterest.teletraan.universal.security.bean.TeletraanPrincipal;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import javax.ws.rs.container.ContainerRequestContext;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * A base class for authorizers that use Pastis for authorization. Pinterest only
+ *
+ * @param <P> the principal type
+ */
+@Slf4j
+public class BasePastisAuthorizer<P extends TeletraanPrincipal> extends BaseAuthorizer<P> {
+    private static final String INPUT = "input";
+    protected final PastisAuthorizer pastis;
+
+    @Builder
+    private BasePastisAuthorizer(
+            String serviceName, PastisAuthorizer pastis, AuthZResourceExtractor.Factory factory) {
+        super(factory);
+        if (pastis == null) {
+            if (serviceName == null) {
+                throw new IllegalArgumentException(
+                        "PastisAuthorizer and serviceName cannot both be null");
+            }
+            this.pastis = new PastisAuthorizer(serviceName);
+        } else {
+            this.pastis = pastis;
+        }
+    }
+
+    public BasePastisAuthorizer(PastisAuthorizer pastis, AuthZResourceExtractor.Factory factory) {
+        super(factory);
+        this.pastis = pastis;
+    }
+
+    @Override
+    public boolean authorize(
+            P principal,
+            String role,
+            AuthZResource requestedResource,
+            @Nullable ContainerRequestContext context) {
+
+        Map<String, PastisRequest> payload = new HashMap<>();
+        payload.put(INPUT, new PastisRequest(principal, role, requestedResource));
+        try {
+            String pastisPayload = new ObjectMapper().writeValueAsString(payload);
+            boolean authorized = pastis.authorize(pastisPayload);
+            log.debug("Authorized: {}", authorized);
+            return authorized;
+        } catch (Exception ex) {
+            return handleAuthorizationException(ex);
+        }
+    }
+
+    /**
+     * Handle an exception that occurred while authorizing a request
+     *
+     * Subclasses can override this method to provide custom handling of authorization exceptions
+     * @param ex
+     * @return true if authorized
+     */
+    protected boolean handleAuthorizationException(Exception ex) {
+        log.error("Failed to authorize request", ex);
+        return false;
+    }
+
+    @Value
+    @AllArgsConstructor
+    protected static class PastisPrincipal {
+        String id;
+        String type;
+
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        List<String> groups;
+    }
+
+    @Value
+    protected static class PastisRequest {
+        PastisPrincipal principal;
+        String action;
+        AuthZResource resource;
+
+        public PastisRequest(TeletraanPrincipal principal, String action, AuthZResource resource) {
+            this.principal =
+                    new PastisPrincipal(
+                            principal.getName(), principal.getType().name(), principal.getGroups());
+            this.action = action;
+            this.resource = resource;
+        }
+    }
+}

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/Constants.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/Constants.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.universal.security;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+public final class Constants {
+    public static final String USER_HEADER = "x-forwarded-user";
+    public static final String GROUPS_HEADER = "x-forwarded-groups";
+    public static final String CLIENT_CERT_HEADER = "x-forwarded-client-cert";
+}

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/EnvoyAuthFilter.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/EnvoyAuthFilter.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.universal.security;
+
+import com.pinterest.teletraan.universal.security.bean.EnvoyCredentials;
+import io.dropwizard.auth.AuthFilter;
+import java.io.IOException;
+import java.security.Principal;
+import java.util.Arrays;
+import java.util.List;
+import javax.annotation.Nullable;
+import javax.annotation.Priority;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.SecurityContext;
+import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+
+/** A filter for authenticating and authorizing requests from processed by Envoy. */
+@Priority(Priorities.AUTHENTICATION)
+@NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+public class EnvoyAuthFilter<P extends Principal> extends AuthFilter<EnvoyCredentials, P> {
+    @Override
+    public void filter(final ContainerRequestContext requestContext) throws IOException {
+        EnvoyCredentials credentials = getCredentials(requestContext);
+
+        if (credentials != null) {
+            String scheme =
+                    StringUtils.isNotBlank(credentials.getSpiffeId())
+                            ? SecurityContext.CLIENT_CERT_AUTH
+                            : SecurityContext.BASIC_AUTH;
+            if (authenticate(requestContext, credentials, scheme)) {
+                return;
+            }
+        }
+        throw unauthorizedHandler.buildException(prefix, realm);
+    }
+
+    /**
+     * Get the Envoy credentials from the request headers.
+     *
+     * @param requestContext the context of the request
+     * @return an instance of {@link EnvoyCredentials} if the request is authenticated, otherwise
+     *     {@code null}
+     */
+    @Nullable
+    private EnvoyCredentials getCredentials(ContainerRequestContext requestContext) {
+        String user = requestContext.getHeaders().getFirst(Constants.USER_HEADER);
+        String spiffeId =
+                getSpiffeId(requestContext.getHeaders().getFirst(Constants.CLIENT_CERT_HEADER));
+        List<String> groups =
+                getGroups(requestContext.getHeaders().getFirst(Constants.GROUPS_HEADER));
+
+        if (StringUtils.isBlank(spiffeId) && StringUtils.isBlank(user)) {
+            return null;
+        }
+
+        return new EnvoyCredentials(user, spiffeId, groups);
+    }
+
+    /**
+     * Builder for {@link EnvoyAuthFilter}.
+     *
+     * <p>An {@link Authenticator} must be provided during the building process.
+     *
+     * @param <P> the type of the principal
+     */
+    public static class Builder<P extends Principal>
+            extends AuthFilterBuilder<EnvoyCredentials, P, EnvoyAuthFilter<P>> {
+
+        @Override
+        protected EnvoyAuthFilter<P> newInstance() {
+            return new EnvoyAuthFilter<>();
+        }
+    }
+
+    /**
+     * Parses the raw value of a spiffe request header
+     *
+     * @return spiffe id
+     */
+    @Nullable
+    protected static String getSpiffeId(String value) {
+        if (value == null) {
+            return null;
+        }
+        String[] headerValues = value.split(",");
+        String lastHeaderValue = headerValues[headerValues.length - 1];
+        String[] pairs = lastHeaderValue.split(";");
+        for (String pair : pairs) {
+            String[] pairKeyAndValue = pair.split("=", 2);
+            if (pairKeyAndValue[0].equals("URI")) {
+                return pairKeyAndValue[1];
+            }
+        }
+        return null;
+    }
+
+    @Nullable
+    protected static List<String> getGroups(String header) {
+        if (header == null) {
+            return null;
+        }
+        return Arrays.asList(header.trim().split("[\\s,]+"));
+    }
+}

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/EnvoyAuthenticator.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/EnvoyAuthenticator.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.universal.security;
+
+import com.pinterest.teletraan.universal.security.bean.EnvoyCredentials;
+import com.pinterest.teletraan.universal.security.bean.ServicePrincipal;
+import com.pinterest.teletraan.universal.security.bean.TeletraanPrincipal;
+import com.pinterest.teletraan.universal.security.bean.UserPrincipal;
+import io.dropwizard.auth.AuthenticationException;
+import io.dropwizard.auth.Authenticator;
+import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
+
+/** An authenticator for Envoy credentials. */
+public class EnvoyAuthenticator implements Authenticator<EnvoyCredentials, TeletraanPrincipal> {
+
+    @Override
+    public Optional<TeletraanPrincipal> authenticate(EnvoyCredentials credentials)
+            throws AuthenticationException {
+        if (StringUtils.isNotBlank(credentials.getUser())) {
+            return Optional.of(new UserPrincipal(credentials.getUser(), credentials.getGroups()));
+        }
+        if (StringUtils.isNotBlank(credentials.getSpiffeId())) {
+            return Optional.of(new ServicePrincipal(credentials.getSpiffeId()));
+        }
+        return Optional.empty();
+    }
+}

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/OAuthAuthenticator.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/OAuthAuthenticator.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.universal.security;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pinterest.teletraan.universal.security.bean.UserPrincipal;
+import io.dropwizard.auth.Authenticator;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import reactor.netty.http.client.HttpClient;
+import reactor.util.retry.Retry;
+
+/**
+ * @deprecated Do not use this class for new development. It is kept here for backward compatibility
+ *     OAuthAuthenticator is an authenticator that authenticates a user using OAuth token.
+ */
+@Deprecated
+@Slf4j
+public class OAuthAuthenticator implements Authenticator<String, UserPrincipal> {
+    private static final String USER = "user";
+    private static final String GROUPS = "groups";
+    private static final String USERNAME_FIELD = "username";
+    private static final String ACCESS_TOKEN_QUERY = "/?access_token=%s";
+
+    private final String groupDataUrl;
+    private final HttpClient userDataClient;
+    private final HttpClient groupDataClient;
+
+    public OAuthAuthenticator(String userDataUrl, String groupDataUrl)
+            throws MalformedURLException {
+        if (StringUtils.isBlank(userDataUrl)) {
+            throw new IllegalArgumentException("User data url cannot be empty");
+        }
+        userDataUrl = sanitizeUrl(userDataUrl);
+        groupDataUrl = sanitizeUrl(groupDataUrl);
+        HttpClient baseClient = HttpClient.create().responseTimeout(Duration.ofSeconds(3));
+        userDataClient = baseClient.baseUrl(userDataUrl);
+        groupDataClient = baseClient.baseUrl(groupDataUrl);
+        this.groupDataUrl = groupDataUrl;
+    }
+
+    @Override
+    public Optional<UserPrincipal> authenticate(String token) {
+        log.debug("Authenticating...");
+        try {
+            String username = getUsername(token);
+            List<String> groups = getUserGroups(token);
+            return Optional.of(new UserPrincipal(username, groups));
+        } catch (Exception exception) {
+            log.debug("authN failed", exception);
+            return Optional.empty();
+        }
+    }
+
+    private List<String> getUserGroups(String token) {
+        if (groupDataUrl.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        // Get user groups through auth server with user oauth token
+        String jsonResponse = getData(groupDataClient, token);
+        // Parse response
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            JsonNode jsonNode = objectMapper.readTree(jsonResponse);
+            if (jsonNode.has(GROUPS)) {
+                JsonNode groupsNode = jsonNode.get(GROUPS);
+                String[] groups = objectMapper.convertValue(groupsNode, String[].class);
+                log.debug("Retrieved groups {} from token.", Arrays.asList(groups));
+                return Arrays.asList(groups);
+            }
+        } catch (JsonProcessingException e) {
+            log.debug("Failed to parse {}", jsonResponse, e);
+        }
+        return Collections.emptyList();
+    }
+
+    private String getUsername(String token) throws JsonProcessingException {
+        String jsonResponse = getData(userDataClient, token);
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode = objectMapper.readTree(jsonResponse);
+        JsonNode userNode = jsonNode.get(USER);
+        String userName = userNode.get(USERNAME_FIELD).asText();
+        log.debug("Retrieved username {} from identity provider.", userName);
+        return userName;
+    }
+
+    private static String getUriString(String token) {
+        return String.format(ACCESS_TOKEN_QUERY, token);
+    }
+
+    private static String sanitizeUrl(String url) throws MalformedURLException {
+        if (StringUtils.isBlank(url)) {
+            return "";
+        }
+        url = url.trim();
+        url = url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
+        new URL(url);
+        return url;
+    }
+
+    private String getData(HttpClient client, String token) {
+        return client.get()
+                .uri(getUriString(token))
+                .responseContent()
+                .aggregate()
+                .asString()
+                .retryWhen(Retry.backoff(3, Duration.ofSeconds(2)).jitter(0.75))
+                .onErrorReturn("")
+                // Timeout should be enough to get the response from the auth server
+                // after all retries.
+                .block(Duration.ofSeconds(10));
+    }
+}

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/ResourceAuthZInfo.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/ResourceAuthZInfo.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.universal.security;
+
+import com.pinterest.teletraan.universal.security.bean.AuthZResource;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** This annotation is used to specify the resource information useful for authorization. */
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ResourceAuthZInfo {
+    AuthZResource.Type type();
+
+    /** The location of the resource identifier in the request. */
+    Location idLocation() default Location.NA;
+
+    Class<?> beanClass() default Object.class;
+
+    public enum Location {
+        PATH,
+        QUERY,
+        BODY,
+        NA
+    }
+}

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/ResourceAuthZInfoFeature.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/ResourceAuthZInfoFeature.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.universal.security;
+
+import javax.ws.rs.container.DynamicFeature;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.FeatureContext;
+
+/**
+ * This class is used to register the ResourceAuthZInfoFilter when the ResourceAuthZInfo annotation
+ * is present on a resource method.
+ */
+public class ResourceAuthZInfoFeature implements DynamicFeature {
+    @Override
+    public void configure(ResourceInfo resourceInfo, FeatureContext context) {
+        if (resourceInfo.getResourceMethod().getAnnotation(ResourceAuthZInfo.class) != null) {
+            context.register(ResourceAuthZInfoFilter.class);
+        }
+    }
+}

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/ResourceAuthZInfoFilter.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/ResourceAuthZInfoFilter.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.universal.security;
+
+import java.io.IOException;
+import javax.annotation.Priority;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * This filter adds the ResourceAuthZInfo annotation to the request context properties so that it
+ * can be used by the AuthZResourceExtractor to extract the resource information.
+ */
+@Provider
+@Priority(Priorities.AUTHENTICATION - 1) // Run before authentication filters
+public class ResourceAuthZInfoFilter implements ContainerRequestFilter {
+    @Context private ResourceInfo resourceInfo;
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        ResourceAuthZInfo authZInfo =
+                resourceInfo.getResourceMethod().getAnnotation(ResourceAuthZInfo.class);
+        requestContext.setProperty(ResourceAuthZInfo.class.getName(), authZInfo);
+    }
+}

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/ScriptTokenAuthenticator.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/ScriptTokenAuthenticator.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.universal.security;
+
+import com.pinterest.teletraan.universal.security.bean.Role;
+import com.pinterest.teletraan.universal.security.bean.ScriptTokenPrincipal;
+import io.dropwizard.auth.AuthenticationException;
+import io.dropwizard.auth.Authenticator;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * ScriptTokenAuthenticator is an authenticator that authenticates a principal using a script token.
+ */
+@Slf4j
+public class ScriptTokenAuthenticator<R extends Role<R>>
+        implements Authenticator<String, ScriptTokenPrincipal<R>> {
+
+    private ScriptTokenProvider<R> tokenProvider;
+
+    public ScriptTokenAuthenticator(ScriptTokenProvider<R> tokenProvider) {
+        this.tokenProvider = tokenProvider;
+    }
+
+    @Override
+    public Optional<ScriptTokenPrincipal<R>> authenticate(String credentials)
+            throws AuthenticationException {
+        log.debug("Authenticating...");
+        try {
+            return tokenProvider.getPrincipal(credentials);
+        } catch (Exception e) {
+            throw new AuthenticationException(e);
+        }
+    }
+}

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/ScriptTokenProvider.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/ScriptTokenProvider.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.universal.security;
+
+import com.pinterest.teletraan.universal.security.bean.Role;
+import com.pinterest.teletraan.universal.security.bean.ScriptTokenPrincipal;
+import java.util.Optional;
+
+/**
+ * ScriptTokenProvider is an interface that provides a way to get a principal from a script token.
+ */
+public interface ScriptTokenProvider<R extends Role<R>> {
+    Optional<ScriptTokenPrincipal<R>> getPrincipal(String token);
+}

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/AnonymousUser.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/AnonymousUser.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.universal.security.bean;
+
+import java.util.Collections;
+
+public class AnonymousUser extends UserPrincipal {
+    public AnonymousUser() {
+        super("Anonymous", Collections.emptyList());
+    }
+}

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/AuthZResource.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/AuthZResource.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.universal.security.bean;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import javax.annotation.Nonnull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/** AuthZResource represents a resource for authorization purposes. */
+@Data
+@AllArgsConstructor
+public class AuthZResource {
+    private @Nonnull String name;
+    private final Type type;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String accountId;
+
+    public static final String ALL = "*";
+    public static final AuthZResource SYSTEM_RESOURCE = new AuthZResource(ALL, Type.SYSTEM);
+
+    public AuthZResource(@Nonnull String name, Type type) {
+        this(name, type, null);
+    }
+
+    /**
+     * Convenient constructor for creating an ENV_STAGE resource, the most common resource type.
+     *
+     * @param envName the name of the environment
+     * @param stageName the name of the stage
+     */
+    public AuthZResource(String envName, String stageName) {
+        if (envName == null) {
+            throw new IllegalArgumentException("envName cannot be null");
+        }
+        this.name = String.format("%s/%s", envName, stageName);
+        this.type = Type.ENV_STAGE;
+    }
+
+    /**
+     * Convenient method for getting the environment name from the resource name.
+     *
+     * @return the environment name if the resource is of type ENV_STAGE or ENV, null otherwise
+     */
+    @JsonIgnore
+    public String getEnvName() {
+        if (type == Type.ENV_STAGE) {
+            return name.split("/")[0];
+        } else if (type == Type.ENV) {
+            return name;
+        }
+        return null;
+    }
+
+    /** The type of the resource. */
+    public enum Type {
+        /** For resources that are not tied to a specific stage. */
+        ENV,
+        /** For groups. */
+        GROUP,
+        /** For resources related to global Teletraan system. */
+        SYSTEM,
+        /** For resources related to a specific environment-stage. The most common resource type. */
+        ENV_STAGE,
+        /** For placement related to a specific environment. */
+        PLACEMENT,
+        /** For base image related to a specific environment. */
+        BASE_IMAGE,
+        /** For security zone related to a specific environment. */
+        SECURITY_ZONE,
+        /** For IAM role related to a specific environment. */
+        IAM_ROLE,
+        /** For build related resources. */
+        BUILD
+    }
+
+    /**
+     * @deprecated Use getName() instead this. It is needed for converting DB records to
+     *     AuthZResource objects.
+     */
+    @Deprecated
+    public void setId(@Nonnull String id) {
+        this.name = id;
+    }
+}

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/EnvoyCredentials.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/EnvoyCredentials.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.universal.security.bean;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class EnvoyCredentials {
+    String user;
+    String spiffeId;
+    List<String> groups;
+}

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/MaskBasedRole.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/MaskBasedRole.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.universal.security.bean;
+
+/**
+ * MaskBasedRole is a role that is based on a mask which is used for role comparison. The use of
+ * mask is similar to Unix file permission.
+ */
+public class MaskBasedRole implements Role<MaskBasedRole> {
+    private long mask;
+
+    public MaskBasedRole(long mask) {
+        this.mask = mask;
+    }
+
+    public long getMask() {
+        return mask;
+    }
+
+    public String getName() {
+        return String.valueOf(mask);
+    }
+
+    @Override
+    public boolean isEqualOrSuperior(MaskBasedRole requiredRole) {
+        return (mask & requiredRole.mask) == requiredRole.mask;
+    }
+}

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/Role.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/Role.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2016-2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.universal.security.bean;
+
+public interface Role<T extends Role<T>> {
+    boolean isEqualOrSuperior(T requiredRole);
+}

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/RoleEnum.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/RoleEnum.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.universal.security.bean;
+
+public interface RoleEnum<R extends Role<R>> {
+    R getRole();
+}

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/ScriptTokenPrincipal.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/ScriptTokenPrincipal.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.universal.security.bean;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/** A principal represented by a script token. */
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class ScriptTokenPrincipal<R extends Role<R>> extends ServicePrincipal {
+    private final R role;
+    private final AuthZResource resource;
+
+    public ScriptTokenPrincipal(String name, R role, AuthZResource resource) {
+        super(name);
+        this.role = role;
+        this.resource = resource;
+    }
+}

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/ServicePrincipal.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/ServicePrincipal.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.universal.security.bean;
+
+import java.util.Collections;
+import java.util.List;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+
+@Data
+@RequiredArgsConstructor
+public class ServicePrincipal implements TeletraanPrincipal {
+
+    private final String name;
+    private String group;
+
+    public List<String> getGroups() {
+        if (StringUtils.isBlank(group)) {
+            return Collections.emptyList();
+        } else {
+            return Collections.singletonList(group);
+        }
+    }
+
+    @Override
+    public Type getType() {
+        return Type.SERVICE;
+    }
+}

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/TeletraanPrincipal.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/TeletraanPrincipal.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.universal.security.bean;
+
+import java.security.Principal;
+import java.util.List;
+
+public interface TeletraanPrincipal extends Principal {
+    List<String> getGroups();
+
+    Type getType();
+
+    public enum Type {
+        USER,
+        SERVICE
+    }
+}

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/UserPrincipal.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/UserPrincipal.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.universal.security.bean;
+
+import java.util.List;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+@Data
+@RequiredArgsConstructor
+public class UserPrincipal implements TeletraanPrincipal {
+    private final String name;
+    private final List<String> groups;
+
+    @Override
+    public Type getType() {
+        return Type.USER;
+    }
+}

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/ValueBasedRole.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/ValueBasedRole.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.universal.security.bean;
+
+/**
+ * ValueBasedRole is a role that is based on a value. It is used to compare roles based on their
+ * values. Higher value means more permissions.
+ */
+public class ValueBasedRole implements Role<ValueBasedRole> {
+    private int value;
+
+    public ValueBasedRole(int value) {
+        this.value = value;
+    }
+
+    @Override
+    public boolean isEqualOrSuperior(ValueBasedRole requiredRole) {
+        return this.equals(requiredRole) || this.value > requiredRole.value;
+    }
+}

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/AnonymousAuthFilterTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/AnonymousAuthFilterTest.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.universal.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.SecurityContext;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class AnonymousAuthFilterTest {
+    @Test
+    void testFilter() throws IOException {
+        AnonymousAuthFilter sut = new AnonymousAuthFilter();
+        ContainerRequestContext containerRequestContext = mock(ContainerRequestContext.class);
+        sut.filter(containerRequestContext);
+
+        ArgumentCaptor<SecurityContext> securityContextCaptor =
+                ArgumentCaptor.forClass(SecurityContext.class);
+        verify(containerRequestContext).setSecurityContext(securityContextCaptor.capture());
+        SecurityContext securityContext = securityContextCaptor.getValue();
+
+        assertEquals(AnonymousAuthFilter.USER, securityContext.getUserPrincipal());
+        assertEquals("Anonymous", securityContext.getAuthenticationScheme());
+        assertEquals(false, securityContext.isSecure());
+        assertEquals(true, securityContext.isUserInRole("any"));
+    }
+}

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/BaseAuthorizerTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/BaseAuthorizerTest.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.universal.security;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.pinterest.teletraan.universal.security.AuthZResourceExtractor.ExtractionException;
+import com.pinterest.teletraan.universal.security.bean.AuthZResource;
+import com.pinterest.teletraan.universal.security.bean.TeletraanPrincipal;
+import com.pinterest.teletraan.universal.security.bean.UserPrincipal;
+import java.util.Collections;
+import javax.annotation.Nullable;
+import javax.ws.rs.container.ContainerRequestContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class BaseAuthorizerTest {
+    private static final String TEST_ROLE = "testRole";
+    private AuthZResourceExtractor.Factory extractorFactory;
+    private BaseAuthorizer<TeletraanPrincipal> sut;
+    private TeletraanPrincipal principal;
+    private ContainerRequestContext context;
+
+    @BeforeEach
+    void setUp() {
+        extractorFactory = mock(AuthZResourceExtractor.Factory.class);
+        context = mock(ContainerRequestContext.class);
+        sut = new TestAuthorizer(extractorFactory);
+        principal = new UserPrincipal("testUser", Collections.singletonList("group"));
+    }
+
+    @Test
+    void testAuthorizeWithoutContext() {
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> {
+                    sut.authorize(principal, TEST_ROLE);
+                });
+    }
+
+    @Test
+    void testAuthorize_contextIsNull() {
+        assertFalse(sut.authorize(principal, TEST_ROLE, null));
+    }
+
+    @Test
+    void testAuthorize_contextHasNoResourceAuthZInfo() {
+        assertFalse(sut.authorize(principal, TEST_ROLE, context));
+    }
+
+    @Test
+    void testAuthorize_contextHasInvalidResourceAuthZInfo() {
+        when(context.getProperty(ResourceAuthZInfo.class.getName())).thenReturn(new Object());
+
+        assertFalse(sut.authorize(principal, TEST_ROLE, context));
+    }
+
+    @Test
+    void testAuthorize_contextHasValidResourceAuthZInfo() throws ExtractionException {
+        ResourceAuthZInfo authZInfo = mock(ResourceAuthZInfo.class);
+        AuthZResourceExtractor extractor = mock(AuthZResourceExtractor.class);
+
+        when(context.getProperty(ResourceAuthZInfo.class.getName())).thenReturn(authZInfo);
+        when(extractorFactory.create(authZInfo)).thenReturn(extractor);
+        when(extractor.extractResource(any(), any()))
+                .thenReturn(new AuthZResource("test", AuthZResource.Type.ENV));
+
+        assertTrue(sut.authorize(principal, TEST_ROLE, context));
+        verify(extractorFactory).create(authZInfo);
+        verify(extractor).extractResource(context, authZInfo.beanClass());
+
+        when(extractor.extractResource(any(), any())).thenThrow(new ExtractionException(null));
+        assertFalse(sut.authorize(principal, TEST_ROLE, context));
+    }
+
+    class TestAuthorizer extends BaseAuthorizer<TeletraanPrincipal> {
+        public TestAuthorizer(AuthZResourceExtractor.Factory extractorFactory) {
+            super(extractorFactory);
+        }
+
+        @Override
+        public boolean authorize(
+                TeletraanPrincipal principal,
+                String role,
+                AuthZResource requestedResource,
+                @Nullable ContainerRequestContext context) {
+            return true;
+        }
+    }
+}

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/BasePastisAuthorizerTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/BasePastisAuthorizerTest.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.universal.security;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.pinterest.commons.pastis.PastisAuthorizer;
+import com.pinterest.teletraan.universal.security.bean.AuthZResource;
+import com.pinterest.teletraan.universal.security.bean.ServicePrincipal;
+import com.pinterest.teletraan.universal.security.bean.UserPrincipal;
+import java.io.IOException;
+import java.util.Arrays;
+import javax.ws.rs.container.ContainerRequestContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class BasePastisAuthorizerTest {
+    private static final String principalName = "testUser";
+    private static final String spiffeId = "testSpiffe";
+    private static final String group = "testGroup";
+    private static final String actionRead = "READ";
+    private static final String actionWrite = "WRITE";
+    private static final String requestTemplate =
+            "{\"input\":{\"principal\":{\"id\":\"%s\",\"type\":\"%s\",\"groups\":[\"%s\"]},\"action\":\"%s\",\"resource\":{\"name\":\"%s\",\"type\":\"%s\"}}}";
+    private static final String serviceRequestTemplate =
+            "{\"input\":{\"principal\":{\"id\":\"%s\",\"type\":\"%s\"},\"action\":\"%s\",\"resource\":{\"name\":\"%s\",\"type\":\"%s\"}}}";
+    private static final AuthZResource resource = new AuthZResource("env", "stage");
+
+    private static ContainerRequestContext context;
+    private static PastisAuthorizer pastis;
+    private static AuthZResourceExtractor.Factory factory;
+
+    @BeforeEach
+    public void setUp() {
+        context = mock(ContainerRequestContext.class);
+        pastis = mock(PastisAuthorizer.class);
+        factory = mock(AuthZResourceExtractor.Factory.class);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {actionRead, actionWrite})
+    void testAuthorize_userPrincipal(String action) throws IOException {
+        BasePastisAuthorizer<UserPrincipal> sut = new BasePastisAuthorizer<>(pastis, factory);
+        UserPrincipal principal = new UserPrincipal(principalName, Arrays.asList(group));
+        sut.authorize(principal, action, resource, context);
+        verify(pastis)
+                .authorize(
+                        String.format(
+                                requestTemplate,
+                                principalName,
+                                principal.getType(),
+                                group,
+                                action,
+                                resource.getName(),
+                                resource.getType()));
+    }
+
+    @Test
+    void testAuthorize_userPrincipal_failure() {
+        BasePastisAuthorizer<UserPrincipal> sut = new BasePastisAuthorizer<>(pastis, factory);
+        UserPrincipal principal = new UserPrincipal(principalName, Arrays.asList(group));
+        when(pastis.authorize(anyString())).thenThrow(new RuntimeException());
+        assertFalse(sut.authorize(principal, actionRead, resource, context));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {actionRead, actionWrite})
+    void testAuthorize_servicePrincipal(String action) throws IOException {
+        BasePastisAuthorizer<ServicePrincipal> sut = new BasePastisAuthorizer<>(pastis, factory);
+        ServicePrincipal principal = new ServicePrincipal(spiffeId);
+        sut.authorize(principal, action, resource, context);
+        verify(pastis)
+                .authorize(
+                        String.format(
+                                serviceRequestTemplate,
+                                spiffeId,
+                                principal.getType(),
+                                action,
+                                resource.getName(),
+                                resource.getType()));
+    }
+
+    @Test
+    void testBuilder() {
+        assertThrows(IllegalArgumentException.class, () -> BasePastisAuthorizer.builder().build());
+        assertDoesNotThrow(() -> BasePastisAuthorizer.builder().serviceName("").build());
+        assertDoesNotThrow(() -> BasePastisAuthorizer.builder().pastis(pastis).build());
+    }
+}

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/EnvoyAuthFilterTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/EnvoyAuthFilterTest.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.universal.security;
+
+import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.pinterest.teletraan.universal.security.bean.EnvoyCredentials;
+import com.pinterest.teletraan.universal.security.bean.TeletraanPrincipal;
+import io.dropwizard.auth.AuthFilter;
+import io.dropwizard.auth.AuthenticationException;
+import io.dropwizard.auth.Authenticator;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.SecurityContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class EnvoyAuthFilterTest {
+    private static final String CERT_HEADER =
+            "C=US\";URI=spiffe://pin220.com/k8s/jupyter/fgac-test/username/testuser;DNS=fa2a9e01-dc86-477a-9661-d6ca997556ec.k8s.pin220.com";
+    private static final String SPIFFE_ID =
+            "spiffe://pin220.com/k8s/jupyter/fgac-test/username/testuser";
+
+    private ContainerRequestContext requestContext;
+    private MultivaluedMap<String, String> headers;
+    private Authenticator<EnvoyCredentials, TeletraanPrincipal> authenticator;
+
+    @BeforeEach
+    void prepareFilterTest() throws IOException, AuthenticationException {
+        requestContext = mock(ContainerRequestContext.class);
+        headers = new MultivaluedHashMap<>();
+        authenticator = new EnvoyAuthenticator();
+        when(requestContext.getHeaders()).thenReturn(headers);
+    }
+
+    @Test
+    void getSpiffeId_null() {
+        String spiffeId = EnvoyAuthFilter.getSpiffeId(null);
+        assertNull(spiffeId);
+    }
+
+    @Test
+    void getSpiffeId_valid() {
+        String spiffeId = EnvoyAuthFilter.getSpiffeId(CERT_HEADER);
+        assertEquals(SPIFFE_ID, spiffeId);
+    }
+
+    @Test
+    void getSpiffeId_invalid() {
+        String spiffeId = EnvoyAuthFilter.getSpiffeId("random stuff");
+        assertNull(spiffeId);
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "group1 group2   group3",
+                "group1,group2,,group3",
+                "group1, group2,,   group3",
+                " group1,group2,group3 "
+            })
+    void getGroups_space(String groups) {
+        List<String> groupsList = EnvoyAuthFilter.getGroups(groups);
+        assertNotNull(groupsList);
+        assertEquals(3, groupsList.size());
+    }
+
+    @Test
+    void getGroups_null() {
+        List<String> groupsList = EnvoyAuthFilter.getGroups(null);
+        assertNull(groupsList);
+    }
+
+    @Test
+    void testFilter_user() {
+        headers.put(Constants.USER_HEADER, Collections.singletonList("user"));
+        headers.put(Constants.GROUPS_HEADER, Collections.singletonList("group1 group2 group3"));
+
+        doFilterTest();
+
+        verify(requestContext).setSecurityContext(any(SecurityContext.class));
+    }
+
+    @Test
+    void testFilter_group() {
+        headers.put(Constants.CLIENT_CERT_HEADER, Collections.singletonList(CERT_HEADER));
+
+        doFilterTest();
+
+        verify(requestContext).setSecurityContext(any(SecurityContext.class));
+    }
+
+    @Test
+    void testFilter_failure() {
+        AuthFilter<EnvoyCredentials, TeletraanPrincipal> sut =
+                new EnvoyAuthFilter.Builder<TeletraanPrincipal>()
+                        .setAuthenticator(authenticator)
+                        .buildAuthFilter();
+        assertThrows(RuntimeException.class, () -> sut.filter(requestContext));
+        verify(requestContext, never()).setSecurityContext(any(SecurityContext.class));
+    }
+
+    private void doFilterTest() {
+        AuthFilter<EnvoyCredentials, TeletraanPrincipal> sut =
+                new EnvoyAuthFilter.Builder<TeletraanPrincipal>()
+                        .setAuthenticator(authenticator)
+                        .buildAuthFilter();
+
+        assertDoesNotThrow(() -> sut.filter(requestContext));
+    }
+}

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/OAuthAuthenticatorTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/OAuthAuthenticatorTest.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.universal.security;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.pinterest.teletraan.universal.security.bean.UserPrincipal;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class OAuthAuthenticatorTest {
+    private static final String GROUP_PATH = "/group/";
+    private static final String USER_PATH = "/user/";
+    private static final String USER_NAME = "devinlundberg";
+    private static final String EXAMPLE_URL = "http://example.com/";
+    private static final String EXAMPLE_BAD_URL = "http // as";
+    private static final String USER_DATA =
+            String.join(
+                    "",
+                    "{\"user\": {",
+                    "\"username\": \"devinlundberg\",",
+                    "\"first_name\": \"Devin\",",
+                    "\"last_name\": \"Lundberg\",",
+                    "\"pinterest_url\": \"http://www.pinterest.com/devin60070\",",
+                    "\"manager\": \"uid=raj,ou=people,dc=pinterest,dc=com\",",
+                    "\"department\": \"2120 Technical Operations\",",
+                    "\"employee_type\": \"fulltime\",",
+                    "\"email\": \"devinlundberg@pinterest.com\"}}");
+    private static final String GROUP_DATA = "{\"groups\": [\"g1\", \"g2\"]}";
+    private static final List<String> GROUPS = Arrays.asList("g1", "g2");
+    private MockWebServer mockWebServer;
+    private MockResponse baseResponse =
+            new MockResponse().setHeader("Content-Type", "application/json");
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidConstructorArguments")
+    void testConstructor_invalidArguments(
+            String userDataUrl, String groupDataUrl, Class<Exception> expectedException) {
+        assertThrows(expectedException, () -> new OAuthAuthenticator(userDataUrl, groupDataUrl));
+    }
+
+    @ParameterizedTest
+    @MethodSource("validConstructorArguments")
+    void testConstructor_validArguments(String userDataUrl, String groupDataUrl) {
+        assertDoesNotThrow(() -> new OAuthAuthenticator(userDataUrl, groupDataUrl));
+    }
+
+    @Test
+    void testAuthenticate_failure() throws MalformedURLException {
+        OAuthAuthenticator sut =
+                new OAuthAuthenticator(mockWebServer.url(USER_PATH).toString(), null);
+        mockWebServer.enqueue(baseResponse.clone().setBody("{\"random\": \"body\"}"));
+        Optional<UserPrincipal> userPrincipal = sut.authenticate("");
+        assertFalse(userPrincipal.isPresent());
+    }
+
+    @Test
+    void testAuthenticate_withValidUserData() throws MalformedURLException, InterruptedException {
+        OAuthAuthenticator sut =
+                new OAuthAuthenticator(mockWebServer.url(USER_PATH).toString(), null);
+        mockWebServer.enqueue(baseResponse.clone().setBody(USER_DATA));
+        Optional<UserPrincipal> userPrincipal = sut.authenticate("");
+        assertTrue(userPrincipal.isPresent());
+        assertTrue(userPrincipal.get().getGroups().isEmpty());
+        assertEquals(USER_NAME, userPrincipal.get().getName());
+    }
+
+    @Test
+    void testAuthenticate_withValidUserDataAndGroupData() throws MalformedURLException {
+        OAuthAuthenticator sut =
+                new OAuthAuthenticator(
+                        mockWebServer.url(USER_PATH).toString(),
+                        mockWebServer.url(GROUP_PATH).toString());
+        mockWebServer.enqueue(baseResponse.clone().setBody(USER_DATA));
+        mockWebServer.enqueue(baseResponse.clone().setBody(GROUP_DATA));
+        Optional<UserPrincipal> userPrincipal = sut.authenticate("");
+        assertTrue(userPrincipal.isPresent());
+        assertEquals(GROUPS, userPrincipal.get().getGroups());
+    }
+
+    @Test
+    void testAuthenticate_withValidUserDataAndInvalidGroupData() throws MalformedURLException {
+        OAuthAuthenticator sut =
+                new OAuthAuthenticator(
+                        mockWebServer.url(USER_PATH).toString(),
+                        mockWebServer.url(GROUP_PATH).toString());
+        mockWebServer.enqueue(baseResponse.clone().setBody(USER_DATA));
+        mockWebServer.enqueue(baseResponse.clone().setBody("bad data"));
+        Optional<UserPrincipal> userPrincipal = sut.authenticate("");
+        assertTrue(userPrincipal.isPresent());
+        assertTrue(userPrincipal.get().getGroups().isEmpty());
+    }
+
+    static Stream<Arguments> invalidConstructorArguments() {
+        return Stream.of(
+                Arguments.of(null, null, IllegalArgumentException.class),
+                Arguments.of(" ", null, IllegalArgumentException.class),
+                Arguments.of(EXAMPLE_BAD_URL, null, MalformedURLException.class),
+                Arguments.of(EXAMPLE_URL, EXAMPLE_BAD_URL, MalformedURLException.class),
+                Arguments.of(EXAMPLE_URL, EXAMPLE_BAD_URL, MalformedURLException.class));
+    }
+
+    static Stream<Arguments> validConstructorArguments() {
+        return Stream.of(
+                Arguments.of(EXAMPLE_URL, EXAMPLE_URL),
+                Arguments.of(EXAMPLE_URL, null),
+                Arguments.of(EXAMPLE_URL, " "));
+    }
+}

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/ScriptTokenAuthenticatorTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/ScriptTokenAuthenticatorTest.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.universal.security;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.pinterest.teletraan.universal.security.bean.ScriptTokenPrincipal;
+import com.pinterest.teletraan.universal.security.bean.ValueBasedRole;
+import io.dropwizard.auth.AuthenticationException;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ScriptTokenAuthenticatorTest {
+    private static final String CREDENTIALS = "credentials";
+    private ScriptTokenProvider<ValueBasedRole> scriptTokenProvider;
+    private ScriptTokenPrincipal<ValueBasedRole> scriptTokenPrincipal;
+    private ScriptTokenAuthenticator<ValueBasedRole> sut;
+
+    @SuppressWarnings("unchecked")
+    @BeforeEach
+    void setUp() throws Exception {
+        scriptTokenProvider = mock(ScriptTokenProvider.class);
+        scriptTokenPrincipal = mock(ScriptTokenPrincipal.class);
+        when(scriptTokenProvider.getPrincipal(anyString())).thenReturn(Optional.empty());
+        when(scriptTokenProvider.getPrincipal(CREDENTIALS))
+                .thenReturn(Optional.of(scriptTokenPrincipal));
+
+        sut = new ScriptTokenAuthenticator<>(scriptTokenProvider);
+    }
+
+    @Test
+    void testAuthenticate() throws Exception {
+        Optional<ScriptTokenPrincipal<ValueBasedRole>> principal = sut.authenticate(CREDENTIALS);
+        assertTrue(principal.isPresent());
+    }
+
+    @Test
+    void testAuthenticate_nonExistCredential() throws Exception {
+        Optional<ScriptTokenPrincipal<ValueBasedRole>> principal =
+                sut.authenticate("bad-credentials");
+        assertFalse(principal.isPresent());
+    }
+
+    @Test
+    void testAuthenticateWithException() throws Exception {
+        when(scriptTokenProvider.getPrincipal(anyString())).thenThrow(new RuntimeException());
+        assertThrows(AuthenticationException.class, () -> sut.authenticate(CREDENTIALS));
+    }
+}

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/bean/MaskBasedRoleTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/bean/MaskBasedRoleTest.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.universal.security.bean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class MaskBasedRoleTest {
+    private static final MaskBasedRole ADMIN = new MaskBasedRole(0xFFFFFFFFL);
+    private static final MaskBasedRole READ = new MaskBasedRole(0b100L);
+    private static final MaskBasedRole WRITE = new MaskBasedRole(0b010L);
+    private static final MaskBasedRole READ_WRITE = new MaskBasedRole(0b110L);
+    private static final MaskBasedRole READ_WRITE_EXECUTE = new MaskBasedRole(0b111L);
+
+    @Test
+    void testGetMask() {
+        assertEquals(0b100L, READ.getMask());
+    }
+
+    @Test
+    void testGetName() {
+        assertEquals("4294967295", ADMIN.getName());
+        assertEquals("4", READ.getName());
+        assertEquals("2", WRITE.getName());
+        assertEquals("6", READ_WRITE.getName());
+        assertEquals("7", READ_WRITE_EXECUTE.getName());
+    }
+
+    @Test
+    void testIsEqualOrSuperior_ADMIN() {
+        assertTrue(ADMIN.isEqualOrSuperior(ADMIN));
+        assertTrue(ADMIN.isEqualOrSuperior(READ));
+        assertTrue(ADMIN.isEqualOrSuperior(WRITE));
+        assertTrue(ADMIN.isEqualOrSuperior(READ_WRITE));
+        assertTrue(ADMIN.isEqualOrSuperior(READ_WRITE_EXECUTE));
+    }
+
+    @Test
+    void testIsEqualOrSuperior_READ() {
+        assertFalse(READ.isEqualOrSuperior(ADMIN));
+        assertTrue(READ.isEqualOrSuperior(READ));
+        assertFalse(READ.isEqualOrSuperior(WRITE));
+        assertFalse(READ.isEqualOrSuperior(READ_WRITE));
+        assertFalse(READ.isEqualOrSuperior(READ_WRITE_EXECUTE));
+    }
+
+    @Test
+    void testIsEqualOrSuperior_WRITE() {
+        assertFalse(WRITE.isEqualOrSuperior(ADMIN));
+        assertFalse(WRITE.isEqualOrSuperior(READ));
+        assertTrue(WRITE.isEqualOrSuperior(WRITE));
+        assertFalse(WRITE.isEqualOrSuperior(READ_WRITE));
+        assertFalse(WRITE.isEqualOrSuperior(READ_WRITE_EXECUTE));
+    }
+
+    @Test
+    void testIsEqualOrSuperior_READ_WRITE() {
+        assertFalse(READ_WRITE.isEqualOrSuperior(ADMIN));
+        assertTrue(READ_WRITE.isEqualOrSuperior(READ));
+        assertTrue(READ_WRITE.isEqualOrSuperior(WRITE));
+        assertTrue(READ_WRITE.isEqualOrSuperior(READ_WRITE));
+        assertFalse(READ_WRITE.isEqualOrSuperior(READ_WRITE_EXECUTE));
+    }
+
+    @Test
+    void testIsEqualOrSuperiorREAD_WRITE_EXECUTE() {
+        assertFalse(READ_WRITE_EXECUTE.isEqualOrSuperior(ADMIN));
+        assertTrue(READ_WRITE_EXECUTE.isEqualOrSuperior(READ));
+        assertTrue(READ_WRITE_EXECUTE.isEqualOrSuperior(WRITE));
+        assertTrue(READ_WRITE_EXECUTE.isEqualOrSuperior(READ_WRITE));
+        assertTrue(READ_WRITE_EXECUTE.isEqualOrSuperior(READ_WRITE_EXECUTE));
+    }
+}

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/bean/ValueBasedRoleTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/bean/ValueBasedRoleTest.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.universal.security.bean;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class ValueBasedRoleTest {
+    @Test
+    void testIsEqualOrSuperior() {
+        ValueBasedRole role = new ValueBasedRole(10);
+        assertTrue(role.isEqualOrSuperior(new ValueBasedRole(Integer.MIN_VALUE)));
+        assertTrue(role.isEqualOrSuperior(new ValueBasedRole(5)));
+        assertTrue(role.isEqualOrSuperior(role));
+
+        assertFalse(role.isEqualOrSuperior(new ValueBasedRole(10)));
+        assertFalse(role.isEqualOrSuperior(new ValueBasedRole(11)));
+        assertFalse(role.isEqualOrSuperior(new ValueBasedRole(Integer.MAX_VALUE)));
+    }
+}


### PR DESCRIPTION
This change reimplements the AuthN and AuthZ components. 

Had to change the github workflows to include internal dependencies in order to get this pass PR validations. 

**Stack**:
- #1485
- #1480
- #1479


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

Things remaining
- [x] More test coverage
- [x] Javadoc