### PR TITLE
Update utils.py to disable  IMDSv1 request for deploy-agent facter call

### DIFF
--- a/deploy-agent/deployd/__init__.py
+++ b/deploy-agent/deployd/__init__.py
@@ -27,4 +27,4 @@ REDEPLOY_MAX_RETRY = 3
 # 2: puppet applied successfully with changes
 PUPPET_SUCCESS_EXIT_CODES = [0, 2]
 
-__version__ = '1.2.60'
+__version__ = '1.2.61'

--- a/deploy-agent/deployd/common/utils.py
+++ b/deploy-agent/deployd/common/utils.py
@@ -207,7 +207,7 @@ def get_info_from_facter(keys) -> Optional[dict]:
         # increment stats - facter calls
         create_sc_increment('deployd.stats.internal.facter_calls_sum', 1)
         log.info(f"Fetching {keys} keys from facter")
-        cmd = ['facter', '-jp']
+        cmd = ['AWS_EC2_METADATA_V1_DISABLED=true', 'facter', '-jp']
         cmd.extend(keys)
         output = subprocess.run(cmd, check=True, stdout=subprocess.PIPE).stdout
         # timing stats - facter run time


### PR DESCRIPTION
By default, AWS SDK will retry IMDSv1 request if v2 request is not successful. This change is to disable the behavior and prevent the IMDSv1 request.
Why is IMDSv1 bad?
IMDSv1 is dangerous to use with AWS EC2 because it lacks any built-in security features. The metadata endpoint is publicly accessible, which means that anyone who can reach the EC2 instance can potentially access the metadata. This can be a significant risk if an attacker gains access to the EC2 instance.