### PR TITLE
scroll buttons for sidecar deployments

### DIFF
--- a/deploy-board/deploy_board/templates/hosts/host_details.html
+++ b/deploy-board/deploy_board/templates/hosts/host_details.html
@@ -44,12 +44,20 @@
 <div class="panel panel-default">
     {% if has_host_env_sidecar_agents %}
     {% include "panel_heading.tmpl" with panel_title="Sidecar Agent Details" panel_body_id="sidecarAgentDetailsId" direction="down" copy_host_name_button=True %}
-    <div id="sidecarAgentDetailsId" class="collapse in panel-body">
-        <span>This is a sidecar deployment on the host. The relevant sidecar has been marked with a <span class="bg-info">blue background</span> for visibility.</span>
+    <div id="sidecarAgentDetailsId" class="panel-body">
     {% else %}
     {% include "panel_heading.tmpl" with panel_title="Sidecar Agent Details" panel_body_id="sidecarAgentDetailsId" direction="right" copy_host_name_button=True %}
     <div id="sidecarAgentDetailsId" class="collapse panel-body">
     {% endif %}
+        {% for agent_wrapper in agent_wrappers.sidecars %}
+            {% with env=agent_wrapper.env agent=agent_wrapper.agent %}
+            <button
+                class="{% if env and env_name == env.envName and stage_name == env.stageName %}sidecarButton{% endif %} deployToolTip btn btn-xs btn-default"
+                onclick="scrollToSidecar('{{agent.deployId}}')">
+                {{ env.envName }}
+            </button>
+            {% endwith %}
+        {% endfor %}
         {% for agent_wrapper in agent_wrappers.sidecars %}
         {% with env=agent_wrapper.env agent=agent_wrapper.agent hostdetailsvalue=host_details|getValue:"Phobos Link" %}
         {% if env and env_name == env.envName and stage_name == env.stageName %}
@@ -180,6 +188,16 @@
         document.execCommand('copy');
         document.body.removeChild(el);
     });
-</script>
 
+    function scrollToSidecar(sideCarId) {
+        const el = document.getElementById(`hostInfo${sideCarId}`);
+        el?.scrollIntoView({behavior: 'smooth', block: 'start'});
+    }
+</script>
+<style>
+     button.sidecarButton {
+        background-color: #d9edf7;
+        font-weight: bold;
+    }
+</style>
 {% endblock %}

--- a/deploy-board/deploy_board/templates/hosts/host_details.tmpl
+++ b/deploy-board/deploy_board/templates/hosts/host_details.tmpl
@@ -1,5 +1,5 @@
 {% load utils %}
-<div id="hostInfo" class="panel panel-default">
+<div id="hostInfo{{agent.deployId}}" class="panel panel-default">
     {% if host_related_sidecar %}
     <div class="panel-heading host-related-sidecar">
     {% else %}
@@ -88,10 +88,13 @@
     </div>
 </div>
 <style>
-    #hostInfo>.panel-heading.host-related-sidecar {
+    #hostInfo{{agent.deployId}}>.panel-heading.host-related-sidecar {
         background-image: none;
         background-color: #d9edf7;
         font-weight: bold;
+    }
+    #hostInfo{{agent.deployId}} {
+        scroll-margin-top: 80px;
     }
 </style>
 <script>


### PR DESCRIPTION
Add buttons at the top of the page that scrolls the user to a sidecar. If deploy is sidecar deployment, highlight the relevant sidecar button blue.


### Manual Testing

tested on dev1
<img width="254" alt="Screenshot 2024-04-04 at 11 29 02 PM" src="https://github.com/pinterest/teletraan/assets/104773032/089245fb-5945-4eed-86cd-a9b0e88f7b12">
