### PR TITLE
Adding additional validation to Environ API create and update

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironBean.java
@@ -229,8 +229,8 @@ public class EnvironBean implements Updatable, Serializable {
             throw new IllegalArgumentException(String.format("Chatroom must match regex %s", chatRegex));
         }
         if (this.stage_type == EnvType.DEFAULT) {
-            throw new IllegalArgumentException("DEFAULT stage type is not allowed!" +
-                        "Please one of the following Stage Types: " +
+            throw new IllegalArgumentException("DEFAULT stage type is not allowed! " +
+                        "Please select one of the following Stage Types: " +
                         "PRODUCTION, CONTROL, CANARY, STAGING, LATEST, DEV.");
         }
     }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironBean.java
@@ -228,6 +228,11 @@ public class EnvironBean implements Updatable, Serializable {
         if (this.chatroom != null && !this.chatroom.matches(chatRegex)) {
             throw new IllegalArgumentException(String.format("Chatroom must match regex %s", chatRegex));
         }
+        if (this.stage_type == EnvType.DEFAULT) {
+            throw new IllegalArgumentException("DEFAULT stage type is not allowed!" +
+                        "Please one of the following Stage Types: " +
+                        "PRODUCTION, CONTROL, CANARY, STAGING, LATEST, DEV.");
+        }
     }
 
     public String getWebhooks_config_id() {

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
@@ -124,7 +124,9 @@ public class EnvStages {
             throw new TeletaanInternalException(Response.Status.BAD_REQUEST, e.toString());
         }
 
-        if (environBean.getStage_type() == null) {
+        if (origBean.getStage_type() == EnvType.DEFAULT && environBean.getStage_type() == EnvType.DEFAULT) {
+            throw new TeletaanInternalException(Response.Status.BAD_REQUEST, "Please update the Stage Type to a value other than DEFAULT.");
+        } else if (environBean.getStage_type() == null) {
             // Request has no intention to change stage type, so set it to the current value
             // to avoid the default value being used.
             environBean.setStage_type(origBean.getStage_type());

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
@@ -124,7 +124,7 @@ public class EnvStages {
             throw new TeletaanInternalException(Response.Status.BAD_REQUEST, e.toString());
         }
 
-        if (origBean.getStage_type() == EnvType.DEFAULT && environBean.getStage_type() == EnvType.DEFAULT) {
+        if (origBean.getStage_type() == EnvType.DEFAULT && environBean.getStage_type() == null) {
             throw new TeletaanInternalException(Response.Status.BAD_REQUEST, "Please update the Stage Type to a value other than DEFAULT.");
         } else if (environBean.getStage_type() == null) {
             // Request has no intention to change stage type, so set it to the current value

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Environs.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Environs.java
@@ -162,11 +162,6 @@ public class Environs {
         String operator = sc.getUserPrincipal().getName();
         String envName = environBean.getEnv_name();
         List<EnvironBean> environBeans = environDAO.getByName(envName);
-        if (environBean.getStage_type() == EnvType.DEFAULT) {
-            throw new TeletaanInternalException(Response.Status.BAD_REQUEST,
-                    "DEFAULT stage type is not allowed! Please one of the following Stage Types: " +
-                        "PRODUCTION, CONTROL, CANARY, STAGING, LATEST, DEV.");
-        }
         String id = environHandler.createEnvStage(environBean, operator);
         if (sc.getUserPrincipal() instanceof UserPrincipal && CollectionUtils.isEmpty(environBeans)) {
             // This is the first stage for this env, let's make operator ADMIN of this env

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Environs.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Environs.java
@@ -22,6 +22,7 @@ import com.pinterest.deployservice.bean.TagTargetType;
 import com.pinterest.deployservice.bean.TagValue;
 import com.pinterest.deployservice.bean.TeletraanPrincipalRole;
 import com.pinterest.deployservice.bean.UserRolesBean;
+import com.pinterest.deployservice.bean.EnvType;
 import com.pinterest.deployservice.dao.EnvironDAO;
 import com.pinterest.deployservice.dao.UserRolesDAO;
 import com.pinterest.deployservice.handler.EnvTagHandler;
@@ -161,6 +162,11 @@ public class Environs {
         String operator = sc.getUserPrincipal().getName();
         String envName = environBean.getEnv_name();
         List<EnvironBean> environBeans = environDAO.getByName(envName);
+        if (environBean.getStage_type() == EnvType.DEFAULT) {
+            throw new TeletaanInternalException(Response.Status.BAD_REQUEST,
+                    "DEFAULT stage type is not allowed! Please one of the following Stage Types: " +
+                        "PRODUCTION, CONTROL, CANARY, STAGING, LATEST, DEV.");
+        }
         String id = environHandler.createEnvStage(environBean, operator);
         if (sc.getUserPrincipal() instanceof UserPrincipal && CollectionUtils.isEmpty(environBeans)) {
             // This is the first stage for this env, let's make operator ADMIN of this env

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Environs.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Environs.java
@@ -157,7 +157,7 @@ public class Environs {
         try {
             environBean.validate();
         } catch (Exception e) {
-            throw new IllegalArgumentException("Environment bean validation failed", e);
+            throw new IllegalArgumentException(String.format("Environment bean validation failed: %s", e));
         }
         String operator = sc.getUserPrincipal().getName();
         String envName = environBean.getEnv_name();


### PR DESCRIPTION
## Background: 
Non-default stage types are only being enforced at the UI level. This PR is to add additional enforcement to the API

## Tests:
<details><summary>Updating Stage Type from DEFAULT to another value</summary>
<p>
<img width="1834" alt="image" src="https://github.com/pinterest/teletraan/assets/69278532/001844f4-bd0f-479d-9942-e87533adb82d">
</p>
</details> 

<details><summary>Updating Stage Type from non-DEFAULT to DEFAULT</summary>
<p>
<img width="1846" alt="image" src="https://github.com/pinterest/teletraan/assets/69278532/96034e67-595a-43a4-886c-1a568b62afc9">
</p>
</details> 

<details><summary>Updating Env where Stage Type = DEFAULT but is not in request body</summary>
<p>
<img width="1877" alt="image" src="https://github.com/pinterest/teletraan/assets/69278532/b5fba8bb-e101-443c-96ea-d6008138a621">
</p>
</details> 

<details><summary>Updating Env where Stage Type = DEFAULT but is in request body</summary>
<p>
<img width="1875" alt="image" src="https://github.com/pinterest/teletraan/assets/69278532/11ad6bf7-539f-4829-8d0d-7b5b0533534f">
</p>
</details> 

<details><summary>Creating Env with stage type = DEFAULT</summary>
<p>
<img width="1829" alt="image" src="https://github.com/pinterest/teletraan/assets/69278532/91a43b3e-46d4-450e-90b7-238f6989c668">
</p>
</details> 

<details><summary>Creating Env with stage type != DEFAULT </summary>
<p>
<img width="1878" alt="image" src="https://github.com/pinterest/teletraan/assets/69278532/a4ae5238-0d97-4841-9e8a-0f78416a8827">
</p>
</details> 




