### PR TITLE
add account id to deploy history

### DIFF
--- a/deploy-board/deploy_board/templates/deploys/deploy_history.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/deploy_history.tmpl
@@ -65,11 +65,17 @@
             </td>
             <td>{{ deploy_summary.deploy.operator }}</td>
             <td>
-                {% if deploy_summary.account %}
-                <a href="/clouds/accounts/{{ deploy_summary.account.cloudProvider }}/{{ deploy_summary.account.cell }}/{{ deploy_summary.account.id }}">
-                    {{ deploy_summary.account.data.ownerId }} / {{ deploy_summary.account.name }}
-                </a>
-                {% endif %}
+                {% for account in deploy_summary.deploy_accounts %}
+                    {% if account.legacy_name %}
+                    <div class="deployToolTip btn btn-xs btn-default host-btn">
+                    {{ account.legacy_name }}
+                    </div>
+                    {% else %}
+                    <a class="deployToolTip btn btn-xs btn-default host-btn" href="/clouds/accounts/{{ account.cloudProvider }}/{{ account.cell }}/{{ account.id }}">
+                        {{ account.data.ownerId }} / {{ account.name }}
+                    </a>
+                    {% endif %}
+                {% endfor %}
             </td>
             <td><a href="/deploy/{{ deploy_summary.deploy.id }}">Details</a></td>
         </tr>

--- a/deploy-board/deploy_board/templates/deploys/deploy_history.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/deploy_history.tmpl
@@ -64,7 +64,13 @@
                 {% endif %}
             </td>
             <td>{{ deploy_summary.deploy.operator }}</td>
-            <td><a href="/clouds/accounts/{{ deploy_summary.account.provider }}/{{ deploy_summary.account.cell }}/{{ deploy_summary.account.id }}">{{ deploy_summary.account.id }}</a></td>
+            <td>
+                {% if deploy_summary.account %}
+                <a href="/clouds/accounts/{{ deploy_summary.account.cloudProvider }}/{{ deploy_summary.account.cell }}/{{ deploy_summary.account.id }}">
+                    {{ deploy_summary.account.data.ownerId }} / {{ deploy_summary.account.name }}
+                </a>
+                {% endif %}
+            </td>
             <td><a href="/deploy/{{ deploy_summary.deploy.id }}">Details</a></td>
         </tr>
         <tr id="deployAction{{forloop.counter}}" class="collapse out deployActionPanel">

--- a/deploy-board/deploy_board/templates/deploys/deploy_history.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/deploy_history.tmpl
@@ -12,6 +12,7 @@
             <th>Success</th>
             <th>Build</th>
             <th>Operator</th>
+            <th>Account</th>
             <th>Details</th>
         </tr>
         {% for deploy_summary in deploy_summaries %}
@@ -63,6 +64,7 @@
                 {% endif %}
             </td>
             <td>{{ deploy_summary.deploy.operator }}</td>
+            <td><a href="/clouds/accounts/{{ deploy_summary.account.provider }}/{{ deploy_summary.account.cell }}/{{ deploy_summary.account.id }}">{{ deploy_summary.account.id }}</a></td>
             <td><a href="/deploy/{{ deploy_summary.deploy.id }}">Details</a></td>
         </tr>
         <tr id="deployAction{{forloop.counter}}" class="collapse out deployActionPanel">

--- a/deploy-board/deploy_board/templates/deploys/deploys.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/deploys.tmpl
@@ -42,11 +42,17 @@
             </a>
         </td>
         <td>
