### PR TITLE
Added displaying accounts on an environment page

### DIFF
--- a/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
@@ -4,26 +4,27 @@
 {% include "deploys/deploy_progress_summary.tmpl" %}
 
 {% if report.showMode != "simple" %}
+
+<div class="panel panel-default">
+<div class="panel-heading clearfix">
+    <h4 class="panel-title pull-left"><i class="fa fa-fw fa-user"></i> Accounts</h4>
+</div>
+<div class="panel-body">
+    <div class="row">
+        {% for account in accounts %}
+            <a href="#" class="deployToolTip btn btn-xs btn-default host-btn">
+                <small>{{ account }}</small>
+                <i class="fa fa-fw fa-user"></i>
+            </a>
+        {% endfor %}
+    </div>
+</div>
+
 <div class="panel panel-default">
 <div class="panel-heading clearfix">
     <h4 class="panel-title pull-left">Hosts</h4>
 </div>
 <div class="panel-body">
-    {% if report.showMode != "compact" %}
-        <div class="row">
-            <div class="col-6">
-                <strong>Accounts:</strong>
-            </div>
-        </div>
-        <div class="row">
-            {% for account in accounts %}
-                <a href="#" class="deployToolTip btn btn-xs host-btn">
-                    <small>{{ account }}</small>
-                    <i class="fa fa-fw fa-user"></i>
-                </a>
-            {% endfor %}
-        </div>
-    {% endif %}
     <div class="row">
     {% for agentStat in report.agentStats %}
         {% if report.account == primaryAccount %}

--- a/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
@@ -9,16 +9,21 @@
     <h4 class="panel-title pull-left">Hosts</h4>
 </div>
 <div class="panel-body">
-    <div class="row">
-        <div class="col-6">
-            <strong>Accounts:</strong>
-        </div>
-    </div>
-    {% for account in accounts %}
+    {% if report.showMode != "compact" %}
         <div class="row">
-            <a href="#" class="deployToolTip btn btn-xs host-btn"><i class="fa fa-fw fa-user"></i> {{ account }}</a>
+            <div class="col-6">
+                <strong>Accounts:</strong>
+            </div>
         </div>
-    {% endfor %}
+        <div class="row">
+            {% for account in accounts %}
+                <a href="#" class="deployToolTip btn btn-xs host-btn">
+                    <small>{{ account }}</small>
+                    <i class="fa fa-fw fa-user"></i>
+                </a>
+            {% endfor %}
+        </div>
+    {% endif %}
     <div class="row">
     {% for agentStat in report.agentStats %}
         {% if report.account == primaryAccount %}

--- a/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
@@ -13,7 +13,7 @@
         <div class="row">
             {% for account in accounts %}
                 <a href="#" class="deployToolTip btn btn-xs btn-default host-btn">
-                    <small>{{ account }}</small>
+                    <small>{{ account.name }}</small>
                     <i class="fa fa-fw fa-user"></i>
                 </a>
             {% endfor %}

--- a/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
@@ -16,7 +16,7 @@
     </div>
     {% for account in accounts %}
         <div class="row">
-            <span class="label label-primary"><i class="fa fa-fw fa-user"></i> {{ account }}</span>
+            <a href="#" class="deployToolTip btn btn-xs host-btn"><i class="fa fa-fw fa-user"></i> {{ account }}</a>
         </div>
     {% endfor %}
     <div class="row">

--- a/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
@@ -10,6 +10,16 @@
 </div>
 <div class="panel-body">
     <div class="row">
+        <div class="col-6">
+            <strong>Accounts:</strong>
+        </div>
+    </div>
+    {% for account in accounts %}
+        <div class="row">
+            <span class="label label-primary">account.name</span>
+        </div>
+    {% endfor %}
+    <div class="row">
     {% for agentStat in report.agentStats %}
         {% if report.account == primaryAccount %}
             {% if not agentStat.agent.accountId or agentStat.agent.accountId == primaryAccount or agentStat.agent.accountId == "null" %}

--- a/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
@@ -16,7 +16,7 @@
     </div>
     {% for account in accounts %}
         <div class="row">
-            <span class="label label-primary">account.name</span>
+            <span class="label label-primary"><i class="fa fa-fw fa-user"></i> {{ account }}</span>
         </div>
     {% endfor %}
     <div class="row">

