### PR TITLE
Added deduplication and sorting for displayed accounts in the dropdown menu

### DIFF
--- a/deploy-board/deploy_board/webapp/cluster_view.py
+++ b/deploy-board/deploy_board/webapp/cluster_view.py
@@ -177,7 +177,7 @@ class EnvCapacityAdvCreateView(View):
             'enable_ami_auto_update': ENABLE_AMI_AUTO_UPDATE,
             'stateful_status': clusters_helper.StatefulStatuses.get_status(None),
             'stateful_options': clusters_helper.StatefulStatuses.get_all_statuses(),
-            'accounts': list(map(create_ui_account, accounts)) if accounts is not None else None,
+            'accounts': create_ui_accounts(accounts),
             'defaultAccountId': default_account['id'] if default_account is not None else None,
         }
         # cluster manager
@@ -587,6 +587,15 @@ def create_ui_account(account):
         'description': account['description'],
         'ownerId': account['data']['ownerId'],
     }
+
+
+def create_ui_accounts(accounts):
+    if accounts is None:
+        return None
+
+    deduplicated_accounts = {account['id']: account for account in accounts}.values()
+    sorted_accounts = sorted(deduplicated_accounts, key=lambda account: account['name'])
+    return list(map(create_ui_account, sorted_accounts))
 
 
 def get_default_account(accounts):


### PR DESCRIPTION
## Context

Added deduplication and sorting for displayed accounts in the dropdown menu. Fixes an issue when Teletraan receives duplicates of accounts with the same id for different cells. (But that accounts contains different configs as well, that's why we need them to store in Rodimus)

## Tests

### Before these changes

![Screenshot 2024-03-07 at 5 22 24 PM](https://github.com/pinterest/teletraan/assets/20383875/ef35de5c-403c-407a-8e5b-233e88fb2f75)

### After these changes

![Screenshot 2024-03-07 at 5 37 48 PM](https://github.com/pinterest/teletraan/assets/20383875/bb2fa2c3-a7a7-4670-90f1-c25bafe9b608)