-            {% if deploy_summary.account %}
-            <a href="/clouds/accounts/{{ deploy_summary.account.cloudProvider }}/{{ deploy_summary.account.cell }}/{{ deploy_summary.account.id }}">
-                {{ deploy_summary.account.data.ownerId }} / {{ deploy_summary.account.name }}
-            </a>
-            {% endif %}
+            {% for account in deploy_summary.deploy_accounts %}
+                {% if account.legacy_name %}
+                <div class="deployToolTip btn btn-xs btn-default host-btn">
+                {{ account.legacy_name }}
+                </div>
+                {% else %}
+                <a class="deployToolTip btn btn-xs btn-default host-btn" href="/clouds/accounts/{{ account.cloudProvider }}/{{ account.cell }}/{{ account.id }}">
+                    {{ account.data.ownerId }} / {{ account.name }}
+                </a>
+                {% endif %}
+            {% endfor %}
         </td>
         <td>{{ deploy_summary.deploy.operator }}</td>
     </tr>

--- a/deploy-board/deploy_board/templates/deploys/deploys.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/deploys.tmpl
@@ -41,7 +41,13 @@
                 {{ deploy_summary.build|branchAndCommit }}
             </a>
         </td>
-        <td><a href="/clouds/accounts/{{ deploy_summary.account.provider }}/{{ deploy_summary.account.cell }}/{{ deploy_summary.account.id }}">{{ deploy_summary.account.id }}</a></td>
+        <td>
+            {% if deploy_summary.account %}
+            <a href="/clouds/accounts/{{ deploy_summary.account.cloudProvider }}/{{ deploy_summary.account.cell }}/{{ deploy_summary.account.id }}">
+                {{ deploy_summary.account.data.ownerId }} / {{ deploy_summary.account.name }}
+            </a>
+            {% endif %}
+        </td>
         <td>{{ deploy_summary.deploy.operator }}</td>
     </tr>
     {% endfor%}

--- a/deploy-board/deploy_board/templates/deploys/deploys.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/deploys.tmpl
@@ -10,6 +10,7 @@
         <th>State</th>
         <th>Success Rate</th>
         <th>Build</th>
+        <th>Account</th>
         <th>Operator</th>
     </tr>
     {% for deploy_summary in deploy_summaries %}
@@ -40,6 +41,7 @@
                 {{ deploy_summary.build|branchAndCommit }}
             </a>
         </td>
+        <td><a href="/clouds/accounts/{{ deploy_summary.account.provider }}/{{ deploy_summary.account.cell }}/{{ deploy_summary.account.id }}">{{ deploy_summary.account.id }}</a></td>
         <td>{{ deploy_summary.deploy.operator }}</td>
     </tr>
     {% endfor%}

--- a/deploy-board/deploy_board/webapp/accounts.py
+++ b/deploy-board/deploy_board/webapp/accounts.py
@@ -35,20 +35,20 @@ def is_valid_account_id(account_id):
 def get_accounts_from_deploy(request, env, deploy, build_with_tag):
     account = None
     deploy_accounts = []
-    if env.get("clusterName") is not None:
+    if env and env.get("clusterName") is not None:
         cluster = clusters_helper.get_cluster(request, env["clusterName"])
         provider, cell, id = cluster["provider"], cluster["cellName"], cluster.get("accountId", None)
         if not id:
             account = accounts_helper.get_default_account(request, cell, provider=provider)
         else:
             account = accounts_helper.get_by_cell_and_id(request, cell, id, provider)
-        deploy_accounts = []
-    if account is None:
+
+    if account is None and env and deploy and build_with_tag:
         # terraform deploy, get information from deploy report
         progress = deploys_helper.update_progress(request, env["envName"], env["stageName"])
         report = agent_report.gen_report(request, env, progress, deploy=deploy, build_info=build_with_tag)
         deploy_accounts = [create_legacy_ui_account(account) for account in get_accounts(report)]
         deploy_accounts = [{"legacy_name": account["name"]} for account in deploy_accounts]
-    else:
+    elif account:
         deploy_accounts = [account]
     return deploy_accounts

--- a/deploy-board/deploy_board/webapp/env_views.py
+++ b/deploy-board/deploy_board/webapp/env_views.py
@@ -31,7 +31,7 @@ from deploy_board.settings import AWS_PRIMARY_ACCOUNT, AWS_SUB_ACCOUNT
 from . import agent_report
 from . import service_add_ons
 from . import common
