### PR TITLE
add note for skip matching

### DIFF
--- a/deploy-board/deploy_board/templates/clusters/cluster-replacements.tmpl
+++ b/deploy-board/deploy_board/templates/clusters/cluster-replacements.tmpl
@@ -490,8 +490,10 @@
                         <div class="slider round"></div>
                     </label>
                 </div>
-                
+
                 <div class="pull-left" style="padding-top: 20px;">
+                    <p style="color:red;">Note: hosts that are running with latest cluster configurations (AMI, host type, etc.) won't be replaced. If you want to replace them anyway, please uncheck <b>Skip matching launch template</b></p>
+
                     <button type="submit" id="startReplacementBtnId" class="btn"
                             data-toggle="modal"
                             title="Start cluster replacement">


### PR DESCRIPTION
<p style="color:red;">Note: hosts that are running with latest cluster configurations (AMI, host type, etc.) won't be replaced. If you want to replace them anyway, please uncheck <b>Skip matching launch template</b></p>


![Screenshot 2024-03-28 at 8 32 13 AM](https://github.com/pinterest/teletraan/assets/63071572/75aba823-b9f5-4ddd-ad95-c95ca5717bce)
