### PR TITLE
add link to env page

### DIFF
--- a/deploy-board/deploy_board/templates/deploys/deploy_progress_summary.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/deploy_progress_summary.tmpl
@@ -78,10 +78,17 @@
     {% if accounts %}
         <td>
             {% for account in accounts %}
+                {% if account.legacy_name %}
                 <a href="#" class="deployToolTip btn btn-xs btn-default host-btn">
-                    <small>{{ account.name }}</small>
+                    <small>{{ account.legacy_name }}</small>
                     <i class="fa fa-fw fa-user"></i>
                 </a>
+                {% else %}
+                <a href="/clouds/accounts/{{ account.cloudProvider }}/{{ account.cell }}/{{ account.id }}" class="deployToolTip btn btn-xs btn-default host-btn">
+                    <small>{{ account.data.ownerId }} / {{ account.name }}</small>
+                    <i class="fa fa-fw fa-user"></i>
+                </a>
+                {% endif %}
             {% endfor %}
         </td>
     {% endif %}

--- a/deploy-board/deploy_board/templates/environs/env_landing.html
+++ b/deploy-board/deploy_board/templates/environs/env_landing.html
@@ -460,11 +460,11 @@ $('#privateBldUploadBtnId button').click(function () {
                                 {% for account in accounts %}
                                     <li>
                                         <div class="radio"><label>&nbsp;
-                                            <input type="radio" name="account" value="{{ account.ownerId }}"
-                                                   {% if report.account == account.ownerId %}
+                                            <input type="radio" name="account" value="{{ account.data.ownerId }}"
+                                                   {% if report.account == account.data.ownerId %}
                                                    checked
                                                    {% endif %}
-                                            > {{ account.ownerId }}
+                                            > {{ account.data.ownerId }}
                                         </label></div>
                                     </li>
                                 {% endfor %}


### PR DESCRIPTION
Update the env landing page to link account column to link to the respective account page.

### Manual Testing

Went to env landing pages and verified links worked as expected

#### default account to default landing page

<img width="1425" alt="Screenshot 2024-03-21 at 10 20 38 AM" src="https://github.com/pinterest/teletraan/assets/104773032/774d68e4-3e71-4ce0-b05c-f1928e153347">
<img width="1429" alt="Screenshot 2024-03-21 at 10 28 14 AM" src="https://github.com/pinterest/teletraan/assets/104773032/155dd8f9-ee09-442a-9ad0-cee60e3908ea">

#### No link for legacy account/account not in rodimus
<img width="1427" alt="Screenshot 2024-03-21 at 11 02 16 AM" src="https://github.com/pinterest/teletraan/assets/104773032/f490b584-2315-4ad1-ac35-072280e2a852">

#### No account if account is not available from report or cluster
<img width="436" alt="Screenshot 2024-03-21 at 11 06 42 AM" src="https://github.com/pinterest/teletraan/assets/104773032/ab455cf9-20a5-49fe-b7d1-6559271a851d">


### Regression Testing

#### dropdown values still properly set
<img width="463" alt="Screenshot 2024-03-21 at 11 05 13 AM" src="https://github.com/pinterest/teletraan/assets/104773032/ab6e49fa-faa8-48ef-ac2b-9562113285e4">
<img width="494" alt="Screenshot 2024-03-21 at 10 24 40 AM" src="https://github.com/pinterest/teletraan/assets/104773032/bd069054-da9e-4570-9287-7229d911e9e4">

