### PR TITLE
add account id to cluster update

### DIFF
--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -925,6 +925,7 @@
                     // It's really just update cluster info config without capacity
                     //Create the default capacity. The input here aligns to the Rodimus new cluster
                     var clusterInfo = {};
+                    clusterInfo['accountId'] = currentCluster.accountId;
                     clusterInfo['provider'] = this.currentProvider;
                     clusterInfo['cellName'] = this.currentCell;
                     clusterInfo['archName'] = this.currentArch;


### PR DESCRIPTION
When updating the cluster account id, add the cluster id to avoid overwriting with the default. This is the UI change, along with an accompanying rodimus api change catching the same issue.

### Manual Testing

Updated dev1 cluster without account id changing both in advanced and basic cluster configuration. Account id did not change.
<img width="1053" alt="Screenshot 2024-03-27 at 10 39 37 AM" src="https://github.com/pinterest/teletraan/assets/104773032/3596c0a6-0d01-47da-896f-ba8dc2ba1cfe">
