### PR TITLE
add sidecar navigation buttons and show status

### DIFF
--- a/deploy-board/deploy_board/templates/hosts/host_details.html
+++ b/deploy-board/deploy_board/templates/hosts/host_details.html
@@ -44,7 +44,7 @@
 <div class="panel panel-default">
     {% if has_host_env_sidecar_agents %}
     {% include "panel_heading.tmpl" with panel_title="Sidecar Agent Details" panel_body_id="sidecarAgentDetailsId" direction="down" copy_host_name_button=True %}
-    <div id="sidecarAgentDetailsId" class="panel-body">
+    <div id="sidecarAgentDetailsId" class="collapse in panel-body">
     {% else %}
     {% include "panel_heading.tmpl" with panel_title="Sidecar Agent Details" panel_body_id="sidecarAgentDetailsId" direction="right" copy_host_name_button=True %}
     <div id="sidecarAgentDetailsId" class="collapse panel-body">
@@ -52,8 +52,11 @@
         {% for agent_wrapper in agent_wrappers.sidecars %}
             {% with env=agent_wrapper.env agent=agent_wrapper.agent %}
             <button
-                class="{% if env and env_name == env.envName and stage_name == env.stageName %}sidecarButton{% endif %} deployToolTip btn btn-xs btn-default"
+                class="sidecarButton {% if agent.status == 'SUCCEEDED' %}bg-success{% elif agent.status in 'TOO_MANY_RETRY,SCRIPT_TIMEOUT,AGENT_FAILED,AGENT_FAILED,SCRIPT_FAILED' %}bg-danger{% endif %} deployToolTip btn btn-xs btn-default"
                 onclick="scrollToSidecar('{{agent.deployId}}')">
+                {% if env and env_name == env.envName and stage_name == env.stageName %}
+                <i class="fa fa-star"></i>
+                {% endif %}
                 {{ env.envName }}
             </button>
             {% endwith %}
@@ -195,9 +198,11 @@
     }
 </script>
 <style>
-     button.sidecarButton {
-        background-color: #d9edf7;
-        font-weight: bold;
-    }
+    .sidecarButton.bg-success{background-color:#dff0d8}
+    .sidecarButton.bg-success:hover{background-color:#c1e2b3}
+    .sidecarButton.bg-success:focus{background-color:#c1e2b3}
+    .sidecarButton.bg-danger{background-color:#f2dede}
+    .sidecarButton.bg-danger:hover{background-color:#e4b9b9}
+    .sidecarButton.bg-danger:focus{background-color:#e4b9b9}
 </style>
 {% endblock %}

--- a/deploy-board/deploy_board/templates/hosts/host_details.html
+++ b/deploy-board/deploy_board/templates/hosts/host_details.html
@@ -44,12 +44,20 @@
 <div class="panel panel-default">
     {% if has_host_env_sidecar_agents %}
     {% include "panel_heading.tmpl" with panel_title="Sidecar Agent Details" panel_body_id="sidecarAgentDetailsId" direction="down" copy_host_name_button=True %}
-    <div id="sidecarAgentDetailsId" class="collapse in panel-body">
-        <span>This is a sidecar deployment on the host. The relevant sidecar has been marked with a <span class="bg-info">blue background</span> for visibility.</span>
+    <div id="sidecarAgentDetailsId" class="panel-body">
     {% else %}
     {% include "panel_heading.tmpl" with panel_title="Sidecar Agent Details" panel_body_id="sidecarAgentDetailsId" direction="right" copy_host_name_button=True %}
     <div id="sidecarAgentDetailsId" class="collapse panel-body">
     {% endif %}
+        {% for agent_wrapper in agent_wrappers.sidecars %}
+            {% with env=agent_wrapper.env agent=agent_wrapper.agent %}
+            <button
+                class="{% if env and env_name == env.envName and stage_name == env.stageName %}sidecarButton{% endif %} deployToolTip btn btn-xs btn-default"
+                onclick="scrollToSidecar('{{agent.deployId}}')">
+                {{ env.envName }}
+            </button>
+            {% endwith %}
+        {% endfor %}
         {% for agent_wrapper in agent_wrappers.sidecars %}
         {% with env=agent_wrapper.env agent=agent_wrapper.agent hostdetailsvalue=host_details|getValue:"Phobos Link" %}
         {% if env and env_name == env.envName and stage_name == env.stageName %}
@@ -180,6 +188,16 @@
         document.execCommand('copy');
         document.body.removeChild(el);
     });
-</script>
 
+    function scrollToSidecar(sideCarId) {
+        const el = document.getElementById(`hostInfo${sideCarId}`);
+        el?.scrollIntoView({behavior: 'smooth', block: 'start'});
+    }
+</script>
+<style>
+     button.sidecarButton {
+        background-color: #d9edf7;
+        font-weight: bold;
+    }
+</style>
 {% endblock %}

--- a/deploy-board/deploy_board/templates/hosts/host_details.tmpl
+++ b/deploy-board/deploy_board/templates/hosts/host_details.tmpl
@@ -1,5 +1,5 @@
 {% load utils %}
-<div id="hostInfo" class="panel panel-default">
+<div id="hostInfo{{agent.deployId}}" class="panel panel-default">
     {% if host_related_sidecar %}
     <div class="panel-heading host-related-sidecar">
     {% else %}
@@ -88,10 +88,13 @@
     </div>
 </div>
 <style>
-    #hostInfo>.panel-heading.host-related-sidecar {
+    #hostInfo{{agent.deployId}}>.panel-heading.host-related-sidecar {
         background-image: none;
         background-color: #d9edf7;
         font-weight: bold;
+    }
+    #hostInfo{{agent.deployId}} {
+        scroll-margin-top: 80px;
     }
 </style>
 <script>

--- a/deploy-board/deploy_board/templates/hosts/host_details.tmpl
+++ b/deploy-board/deploy_board/templates/hosts/host_details.tmpl
@@ -2,6 +2,7 @@
 <div id="hostInfo{{agent.deployId}}" class="panel panel-default">
     {% if host_related_sidecar %}
     <div class="panel-heading host-related-sidecar">
+        <i class="fa fa-star"></i>
     {% else %}
     <div class="panel-heading">
     {% endif %}
@@ -89,8 +90,6 @@
 </div>
 <style>
     #hostInfo{{agent.deployId}}>.panel-heading.host-related-sidecar {
-        background-image: none;
-        background-color: #d9edf7;
         font-weight: bold;
     }
     #hostInfo{{agent.deployId}} {


### PR DESCRIPTION
update the sidecar section of the host details so that:
- sidecars have navigation buttons at the top of the sidecar section which scroll to the relevant deploy details.
- relevant sidecars are now indicated with a star instead of info colour
- sidecars with status `SUCCESS` show a green navigation button
- sidecars with status `TOO_MANY_RETRY, SCRIPT_TIMEOUT, AGENT_FAILED, AGENT_FAILED, SCRIPT_FAILED` show a red navigation button


### Manual Testing

tested on dev1
<img width="1400" alt="Screenshot 2024-04-05 at 11 01 10 AM" src="https://github.com/pinterest/teletraan/assets/104773032/a7afeb54-af68-43c6-bcaf-a905693a25b5">

