### PR TITLE
Add secondary key for fetching az key

### DIFF
--- a/deploy-agent/deployd/__init__.py
+++ b/deploy-agent/deployd/__init__.py
@@ -27,4 +27,4 @@ REDEPLOY_MAX_RETRY = 3
 # 2: puppet applied successfully with changes
 PUPPET_SUCCESS_EXIT_CODES = [0, 2]
 
-__version__ = '1.2.59'
+__version__ = '1.2.60'

--- a/deploy-agent/deployd/common/config.py
+++ b/deploy-agent/deployd/common/config.py
@@ -282,6 +282,9 @@ class Config(object):
     def get_facter_az_key(self) -> Optional[str]:
         return self.get_var('availability_zone_key', None)
 
+    def get_facter_secondary_az_key(self) -> Optional[str]:
+        return self.get_var('secondary_availability_zone_key', 'ec2_metadata.placement.availability-zone')
+
     def get_facter_ec2_tags_key(self) -> Optional[str]:
         return self.get_var('ec2_tags_key', None)
 


### PR DESCRIPTION
## Summary 
There are cases where the fact with primary key is not available such as puppet did not finish, fetch az fact from another key 

## Test plan 
https://deploy.pinadmin.com/env/deploy-init/test/deploy/
Deploy a new version and restart helloworld deployment 
```
 Host information is loaded. Host name: helloworlddummyservice-server-u20-0a0311fd, IP: 10.3.17.253, host id: i-06e65262a286e5a58, agent_version=1.2.46-pinterest-1.0.2, autoscaling_group: helloworlddummyservice-server-u20, **availability_zone: us-east-1a**, ec2_tags: {"Autoscaling": "helloworlddummyservice-server-u20", "Name": "helloworlddummyservice-server-u20-0a0311fd", "aws:autoscaling:groupName": "helloworlddummyservice-server-u20", "aws:ec2launchtemplate:id": "lt-09d19658f55f87567", "aws:ec2launchtemplate:version": "13", "pinterest.com/identity": "nimbus.teletraan.teletraan.aws-us-east-1.helloworlddummyservice-server.u20", "pinterest.com/nimbus-uuid": "9d24629e-3673-41b1-872f-f2c3887a28a1", "service_mapping": "helloworlddummyservice-server", "usage_tag": "SRE", "availability_zone": "us-east-1a"}, stage_type: None, group: ['CMP', 'helloworlddummyservice-server-u20', 'metrics-agent-prod-sidecar', 'singer-prod-sidecar', 'mcrouter-prod-sidecar', 'envoy-sidecar', 'tcollector-prod-sidecar', 'zk_update_monitor-prod-sidecar'], account id: 998131032990
 ```
 Remove the primary key and restart deployment, fetch info from the secondary fact key 
 I0308 22:20:05.907.7978134155273 MainThread /root/.pex/installed_wheels/b947a9193e85a595eee5e84664cd4e641a0fc43acd6f538159a94e60f623e869/deploy_agent-1.2.60-py3-none-any.whl/deployd/client/client.py:199] Host information is loaded. Host name: helloworlddummyservice-server-u20-0a0311fd, IP: 10.3.17.253, host id: i-06e65262a286e5a58, agent_version=1.2.46-pinterest-1.0.2, autoscaling_group: helloworlddummyservice-server-u20, **availability_zone: us-east-1a**, ec2_tags: {"Autoscaling": "helloworlddummyservice-server-u20", "Name": "helloworlddummyservice-server-u20-0a0311fd", "aws:autoscaling:groupName": "helloworlddummyservice-server-u20", "aws:ec2launchtemplate:id": "lt-09d19658f55f87567", "aws:ec2launchtemplate:version": "13", "pinterest.com/identity": "nimbus.teletraan.teletraan.aws-us-east-1.helloworlddummyservice-server.u20", "pinterest.com/nimbus-uuid": "9d24629e-3673-41b1-872f-f2c3887a28a1", "service_mapping": "helloworlddummyservice-server", "usage_tag": "SRE", "availability_zone": "us-east-1a"}, stage_type: None, group: ['CMP', 'helloworlddummyservice-server-u20', 'metrics-agent-prod-sidecar', 'singer-prod-sidecar', 'mcrouter-prod-sidecar', 'envoy-sidecar', 'tcollector-prod-sidecar', 'zk_update_monitor-prod-sidecar'], account id: 998131032990