### PR TITLE
Teletraan dependency clean up

### DIFF
--- a/deploy-service/common/pom.xml
+++ b/deploy-service/common/pom.xml
@@ -130,6 +130,10 @@
             <artifactId>jackson-annotations</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-afterburner</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>

--- a/deploy-service/common/pom.xml
+++ b/deploy-service/common/pom.xml
@@ -43,7 +43,6 @@
         <dependency>
             <groupId>com.pinterest.teletraan</groupId>
             <artifactId>universal</artifactId>
-            <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.sun.mail</groupId>

--- a/deploy-service/common/pom.xml
+++ b/deploy-service/common/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.pinterest.teletraan</groupId>
         <artifactId>teletraan</artifactId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.2-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/deploy-service/common/pom.xml
+++ b/deploy-service/common/pom.xml
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>eventbridge</artifactId>
-            <version>2.20.162</version>
+            <version>2.20.149</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/deploy-service/common/pom.xml
+++ b/deploy-service/common/pom.xml
@@ -64,17 +64,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.2</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-            <version>1.7.2</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.2</version>
         </dependency>
         <dependency>
             <groupId>mysql</groupId>
@@ -92,44 +81,27 @@
             <version>1.6</version>
         </dependency>
         <dependency>
-            <groupId>commons-configuration</groupId>
-            <artifactId>commons-configuration</artifactId>
-            <version>1.9</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-beanutils</groupId>
-            <artifactId>commons-beanutils</artifactId>
-            <version>1.9.2</version>
-        </dependency>
-        <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
             <version>1.9</version>
         </dependency>
         <dependency>
-            <groupId>net.sf.ehcache</groupId>
-            <artifactId>ehcache</artifactId>
-            <version>2.8.1</version>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>24.1.1-jre</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>eventbridge</artifactId>
-            <version>2.20.149</version>
+            <version>2.20.162</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.2.4</version>
+            <version>2.8.8</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
-            <version>2.9.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -139,7 +111,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.4</version>
+            <version>2.8.0</version>
         </dependency>
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>

--- a/deploy-service/common/pom.xml
+++ b/deploy-service/common/pom.xml
@@ -46,17 +46,6 @@
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>io.swagger</groupId>
-            <artifactId>swagger-jersey2-jaxrs</artifactId>
-            <version>1.6.9</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.validation</groupId>
-                    <artifactId>validation-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>com.sun.mail</groupId>
             <artifactId>javax.mail</artifactId>
             <version>1.5.4</version>
@@ -93,6 +82,10 @@
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
             <version>2.6</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -133,23 +126,29 @@
             <version>1.11.0</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.module</groupId>
-            <artifactId>jackson-module-afterburner</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>1.10.8</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.plugin-tools</groupId>
-            <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/deploy-service/common/pom.xml
+++ b/deploy-service/common/pom.xml
@@ -83,7 +83,16 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.9</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+            <version>3.2.1</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.6</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/deploy-service/pom.xml
+++ b/deploy-service/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.pinterest.teletraan</groupId>
     <artifactId>teletraan</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.2-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>Deploy related modules</description>
     <inceptionYear>2014</inceptionYear>

--- a/deploy-service/pom.xml
+++ b/deploy-service/pom.xml
@@ -54,6 +54,16 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>com.pinterest.teletraan</groupId>
+                <artifactId>universal</artifactId>
+                <version>2.0-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.pinterest.teletraan</groupId>
+                <artifactId>common</artifactId>
+                <version>0.1-SNAPSHOT</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/deploy-service/pom.xml
+++ b/deploy-service/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -246,7 +246,7 @@
                   <dependency>
                     <groupId>io.netty</groupId>
                     <artifactId>netty-buffer</artifactId>
-                    <version>4.1.107.Final</version>
+                    <version>4.1.106.Final</version>
                   </dependency>
                 </dependencies>
               </dependencyManagement>

--- a/deploy-service/pom.xml
+++ b/deploy-service/pom.xml
@@ -72,6 +72,7 @@
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
             <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/deploy-service/teletraanservice/pom.xml
+++ b/deploy-service/teletraanservice/pom.xml
@@ -26,6 +26,12 @@
             <groupId>io.swagger</groupId>
             <artifactId>swagger-jersey2-jaxrs</artifactId>
             <version>1.6.9</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.validation</groupId>
