### PR TITLE
Added dropdown with accounts for advanced cluster settings

### DIFF
--- a/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
+++ b/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
@@ -10,6 +10,20 @@ Vue.component('cloudprovider-select', {
     }
 });
 
+Vue.component('accounts-select', {
+    template: '<div v-if="accounts">\
+  <label-select label="Account" title="Account" \
+      v-bind:value="value" \
+      v-bind:selectoptions="accounts" \
+      v-on:input="updateAccountValue"></label-select></div>',
+    props: ['accounts', 'value'],
+    methods: {
+        updateAccountValue: function (value) {
+            this.$emit('accountchange', value);
+        }
+    }
+});
+
 Vue.component('cell-select', {
     template: '<div>\
   <label-select label="Cell" title="Cell" \

--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -45,8 +45,8 @@
         <div class="container-fluid">
             <form id="clusterConfigFormId" class="form-horizontal" role="form">
                 <fieldset id="clusterConfigFieldSetId">
-                    <accounts-select v-bind:accounts="accounts" v-on:accountchange="accountChange" v-bind:value="currentAccountId"></accounts-select>
                     <cloudprovider-select v-bind:cloudproviders="providers" v-bind:value="currentProvider"></cloudprovider-select>
+                    <accounts-select v-bind:accounts="accounts" v-on:accountchange="accountChange" v-bind:value="currentAccountId"></accounts-select>
                     <cell-select v-bind:cells="cells" v-on:cellchange="cellChange"  v-bind:value="currentCell"></cell-select>
                     <label-input label="Capacity" placeholder="# of instances" v-model="instanceCount"></label-input>
                     <arch-select v-bind:arches="arches" v-on:archchange="archChange"  v-bind:value="archValue"></arch-select>

--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -45,6 +45,7 @@
         <div class="container-fluid">
             <form id="clusterConfigFormId" class="form-horizontal" role="form">
                 <fieldset id="clusterConfigFieldSetId">
+                    <accounts-select v-bind:accounts="accounts" v-on:accountchange="accountChange" v-bind:value="currentAccountId"></accounts-select>
                     <cloudprovider-select v-bind:cloudproviders="providers" v-bind:value="currentProvider"></cloudprovider-select>
                     <cell-select v-bind:cells="cells" v-on:cellchange="cellChange"  v-bind:value="currentCell"></cell-select>
                     <label-input label="Capacity" placeholder="# of instances" v-model="instanceCount"></label-input>
@@ -141,6 +142,7 @@ var capacitySetting = new Vue({
         confirmDialogTitle: "Confirm New Capacity Creation",
         confirmDialogId: "createHostGroup",
         currentProvider: info.defaultProvider,
+        currentAccountId: info.defaultAccountId,
         currentCell: info.defaultCell,
         currentArch: info.defaultArch,
         hostTypeHelpData:[],
@@ -160,6 +162,14 @@ var capacitySetting = new Vue({
         instanceCount: "",
         placements: placements.getFullList(false, null),
         placementsHelpData: [],
+        accounts: info.accounts != null ? info.accounts.map(
+            function (o) {
+                return {
+                    value: o.id,
+                    text: o.ownerId + " / " + o.name + " / " + o.description,
+                    isSelected: o.id === info.defaultAccountId,
+                }
+            }) : null,
         providers: info.providerList.map(
             function (o) {
                 return {
@@ -284,6 +294,9 @@ var capacitySetting = new Vue({
                         capacitySetting.showHostTypeHelp = true
                     }, {cell: capacitySetting.currentCell})
             }
+        },
+        accountChange: function (value) {
+            capacitySetting.currentAccountId = value;
         },
         cellChange: function(value) {
             capacitySetting.currentCell = value;
@@ -575,6 +588,7 @@ var capacitySetting = new Vue({
             clusterInfo['securityZone'] = this.selectedSecurityZoneValue;
             clusterInfo['replacementTimeout'] = this.replacementTimeout;
             clusterInfo['statefulStatus'] =  this.selectedStatefulStatus;
+            clusterInfo['accountId'] = this.currentAccountId;
             if (this.selectedPlacements != null && this.selectedPlacements.length>0){
                 clusterInfo['placement'] = this.selectedPlacements.join(',');
             }

--- a/deploy-board/deploy_board/webapp/cluster_view.py
+++ b/deploy-board/deploy_board/webapp/cluster_view.py
@@ -31,7 +31,7 @@ import json
 import logging
 
 from .helpers import baseimages_helper, hosttypes_helper, securityzones_helper, placements_helper, \
-    autoscaling_groups_helper, groups_helper, cells_helper, arches_helper
+    autoscaling_groups_helper, groups_helper, cells_helper, arches_helper, accounts_helper
 from .helpers import clusters_helper, environs_helper, environ_hosts_helper, baseimages_helper
 from .helpers.exceptions import NotAuthorizedException, TeletraanException, IllegalArgumentException
 from . import common
@@ -147,6 +147,9 @@ class EnvCapacityAdvCreateView(View):
         base_images_names = baseimages_helper.get_image_names_by_arch(
             request, DEFAULT_PROVIDER, DEFAULT_CELL, DEFAULT_ARCH)
 
+        accounts = accounts_helper.get_all_accounts(request)
+        default_account = get_default_account(accounts)
+
         env = environs_helper.get_env_by_stage(request, name, stage)
         provider_list = baseimages_helper.get_all_providers(request)
 
@@ -173,7 +176,9 @@ class EnvCapacityAdvCreateView(View):
             'configList': get_aws_config_name_list_by_image(DEFAULT_CMP_IMAGE),
             'enable_ami_auto_update': ENABLE_AMI_AUTO_UPDATE,
             'stateful_status': clusters_helper.StatefulStatuses.get_status(None),
-            'stateful_options': clusters_helper.StatefulStatuses.get_all_statuses()
+            'stateful_options': clusters_helper.StatefulStatuses.get_all_statuses(),
+            'accounts': list(map(create_ui_account, accounts)) if accounts is not None else None,
+            'defaultAccountId': default_account['id'] if default_account is not None else None,
         }
         # cluster manager
         return render(request, 'configs/new_capacity_adv.html', {
@@ -566,6 +571,25 @@ def get_base_image_info_by_name(request, name, cell):
         return with_acceptance_rs
     return baseimages_helper.get_by_name(request, name, cell)
 
+
+def create_ui_account(account):
+    if account is None:
+        return None
+    return {
+        'id': account['id'],
+        'name': account['name'],
+        'description': account['description'],
+        'ownerId': account['data']['ownerId'],
+    }
+
+
+def get_default_account(accounts):
+    if accounts is None:
+        return None
+    for account in accounts:
+        if account['name'] == 'default':
+            return account
+    return None
 
 def get_base_images_by_name_json(request, name):
     cell = DEFAULT_CELL
@@ -1107,7 +1131,7 @@ def sanitize_slack_email_input(input):
     res = ''
     if input == None or len(input) == 0:
         return res
-    
+
     tokens = input.strip().split(',')
     for e in tokens:
         e = e.strip()
@@ -1176,7 +1200,7 @@ def submit_auto_refresh_config(request, name, stage):
     auto_refresh_config["bakeTime"] = params["bakeTime"]
     auto_refresh_config["config"] = rollingUpdateConfig
     auto_refresh_config["type"] = "LATEST"
-    
+
     emails = params["emails"]
     slack_channels = params["slack_channels"]
 

--- a/deploy-board/deploy_board/webapp/helpers/accounts_helper.py
+++ b/deploy-board/deploy_board/webapp/helpers/accounts_helper.py
@@ -1,0 +1,15 @@
+from deploy_board.webapp.helpers.rodimus_client import RodimusClient
+import logging
+
+log = logging.getLogger(__name__)
+
+rodimus_client = RodimusClient()
+
+
+def get_all_accounts(request):
+    try:
+        return rodimus_client.get("/accounts", request.teletraan_user_id.token, {"provider": "AWS"})
+    except Exception as e:
+        log.error(f"Can't get all accounts: error = {e}")
+        # return None for backward-compatibility
+        return None


### PR DESCRIPTION
## Context
- Added dropdown with accounts for advanced cluster settings
- User can choose from what account cluster should be provisioned

## Test Plan

- [x] Provision cluster from specified account in UI.
- [x] Test update cluster from UI.

<details>
<summary>Test Details</summary>

## Provision cluster from specified account in UI

### Create cluster: basic settings

Unchanged ✅

![Screenshot 2024-03-05 at 12 08 13 PM](https://github.com/pinterest/teletraan/assets/20383875/eaba1d39-914a-42c8-9c40-e27dd15e1dbc)

### Create cluster: advanced settings

#### Default account ✅
![Screenshot 2024-03-05 at 2 53 42 PM](https://github.com/pinterest/teletraan/assets/20383875/3ce078ef-2ade-4c8e-85d3-cc5406042846)

#### Accounts dropdown ✅
![Screenshot 2024-03-05 at 2 55 08 PM](https://github.com/pinterest/teletraan/assets/20383875/d9f3d2bd-168e-430b-aff0-e59ef1313ede)

#### Cluster provision for default account from UI works ✅

#### Cluster provision not works due to a bug in Rodimus, but UI works ✅
<img width="859" alt="Screenshot 2024-03-05 at 4 09 32 PM" src="https://github.com/pinterest/teletraan/assets/20383875/e8c0049a-2a70-40bb-9fb2-971956674f1f">


</details>

## Test Results

UI works as expected, but cluster provisioning from UI not works due to the bug in the cluster provisioning service. AWS account has a lack of some policies:
<img width="859" alt="Screenshot 2024-03-05 at 4 09 32 PM" src="https://github.com/pinterest/teletraan/assets/20383875/e8c0049a-2a70-40bb-9fb2-971956674f1f">

The bug will be fixed in the Jira task CDP-7717.

Links and ids have removed from screenshots due to security reasons and open source nature of the project.