### PR TITLE
Show host type ID on Teletraan UI

### DIFF
--- a/deploy-board/deploy_board/templates/clusters/host_types.tmpl
+++ b/deploy-board/deploy_board/templates/clusters/host_types.tmpl
@@ -4,8 +4,9 @@
 <form name="hostTypeList">
     <table id="hostTypeTableId" class="table table-condensed table-striped table-hover">
         <tr>
+            <th class="col-lg-1">ID</th>
             <th class="col-lg-1">Arch</th>
-            <th class="col-lg-2">Abstract Name</th>
+            <th class="col-lg-1">Abstract Name</th>
             <th class="col-lg-1">Provider Name</th>
             <th class="col-lg-1">Cloud Provider</th>
             <th class="col-lg-1">Core</th>
@@ -19,6 +20,7 @@
         </tr>
         {% for host_type in host_types %}
         <tr>
+            <td> {{ host_type.id }} </td>
             <td> {{ host_type.arch_name }} </td>
             <td> {{ host_type.abstract_name }} </td>
             <td> {{ host_type.provider_name }}  </td>


### PR DESCRIPTION
Teletraan users are seeking clarification on which host type the ID represents.

