### PR TITLE
 Added validation for default host type in cluster creation

### DIFF
--- a/deploy-board/deploy_board/settings.py
+++ b/deploy-board/deploy_board/settings.py
@@ -362,8 +362,8 @@ if IS_PINTEREST:
     # Pinterest Default Host Type
     # TODO: This is a description of the host type but is nonunique. However, it cannot be replaced by host_type ID since it is unique per service database.
     # TODO: The model for host type should be rebuilt based on a unique abstract factor such as ec2 instance type, for now we should keep expected behavior.
-    DEFAULT_CMP_HOST_TYPE = 'EbsComputeLo(Recommended)'
-    DEFAULT_CMP_ARM_HOST_TYPE = 'EbsComputeXLoArm'
+    DEFAULT_CMP_HOST_TYPE = 'm7a.xlarge'
+    DEFAULT_CMP_ARM_HOST_TYPE = 'c7g.large'
     HOST_TYPE_ROADMAP_LINK = os.getenv("HOST_TYPE_ROADMAP_LINK")
 
     DEFAULT_CELL = 'aws-us-east-1'

--- a/deploy-board/deploy_board/static/js/deploy-board.js
+++ b/deploy-board/deploy_board/static/js/deploy-board.js
@@ -271,6 +271,7 @@ function getDefaultPlacement(capacityCreationInfo) {
     }
 }
 
