### PR TITLE
update default account name

### DIFF
--- a/deploy-board/deploy_board/templates/deploys/deploy_details.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/deploy_details.tmpl
@@ -89,7 +89,7 @@
         <td>
             {% for account in deploy_accounts %}
                 {% if account.legacy_name %}
-                <div class="deployToolTip btn btn-xs btn-default host-btn">
+                <div class="deployToolTip btn btn-xs btn-default host-btn disabled" style="opacity:1;">
                 {{ account.legacy_name }}
                 </div>
                 {% else %}

--- a/deploy-board/deploy_board/templates/deploys/deploy_history.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/deploy_history.tmpl
@@ -67,7 +67,7 @@
             <td>
                 {% for account in deploy_summary.deploy_accounts %}
                     {% if account.legacy_name %}
-                    <div class="deployToolTip btn btn-xs btn-default host-btn">
+                    <div class="deployToolTip btn btn-xs btn-default host-btn disabled" style="opacity:1;">
                     {{ account.legacy_name }}
                     </div>
                     {% else %}

--- a/deploy-board/deploy_board/templates/deploys/deploy_progress_summary.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/deploy_progress_summary.tmpl
@@ -79,7 +79,7 @@
         <td>
             {% for account in accounts %}
                 {% if account.legacy_name %}
-                <a href="#" class="deployToolTip btn btn-xs btn-default host-btn">
+                <a href="#" class="deployToolTip btn btn-xs btn-default host-btn disabled" style="opacity:1;">
                     <small>{{ account.legacy_name }}</small>
                     <i class="fa fa-fw fa-user"></i>
                 </a>

--- a/deploy-board/deploy_board/templates/deploys/deploys.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/deploys.tmpl
@@ -44,7 +44,7 @@
         <td>
             {% for account in deploy_summary.deploy_accounts %}
                 {% if account.legacy_name %}
-                <div class="deployToolTip btn btn-xs btn-default host-btn">
+                <div class="deployToolTip btn btn-xs btn-default host-btn disabled" style="opacity:1;">
                 {{ account.legacy_name }}
                 </div>
                 {% else %}

--- a/deploy-board/deploy_board/webapp/accounts.py
+++ b/deploy-board/deploy_board/webapp/accounts.py
@@ -5,7 +5,7 @@ from . import agent_report
 def create_legacy_ui_account(account_id):
     if account_id == AWS_PRIMARY_ACCOUNT:
         return {
-            "legacy_name": f"{AWS_PRIMARY_ACCOUNT} / Primary AWS account",
+            "legacy_name": f"{AWS_PRIMARY_ACCOUNT} / default",
             "data": {
                 "ownerId": AWS_PRIMARY_ACCOUNT
             },


### PR DESCRIPTION
Change the default legacy account name from AWS Primary Account to default. Also update the styling for legacy account buttons to have disabled styling to signal they are not clickable.

<img width="503" alt="Screenshot 2024-03-22 at 11 32 00 AM" src="https://github.com/pinterest/teletraan/assets/104773032/3e415847-c374-4af1-b147-debf9d6e8ca3">

