### PR TITLE
hide links for cluster cmp_base profiles

### DIFF
--- a/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
+++ b/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
@@ -190,8 +190,8 @@ Vue.component('aws-user-data', {
                 return acc;
             }, {});
 
-            // hide link for cmp_base cluster profiles
-            if (userDataObj['pinfo_cluster'] && userDataObj['pinfo_role'] === 'cmp_base') {
+            // hide link for cmp_base profiles
+            if (userDataObj['pinfo_role'] === 'cmp_base') {
                 return ' ';
             }
             const hieraPaths = this.hierapaths.trim().split("\n").reduce(

--- a/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
+++ b/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
@@ -189,6 +189,11 @@ Vue.component('aws-user-data', {
                 acc[entry.name] = entry.value;
                 return acc;
             }, {});
+
+            // hide link for cmp_base cluster profiles
+            if (userDataObj['pinfo_cluster'] && userDataObj['pinfo_role'] === 'cmp_base') {
+                return ' ';
+            }
             const hieraPaths = this.hierapaths.trim().split("\n").reduce(
                 (acc, line) => acc.set(line, [
                     ...new Set(line.matchAll(/(?<=%{::)[a-z0-9_]+(?=})/gi).map(val => val[0]))


### PR DESCRIPTION
If a host has `pinfo_role` set to `cmp_base` and `pinfo_cluster` is also defined, hide the link.

#### cmp_base hidden link
<img width="1115" alt="Screenshot 2024-03-08 at 4 24 55 PM" src="https://github.com/pinterest/teletraan/assets/104773032/0de12e12-10db-4cf4-8049-d17709772116">

#### regression manual testing
<img width="1093" alt="Screenshot 2024-03-08 at 4 02 52 PM" src="https://github.com/pinterest/teletraan/assets/104773032/3bc15934-372f-4a2c-88e6-cac1302ce56d">
<img width="1111" alt="Screenshot 2024-03-08 at 4 02 18 PM" src="https://github.com/pinterest/teletraan/assets/104773032/79c217bc-2e4a-404d-a850-a930a88d4cf3">
<img width="1097" alt="Screenshot 2024-03-08 at 4 02 07 PM" src="https://github.com/pinterest/teletraan/assets/104773032/791cce04-b958-427c-8602-9ae891372389">

<img width="1094" alt="Screenshot 2024-03-08 at 4 02 36 PM" src="https://github.com/pinterest/teletraan/assets/104773032/73d8e20b-d70c-45ff-824d-075aede8442a">
