### PR TITLE
Added filtering by accountId for placements in advanced cluster creation form

### DIFF
--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -358,10 +358,14 @@ var capacitySetting = new Vue({
                     globalNotificationBanner.error = data
                 }
             });
+
+            const placementsUrl =
+                `${location.protocol}//${location.host}/clouds/placements/${provider}/${cell}` +
+                `?accountId=${this.currentAccountId}`
             // grab all placement for this cell
             $.ajax({
                 type: 'GET',
-                url: location.protocol + '//' + location.host + '/clouds/placements/' + provider + '/' + cell,
+                url: placementsUrl,
                 dataType: "json",
                 beforeSend: function (xhr) {
                     var csrftoken = getCookie('csrftoken');

--- a/deploy-board/deploy_board/webapp/helpers/placements_helper.py
+++ b/deploy-board/deploy_board/webapp/helpers/placements_helper.py
@@ -29,9 +29,15 @@ def get_all(request, index, size):
 
 
 def get_by_provider_and_cell_name(request, provider, cell_name):
+    account_id = request.GET.get("accountId", None)
+    query = f"?accountId={account_id}" if account_id is not None else ""
     if cell_name:
-        return rodimus_client.get("/placements/cell/%s" % cell_name, request.teletraan_user_id.token)
-    return rodimus_client.get("/placements/provider/%s" % provider, request.teletraan_user_id.token)
+        return rodimus_client.get(
+            f"/placements/cell/{cell_name}{query}",
+            request.teletraan_user_id.token)
+    return rodimus_client.get(
+        f"/placements/provider/{provider}{query}",
+        request.teletraan_user_id.token)
 
 
 def get_by_id(request, placement_id):


### PR DESCRIPTION
# Context

Added filtering by accountId for placements in advanced cluster creation form

# Tests

## No sub-account placements for primary account

<img width="1259" alt="Screenshot 2024-03-19 at 2 56 40 PM" src="https://github.com/pinterest/teletraan/assets/20383875/8b69825f-552c-43fd-84ff-abc13d01aa87">

## No sub-account placements for account which doesn't has any

<img width="1311" alt="Screenshot 2024-03-19 at 2 57 52 PM" src="https://github.com/pinterest/teletraan/assets/20383875/d7cd16c5-dc8b-47cd-88eb-7554e0480b09">

## Sub-account placements 

<img width="1247" alt="Screenshot 2024-03-19 at 2 58 51 PM" src="https://github.com/pinterest/teletraan/assets/20383875/e37b5185-632b-4d41-83e0-ff5bc6cfc57e">