+                    <artifactId>validation-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/deploy-service/teletraanservice/pom.xml
+++ b/deploy-service/teletraanservice/pom.xml
@@ -38,16 +38,6 @@
             <groupId>com.pinterest.teletraan</groupId>
             <artifactId>common</artifactId>
             <version>0.1-SNAPSHOT</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.pinterest.teletraan</groupId>
@@ -56,12 +46,6 @@
             <type>test-jar</type>
             <version>0.1-SNAPSHOT</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.pinterest.teletraan</groupId>
@@ -86,7 +70,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.10.8</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/deploy-service/teletraanservice/pom.xml
+++ b/deploy-service/teletraanservice/pom.xml
@@ -26,12 +26,6 @@
             <groupId>io.swagger</groupId>
             <artifactId>swagger-jersey2-jaxrs</artifactId>
             <version>1.6.9</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.validation</groupId>
-                    <artifactId>validation-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
@@ -48,7 +42,6 @@
         <dependency>
             <groupId>com.pinterest.teletraan</groupId>
             <artifactId>common</artifactId>
-            <version>0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.pinterest.teletraan</groupId>
@@ -61,7 +54,6 @@
         <dependency>
             <groupId>com.pinterest.teletraan</groupId>
             <artifactId>universal</artifactId>
-            <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.quartz-scheduler</groupId>

--- a/deploy-service/teletraanservice/pom.xml
+++ b/deploy-service/teletraanservice/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.pinterest.teletraan</groupId>
         <artifactId>teletraan</artifactId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.2-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/deploy-service/teletraanservice/pom.xml
