### PR TITLE
expose replacement warmup

### DIFF
--- a/deploy-board/deploy_board/templates/clusters/cluster-replacement-details.tmpl
+++ b/deploy-board/deploy_board/templates/clusters/cluster-replacement-details.tmpl
@@ -108,6 +108,12 @@
                         </td>
                     </tr>
                     <tr>
+                        <th>Instance Warmup</th>
+                        <td>
+                            {{ replace_summary.rollingUpdateConfig.instanceWarmup }} second(s)
+                        </td>
+                    </tr>
+                    <tr>
                         <th>Desired Launch Template Name</th>
                         <td>
                             {{ replace_summary.desiredClusterConfig.launchTemplateName }}

--- a/deploy-board/deploy_board/templates/clusters/cluster-replacements.tmpl
+++ b/deploy-board/deploy_board/templates/clusters/cluster-replacements.tmpl
@@ -491,6 +491,13 @@
                     </label>
                 </div>
 
+                <div style="padding-top: 20px;">
+                    <label for="instanceWarmup" data-toggle="tooltip" title="Extra delay to wait for instance to warm up.">
+                        <span class="fa fa-clock-o"></span> Instance warmup (seconds):
+                    </label>
+                    <input type="number" id="instanceWarmup" name="instanceWarmup" min="0" value="0">
+                </div>
+
                 <div class="pull-left" style="padding-top: 20px;">
                     <p style="color:red;">Note: hosts that are running with latest cluster configurations (AMI, host type, etc.) won't be replaced. If you want to replace them anyway, please uncheck <b>Skip matching launch template</b></p>
 

--- a/deploy-board/deploy_board/webapp/cluster_view.py
+++ b/deploy-board/deploy_board/webapp/cluster_view.py
@@ -1301,6 +1301,7 @@ def gen_replacement_config(request):
     rollingUpdateConfig["scaleInProtectedInstances"] = scaleInProtectedInstances
     rollingUpdateConfig["checkpointPercentages"] = checkpointPercentages
     rollingUpdateConfig["checkpointDelay"] = params["checkpointDelay"]
+    rollingUpdateConfig["instanceWarmup"] = params["instanceWarmup"]
 
     return rollingUpdateConfig
 


### PR DESCRIPTION
Allow users to set instance warmup for cluster replacement:

<img width="1261" alt="image" src="https://github.com/pinterest/teletraan/assets/63071572/33fcf113-cafb-4487-8e46-45d5b077261e">


### Details page

<img width="979" alt="image" src="https://github.com/pinterest/teletraan/assets/63071572/b0de5925-dc7e-40cb-9b2a-9037013a8488">



