### PR TITLE
Fixed displaying the dropdown for the list of accounts

### DIFF
--- a/deploy-board/deploy_board/templates/environs/env_landing.html
+++ b/deploy-board/deploy_board/templates/environs/env_landing.html
@@ -440,53 +440,54 @@ $('#privateBldUploadBtnId button').click(function () {
                 </div>
 
                 <div class="btn-group">
-                    <button class="deployToolTip btn btn-default btn-sm dropdown-toggle"
-                            title="Change how the hosts are displayed based on Account"
-                            data-toggle="dropdown" type="button">
-                        Account <span class="caret"></span>
-                    </button>
-                    <ul class="dropdown-menu" role="menu">
-                        <form id="accountFormId">
-                        <li>
-                            <div class="radio"><label>&nbsp;
-                            <input type="radio" name="account" value="all"
-                            {% if report.account == "all" %}
-                            checked
-                            {% endif %}
-                            > All
-                            </label></div>
-                        </li>
-                        <li>
-                            <div class="radio"><label>&nbsp;
-                            <input type="radio" name="account" value="{{ primaryAccount }}"
-                            {% if report.account == primaryAccount %}
-                            checked
-                            {% endif %}
-                            > {{ primaryAccount }}
-                            </label></div>
-                        </li>
-                        <li>
-                            <div class="radio"><label>&nbsp;
-                            <input type="radio" name="account" value="{{ subAccount }}"
-                            {% if report.account == subAccount %}
-                            checked
-                            {% endif %}
-                            > {{ subAccount }}
-                            </label></div>
-                        </li>
-                        <li>
-                            <div class="radio"><label>&nbsp;
-                            <input type="radio" name="account" value="others"
-                            {% if report.account == "others" %}
-                            checked
-                            {% endif %}
-                            > Others
-                            </label></div>
-                        </li>
-                        </form>
-                    </ul>
+                    <div class="dropdown">
+                        <button class="deployToolTip btn btn-default btn-sm dropdown-toggle"
+                                title="Change how the hosts are displayed based on Account"
+                                data-toggle="dropdown" type="button">
+                            Account <span class="caret"></span>
+                        </button>
+                        <ul class="dropdown-menu" role="menu">
+                            <form id="accountFormId">
+                                <li>
+                                    <div class="radio"><label>&nbsp;
+                                        <input type="radio" name="account" value="all"
+                                               {% if report.account == "all" %}
+                                        checked
+                                        {% endif %}
+                                        > All
+                                    </label></div>
+                                </li>
+                                <li>
+                                    <div class="radio"><label>&nbsp;
+                                        <input type="radio" name="account" value="{{ primaryAccount }}"
+                                               {% if report.account == primaryAccount %}
+                                               checked
+                                               {% endif %}
+                                        > {{ primaryAccount }}
+                                    </label></div>
+                                </li>
+                                <li>
+                                    <div class="radio"><label>&nbsp;
+                                        <input type="radio" name="account" value="{{ subAccount }}"
+                                               {% if report.account == subAccount %}
+                                               checked
+                                               {% endif %}
+                                        > {{ subAccount }}
+                                    </label></div>
+                                </li>
+                                <li>
+                                    <div class="radio"><label>&nbsp;
+                                        <input type="radio" name="account" value="others"
+                                               {% if report.account == "others" %}
+                                        checked
+                                        {% endif %}
+                                        > Others
+                                    </label></div>
+                                </li>
+                            </form>
+                        </ul>
                     </div>
-
+                </div>
             </div>
         </div>
 

--- a/deploy-board/deploy_board/templates/environs/env_landing.html
+++ b/deploy-board/deploy_board/templates/environs/env_landing.html
@@ -446,7 +446,7 @@ $('#privateBldUploadBtnId button').click(function () {
                                 data-toggle="dropdown" type="button">
                             Account <span class="caret"></span>
                         </button>
-                        <ul class="dropdown-menu" role="menu">
+                        <ul class="dropdown-menu dropdown-menu-right" role="menu">
                             <form id="accountFormId">
                                 <li>
                                     <div class="radio"><label>&nbsp;


### PR DESCRIPTION
# Context

Accounts list dropdown shown incorrectly previously. I used Bootstrap class `pull-right` to fix it.

# Tests 

This is minor UI changes, so tests have done locally.

## Before this changes

Dropdown menu was displayed outside of the screen.

![Screenshot 2024-03-12 at 2 03 54 PM](https://github.com/pinterest/teletraan/assets/20383875/6ce239a9-4450-4f97-b3ac-801d99eb9de5)

## After this changes

Dropdown menu was displayed normally.

![Screenshot 2024-03-12 at 2 04 43 PM](https://github.com/pinterest/teletraan/assets/20383875/1a6328cb-3652-4745-b2f4-c9007cd9f803)
