### PR TITLE
Update maven.yml

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,9 +10,6 @@ on:
   pull_request:
     branches:
     - master
-    paths:
-    - 'deploy-service/**'
-    - '.github/workflows/maven.yml'
 
 jobs:
   build:


### PR DESCRIPTION
Remove path filter to unblock PR merge.
This workflow is required for merge PR. It's not ideal to run it for non-related changes, but this is the quickest recover