--- a/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
@@ -4,23 +4,6 @@
 {% include "deploys/deploy_progress_summary.tmpl" %}
 
 {% if report.showMode != "simple" %}
-
-<div class="panel panel-default">
-    <div class="panel-heading clearfix">
-        <h4 class="panel-title pull-left"><i class="fa fa-fw fa-user"></i> Accounts</h4>
-    </div>
-    <div class="panel-body">
-        <div class="row">
-            {% for account in accounts %}
-                <a href="#" class="deployToolTip btn btn-xs btn-default host-btn">
-                    <small>{{ account.name }}</small>
-                    <i class="fa fa-fw fa-user"></i>
-                </a>
-            {% endfor %}
-        </div>
-    </div>
-</div>
-
 <div class="panel panel-default">
 <div class="panel-heading clearfix">
     <h4 class="panel-title pull-left">Hosts</h4>
@@ -295,6 +278,22 @@
     </a>
 </div>
 {% endwith %}
+
+<div class="panel panel-default">
+    <div class="panel-heading clearfix">
+        <h4 class="panel-title pull-left"><i class="fa fa-fw fa-user"></i> Accounts</h4>
+    </div>
+    <div class="panel-body">
+        <div class="row">
+            {% for account in accounts %}
+                <a href="#" class="deployToolTip btn btn-xs btn-default host-btn">
+                    <small>{{ account.name }}</small>
+                    <i class="fa fa-fw fa-user"></i>
+                </a>
+            {% endfor %}
+        </div>
+    </div>
+</div>
 
 <script>
     $(function () {

--- a/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
@@ -6,17 +6,18 @@
 {% if report.showMode != "simple" %}
 
 <div class="panel panel-default">
-<div class="panel-heading clearfix">
-    <h4 class="panel-title pull-left"><i class="fa fa-fw fa-user"></i> Accounts</h4>
-</div>
-<div class="panel-body">
-    <div class="row">
-        {% for account in accounts %}
-            <a href="#" class="deployToolTip btn btn-xs btn-default host-btn">
-                <small>{{ account }}</small>
-                <i class="fa fa-fw fa-user"></i>
-            </a>
-        {% endfor %}
+    <div class="panel-heading clearfix">
+        <h4 class="panel-title pull-left"><i class="fa fa-fw fa-user"></i> Accounts</h4>
+    </div>
+    <div class="panel-body">
+        <div class="row">
+            {% for account in accounts %}
+                <a href="#" class="deployToolTip btn btn-xs btn-default host-btn">
+                    <small>{{ account }}</small>
+                    <i class="fa fa-fw fa-user"></i>
+                </a>
+            {% endfor %}
+        </div>
     </div>
 </div>
 

--- a/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
@@ -5,6 +5,9 @@
 
 {% if report.showMode != "simple" %}
 <div class="panel panel-default">
+<div class="panel-heading clearfix">
+    <h4 class="panel-title pull-left">Hosts</h4>
+</div>
 <div class="panel-body">
     <div class="row">
     {% for agentStat in report.agentStats %}

--- a/deploy-board/deploy_board/templates/environs/env_landing.html
+++ b/deploy-board/deploy_board/templates/environs/env_landing.html
@@ -457,32 +457,17 @@ $('#privateBldUploadBtnId button').click(function () {
                                         > All
                                     </label></div>
                                 </li>
-                                <li>
-                                    <div class="radio">
-                                        <label>&nbsp;
-                                            <input type="radio" name="showMode" value="simple"> Test Account
-                                        </label>
-                                    </div>
-                                </li>
-                                <li role="separator" class="divider"></li>
-                                <li>
-                                    <div class="radio"><label>&nbsp;
-                                        <input type="radio" name="account" value="{{ primaryAccount }}"
-                                               {% if report.account == primaryAccount %}
-                                               checked
-                                               {% endif %}
-                                        > {{ primaryAccount }}
-                                    </label></div>
-                                </li>
-                                <li>
-                                    <div class="radio"><label>&nbsp;
-                                        <input type="radio" name="account" value="{{ subAccount }}"
-                                               {% if report.account == subAccount %}
-                                               checked
-                                               {% endif %}
-                                        > {{ subAccount }}
-                                    </label></div>
-                                </li>
+                                {% for account in accounts %}
+                                    <li>
+                                        <div class="radio"><label>&nbsp;
+                                            <input type="radio" name="account" value="{{ account.ownerId }}"
+                                                   {% if report.account == account.ownerId %}
+                                                   checked
+                                                   {% endif %}
+                                            > {{ account.name }}
+                                        </label></div>
+                                    </li>
+                                {% endfor %}
                                 <li>
                                     <div class="radio"><label>&nbsp;
                                         <input type="radio" name="account" value="others"

--- a/deploy-board/deploy_board/templates/environs/env_landing.html
+++ b/deploy-board/deploy_board/templates/environs/env_landing.html
@@ -464,7 +464,7 @@ $('#privateBldUploadBtnId button').click(function () {
                                                    {% if report.account == account.ownerId %}
                                                    checked
                                                    {% endif %}
-                                            > {{ account.name }}
+                                            > {{ account.ownerId }}
                                         </label></div>
                                     </li>
                                 {% endfor %}

--- a/deploy-board/deploy_board/templates/environs/env_landing.html
+++ b/deploy-board/deploy_board/templates/environs/env_landing.html
@@ -458,15 +458,6 @@ $('#privateBldUploadBtnId button').click(function () {
                                     </label></div>
                                 </li>
                                 <li>
-                                    <div class="radio"><label>&nbsp;
-                                        <input type="radio" name="showMode" value="simple"
-                                               {% if report.showMode == "simple" %}
-                                        checked
-                                        {% endif %}
-                                        > Simple
-                                    </label></div>
-                                </li>
-                                <li>
                                     <div class="radio">
                                         <label>&nbsp;
                                             <input type="radio" name="showMode" value="simple"> Test Account

--- a/deploy-board/deploy_board/templates/environs/env_landing.html
+++ b/deploy-board/deploy_board/templates/environs/env_landing.html
@@ -389,52 +389,52 @@ $('#privateBldUploadBtnId button').click(function () {
                 </button>
                 <ul class="dropdown-menu" role="menu">
                     <form id="updateModeFormId">
-                    <li>
-                        <div class="radio"><label>&nbsp;
-                        <input type="radio" name="showMode" value="simple"
-                        {% if report.showMode == "simple" %}
-                        checked
-                        {% endif %}
-                        > Simple
-                        </label></div>
-                    </li>
-                    <li>
-                        <div class="radio"><label>&nbsp;
-                        <input type="radio" name="showMode" value="compact"
-                        {% if report.showMode == "compact" %}
-                        checked
-                        {% endif %}
-                        > Compact
-                        </label></div>
-                    </li>
-                    <li>
-                        <div class="radio"><label>&nbsp;
-                        <input type="radio" name="showMode" value="complete"
-                        {% if report.showMode == "complete" %}
-                        checked
-                        {% endif %}
-                        > Complete
-                        </label></div>
-                    </li>
-                    <li>
-                        <div class="radio"><label>&nbsp;
-                        <input type="radio" name="showMode" value="containerStatus"
-                        {% if report.showMode == "containerStatus" %}
-                        checked
-                        {% endif %}
-                        > Container Status
-                        </label></div>
-                    </li>
-                    <li role="presentation" class="divider"></li>
-                    <li>
-                        <div class="checkbox"><label>&nbsp;
-                        <input type="checkbox" name="sortByStatus" id="sortByStatusId" value="true"
-                        {% if report.sortByStatus == "true" %}
-                        checked
-                        {% endif %}
-                        > Sort by status
-                        </label></div>
-                    </li>
+                        <li>
+                            <div class="radio"><label>&nbsp;
+                            <input type="radio" name="showMode" value="simple"
+                            {% if report.showMode == "simple" %}
+                            checked
+                            {% endif %}
+                            > Simple
+                            </label></div>
+                        </li>
+                        <li>
+                            <div class="radio"><label>&nbsp;
+                            <input type="radio" name="showMode" value="compact"
+                            {% if report.showMode == "compact" %}
+                            checked
+                            {% endif %}
+                            > Compact
+                            </label></div>
+                        </li>
+                        <li>
+                            <div class="radio"><label>&nbsp;
+                            <input type="radio" name="showMode" value="complete"
+                            {% if report.showMode == "complete" %}
+                            checked
+                            {% endif %}
+                            > Complete
+                            </label></div>
+                        </li>
+                        <li>
+                            <div class="radio"><label>&nbsp;
+                            <input type="radio" name="showMode" value="containerStatus"
+                            {% if report.showMode == "containerStatus" %}
+                            checked
+                            {% endif %}
+                            > Container Status
+                            </label></div>
+                        </li>
+                        <li role="presentation" class="divider"></li>
+                        <li>
+                            <div class="checkbox"><label>&nbsp;
+                            <input type="checkbox" name="sortByStatus" id="sortByStatusId" value="true"
+                            {% if report.sortByStatus == "true" %}
+                            checked
+                            {% endif %}
+                            > Sort by status
+                            </label></div>
+                        </li>
                     </form>
                 </ul>
                 </div>
@@ -457,6 +457,23 @@ $('#privateBldUploadBtnId button').click(function () {
                                         > All
                                     </label></div>
                                 </li>
+                                <li>
+                                    <div class="radio"><label>&nbsp;
+                                        <input type="radio" name="showMode" value="simple"
+                                               {% if report.showMode == "simple" %}
+                                        checked
+                                        {% endif %}
+                                        > Simple
+                                    </label></div>
+                                </li>
+                                <li>
+                                    <div class="radio">
+                                        <label>&nbsp;
+                                            <input type="radio" name="showMode" value="simple"> Test Account
+                                        </label>
+                                    </div>
+                                </li>
+                                <li role="separator" class="divider"></li>
                                 <li>
                                     <div class="radio"><label>&nbsp;
                                         <input type="radio" name="account" value="{{ primaryAccount }}"

--- a/deploy-board/deploy_board/webapp/env_views.py
+++ b/deploy-board/deploy_board/webapp/env_views.py
@@ -263,8 +263,14 @@ def update_deploy_progress(request, name, stage):
 
 
 def add_legacy_accounts(accounts):
-    accounts.append(f"{AWS_PRIMARY_ACCOUNT} / Primary AWS account / Legacy primary account")
-    accounts.append(f"{AWS_SUB_ACCOUNT} / Sub AWS account / Legacy sub account")
+    accounts.append({
+        "name": f"{AWS_PRIMARY_ACCOUNT} / Primary AWS account / Legacy primary account",
+        "ownerId": AWS_PRIMARY_ACCOUNT,
+    })
+    accounts.append({
+        "name": f"{AWS_SUB_ACCOUNT} / Sub AWS account / Legacy sub account",
+        "ownerId": AWS_SUB_ACCOUNT,
+    })
 
 
 def add_account_from_cluster(request, cluster, accounts):
@@ -273,7 +279,10 @@ def add_account_from_cluster(request, cluster, accounts):
         account = accounts_helper.get_by_cell_and_id(
             request, cluster["cellName"], account_id)
         if account is not None:
-            accounts.append(f'{account["ownerId"]} / {account["name"]} / {account["description"]}')
+            accounts.append({
+                "ownerId": account["ownerId"],
+                "name": f'{account["ownerId"]} / {account["name"]} / {account["description"]}'
+            })
 
 
 def update_service_add_ons(request, name, stage):

--- a/deploy-board/deploy_board/webapp/env_views.py
+++ b/deploy-board/deploy_board/webapp/env_views.py
@@ -263,14 +263,24 @@ def update_deploy_progress(request, name, stage):
 
 
 def add_legacy_accounts(accounts):
-    accounts.append({
-        "name": f"{AWS_PRIMARY_ACCOUNT} / Primary AWS account / Legacy primary account",
-        "ownerId": AWS_PRIMARY_ACCOUNT,
-    })
-    accounts.append({
-        "name": f"{AWS_SUB_ACCOUNT} / Sub AWS account / Legacy sub account",
-        "ownerId": AWS_SUB_ACCOUNT,
-    })
+    skip_primary_account = False
+    skip_sub_account = False
+    for account in accounts:
+        if account["ownerId"] == AWS_PRIMARY_ACCOUNT:
+            skip_primary_account = True
+        elif account["ownerId"] == AWS_SUB_ACCOUNT:
+            skip_sub_account = True
+
+    if not skip_primary_account:
+        accounts.append({
+            "name": f"{AWS_PRIMARY_ACCOUNT} / Primary AWS account / Primary account",
+            "ownerId": AWS_PRIMARY_ACCOUNT,
+        })
+    if not skip_sub_account:
+        accounts.append({
+            "name": f"{AWS_SUB_ACCOUNT} / Sub AWS account / Legacy sub account",
+            "ownerId": AWS_SUB_ACCOUNT,
+        })
 
 
 def add_account_from_cluster(request, cluster, accounts):

--- a/deploy-board/deploy_board/webapp/env_views.py
+++ b/deploy-board/deploy_board/webapp/env_views.py
@@ -238,8 +238,7 @@ def update_deploy_progress(request, name, stage):
     cluster = clusters_helper.get_cluster(request, env.get('clusterName'))
     if cluster is not None:
         add_account_from_cluster(request, cluster, accounts)
-    accounts.append(AWS_PRIMARY_ACCOUNT)
-    accounts.append(AWS_SUB_ACCOUNT)
+    add_legacy_accounts(accounts)
 
     context = {
         "report": report,
@@ -261,6 +260,11 @@ def update_deploy_progress(request, name, stage):
     response.set_cookie(STATUS_COOKIE_NAME, sortByStatus)
 
     return response
+
+
+def add_legacy_accounts(accounts):
+    accounts.append(f"{AWS_PRIMARY_ACCOUNT} / Primary AWS account / Legacy primary account")
+    accounts.append(f"{AWS_SUB_ACCOUNT} / Sub AWS account / Legacy sub account")
 
 
 def add_account_from_cluster(request, cluster, accounts):
@@ -446,8 +450,7 @@ class EnvLandingView(View):
                 host_type_blessed_status = host_type['blessed_status']
                 if host_type_blessed_status == "DECOMMISSIONING" or host_type['retired'] is True:
                     messages.add_message(request, messages.ERROR, "This environment is currently using a cluster with an unblessed Instance Type. Please refer to " + HOST_TYPE_ROADMAP_LINK + " for the recommended Instance Type")
-        accounts.append(AWS_PRIMARY_ACCOUNT)
-        accounts.append(AWS_SUB_ACCOUNT)
+        add_legacy_accounts(accounts)
         last_cluster_refresh_status = _getLastClusterRefreshStatus(request, env)
         latest_succeeded_base_image_update_event = baseimages_helper.get_latest_succeeded_image_update_event_by_cluster(request, env.get('clusterName'))
 

--- a/deploy-board/deploy_board/webapp/env_views.py
+++ b/deploy-board/deploy_board/webapp/env_views.py
@@ -37,7 +37,8 @@ import json
 import requests
 from collections import Counter
 from .helpers import builds_helper, environs_helper, agents_helper, ratings_helper, deploys_helper, \
-    systems_helper, environ_hosts_helper, clusters_helper, tags_helper, baseimages_helper, schedules_helper, placements_helper, hosttypes_helper
+    systems_helper, environ_hosts_helper, clusters_helper, tags_helper, baseimages_helper, schedules_helper, placements_helper, hosttypes_helper, \
+    accounts_helper
 from .templatetags import utils
 from .helpers.exceptions import TeletraanException
 import math
@@ -433,6 +434,7 @@ class EnvLandingView(View):
 
         cluster_refresh_suggestion_for_golden_ami = _gen_message_for_refreshing_cluster(request, last_cluster_refresh_status, latest_succeeded_base_image_update_event, env)
 
+        accounts = ["Account 1", "Account 2", "Account 3"]
         if not env['deployId']:
             capacity_hosts = deploys_helper.get_missing_hosts(request, name, stage)
             provisioning_hosts = environ_hosts_helper.get_hosts(request, name, stage)
@@ -471,6 +473,7 @@ class EnvLandingView(View):
                 "hasCluster": bool(capacity_info.get("cluster")),
                 "primaryAccount": AWS_PRIMARY_ACCOUNT,
                 "subAccount": AWS_SUB_ACCOUNT,
+                "accounts": accounts,
             })
             showMode = 'complete'
             account = 'all'
@@ -557,6 +560,7 @@ class EnvLandingView(View):
                 "hasCluster": bool(capacity_info.get("cluster")),
                 "primaryAccount": AWS_PRIMARY_ACCOUNT,
                 "subAccount": AWS_SUB_ACCOUNT,
+                "accounts": accounts,
             }
             response = render(request, 'environs/env_landing.html', context)
 
@@ -591,7 +595,7 @@ def _gen_message_for_refreshing_cluster(request, last_cluster_refresh_status, la
                 return "The cluster was updated with a new AMI at {} PST and should be replaced to ensure the AMI is applied to all existing hosts.".format(utils.convertTimestamp(latest_succeeded_base_image_update_event["finish_time"]))
 
         return None
-    
+
     except:
         # in case of any exception, return None instead of showing the error on landing page
         return None

--- a/deploy-board/deploy_board/webapp/env_views.py
+++ b/deploy-board/deploy_board/webapp/env_views.py
@@ -285,9 +285,11 @@ def add_legacy_accounts(accounts):
 
 def add_account_from_cluster(request, cluster, accounts):
     account_id = cluster.get("accountId")
+    log.info(f"add accountId = ${account_id}, account_id = ${cluster.get('account_id')}")
     if account_id is not None:
         account = accounts_helper.get_by_cell_and_id(
             request, cluster["cellName"], account_id)
+        log.info(f"account = {account}")
         if account is not None:
             accounts.append({
                 "ownerId": account["ownerId"],

--- a/deploy-board/deploy_board/webapp/env_views.py
+++ b/deploy-board/deploy_board/webapp/env_views.py
@@ -285,15 +285,13 @@ def add_legacy_accounts(accounts):
 
 def add_account_from_cluster(request, cluster, accounts):
     account_id = cluster.get("accountId")
-    log.info(f"add accountId = ${account_id}, account_id = ${cluster.get('account_id')}")
     if account_id is not None:
         account = accounts_helper.get_by_cell_and_id(
             request, cluster["cellName"], account_id)
-        log.info(f"account = {account}")
         if account is not None:
             accounts.append({
-                "ownerId": account["ownerId"],
-                "name": f'{account["ownerId"]} / {account["name"]} / {account["description"]}'
+                "ownerId": account["data"]["ownerId"],
+                "name": f'{account["data"]["ownerId"]} / {account["name"]} / {account["description"]}'
             })
 
 

--- a/deploy-board/deploy_board/webapp/env_views.py
+++ b/deploy-board/deploy_board/webapp/env_views.py
@@ -233,6 +233,7 @@ def update_deploy_progress(request, name, stage):
                     report.currentDeployStat.deploy["otherAcctSucHostNum"] += 1
                 else:
                     report.currentDeployStat.deploy["otherAcctFailHostNum"] += 1
+    accounts = ["Account 1", "Account 2", "Account 3"]
 
     context = {
         "report": report,
@@ -241,6 +242,7 @@ def update_deploy_progress(request, name, stage):
         "pinterest": IS_PINTEREST,
         "primaryAccount": AWS_PRIMARY_ACCOUNT,
         "subAccount": AWS_SUB_ACCOUNT,
+        "accounts": accounts,
     }
 
     html = render_to_string('deploys/deploy_progress.tmpl', context)

--- a/deploy-board/deploy_board/webapp/helpers/accounts_helper.py
+++ b/deploy-board/deploy_board/webapp/helpers/accounts_helper.py
@@ -13,3 +13,13 @@ def get_all_accounts(request):
         log.error(f"Can't get all accounts: error = {e}")
         # return None for backward-compatibility
         return None
+
+
+def get_by_cell_and_id(request, cell, account_id):
+    try:
+        return rodimus_client.get(f"/accounts/AWS/{cell}/{account_id}", request.teletraan_user_id.token)
+    except Exception as e:
+        log.error(f"Can't get account by cell and account_id: "
+                  f"cell = {cell}, account_id = {account_id}, error = {e}")
+        # return None for backward-compatibility
+        return None


### PR DESCRIPTION
# Context

In the scope of CDP-7588 displaying accounts on an environment page has added.

- Display list of available AWS accounts on an environment page.
  - Display `AWS_PRIMARY_ACCOUNT` and `AWS_SUB_ACCOUNT` for backward-compatibility.
  - Display AWS account from which cluster was provisioned for current environment.
- Added a possibility to filter by all accounts and not only hardcoded ones by choosing them in the dropdown.

Accounts filtering happens at the Deploy Board side during rendering the template. While we can refactor this and move filtering to the database side, I decided to keep it as is for not increase scope of work for multi-account support. We can revisit it later.

# Tests
Tested locally and at the `dev1` environment.

## Display all accounts
![Screenshot 2024-03-12 at 5 46 02 PM](https://github.com/pinterest/teletraan/assets/20383875/ada6f858-e8b2-499c-9a3c-bf972713bfd7)

## Filter hosts by account

![Screenshot 2024-03-12 at 2 04 43 PM](https://github.com/pinterest/teletraan/assets/20383875/998d2c94-f95a-46e5-83c3-96b260c1e1b6)

