### PR TITLE
Add configs for toggle ACL management

### DIFF
--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/ConfigHelper.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/ConfigHelper.java
@@ -227,6 +227,10 @@ public class ConfigHelper {
 
         context.setDeployBoardUrlPrefix(configuration.getSystemFactory().getDashboardUrl());
         context.setChangeFeedUrl(configuration.getSystemFactory().getChangeFeedUrl());
+
+        context.setAclManagementEnabled(configuration.getSystemFactory().isAclManagementEnabled());
+        context.setAclManagementDisabledMessage(configuration.getSystemFactory().getAclManagementDisabledMessage());
+
         // Only applies to Teletraan agent service
         context.setAgentCountCacheTtl(configuration.getSystemFactory().getAgentCountCacheTtl());
         context.setMaxParallelThreshold(configuration.getSystemFactory().getMaxParallelThreshold());

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanServiceContext.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanServiceContext.java
@@ -27,6 +27,8 @@ public class TeletraanServiceContext extends ServiceContext {
   private ExternalAlertFactory externalAlertsFactory;
   private AuthorizationFactory authorizationFactory;
   private AuthZResourceExtractor.Factory authZResourceExtractorFactory;
+  private boolean aclManagementEnabled;
+  private String aclManagementDisabledMessage;
 
   public ExternalAlertFactory getExternalAlertsFactory() {
     return externalAlertsFactory;
@@ -69,4 +71,21 @@ public class TeletraanServiceContext extends ServiceContext {
       AuthZResourceExtractor.Factory authZResourceExtractorFactory) {
     this.authZResourceExtractorFactory = authZResourceExtractorFactory;
   }
+
+  public boolean isAclManagementEnabled() {
+    return aclManagementEnabled;
+  }
+
+  public void setAclManagementEnabled(boolean environmentAclManagementEnabled) {
+    this.aclManagementEnabled = environmentAclManagementEnabled;
+  }
+
+  public String getAclManagementDisabledMessage() {
+    return aclManagementDisabledMessage;
+  }
+
+  public void setAclManagementDisabledMessage(String environmentAclManagementDisabledMessage) {
+    this.aclManagementDisabledMessage = environmentAclManagementDisabledMessage;
+  }
+
 }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/SystemFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/SystemFactory.java
@@ -31,10 +31,16 @@ public class SystemFactory {
     private String clientError = Constants.CLIENT_ERROR_SHORT;
 
     @JsonProperty
-    private long agentCountCacheTtl = 10 * 1000;
+    private long agentCountCacheTtl = 10 * 1000l;
 
     @JsonProperty
     private long maxParallelThreshold = 10000;
+
+    @JsonProperty
+    private boolean aclManagementEnabled = true;
+
+    @JsonProperty
+    private String aclManagementDisabledMessage = "ACL management is disabled. Please contact your admin for modification.";
 
     public String getDashboardUrl() {
         return dashboardUrl;
@@ -75,4 +81,21 @@ public class SystemFactory {
     public void setMaxParallelThreshold(Long maxParallelThreshold) {
         this.maxParallelThreshold = maxParallelThreshold;
     }
+
+    public boolean isAclManagementEnabled() {
+        return aclManagementEnabled;
+    }
+
+    public void setAclManagementEnabled(boolean aclManagementEnabled) {
+        this.aclManagementEnabled = aclManagementEnabled;
+    }
+
+    public String getAclManagementDisabledMessage() {
+        return aclManagementDisabledMessage;
+    }
+
+    public void setAclManagementDisabledMessage(String aclManagementDisabledMessage) {
+        this.aclManagementDisabledMessage = aclManagementDisabledMessage;
+    }
+
 }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/GroupRoles.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/GroupRoles.java
@@ -20,15 +20,20 @@ import com.pinterest.deployservice.dao.GroupRolesDAO;
 import com.pinterest.teletraan.TeletraanServiceContext;
 import com.pinterest.teletraan.universal.security.bean.AuthZResource;
 
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.*;
 import java.net.URI;
 import java.util.List;
 
 public abstract class GroupRoles {
     private final GroupRolesDAO groupRolesDAO;
+    private boolean aclManagementEnabled;
+    private String aclManagementDisabledMessage;
 
     protected GroupRoles(TeletraanServiceContext context) {
         groupRolesDAO = context.getGroupRolesDAO();
+        aclManagementEnabled = context.isAclManagementEnabled();
+        aclManagementDisabledMessage = context.getAclManagementDisabledMessage();
     }
 
     public List<GroupRolesBean> getByResource(String resourceId,
@@ -43,11 +48,17 @@ public abstract class GroupRoles {
 
     public void update(GroupRolesBean bean, String groupName, String resourceId, AuthZResource.Type resourceType)
             throws Exception {
+        if (!aclManagementEnabled) {
+            throw new WebApplicationException(aclManagementDisabledMessage, Response.Status.FORBIDDEN);
+        }
         groupRolesDAO.update(bean, groupName, resourceId, resourceType);
     }
 
     public Response create(UriInfo uriInfo, GroupRolesBean bean, String resourceId, AuthZResource.Type resourceType)
             throws Exception {
+        if (!aclManagementEnabled) {
+            throw new WebApplicationException(aclManagementDisabledMessage, Response.Status.FORBIDDEN);
+        }
         bean.setResource_id(resourceId);
         bean.setResource_type(resourceType);
         groupRolesDAO.insert(bean);
@@ -58,6 +69,9 @@ public abstract class GroupRoles {
     }
 
     public void delete(String groupName, String resourceId, AuthZResource.Type resourceType) throws Exception {
+        if (!aclManagementEnabled) {
+            throw new WebApplicationException(aclManagementDisabledMessage, Response.Status.FORBIDDEN);
+        }
         groupRolesDAO.delete(groupName, resourceId, resourceType);
     }
 }


### PR DESCRIPTION
Add a flag to enable/disable internal ACL management. This applies to user roles and group roles. Token roles remains intact to maximize backward compatibility. When external authorization is used, Teletraan's own ACL should be disabled, at least for modification. 

We can have follow up changes to hide the UI for user and group management. 

# Tests
Tested in local dev setup. 