+++ b/deploy-service/teletraanservice/pom.xml
@@ -23,6 +23,17 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-jersey2-jaxrs</artifactId>
+            <version>1.6.9</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.validation</groupId>
+                    <artifactId>validation-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
         </dependency>

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/handler/EnvStagesTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/handler/EnvStagesTest.java
@@ -23,7 +23,7 @@ import com.pinterest.teletraan.security.Authorizer;
 public class EnvStagesTest {
     private EnvStages envStages;
     private EnvironDAO environDAO;
-    
+
     @Before
     public void setup() throws Exception {
         environDAO = mock(EnvironDAO.class);
@@ -44,7 +44,7 @@ public class EnvStagesTest {
         Principal mockPrincipal = mock(Principal.class);
         Mockito.when(mockSC.getUserPrincipal()).thenReturn(mockPrincipal);
         envStages.update(mockSC, "test-env", "test-stage", envBean);
-        verify(environDAO).update(Mockito.anyString(), Mockito.anyString(), argument.capture());
+        verify(environDAO).update(Mockito.any(), Mockito.any(), argument.capture());
         assertEquals(true, argument.getValue().getAllow_private_build());
     }
 }

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/resource/EnvAlertsTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/resource/EnvAlertsTest.java
@@ -1,7 +1,8 @@
 package com.pinterest.teletraan.resource;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/worker/AutoPromoteBuildTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/worker/AutoPromoteBuildTest.java
@@ -1,8 +1,7 @@
 package com.pinterest.teletraan.worker;
 
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -25,6 +24,7 @@ import com.pinterest.deployservice.dao.TagDAO;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
+import org.joda.time.Interval;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -125,7 +125,7 @@ public class AutoPromoteBuildTest {
         PromoteBean promoteBean = new PromoteBean();
         AutoPromoter promoter = new AutoPromoter(context);
         //Has builds. Have previous deploy
-        when(buildDAO.getAcceptedBuilds(anyString(), anyString(), anyObject(), anyInt()))
+        when(buildDAO.getAcceptedBuilds(any(), any(), any(Interval.class), anyInt()))
             .thenReturn(Arrays.asList(t9AMBuildBean));
         PromoteResult
             result =
@@ -150,7 +150,7 @@ public class AutoPromoteBuildTest {
         when(tagDAO.getLatestByTargetIdAndType(buildName, TagTargetType.BUILD,
             BuildTagsManagerImpl.MAXCHECKTAGS))
             .thenReturn(new ArrayList<TagBean>(Arrays.asList(tagBean)));
-        when(buildDAO.getAcceptedBuilds(anyString(), anyString(), anyObject(), anyInt()))
+        when(buildDAO.getAcceptedBuilds(any(), any(), any(), anyInt()))
             .thenReturn(Arrays.asList(t9AMBuildBean));
         PromoteResult
             result =
@@ -160,8 +160,9 @@ public class AutoPromoteBuildTest {
         promoter.promoteBuild(environBean, null, 1, promoteBean);
         // bad build, safe promote never gets called
         verify(promoterSpy, never())
-            .safePromote(anyObject(), anyString(), anyString(), anyObject(), anyObject());
+            .safePromote(any(), any(), any(), any(), any());
     }
+
 
     @Test
     public void testOneBadBuildOneGoodBuildPromote() throws Exception {
@@ -197,7 +198,7 @@ public class AutoPromoteBuildTest {
             BuildTagsManagerImpl.MAXCHECKTAGS))
             .thenReturn(new ArrayList<TagBean>(Arrays.asList(tagBean)));
 
-        when(buildDAO.getAcceptedBuilds(anyString(), anyString(), anyObject(), anyInt()))
+        when(buildDAO.getAcceptedBuilds(any(), any(), any(), anyInt()))
             .thenReturn(Arrays.asList(build1, build2));
         // build1 is bad
         when(buildTagsManager.getEffectiveTagsWithBuilds(Arrays.asList(build1)))
@@ -244,7 +245,7 @@ public class AutoPromoteBuildTest {
         previousDeploy.setBuild_id(t8AMBuildBean.getBuild_id());
 
         when(buildDAO.getById(t8AMBuildBean.getBuild_id())).thenReturn(t8AMBuildBean);
-        when(buildDAO.getAcceptedBuilds(anyString(), anyString(), anyObject(), anyInt()))
+        when(buildDAO.getAcceptedBuilds(any(), any(), any(Interval.class), anyInt()))
             .thenReturn(Arrays.asList(t9AMBuildBean));
         PromoteResult
             result =
@@ -281,7 +282,7 @@ public class AutoPromoteBuildTest {
         DateTimeUtils.setCurrentMillisProvider(timeProvider);
         timeProvider.setClock(t10AM.getMillis());
 
-        when(buildDAO.getAcceptedBuilds(anyString(), anyString(), anyObject(), anyInt()))
+        when(buildDAO.getAcceptedBuilds(any(), any(), any(), anyInt()))
             .thenReturn(Arrays.asList(t9AMBuildBean));
         PromoteResult
             result =
@@ -305,7 +306,7 @@ public class AutoPromoteBuildTest {
         DateTimeUtils.setCurrentMillisProvider(timeProvider);
         timeProvider.setClock(t10AM.getMillis());
 
-        when(buildDAO.getAcceptedBuilds(anyString(), anyString(), anyObject(), anyInt()))
+        when(buildDAO.getAcceptedBuilds(any(), any(), any(), anyInt()))
             .thenReturn(Arrays.asList(build));
         PromoteResult
             result =
@@ -368,7 +369,7 @@ public class AutoPromoteBuildTest {
         timeProvider.setClock(t10AM.getMillis());
 
         when(buildDAO.getById(t8AMBuildBean.getBuild_id())).thenReturn(t8AMBuildBean);
-        when(buildDAO.getAcceptedBuilds(anyString(), anyString(), anyObject(), anyInt()))
+        when(buildDAO.getAcceptedBuilds(any(), any(), any(), anyInt()))
             .thenReturn(Arrays.asList(t9AMBuildBean));
         PromoteResult
             result =
@@ -422,7 +423,7 @@ public class AutoPromoteBuildTest {
                 .withBufferTimeMinutes(bufferTimeMinutes);
         AutoPromoter promoterSpy = Mockito.spy(promoter);
 
-        when(buildDAO.getAcceptedBuilds(anyString(), anyString(), anyObject(), anyInt()))
+        when(buildDAO.getAcceptedBuilds(any(), any(), any(), anyInt()))
                 .thenReturn(Arrays.asList(t9AMBuildBean));
 
         DateTimeUtils.setCurrentMillisProvider(timeProvider);
@@ -456,7 +457,7 @@ public class AutoPromoteBuildTest {
 
         promoter.promoteBuild(environBean, null, 1, t10AMPromoteBean);
         verify(promoterSpy, never())
-                .safePromote(anyObject(), anyString(), anyString(), anyObject(), anyObject());
+                .safePromote(any(), any(), any(), any(), any());
 
         // Set time to tomorrow 10AM, next buffer time window
         timeProvider.setClock(t9AM.plusDays(1).plusHours(1).getMillis());

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/worker/AutoPromoteDeployTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/worker/AutoPromoteDeployTest.java
@@ -1,8 +1,8 @@
 package com.pinterest.teletraan.worker;
 
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -162,7 +162,7 @@ public class AutoPromoteDeployTest {
 
         when(deployDAO.getById("deploy1")).thenReturn(prevDeploy);
         when(environDAO.getByStage(environBean.getEnv_name(), "pred")).thenReturn(predEnvironBean);
-        when(deployDAO.getAcceptedDeploys(anyString(), anyObject(), anyInt()))
+        when(deployDAO.getAcceptedDeploys(anyString(), any(), anyInt()))
             .thenReturn(Arrays.asList(prevDeploy));
         when(buildDAO.getBuildsFromIds(new HashSet<>(Arrays.asList(badBuildId))))
             .thenReturn(Arrays.asList(badBuild));
@@ -184,7 +184,7 @@ public class AutoPromoteDeployTest {
             result.getResult());
         // bad build, safe promote never gets called
         verify(promoterSpy, never())
-            .safePromote(anyObject(), anyString(), anyString(), anyObject(), anyObject());
+            .safePromote(any(), anyString(), anyString(), any(), any());
     }
 
     /* Autopromote enabled. Has pred env but it has no deploys*/
@@ -231,7 +231,7 @@ public class AutoPromoteDeployTest {
         allDeployBeans.add(prevDeploy);
         when(environDAO.getByStage(environBean.getEnv_name(), "pred")).thenReturn(predEnvironBean);
         when(deployDAO.getById("deploy1")).thenReturn(prevDeploy);
-        when(deployDAO.getAcceptedDeploys(anyString(), anyObject(), anyInt())).thenAnswer(
+        when(deployDAO.getAcceptedDeploys(anyString(), any(), anyInt())).thenAnswer(
             new Answer<List<DeployBean>>() {
                 @Override
                 public List<DeployBean> answer(InvocationOnMock invocationOnMock) throws Throwable {
@@ -286,7 +286,7 @@ public class AutoPromoteDeployTest {
         when(environDAO.getByStage(environBean.getEnv_name(), "pred")).thenReturn(predEnvironBean);
         when(deployDAO.getById(prevDeploy.getDeploy_id())).thenReturn(prevDeploy);
         when(deployDAO.getById(newDeploy.getDeploy_id())).thenReturn(newDeploy);
-        when(deployDAO.getAcceptedDeploys(anyString(), anyObject(), anyInt())).thenAnswer(
+        when(deployDAO.getAcceptedDeploys(anyString(), any(), anyInt())).thenAnswer(
             new Answer<List<DeployBean>>() {
                 @Override
                 public List<DeployBean> answer(InvocationOnMock invocationOnMock) throws Throwable {
@@ -339,7 +339,7 @@ public class AutoPromoteDeployTest {
         allDeployBeans.add(newDeploy);
         when(environDAO.getByStage(environBean.getEnv_name(), "pred")).thenReturn(predEnvironBean);
         when(deployDAO.getById("deploy1")).thenReturn(newDeploy);
-        when(deployDAO.getAcceptedDeploys(anyString(), anyObject(), anyInt())).thenAnswer(
+        when(deployDAO.getAcceptedDeploys(anyString(), any(), anyInt())).thenAnswer(
             new Answer<List<DeployBean>>() {
                 @Override
                 public List<DeployBean> answer(InvocationOnMock invocationOnMock) throws Throwable {
@@ -400,7 +400,7 @@ public class AutoPromoteDeployTest {
         when(environDAO.getByStage(environBean.getEnv_name(), "pred")).thenReturn(predEnvironBean);
         when(deployDAO.getById(prevDeploy.getDeploy_id())).thenReturn(prevDeploy);
         when(deployDAO.getById(newDeploy.getDeploy_id())).thenReturn(newDeploy);
-        when(deployDAO.getAcceptedDeploys(anyString(), anyObject(), anyInt())).thenAnswer(
+        when(deployDAO.getAcceptedDeploys(anyString(), any(), anyInt())).thenAnswer(
             new Answer<List<DeployBean>>() {
                 @Override
                 public List<DeployBean> answer(InvocationOnMock invocationOnMock) throws Throwable {
@@ -481,7 +481,7 @@ public class AutoPromoteDeployTest {
         when(environDAO.getByStage(environBean.getEnv_name(), "pred")).thenReturn(predEnvironBean);
         when(deployDAO.getById(prevDeploy.getDeploy_id())).thenReturn(prevDeploy);
         when(deployDAO.getById(newDeploy.getDeploy_id())).thenReturn(newDeploy);
-        when(deployDAO.getAcceptedDeploys(anyString(), anyObject(), anyInt())).thenAnswer(
+        when(deployDAO.getAcceptedDeploys(anyString(), any(), anyInt())).thenAnswer(
             new Answer<List<DeployBean>>() {
                 @Override
                 public List<DeployBean> answer(InvocationOnMock invocationOnMock) throws Throwable {

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/worker/HostTerminatorTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/worker/HostTerminatorTest.java
@@ -1,6 +1,6 @@
 package com.pinterest.teletraan.worker;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/worker/MetricsEmitterTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/worker/MetricsEmitterTest.java
@@ -6,8 +6,8 @@ import static com.pinterest.teletraan.universal.metrics.ErrorBudgetCounterFactor
 import static com.pinterest.teletraan.universal.metrics.ErrorBudgetCounterFactory.ERROR_BUDGET_TAG_VALUE_RESPONSE_TYPE_FAILURE;
 import static com.pinterest.teletraan.universal.metrics.ErrorBudgetCounterFactory.ERROR_BUDGET_TAG_NAME_RESPONSE_TYPE;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/deploy-service/universal/pom.xml
+++ b/deploy-service/universal/pom.xml
@@ -18,29 +18,13 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <micrometer.version>1.11.3</micrometer.version>
     <pinterest.commons.version>0.1-20220908.230942-22097</pinterest.commons.version>
   </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>io.projectreactor</groupId>
-        <artifactId>reactor-bom</artifactId>
-        <version>2023.0.3</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <dependencies>
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
-      <version>${micrometer.version}</version>
     </dependency>
     <dependency>
       <groupId>io.micrometer</groupId>
@@ -73,12 +57,10 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.11</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.36</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -87,7 +69,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>32.1.2-jre</version>
     </dependency>
     <dependency>
       <groupId>javax.ws.rs</groupId>
@@ -109,27 +90,25 @@
 
     <!-- Test dependencies -->
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <version>5.10.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>1.10.19</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-test</artifactId>
-      <version>1.9.3</version>
+      <version>${micrometer.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
       <version>4.12.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -221,7 +200,7 @@
           <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-buffer</artifactId>
-            <version>4.1.107.Final</version>
+            <version>4.1.106.Final</version>
           </dependency>
         </dependencies>
       </dependencyManagement>

--- a/deploy-service/universal/pom.xml
+++ b/deploy-service/universal/pom.xml
@@ -64,6 +64,10 @@
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
@@ -73,12 +77,10 @@
     <dependency>
       <groupId>jakarta.ws.rs</groupId>
       <artifactId>jakarta.ws.rs-api</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>jakarta.annotation</groupId>
       <artifactId>jakarta.annotation-api</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.dropwizard</groupId>

--- a/deploy-service/universal/pom.xml
+++ b/deploy-service/universal/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>com.pinterest.teletraan</groupId>
   <artifactId>universal</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>2.0-SNAPSHOT</version>
 
   <name>Teletraan platform universal components</name>
   <url>https://github.com/pinterest/teletraan/</url>

--- a/deploy-service/universal/pom.xml
+++ b/deploy-service/universal/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>teletraan</artifactId>
     <groupId>com.pinterest.teletraan</groupId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.2-SNAPSHOT</version>
   </parent>
 
   <groupId>com.pinterest.teletraan</groupId>

--- a/deploy-service/universal/pom.xml
+++ b/deploy-service/universal/pom.xml
@@ -71,15 +71,13 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>javax.ws.rs-api</artifactId>
-      <version>2.1</version>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-      <version>1.3.2</version>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/deploy-service/universal/pom.xml
+++ b/deploy-service/universal/pom.xml
@@ -215,6 +215,10 @@
               <artifactId>*</artifactId>
             </exclusion>
             <exclusion>
+              <groupId>log4j</groupId>
+              <artifactId>*</artifactId>
+            </exclusion>
+            <exclusion>
               <groupId>com.amazonaws</groupId>
               <artifactId>*</artifactId>
             </exclusion>
@@ -235,6 +239,10 @@
               <artifactId>psc-internal-shaded</artifactId>
             </exclusion>
           </exclusions>
+        </dependency>
+        <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>log4j-over-slf4j</artifactId>
         </dependency>
       </dependencies>
     </profile>

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/events/GenericEventPublisherTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/events/GenericEventPublisherTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.pinterest.teletraan.universal.events;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -9,7 +24,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.concurrent.TimeUnit;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -36,10 +50,10 @@ public class GenericEventPublisherTest {
         mockChildTestEventListener = mockEventListener(ChildTestEvent.class);
         mockSiblingTestEventListener = mockEventListener(SiblingTestEvent.class);
         doAnswer(
-                invocation -> {
-                    TimeUnit.MILLISECONDS.sleep(2);
-                    return null;
-                })
+                        invocation -> {
+                            TimeUnit.MILLISECONDS.sleep(2);
+                            return null;
+                        })
                 .when(mockSlowListener)
                 .onEvent(any());
     }
@@ -83,7 +97,8 @@ public class GenericEventPublisherTest {
         sut.terminate();
 
         // All events are processed
-        verify(mockResourceChangedEventListener, times(numEvents)).onEvent(eq(resourceChangedEvent));
+        verify(mockResourceChangedEventListener, times(numEvents))
+                .onEvent(eq(resourceChangedEvent));
     }
 
     @Test

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/events/GenericEventPublisherTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/events/GenericEventPublisherTest.java
@@ -1,7 +1,7 @@
 package com.pinterest.teletraan.universal.events;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/BaseAuthorizerTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/BaseAuthorizerTest.java
@@ -18,7 +18,7 @@ package com.pinterest.teletraan.universal.security;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/BasePastisAuthorizerTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/BasePastisAuthorizerTest.java
@@ -18,7 +18,7 @@ package com.pinterest.teletraan.universal.security;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/EnvoyAuthFilterTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/EnvoyAuthFilterTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/ScriptTokenAuthenticatorTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/ScriptTokenAuthenticatorTest.java
@@ -18,7 +18,7 @@ package com.pinterest.teletraan.universal.security;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 


### PR DESCRIPTION
## Summary
Thing I did for this PR
1. Removed version tag for some dependencies.
Since we use dropwizard-dependencies bom, it's no longer needed to specify version for dependencies bundled with dropwizard. Those versions are misleading as they will be override by the bom. 
3. Removed previously unused but declared dependencies
4. Added used but previously undeclared dependencies
5. Since the mockito version changed, I updated some tests. 
6. Upgraded gson to avoid version conflicts. 
7. Upgraded commons-io avoid version conflicts. 


## Validations

### Inspection of final tar
I created a build with this PR, and compared its contents with build 16a17ac from master. Most dependencies remained unchanged. 
```diff
diff --git a/old.txt b/pr.txt
index 6fba7a6..0c9d093 100644
--- a/old.txt
+++ b/pr.txt
@@ -1 +1 @@
-528384
+512344
@@ -13 +12,0 @@ apache-client-2.20.149.jar
-apiguardian-api-1.1.2.jar
@@ -34 +32,0 @@ common-0.1-SNAPSHOT.jar
-commons-beanutils-1.9.2.jar
@@ -43 +41 @@ commons-dbutils-1.6.jar
-commons-io-2.4.jar
+commons-io-2.8.0.jar
@@ -71 +68,0 @@ dynamic-host-set-0.0.56.jar
-ehcache-2.8.1.jar
@@ -94 +91 @@ group-0.0.92.jar
-gson-2.2.4.jar
+gson-2.8.8.jar
@@ -129,0 +127 @@ jakarta.el-3.0.4.jar
+jakarta.inject-2.6.1.jar
@@ -176,3 +173,0 @@ jul-to-slf4j-1.7.36.jar
-junit-platform-commons-1.10.1.jar
-junit-platform-engine-1.10.1.jar
-junit-vintage-engine-5.10.1.jar
@@ -185 +179,0 @@ listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
-log4j-1.2.15.jar
@@ -192 +185,0 @@ lz4-1.3.0.jar
-mail-1.4.jar
@@ -220 +213 @@ netty-3.10.1.Final-p1.jar
-netty-buffer-4.1.107.Final.jar
+netty-buffer-4.1.106.Final.jar
@@ -248 +240,0 @@ okio-2.8.0.jar
-opentest4j-1.3.0.jar
```

### Dev1
Deployed to dev1 and validate the application is running. 