### PR TITLE
Implement Agent AuthZ

### DIFF
--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/DeployCandidates.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/DeployCandidates.java
@@ -49,7 +49,7 @@ public class DeployCandidates {
         notes = "Returns a list of build bean",
         response = DeployCandidatesResponse.class)
     @RolesAllowed(TeletraanPrincipalRole.Names.PINGER)
-    @ResourceAuthZInfo(type = AuthZResource.Type.GROUP)
+    @ResourceAuthZInfo(type = AuthZResource.Type.SYSTEM)
     public DeployCandidatesResponse getDeployCandidates(@Context SecurityContext sc,
                 @Context HttpHeaders headers,
                 @ApiParam(value = "Ping request object", required = true)@Valid PingRequestBean requestBean) throws Exception {

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/ScriptTokenRoleAuthorizer.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/ScriptTokenRoleAuthorizer.java
@@ -47,20 +47,19 @@ public class ScriptTokenRoleAuthorizer
             return false;
         }
 
-        if (requestedResource.getType().equals(AuthZResource.Type.ENV_STAGE)) {
+        if (requestedResource.equals(principal.getResource())
+                || AuthZResource.Type.SYSTEM.equals(principal.getResource().getType())) {
+            return true;
+        }
+
+        if (AuthZResource.Type.ENV_STAGE.equals(requestedResource.getType())) {
             if (requestedResource.getEnvName().equals(principal.getResource().getName())) {
                 return true;
             }
-        } else if (requestedResource.getType().equals(AuthZResource.Type.ENV)
+        } else if (AuthZResource.Type.ENV.equals(requestedResource.getType())
                 && !(TeletraanPrincipalRole.ADMIN.getRole().equals(principal.getRole())
-                        || principal.getResource().getType().equals(AuthZResource.Type.SYSTEM))) {
+                        || AuthZResource.Type.SYSTEM.equals(principal.getResource().getType()))) {
             return false;
-        }
-
-        if (requestedResource.equals(principal.getResource())
-                || principal.getResource().getType().equals(AuthZResource.Type.SYSTEM)) {
-            LOG.debug("Authorized");
-            return true;
         }
 
         LOG.info("Requested resource does not match principal resource");

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/ScriptTokenRoleAuthorizerTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/ScriptTokenRoleAuthorizerTest.java
@@ -39,6 +39,8 @@ public class ScriptTokenRoleAuthorizerTest {
     private TokenRolesBean envOperator;
     private TokenRolesBean envReader;
 
+    private TokenRolesBean pinger;
+
     private AuthZResource env1;
     private AuthZResource envX;
     private AuthZResource env1Stage;
@@ -79,6 +81,11 @@ public class ScriptTokenRoleAuthorizerTest {
         envReader.setResource_id("envX");
         envReader.setResource_type(AuthZResource.Type.ENV);
         envReader.setRole(TeletraanPrincipalRole.READER);
+
+        pinger = new TokenRolesBean();
+        pinger.setResource_id(AuthZResource.ALL);
+        pinger.setResource_type(AuthZResource.Type.SYSTEM);
+        pinger.setRole(TeletraanPrincipalRole.PINGER);
 
         env1 = new AuthZResource("env1", AuthZResource.Type.ENV);
         envX = new AuthZResource("envX", AuthZResource.Type.ENV);
@@ -202,5 +209,10 @@ public class ScriptTokenRoleAuthorizerTest {
 
         checkNegative(envReader, envXStage, TeletraanPrincipalRole.OPERATOR);
         checkNegative(envReader, envXStage, TeletraanPrincipalRole.ADMIN);
+    }
+
+    @Test
+    public void testPingerCanPing() throws Exception {
+        checkPositive(pinger, AuthZResource.SYSTEM_RESOURCE, TeletraanPrincipalRole.PINGER);
     }
 }

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/BaseAuthorizer.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/BaseAuthorizer.java
@@ -62,20 +62,24 @@ public abstract class BaseAuthorizer<P extends TeletraanPrincipal> implements Au
 
         ResourceAuthZInfo safeAuthZInfo = (ResourceAuthZInfo) authZInfo;
 
-        AuthZResource requestedResource;
-        try {
-            requestedResource =
-                    extractorFactory
-                            .create(safeAuthZInfo)
-                            .extractResource(context, safeAuthZInfo.beanClass());
-        } catch (ExtractionException ex) {
-            log.warn(
-                    "Failed to extract resource. Did you forget to annotate the resource with @ResourceAuthZInfo?",
-                    ex);
-            return false;
-        }
+        if (AuthZResource.Type.SYSTEM.equals(safeAuthZInfo.type())) {
+            return authorize(principal, role, AuthZResource.SYSTEM_RESOURCE, context);
+        } else {
+            AuthZResource requestedResource;
+            try {
+                requestedResource =
+                        extractorFactory
+                                .create(safeAuthZInfo)
+                                .extractResource(context, safeAuthZInfo.beanClass());
+            } catch (ExtractionException ex) {
+                log.warn(
+                        "Failed to extract resource. Did you forget to annotate the resource with @ResourceAuthZInfo?",
+                        ex);
+                return false;
+            }
 
-        return authorize(principal, role, requestedResource, context);
+            return authorize(principal, role, requestedResource, context);
+        }
     }
 
     public abstract boolean authorize(

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/BaseAuthorizerTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/BaseAuthorizerTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -90,6 +91,17 @@ class BaseAuthorizerTest {
 
         when(extractor.extractResource(any(), any())).thenThrow(new ExtractionException(null));
         assertFalse(sut.authorize(principal, TEST_ROLE, context));
+    }
+
+    @Test
+    void testAuthorize_systemResource() throws ExtractionException {
+        ResourceAuthZInfo authZInfo = mock(ResourceAuthZInfo.class);
+
+        when(authZInfo.type()).thenReturn(AuthZResource.Type.SYSTEM);
+        when(context.getProperty(ResourceAuthZInfo.class.getName())).thenReturn(authZInfo);
+
+        assertTrue(sut.authorize(principal, TEST_ROLE, context));
+        verify(extractorFactory, never()).create(authZInfo);
     }
 
     class TestAuthorizer extends BaseAuthorizer<TeletraanPrincipal> {


### PR DESCRIPTION
This part of incomplete and caught in Dev1. Implemented Pinger-Agent service Authorzation.
Changed the order of `ScriptTokenRoleAuthorizer.authorize()` as pinger requests are most common.