### PR TITLE
Made dynamically displaying accounts depending on available hosts reports

### DIFF
--- a/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/deploy_progress.tmpl
@@ -279,22 +279,6 @@
 </div>
 {% endwith %}
 
-<div class="panel panel-default">
-    <div class="panel-heading clearfix">
-        <h4 class="panel-title pull-left"><i class="fa fa-fw fa-user"></i> Accounts</h4>
-    </div>
-    <div class="panel-body">
-        <div class="row">
-            {% for account in accounts %}
-                <a href="#" class="deployToolTip btn btn-xs btn-default host-btn">
-                    <small>{{ account.name }}</small>
-                    <i class="fa fa-fw fa-user"></i>
-                </a>
-            {% endfor %}
-        </div>
-    </div>
-</div>
-
 <script>
     $(function () {
         $('.deployToolTip').tooltip({container: "#toolTipContent", delay: { show: 400, hide: 10 }});

--- a/deploy-board/deploy_board/templates/deploys/deploy_progress_summary.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/deploy_progress_summary.tmpl
@@ -6,11 +6,20 @@
     <tr>
         <th class="col-lg-2">Build</th>
         <th class="col-lg-1">Type</th>
-        <th class="col-lg-2">State</th>
+        <th class="col-lg-1">State</th>
         <th class="col-lg-2">Progress</th>
         <th class="col-lg-1">Elapsed</th>
-        <th class="col-lg-2">Acceptance</th>
+        <th class="col-lg-1">Acceptance</th>
         <th class="col-lg-1">Operator</th>
+        {% if accounts %}
+            <th class="col-lg-1">
+                <span>Account</span>
+                <span class="ml-1 deployToolTip glyphicon glyphicon-question-sign"
+                    data-toggle="tooltip" title=""
+                    data-original-title="This is the AWS account is being used in this stage">
+                </span>
+            </th>
+        {% endif %}
         <th class="col-lg-1">Details</th>
         <th class="col-lg-1">Schedule</th>
     </tr>
@@ -66,6 +75,16 @@
         <small>{{ deploy.acceptanceStatus }}</small>
     </td>
     <td>{{ deploy.operator }}</td>
+    {% if accounts %}
+        <td>
+            {% for account in accounts %}
+                <a href="#" class="deployToolTip btn btn-xs btn-default host-btn">
+                    <small>{{ account.name }}</small>
+                    <i class="fa fa-fw fa-user"></i>
+                </a>
+            {% endfor %}
+        </td>
+    {% endif %}
     <td><a href="/deploy/{{ deploy.id }}">view</a></td>
     <td><a href="/env/{{ env.envName }}/{{ env.stageName }}/schedule">view</a></td>
   </tr>

--- a/deploy-board/deploy_board/webapp/agent_report.py
+++ b/deploy-board/deploy_board/webapp/agent_report.py
@@ -23,7 +23,6 @@ import time
 from collections import OrderedDict
 from functools import cmp_to_key
 
-
 # Constants used to distinguish the action to generate the host report
 TOTAL_ALIVE_HOST_REPORT = "TOTAL_ALIVE_HOST_REPORT"
 UNKNOWN_HOST_REPORT = "UNKNOWN_HOST_REPORT"


### PR DESCRIPTION
# Context
Made dynamically displaying accounts depending on available hosts reports.

- Hide Accounts panel on an environment landing page if no hosts were provisioned from an account.

# Tests

## Display account from which cluster was provisioned

![Screenshot 2024-03-14 at 12 29 34 PM](https://github.com/pinterest/teletraan/assets/20383875/c4d68481-d271-418e-a736-31817f272fdc)


## Display hard coded primary accounts if hosts were provisioned from that cluster
![Screenshot 2024-03-14 at 12 58 00 PM](https://github.com/pinterest/teletraan/assets/20383875/d8086de6-6153-4fa4-ae16-56524a2ef346)


## Don't display accounts panel if no information about account is available

![Screenshot 2024-03-14 at 12 32 13 PM](https://github.com/pinterest/teletraan/assets/20383875/e6211a49-67dd-4030-a74c-172f30ac7786)