+
 function getAccount(accountId) {
     return info.accounts != null ?
         info.accounts.find(function (o) { return o.id === accountId })
@@ -280,4 +281,57 @@ function getAccount(accountId) {
 function getAccountOwnerId(accountId) {
     const account = getAccount(accountId);
     return account ? account.ownerId : null;
+
+function getDefaultHostType(capacityCreationInfo) {
+    this.capacityCreationInfo = capacityCreationInfo
+        var isProcessed = false;
+        var selected = false;
+        var lowestHostType = false;
+        var isDisabledHostType = function(item){
+            return item.retired || item.blessed_status === "DECOMMISSIONING";
+        };
+
+        var isSelected = function(item) {
+            return (item.abstract_name === capacityCreationInfo.defaultHostType) && !isDisabledHostType(item);
+        }
+
+        this.options = this.capacityCreationInfo.hostTypes.map(function(item,idx){
+            if(isSelected(item)){
+                selected = item;
+            } else if(!isDisabledHostType(item)){
+                lowestHostType = item;
+                console.log(lowestHostType);
+            }
+            isProcessed = true;
+            return {
+            value: item.id,
+            text: item.abstract_name+" ("+item.core+" cores, "+item.mem+" GB, "+item.network+", " +item.storage+")",
+            isSelected: isSelected(item),
+            isDisabled: isDisabledHostType(item)
+        };
+    });
+
+    return {
+        getOptions: function () {
+            return options;
+        },
+        getSelected: function () {
+            if(isProcessed === false){
+                this.getOptions();
+                isProcessed = true;
+            }
+            if(selected !== false){
+                return selected;
+            }
+            return lowestHostType;
+        },
+        isDisabledHostType: function(item){
+            return isDisabledHostType(item);
+        },
+        getSelectedId: function() {
+            var selected = this.getSelected();
+            return selected != undefined ? selected.id : "";
+        }
+    }
+
 }

--- a/deploy-board/deploy_board/static/js/deploy-board.js
+++ b/deploy-board/deploy_board/static/js/deploy-board.js
@@ -280,7 +280,7 @@ function getAccount(accountId) {
 function getAccountOwnerId(accountId) {
     const account = getAccount(accountId);
     return account ? account.ownerId : null;
-
+}
 
 function getDefaultHostType(hostTypes, defaultHostType, defaultARMHostType) {
     this.hostTypes = hostTypes;
@@ -341,5 +341,4 @@ function getDefaultHostType(hostTypes, defaultHostType, defaultARMHostType) {
             return selected != undefined ? selected.id : "";
         }
     }
-
 }

--- a/deploy-board/deploy_board/templates/configs/new_capacity.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity.html
@@ -102,6 +102,7 @@ var statefulOptions = capacityCreationInfo.stateful_options;
 let goldenImage = capacityCreationInfo.baseImages.find(goldenImageFinder);
 
 var placements = getDefaultPlacement(capacityCreationInfo);
+var hostTypes = getDefaultHostType(capacityCreationInfo);
 
 var capacitySetting = new Vue({
     el:"#capacityPanel",
@@ -112,14 +113,7 @@ var capacitySetting = new Vue({
         confirmDialogTitle:"Confirm New Capacity Creation",
         confirmDialogId:"createHostGroup",
         instanceCount:"",
-        hostTypeOptions: capacityCreationInfo.hostTypes.map(function(item,idx){
-            return {
-                value: item.id,
-                text: item.abstract_name+" ("+item.core+" cores, "+item.mem+" GB, "+item.network+", " +item.storage+")",
-                isSelected: item.abstract_name === capacityCreationInfo.defaultHostType,
-                isDisabled: item.retired || item.blessed_status === "DECOMMISSIONING"
-            }
-        }),
+        hostTypeOptions: hostTypes.getOptions(),
         placements: placements.getSimpleList(false, null),
         securityZoneOptions:capacityCreationInfo.securityZones.map(function(item,idx){
             return {
@@ -129,7 +123,7 @@ var capacitySetting = new Vue({
             }
         }),
         // TODO: The default host type comes from settings and should probably not be an abstract_name since they are not guaranteed to be unique.
-        selectedHostTypeValue: capacityCreationInfo.hostTypes.find(hostType => hostType.abstract_name === capacityCreationInfo.defaultHostType) != undefined ? capacityCreationInfo.hostTypes.find(hostType => hostType.abstract_name === capacityCreationInfo.defaultHostType).id : "",
+        selectedHostTypeValue: hostTypes.getSelectedId(),
         selectedSecurityZoneValue: capacityCreationInfo.defaultSeurityZone,
         selectedPlacements: null,
         accessRole: localStorage.getItem("accessRole") ? localStorage.getItem("accessRole") : capacityCreationInfo.defaultCMPConfigs['access_role'],
@@ -164,6 +158,19 @@ var capacitySetting = new Vue({
                 globalNotificationBanner.error = "Access Role must be specified";
                 return false;
             }
+
+            var host_type = clusterInfo['hostType'];
+            if (host_type ===undefined || host_type === null || host_type.trim().length===0){
+                globalNotificationBanner.error = "Host type must be specified";
+                return false;
+            }
+
+            host_type = capacityCreationInfo.hostTypes.find(hostType => hostType.id === clusterInfo['hostType']);
+            if (!host_type || hostTypes.isDisabledHostType(host_type)) {
+                globalNotificationBanner.error = "Host type must not be retired or decommissioned";
+                return false;
+            }
+
             return true;
         },
         sendRequest: function(clusterInfo){

--- a/deploy-board/deploy_board/templates/configs/new_capacity.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity.html
@@ -102,7 +102,7 @@ var statefulOptions = capacityCreationInfo.stateful_options;
 let goldenImage = capacityCreationInfo.baseImages.find(goldenImageFinder);
 
 var placements = getDefaultPlacement(capacityCreationInfo);
-var hostTypes = getDefaultHostType(capacityCreationInfo);
+var hostTypes = getDefaultHostType(capacityCreationInfo.hostTypes, capacityCreationInfo.defaultHostType, capacityCreationInfo.defaultARMHostType);
 
 var capacitySetting = new Vue({
     el:"#capacityPanel",

--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -113,7 +113,7 @@ var capacityView = new Vue({
 var info = {{capacity_creation_info|safe}};
 var environment = info.environment;
 var placements = getDefaultPlacement(info);
-var hostTypes = getDefaultHostType(info);
+var hostTypes = getDefaultHostType(info.hostTypes, info.defaultHostType, info.defaultARMHostType);
 var statefulOptions = info.stateful_options;
 const goldenImage = info.baseImages.find(goldenImageFinder);
 const baseImagesSorted = info.baseImages.sort(baseImageSorter);
@@ -410,16 +410,10 @@ var capacitySetting = new Vue({
                     xhr.setRequestHeader("X-CSRFToken", csrftoken);
                 },
                 success: function (data) {
-                    capacitySetting.hostTypeOptions = data.map(
-                            function (item) {
-                                return {
-                                    value: item.id,
-                                    text: item.abstract_name + " (" + item.core + " cores, " + item.mem + " GB, " + item.storage + ", " + item.network + ", " + item.provider + ": " + item.provider_name + ", " + item.network + ")",
-                                    isSelected: item.id === data[0].id,
-                                    isDisabled: item.retired || item.blessed_status === "DECOMMISSIONING"
-                                }
-                            });
-                    capacitySetting.selectedHostTypeValue = data[0].id;
+                    hostTypes = getDefaultHostType(data, info.defaultHostType, info.defaultARMHostType);
+                    capacitySetting.hostTypeOptions = hostTypes.getOptions();
+                    capacitySetting.selectedHostTypeValue = hostTypes.getSelectedId();
+                    capacityCreationInfo.hostTypes = data;
                     //Schedule this to nextTick that calls after next DOM refresh
                     //as JQuery chosen call must happen after DOM updates finished
                     Vue.nextTick(function(){
@@ -575,6 +569,9 @@ var capacitySetting = new Vue({
             }
 
             var host_type = capacityCreationInfo.hostTypes.find(hostType => hostType.id === clusterInfo['hostType']);
+            console.log(host_type);
+            console.log(hostTypes);
+
             if (!host_type || hostTypes.isDisabledHostType(host_type)) {
                 globalNotificationBanner.error = "Host type must not be retired or decomissioned";
                 return false;

--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -113,6 +113,7 @@ var capacityView = new Vue({
 var info = {{capacity_creation_info|safe}};
 var environment = info.environment;
 var placements = getDefaultPlacement(info);
+var hostTypes = getDefaultHostType(info);
 var statefulOptions = info.stateful_options;
 const goldenImage = info.baseImages.find(goldenImageFinder);
 const baseImagesSorted = info.baseImages.sort(baseImageSorter);
@@ -157,15 +158,7 @@ var capacitySetting = new Vue({
         currentCell: getDefaultCell(info.defaultAccountId),
         currentArch: info.defaultArch,
         hostTypeHelpData:[],
-        hostTypeOptions: info.hostTypes.map(
-            function (item, idx) {
-                return {
-                    value: item.id,
-                    text: item.abstract_name + " (" + item.core + " cores, " + item.mem + " GB, " + item.storage + ", " + item.network + ", " + item.provider + ": " + item.provider_name + ", " + item.network + ")",
-                    isSelected: item.abstract_name === info.defaultHostType,
-                    isDisabled: item.retired || item.blessed_status === "DECOMMISSIONING"
-                }
-            }),
+        hostTypeOptions: hostTypes.getOptions(),
         archValue: info.defaultArch,
         imageNameValue: info.defaultBaseImage,
         imageNames: mapImageNameToOptions(info.baseImageNames),
@@ -206,7 +199,7 @@ var capacitySetting = new Vue({
                 }
             }),
         // TODO: The default host type comes from settings and should probably not be an abstract_name since they are not guaranteed to be unique.
-        selectedHostTypeValue: capacityCreationInfo.hostTypes.find(hostType => hostType.abstract_name === capacityCreationInfo.defaultHostType) != undefined ? capacityCreationInfo.hostTypes.find(hostType => hostType.abstract_name === capacityCreationInfo.defaultHostType).id : "",
+        selectedHostTypeValue: hostTypes.getSelectedId(),
         selectedSecurityZoneValue: info.defaultSeurityZone,
         selectedPlacements: [],
         showBaseImageHelp: false,
@@ -572,6 +565,18 @@ var capacitySetting = new Vue({
             var access_role = clusterInfo.configs['access_role'].trim();
             if (!access_role) {
                 globalNotificationBanner.error = "Access Role must be specified";
+                return false;
+            }
+
+            var host_type = clusterInfo['hostType'];
+            if (host_type ===undefined || host_type === null || host_type.trim().length===0){
+                globalNotificationBanner.error = "Host type must be specified";
+                return false;
+            }
+
+            var host_type = capacityCreationInfo.hostTypes.find(hostType => hostType.id === clusterInfo['hostType']);
+            if (!host_type || hostTypes.isDisabledHostType(host_type)) {
+                globalNotificationBanner.error = "Host type must not be retired or decomissioned";
                 return false;
             }
 


### PR DESCRIPTION
Changes:
- Instead of the Default cmp host type value being assigned since it is a static value, assign the the next available host type in the list
- DEFAULT_CMP_HOST_TYPE and DEFAULT_CMP_ARM_HOST_TYPE in settings.py
 EbsComputeLo to m7a.xlarge
 EbsComputeXLoArm to c7g.large
- Added fallback logic for selecting next available host type  
-  Added validation to cluster creation that will display an error if a user attempts to create a cluster with an unblessed hsot type (ie. Blessed Status = DECOMMISSIONING and/or Retired = True)