### PR TITLE
Add support for composite AuthN and AuthZ filters

### DIFF
--- a/deploy-service/teletraanservice/pom.xml
+++ b/deploy-service/teletraanservice/pom.xml
@@ -166,5 +166,24 @@
                 </plugins>
             </build>
         </profile>
+
+        <profile>
+            <!-- If you are outside Pinterest, use this profile instead -->
+            <!-- i.e. mvn clean package -P-pinterest-dependenies,exclude-pinterest-only-classes -->
+            <id>exclude-pinterest-only-classes</id>
+            <build>
+              <plugins>
+                <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-compiler-plugin</artifactId>
+                  <configuration>
+                    <excludes>
+                      <exclude>com/pinterest/teletraan/config/CompositeAuthorizationFactory.java</exclude>
+                    </excludes>
+                  </configuration>
+                </plugin>
+              </plugins>
+            </build>
+          </profile>
     </profiles>
 </project>

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/CompositeAuthenticationFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/CompositeAuthenticationFactory.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.config;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.SharedMetricRegistries;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.pinterest.teletraan.TeletraanServiceContext;
+import com.pinterest.teletraan.universal.security.EnvoyAuthFilter;
+import com.pinterest.teletraan.universal.security.EnvoyAuthenticator;
+import com.pinterest.teletraan.universal.security.bean.EnvoyCredentials;
+import com.pinterest.teletraan.universal.security.bean.TeletraanPrincipal;
+import io.dropwizard.auth.AuthFilter;
+import io.dropwizard.auth.Authenticator;
+import io.dropwizard.auth.CachingAuthenticator;
+import io.dropwizard.auth.chained.ChainedAuthFilter;
+import java.util.ArrayList;
+import java.util.List;
+import javax.ws.rs.container.ContainerRequestFilter;
+import org.apache.commons.lang3.StringUtils;
+
+@JsonTypeName("composite")
+public class CompositeAuthenticationFactory extends TokenAuthenticationFactory {
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    @Override
+    public ContainerRequestFilter create(TeletraanServiceContext context) throws Exception {
+        List<AuthFilter> tokenFilters = createAuthFilters(context);
+        Authenticator<EnvoyCredentials, TeletraanPrincipal> authenticator =
+                new EnvoyAuthenticator();
+
+        if (StringUtils.isNotBlank(getTokenCacheSpec())) {
+            MetricRegistry registry = SharedMetricRegistries.getDefault();
+            Caffeine<Object, Object> cacheBuilder = Caffeine.from(getTokenCacheSpec());
+            authenticator = new CachingAuthenticator<>(registry, authenticator, cacheBuilder);
+        }
+
+        AuthFilter<EnvoyCredentials, TeletraanPrincipal> envoyAuthFilter =
+                new EnvoyAuthFilter.Builder<TeletraanPrincipal>()
+                        .setAuthenticator(authenticator)
+                        .setAuthorizer(context.getAuthorizationFactory().create(context))
+                        .buildAuthFilter();
+
+        List<AuthFilter> filters = new ArrayList<>();
+        filters.addAll(tokenFilters);
+        filters.add(envoyAuthFilter);
+
+        return new ChainedAuthFilter(filters);
+    }
+}

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/CompositeAuthorizationFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/CompositeAuthorizationFactory.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.pinterest.teletraan.TeletraanServiceContext;
+import com.pinterest.teletraan.security.ScriptTokenRoleAuthorizer;
+import com.pinterest.teletraan.security.UserRoleAuthorizer;
+import com.pinterest.teletraan.universal.security.BasePastisAuthorizer;
+import com.pinterest.teletraan.universal.security.bean.ServicePrincipal;
+import com.pinterest.teletraan.universal.security.bean.TeletraanPrincipal;
+import com.pinterest.teletraan.universal.security.bean.UserPrincipal;
+import io.dropwizard.auth.Authorizer;
+
+@JsonTypeName("composite")
+public class CompositeAuthorizationFactory implements AuthorizationFactory {
+    private static final String DEFAULT_PASTIS_SERVICE_NAME = "teletraan_dev";
+
+    @JsonProperty private String pastisServiceName = DEFAULT_PASTIS_SERVICE_NAME;
+
+    public void setPastisServiceName(String pastisServiceName) {
+        this.pastisServiceName = pastisServiceName;
+    }
+
+    public String getPastisServiceName() {
+        return pastisServiceName;
+    }
+
+    @Override
+    public <P extends TeletraanPrincipal> Authorizer<P> create(TeletraanServiceContext context)
+            throws Exception {
+        return (Authorizer<P>)
+                BasePastisAuthorizer.builder()
+                        .factory(context.getAuthZResourceExtractorFactory())
+                        .serviceName(pastisServiceName)
+                        .build();
+    }
+
+    @Override
+    public <P extends TeletraanPrincipal> Authorizer<? extends TeletraanPrincipal> create(
+            TeletraanServiceContext context, Class<P> principalClass) throws Exception {
+        if (ServicePrincipal.class.equals(principalClass)) {
+            return new ScriptTokenRoleAuthorizer(context.getAuthZResourceExtractorFactory());
+        } else if (UserPrincipal.class.equals(principalClass)) {
+            return new UserRoleAuthorizer(context, context.getAuthZResourceExtractorFactory());
+        }
+        return create(context);
+    }
+}

--- a/deploy-service/teletraanservice/src/main/resources/META-INF/services/com.pinterest.teletraan.config.AuthenticationFactory
+++ b/deploy-service/teletraanservice/src/main/resources/META-INF/services/com.pinterest.teletraan.config.AuthenticationFactory
@@ -1,2 +1,3 @@
 com.pinterest.teletraan.config.AnonymousAuthenticationFactory
 com.pinterest.teletraan.config.TokenAuthenticationFactory
+com.pinterest.teletraan.config.CompositeAuthenticationFactory


### PR DESCRIPTION
With `CompositeAuthenticationFactory` and `CompositeAuthorizationFactory`, Teletraan can be configured to run with Envoy authenticator and Pastis authorizer.

# Tests
Validated the change will not affect normal operation without changing configurations in dev1. 

**Stack**:
- #1487
- #1486
- #1485
- #1480
- #1479


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*