### PR TITLE
Add maven build flags

### DIFF
--- a/deploy-service/.mvn/maven.config
+++ b/deploy-service/.mvn/maven.config
@@ -1,0 +1,3 @@
+-Daether.dependencyCollector.impl=bf
+-Dmaven.artifact.threads=4
+-T=2

--- a/deploy-service/.mvn/maven.config
+++ b/deploy-service/.mvn/maven.config
@@ -1,3 +1,3 @@
 -Daether.dependencyCollector.impl=bf
--Dmaven.artifact.threads=4
+-Dmaven.artifact.threads=12
 --threads=2C

--- a/deploy-service/.mvn/maven.config
+++ b/deploy-service/.mvn/maven.config
@@ -1,3 +1,3 @@
 -Daether.dependencyCollector.impl=bf
 -Dmaven.artifact.threads=4
--T=2C
+--threads=2C

--- a/deploy-service/.mvn/maven.config
+++ b/deploy-service/.mvn/maven.config
@@ -1,3 +1,3 @@
 -Daether.dependencyCollector.impl=bf
 -Dmaven.artifact.threads=4
--T=2
+-T=2C


### PR DESCRIPTION
Add [maven.config](https://maven.apache.org/configure.html#mvn-maven-config-file) with default configs that are helpful for build speed. 


Option | Type | Description
-- | -- | --
aether.dependencyCollector.bf.threads or maven.artifact.threads | int | Number of threads to use for collecting POMs and version ranges in BF collector.
aether.dependencyCollector.impl | String | The name of the dependency collector implementation to use: depth-first (original) named df, and breadth-first (new in 1.8.0) named bf. Both collectors produce equivalent results, but they may differ performance wise, depending on project being applied to. Our experience shows that existing df is well suited for smaller to medium size projects, while bf may perform better on huge projects with many dependencies. Experiment (and come back to us!) to figure out which one suits you the better. 