-from .accounts import get_accounts, get_accounts_from_deploy
+from .accounts import get_accounts, get_accounts_from_deploy, create_legacy_ui_account
 import random
 import json
 import requests
@@ -270,23 +270,6 @@ def add_legacy_accounts(accounts, report):
 
     for account in accounts_from_report:
         accounts.append(create_legacy_ui_account(account))
-
-
-def create_legacy_ui_account(account_id):
-    if account_id == AWS_PRIMARY_ACCOUNT:
-        return {
-            "name": f"{AWS_PRIMARY_ACCOUNT} / Primary AWS account",
-            "ownerId": AWS_PRIMARY_ACCOUNT,
-        }
-    if account_id == AWS_SUB_ACCOUNT:
-        return {
-            "name": f"{AWS_SUB_ACCOUNT} / Moka account",
-            "ownerId": AWS_SUB_ACCOUNT,
-        }
-    return {
-        "name": f"{account_id} / Sub AWS account",
-        "ownerId": account_id,
-    }
 
 
 def add_account_from_cluster(request, cluster, accounts):

--- a/deploy-board/deploy_board/webapp/env_views.py
+++ b/deploy-board/deploy_board/webapp/env_views.py
@@ -800,7 +800,7 @@ def _gen_deploy_summary(request, deploys, for_env=None):
             env = environs_helper.get(request, deploy['envId'])
         build_with_tag = builds_helper.get_build_and_tag(request, deploy['buildId'])
         account = None
-        if env.get("clusterName") is not None:
+        if env and env.get("clusterName") is not None:
             cluster = clusters_helper.get_cluster(request, env["clusterName"])
             provider, cell, id = cluster["provider"], cluster["cellName"], cluster.get("accountId")
             account_key = (provider, cell, id)
@@ -812,13 +812,13 @@ def _gen_deploy_summary(request, deploys, for_env=None):
                     account = accounts_helper.get_default_account(request, cell, provider)
                 accounts[account_key] = account
         deploy_accounts = []
-        if account is None:
+        if account is None and env and deploy and build_with_tag:
             # terraform deploy, get information from deploy report
             progress = deploys_helper.update_progress(request, env["envName"], env["stageName"])
             report = agent_report.gen_report(request, env, progress, deploy=deploy, build_info=build_with_tag)
             deploy_accounts = [create_legacy_ui_account(account) for account in get_accounts(report)]
             deploy_accounts = [{"legacy_name": account["name"]} for account in deploy_accounts]
-        else:
+        elif account:
             deploy_accounts = [account]
             
         summary = {}

--- a/deploy-board/deploy_board/webapp/helpers/accounts_helper.py
+++ b/deploy-board/deploy_board/webapp/helpers/accounts_helper.py
@@ -21,9 +21,9 @@ def get_by_cell_and_id(request, cell, account_id, provider="AWS"):
         return rodimus_client.get(f"/accounts/{provider}/{cell}/{account_id}", request.teletraan_user_id.token)
     except Exception as e:
         log.error(f"Can't get account by cell and account_id: "
-                  f"provider={provider}, cell = {cell}, account_id = {account_id}, error = {e}")
+                  f"provder = {provider}, cell = {cell}, account_id = {account_id}, error = {e}")
         # return None for backward-compatibility
         return None
-    
-def get_default_account(request, cell, provider='AWS'):
+
+def get_default_account(request, cell, provider="AWS"):
     return get_by_cell_and_id(request, cell, "default", provider)


### PR DESCRIPTION
Add account id with link to account details page in deploy history pages.


#### Manual Testing
went to `/envs/<env>/<stage>/deploys` and `envs/deploys/`, verified accounts links were working as expected
<img width="1412" alt="Screenshot 2024-03-19 at 1 53 02 PM" src="https://github.com/pinterest/teletraan/assets/104773032/21ee5b94-85b2-4fb6-b352-78ef5f26f5cf">