### PR TITLE
Handle client errors in `BaseAuthorizer`

### DIFF
--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/EnvStageBodyExtractor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/EnvStageBodyExtractor.java
@@ -124,10 +124,4 @@ public class EnvStageBodyExtractor implements AuthZResourceExtractor {
         EnvironBean envBean = environDAO.getById(agentBean.getEnv_id());
         return new AuthZResource(envBean.getEnv_name(), envBean.getStage_name());
     }
-
-    class BeanClassExtractionException extends ExtractionException {
-        public BeanClassExtractionException(Class<?> beanClass, Throwable cause) {
-            super(String.format("failed to extract as %s", beanClass.getName()), cause);
-        }
-    }
 }

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/EnvStageBodyExtractorTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/EnvStageBodyExtractorTest.java
@@ -29,7 +29,7 @@ import com.pinterest.deployservice.bean.EnvironBean;
 import com.pinterest.deployservice.bean.HotfixBean;
 import com.pinterest.deployservice.dao.EnvironDAO;
 import com.pinterest.teletraan.fixture.EnvironBeanFixture;
-import com.pinterest.teletraan.security.EnvStageBodyExtractor.BeanClassExtractionException;
+import com.pinterest.teletraan.universal.security.AuthZResourceExtractor.BeanClassExtractionException;
 import com.pinterest.teletraan.universal.security.AuthZResourceExtractor.ExtractionException;
 import com.pinterest.teletraan.universal.security.bean.AuthZResource;
 import java.io.ByteArrayInputStream;

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/AuthZResourceExtractor.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/AuthZResourceExtractor.java
@@ -55,4 +55,10 @@ public interface AuthZResourceExtractor {
             super(message);
         }
     }
+
+    class BeanClassExtractionException extends ExtractionException {
+        public BeanClassExtractionException(Class<?> beanClass, Throwable cause) {
+            super(String.format("failed to extract as %s. Check if request body is valid", beanClass.getName()), cause);
+        }
+    }
 }

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/BaseAuthorizerTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/BaseAuthorizerTest.java
@@ -30,6 +30,7 @@ import com.pinterest.teletraan.universal.security.bean.TeletraanPrincipal;
 import com.pinterest.teletraan.universal.security.bean.UserPrincipal;
 import java.util.Collections;
 import javax.annotation.Nullable;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.ContainerRequestContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -90,7 +91,7 @@ class BaseAuthorizerTest {
         verify(extractor).extractResource(context, authZInfo.beanClass());
 
         when(extractor.extractResource(any(), any())).thenThrow(new ExtractionException(null));
-        assertFalse(sut.authorize(principal, TEST_ROLE, context));
+        assertThrows(WebApplicationException.class, () -> sut.authorize(principal, TEST_ROLE, context));
     }
 
     @Test


### PR DESCRIPTION
This PR improves accuracy of HTTP response status by differentiating client errors and server errors. In the authorization process, if we cannot extract the bean from the request body, it is a client error.

### Before

The extra comma makes this an invalid Json. The previous handling makes this a 403, which is misleading. 

```bash
curl --location 'http://127.0.0.1:8011/v1/envs' --header 'Content-Type: application/json' --header 'Authorization: token redacted' --data '{
  "id": "f3LLmLiaTnODsyMwHF_S3g",
  "envName": "helloworlddummyservice",
}'
Message: User not authorized.
Resource: http://127.0.0.1:8011/v1/envs
Method: POST
Stack:
javax.ws.rs.ForbiddenException: User not authorized.
        at org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature$RolesAllowedRequestFilter.filter(RolesAllowedDynamicFeature.java:125)
        at org.glassfish.jersey.server.ContainerFilteringStage.apply(ContainerFilteringStage.java:108)
        at org.glassfish.jersey.server.ContainerFilteringStage.apply(ContainerFilteringStage.java:44)
...
```

### After

With this PR, the service will return 400 instead. 

```bash
curl --location 'http://127.0.0.1:8011/v1/envs' --header 'Content-Type: application/json' --header 'Authorization: token redated' --data '{
  "id": "f3LLmLiaTnODsyMwHF_S3g",
  "envName": "helloworlddummyservice",
}'
Message: HTTP 400 Bad Request
Resource: http://127.0.0.1:8011/v1/envs
Method: POST
Stack:
javax.ws.rs.WebApplicationException: HTTP 400 Bad Request
        at com.pinterest.teletraan.universal.security.BaseAuthorizer.authorize(BaseAuthorizer.java:80)
        at com.pinterest.teletraan.universal.security.BaseAuthorizer.authorize(BaseAuthorizer.java:1)
        at io.dropwizard.auth.AuthFilter$1.isUserInRole(AuthFilter.java:155)
        at org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature$RolesAllowedRequestFilter.filter(RolesAllowedDynamicFeature.java:119)
        at org.glassfish.jersey.server.ContainerFilteringStage.apply(ContainerFilteringStage.java:108)
        at org.glassfish.jersey.server.ContainerFilteringStage.apply(ContainerFilteringStage.java:44)
```