### PR TITLE
Added warning message for old base images of sub-account has chosen

### DIFF
--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -50,7 +50,7 @@
                     <cell-select v-bind:cells="cells" v-on:cellchange="cellChange"  v-bind:value="currentCell"></cell-select>
                     <label-input label="Capacity" placeholder="# of instances" v-model="instanceCount"></label-input>
                     <arch-select v-bind:arches="arches" v-on:archchange="archChange"  v-bind:value="archValue"></arch-select>
-                    <baseimage-select v-model="pinImage" :image-names="imageNames" :base-images="baseImages"
+                    <baseimage-select v-model="pinImage" :image-names="imageNames" :base-images="baseImages" v-bind:account-owner-id="currentAccountOwnerId"
                         :selected-image-name="imageNameValue" :selected-base-image="baseImageValue" :pin-image-enabled="pinImageEnabled"
                         @base-image-change="baseImageChange" @image-name-change="imageNameChange" @help-clicked="baseImageHelpClick" >
                     </baseimage-select>
@@ -153,6 +153,7 @@ var capacitySetting = new Vue({
         confirmDialogId: "createHostGroup",
         currentProvider: info.defaultProvider,
         currentAccountId: info.defaultAccountId,
+        currentAccountOwnerId: getAccountOwnerId(info.defaultAccountId),
         currentCell: info.defaultCell,
         currentArch: info.defaultArch,
         hostTypeHelpData:[],
@@ -308,7 +309,8 @@ var capacitySetting = new Vue({
             }
         },
         accountChange: function (value) {
-            capacitySetting.currentAccountId = value;
+            this.currentAccountId = value;
+            this.currentAccountOwnerId = getAccountOwnerId(value);
         },
         cellChange: function(value) {
             capacitySetting.currentCell = value;
@@ -648,7 +650,7 @@ var capacitySetting = new Vue({
         },
         updateStatefulStatus: function(value) {
             this.selectedStatefulStatus = value
-        }
+        },
     },
     watch: {
         placements: function(){
@@ -663,8 +665,13 @@ var capacitySetting = new Vue({
             localStorage.setItem("accessRole", accessRoleObj.value);
         }
     }
-})
+});
 
+function getAccountOwnerId(accountId) {
+    return info.accounts != null ?
+        info.accounts.find(function (o) { return o.id === accountId }).ownerId
+        : null;
+}
 
 $(document).ready(function () {
     $('.single-select-search').chosen({


### PR DESCRIPTION
# Context

Next: https://github.com/pinterest/teletraan/pull/1528

Added warning message for old base images of sub-account has chosen.

- Display warning message if chosen image is oldest than 2024-03-15 and sub-account has chosen.

# Tests

## Displayed warning message

Note: date has converted in my timezone, that's why it's 2024-03-14

<img width="1261" alt="Screenshot 2024-03-18 at 12 50 32 PM" src="https://github.com/pinterest/teletraan/assets/20383875/a550307c-72a7-41f0-82f3-526b780d3a56">

## No warning message

<img width="1257" alt="Screenshot 2024-03-18 at 12 53 37 PM" src="https://github.com/pinterest/teletraan/assets/20383875/7e81e5dd-795d-4d12-b33b-5e367f5d0d3f">

## Two warning messages

<img width="1274" alt="Screenshot 2024-03-18 at 12 55 30 PM" src="https://github.com/pinterest/teletraan/assets/20383875/a7edb565-733f-4203-b48b-bd00223c9f53">

