### PR TITLE
Add http download failure metric

### DIFF
--- a/deploy-agent/deployd/common/helper.py
+++ b/deploy-agent/deployd/common/helper.py
@@ -45,6 +45,16 @@ class Helper(object):
             log.debug("OSError: {} does not exist.".format(builds_dir))
         finally:
             return builds
+        
+    @staticmethod
+    def get_build_name(filename) -> str:
+        """
+        Extract build name from the file name
+        In downloader.py, we have the following name convenion
+             local_fn = u'{}-{}.{}'.format(self._build_name, self._build, extension)
+        """
+        fn_without_extension = filename.split('.')[0]
+        return fn_without_extension.rsplit('-', 1)[0]
 
     @staticmethod
     def get_build_id(filename, env_name) -> Tuple[bool, Optional[str]]:

--- a/deploy-agent/deployd/common/helper.py
+++ b/deploy-agent/deployd/common/helper.py
@@ -47,7 +47,7 @@ class Helper(object):
             return builds
         
     @staticmethod
-    def get_build_name(filename) -> str:
+    def get_build_name(filename: str) -> str:
         """
         Extract build name from the file name
         In downloader.py, we have the following name convenion

--- a/deploy-agent/deployd/download/http_download_helper.py
+++ b/deploy-agent/deployd/download/http_download_helper.py
@@ -55,6 +55,7 @@ class HTTPDownloadHelper(DownloadHelper):
         status_code = self._download_files(local_full_fn)
         if status_code != Status.SUCCEEDED:
             log.error('Failed to download the tar ball for {}'.format(local_full_fn))
+            create_sc_increment('deployd.failed.agent.download', tags=tags)
             return status_code
 
         try:

--- a/deploy-agent/deployd/download/http_download_helper.py
+++ b/deploy-agent/deployd/download/http_download_helper.py
@@ -14,6 +14,7 @@ from __future__ import absolute_import
 # limitations under the License.
 
 from deployd.common.caller import Caller
+from deployd.common.helper import Helper
 from deployd.common.status_code import Status
 from deployd.common.config import Config
 from deployd.download.download_helper import DownloadHelper, DOWNLOAD_VALIDATE_METRICS
@@ -55,7 +56,9 @@ class HTTPDownloadHelper(DownloadHelper):
         status_code = self._download_files(local_full_fn)
         if status_code != Status.SUCCEEDED:
             log.error('Failed to download the tar ball for {}'.format(local_full_fn))
-            create_sc_increment('deployd.failed.agent.download', tags=tags)
+            build_name = Helper.get_build_name(local_full_fn.rsplit('/', 1)[-1])
+            tags = {'type': 'http', 'build_name': build_name }
+            create_sc_increment('deployd.stats.download.failed', tags=tags)
             return status_code
 
         try:

--- a/deploy-agent/tests/unit/deploy/utils/test_agent.py
+++ b/deploy-agent/tests/unit/deploy/utils/test_agent.py
@@ -86,6 +86,15 @@ class TestAgentHelperFunctions(tests.FileTestCase):
         self.assertFalse(Helper.get_build_id("whateverfile.tar.gz", "cmp_test")[0])
         self.assertFalse(Helper.get_build_id("cmp_test-tmp", "cmp_test")[0])
 
+    def test_get_build_name(self):
+        """
+        Test get_build_name method
+        """
+        self.assertEqual(Helper.get_build_name("cmp_test-r4TTZfrWQEmgyaYic8uU6w_8ef9007.tar.gz"),
+            "cmp_test")
+        self.assertEqual(Helper.get_build_name("cmp_test-r4TTZfrWQEmgyaYic8uU6w_8ef9007.zip"),
+            "cmp_test")
+
     def test_get_uptime(self):
         """
         Test utils.uptime()


### PR DESCRIPTION
Add a http download failure metric emission to the deploy-agent.

#### Tested on devapp by running
```bash
> IS_PINTEREST=true METRIC_PORT_HEALTH=18126 METRIC_CACHE_PATH=/mnt/deployd/metrics.cache /home/ruizhu/code/teletraan/deploy-agent/bazel-bin/deployd/deploy-downloader -f /etc/deployagent.conf -v nonexistant_aa874a6 -u https://deployrepo.pinadmin.com/deploy-agent-pex/non_existant-aa874a6.tar.gz -e deploy-init
2024-03-07 03:53:30,000:INFO: Start to download the package.
2024-03-07 03:53:30,000:INFO: Start to download from url https://deployrepo.pinadmin.com/deploy-agent-pex/non_existant-aa874a6.tar.gz to /mnt/builds/deploy-init-nonexistant_aa874a6.tar.gz
2024-03-07 03:53:30,000:INFO: Running command: curl -o /mnt/builds/deploy-init-nonexistant_aa874a6.tar.gz -fksS https://deployrepo.pinadmin.com/deploy-agent-pex/non_existant-aa874a6.tar.gz
2024-03-07 03:53:30,070:INFO: [0.07]curl: (22) The requested URL returned error: 404 Not Found
2024-03-07 03:53:30,070:INFO: Finish downloading: https://deployrepo.pinadmin.com/deploy-agent-pex/non_existant-aa874a6.tar.gz to /mnt/builds/deploy-init-nonexistant_aa874a6.tar.gz
2024-03-07 03:53:30,070:ERROR: Failed to download the tar ball for /mnt/builds/deploy-init-nonexistant_aa874a6.tar.gz
2024-03-07 03:53:30,070:ERROR: Download failed.
```
#### metric being populated
<img width="829" alt="Screenshot 2024-03-06 at 10 47 56 PM" src="https://github.com/pinterest/teletraan/assets/104773032/238e46fe-8959-4b63-852b-23091e6e7096">
