### PR TITLE
 Modified label remaining capacity

### DIFF
--- a/deploy-board/deploy_board/static/js/components/capacitycomponents.js
+++ b/deploy-board/deploy_board/static/js/components/capacitycomponents.js
@@ -121,10 +121,10 @@ Vue.component('in-rolling-alert', {
 });
 
 function getCapacityAlertMessage(isWarning, remainingCapacity, placements, increase) {
-    const errorMessage = `Insufficient combined remaining capacity in this cluster/auto scaling group. `;
+    const errorMessage = `Insufficient combined remaining subnet capacity in this cluster/auto scaling group. `;
     const instruction = `You can attach additional placements to the corresponding clutter to increase` +
                         ` total potential capacity at Cluster Configuration -> Advanced Settings.\n`;
-    const status = `Combined remaining capacity: ${remainingCapacity}\n` +
+    const status = `Combined remaining subnet capacity: ${remainingCapacity}\n` +
                    `Current placement(s): ${JSON.stringify(placements, ['capacity', 'provider_name', 'abstract_name'], 2)}`;
 
     if (isWarning) {
@@ -197,7 +197,7 @@ Vue.component("static-capacity-config", {
             <input name="capacity" class="form-control" type="number" min="0" required
                 :value="capacity" v-on:change="onCapacityChange($event.target.value)" @keydown.enter.prevent="">
             <div v-model="remainingCapacity">\
-                Remaining Capacity: {{remainingCapacity}}\
+                Remaining Subnet Capacity: {{remainingCapacity}}\
             </div>\
         </div>
     </div>

--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -83,7 +83,7 @@
                     <securityzone-help v-show="showSecurityZoneHelp" v-bind:data="securityZoneHelpData"></securityzone-help>
                     <placements-select label="Placements" title="Placements" showsubnettype="true" v-bind:selectoptions="placements" v-bind:assignpublicip="assignPublicIP" v-bind:subnettype="subnetType"
                  showhelp="true" v-on:helpclick="placementsHelpClick" v-on:assignpublicipclick="selectpublicip" v-on:subnetfilterclick="changeSubnetType"></placements-select>
-                    <remaining-capacity title="The total remaining capacity of selected placements" v-bind:remainingcapacity="remainingCapacity" v-bind:inadvanced="inAdvanced"></remaining-capacity>
+                    <remaining-capacity title="The total remaining subnet capacity of selected placements" v-bind:remainingcapacity="remainingCapacity" v-bind:inadvanced="inAdvanced"></remaining-capacity>
                     <form-warning v-show="showSubnetReplacementAlert" v-bind:alert-text="subnetReplacementWarning"></form-warning>
                     <placements-help v-show="showPlacementsHelp" v-bind:data="placementsHelpData"></placements-help>
                     <stateful-select :statefuloptions="statefulStatusOptions" :value="currentStatefulStatus" @help-clicked="statefulHelpClick" @stateful-change="statefulStatusChange"></stateful-select>

--- a/deploy-board/deploy_board/templates/environs/env_landing.html
+++ b/deploy-board/deploy_board/templates/environs/env_landing.html
@@ -243,7 +243,7 @@ var capacityPanel = new Vue({
                 capacityText: function() {
                     if (this.remainingCapacity != null && this.remainingCapacity < 100) {
                         this.capacityStateStyle = "color: #d32a0e"
-                        return `Capacity (Remaining Capacity: ${this.remainingCapacity})`
+                        return `Capacity (Remaining Subnet Capacity: ${this.remainingCapacity})`
                     } else {
                         return "Capacity"
                     }


### PR DESCRIPTION


On the Environment Landing page, Capacity page, and Cluster Configuration page "Remaining Capacity" should be changed to be more descriptive to "Remaining Subnet Capacity"
