### PR TITLE
validate not trusted build urls and marked as private in non-dev systems

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
@@ -384,7 +384,7 @@ public class DeployHandler implements DeployHandlerInterface{
         5. no private build for sox env
         6. only sox build can be deployed for sox env
     */
-    private void validateBuild(EnvironBean envBean, String buildId) throws Exception {
+    protected void validateBuild(EnvironBean envBean, String buildId) throws Exception {
         if(StringUtils.isEmpty(buildId)) {
             throw new WebApplicationException("Build id can not be empty.", Response.Status.BAD_REQUEST);
         }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
@@ -442,8 +442,8 @@ public class DeployHandler implements DeployHandlerInterface{
     }
 
     private boolean isPrivateBuild(BuildBean buildBean) {
-        return buildBean.getScm_branch() != null
-                && buildBean.getScm_branch().toLowerCase().startsWith(PRIVATE_BUILD_SCM_BRANCH);
+        return buildBean.getScm_branch() == null
+                || buildBean.getScm_branch().toLowerCase().startsWith(PRIVATE_BUILD_SCM_BRANCH);
     }
 
     public String deploy(EnvironBean envBean, String buildId, String desc, String deliveryType, String operator) throws Exception {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
@@ -395,11 +395,10 @@ public class DeployHandler implements DeployHandlerInterface{
             throw new DeployInternalException("Build name (%s) does not match stage config (%s).",
                     buildBean.getBuild_name(), envBean.getBuild_name());
         }
-        
+
         if(envBean.getStage_type() != EnvType.DEV &&
                 buildAllowlist != null && !buildAllowlist.trusted(buildBean.getArtifact_url())
-                && buildBean.getScm_branch() != null
-                && !buildBean.getScm_branch().toLowerCase().startsWith(PRIVATE_BUILD_SCM_BRANCH)) {
+                && isPrivateBuild(buildBean)){
             buildBean.setScm_branch(PRIVATE_BUILD_SCM_BRANCH);
         }
 
@@ -431,6 +430,11 @@ public class DeployHandler implements DeployHandlerInterface{
                     "This stage requires SOX builds. The build must be from a sox-compliant source. Contact your sox administrators.",
                     Response.Status.BAD_REQUEST);
         }
+    }
+
+    private boolean isPrivateBuild(BuildBean buildBean) {
+        return buildBean.getScm_branch() != null
+                && !buildBean.getScm_branch().toLowerCase().startsWith(PRIVATE_BUILD_SCM_BRANCH);
     }
 
     public String deploy(EnvironBean envBean, String buildId, String desc, String deliveryType, String operator) throws Exception {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
@@ -89,6 +89,15 @@ public class DeployHandler implements DeployHandlerInterface{
         + "\"nimbus_uuid\":\"%s\"}";
     private static final String COMPARE_DEPLOY_URL = "https://deploy.pinadmin.com/env/%s/%s/compare_deploys_2/?chkbox_1=%s&chkbox_2=%s";
 
+    static final String ERROR_EMPTY_BUILD_ID = "Build id can not be empty.";
+    static final String ERROR_BUILD_NAME_NOT_MATCH_STAGE_CONFIG = "Build name (%s) does not match stage config (%s).";
+    static final String ERROR_NON_PRIVATE_UNTRUSTED_LOCATION = "Non-private build url points to an untrusted location (%s)."
+            + " Please Contact #teletraan to ensure the build artifact is published to a trusted url.";
+    static final String ERROR_STAGE_NOT_ALLOW_PRIVATE_BUILD = "This stage does not allow deploying a private build. "
+            + "Please Contact #teletraan to allow your stage for deploying private build.";
+    static final String ERROR_STAGE_REQUIRES_SOX_BUILD_COMPLIANT_STAGE = "This stage requires SOX builds. A private build cannot be used in a sox-compliant stage.";
+    static final String ERROR_STAGE_REQUIRES_SOX_BUILD_COMPLIANT_SOURCE = "This stage requires SOX builds. The build must be from a sox-compliant source. Contact your sox administrators.";
+
     private final DeployDAO deployDAO;
     private final EnvironDAO environDAO;
     private final BuildDAO buildDAO;
@@ -106,7 +115,7 @@ public class DeployHandler implements DeployHandlerInterface{
     private final BuildTagsManager buildTagsManager;
     private final Allowlist buildAllowlist;
     private final ConfigHistoryHandler configHistoryHandler;
-    private final String PRIVATE_BUILD_SCM_BRANCH = "private";
+    static final String PRIVATE_BUILD_SCM_BRANCH = "private";
 
     private final class NotifyJob implements Callable<Void> {
         private final EnvironBean envBean;
@@ -392,7 +401,7 @@ public class DeployHandler implements DeployHandlerInterface{
 
         // check build name must match stage config
         if(!buildBean.getBuild_name().equals(envBean.getBuild_name())) {
-            throw new DeployInternalException("Build name (%s) does not match stage config (%s).",
+            throw new DeployInternalException(ERROR_BUILD_NAME_NOT_MATCH_STAGE_CONFIG,
                     buildBean.getBuild_name(), envBean.getBuild_name());
         }
 
@@ -434,7 +443,7 @@ public class DeployHandler implements DeployHandlerInterface{
 
     private boolean isPrivateBuild(BuildBean buildBean) {
         return buildBean.getScm_branch() != null
-                && !buildBean.getScm_branch().toLowerCase().startsWith(PRIVATE_BUILD_SCM_BRANCH);
+                && buildBean.getScm_branch().toLowerCase().startsWith(PRIVATE_BUILD_SCM_BRANCH);
     }
 
     public String deploy(EnvironBean envBean, String buildId, String desc, String deliveryType, String operator) throws Exception {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
@@ -106,7 +106,7 @@ public class DeployHandler implements DeployHandlerInterface{
     private final BuildTagsManager buildTagsManager;
     private final Allowlist buildAllowlist;
     private final ConfigHistoryHandler configHistoryHandler;
-
+    private final String PRIVATE_BUILD_SCM_BRANCH = "private";
 
     private final class NotifyJob implements Callable<Void> {
         private final EnvironBean envBean;
@@ -398,8 +398,9 @@ public class DeployHandler implements DeployHandlerInterface{
         
         if(envBean.getStage_type() != EnvType.DEV &&
                 buildAllowlist != null && !buildAllowlist.trusted(buildBean.getArtifact_url())
-                &&  !buildBean.getScm_branch().equalsIgnoreCase("private")) {
-            buildBean.setScm_branch("private");
+                && buildBean.getScm_branch() != null
+                && !buildBean.getScm_branch().toLowerCase().startsWith(PRIVATE_BUILD_SCM_BRANCH)) {
+            buildBean.setScm_branch(PRIVATE_BUILD_SCM_BRANCH);
         }
 
         // only allow a non-private deploy if the build is from a trusted artifact url

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
@@ -395,6 +395,13 @@ public class DeployHandler implements DeployHandlerInterface{
             throw new DeployInternalException("Build name (%s) does not match stage config (%s).",
                     buildBean.getBuild_name(), envBean.getBuild_name());
         }
+        
+        if(envBean.getStage_type() != EnvType.DEV &&
+                buildAllowlist != null && !buildAllowlist.trusted(buildBean.getArtifact_url())
+                &&  !buildBean.getScm_branch().equalsIgnoreCase("private")) {
+            buildBean.setScm_branch("private");
+        }
+
         // only allow a non-private deploy if the build is from a trusted artifact url
         if(envBean.getEnsure_trusted_build() && !buildBean.getScm_branch().equals("private") &&
             buildAllowlist != null && !buildAllowlist.trusted(buildBean.getArtifact_url())) {

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/handler/DeployHandlerTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/handler/DeployHandlerTest.java
@@ -1,0 +1,205 @@
+package com.pinterest.deployservice.handler;
+
+import com.pinterest.deployservice.ServiceContext;
+import com.pinterest.deployservice.allowlists.BuildAllowlistImpl;
+import com.pinterest.deployservice.bean.BuildBean;
+import com.pinterest.deployservice.bean.EnvType;
+import com.pinterest.deployservice.bean.EnvironBean;
+import com.pinterest.deployservice.common.DeployInternalException;
+import com.pinterest.deployservice.dao.BuildDAO;
+import com.pinterest.deployservice.exception.TeletaanInternalException;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+import static com.pinterest.deployservice.handler.DeployHandler.ERROR_BUILD_NAME_NOT_MATCH_STAGE_CONFIG;
+import static com.pinterest.deployservice.handler.DeployHandler.ERROR_EMPTY_BUILD_ID;
+import static com.pinterest.deployservice.handler.DeployHandler.ERROR_NON_PRIVATE_UNTRUSTED_LOCATION;
+import static com.pinterest.deployservice.handler.DeployHandler.ERROR_STAGE_NOT_ALLOW_PRIVATE_BUILD;
+import static com.pinterest.deployservice.handler.DeployHandler.ERROR_STAGE_REQUIRES_SOX_BUILD_COMPLIANT_SOURCE;
+import static com.pinterest.deployservice.handler.DeployHandler.ERROR_STAGE_REQUIRES_SOX_BUILD_COMPLIANT_STAGE;
+import static com.pinterest.deployservice.handler.DeployHandler.PRIVATE_BUILD_SCM_BRANCH;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class DeployHandlerTest {
+    private DeployHandler deployHandler;
+    private BuildDAO buildDAO;
+    private final String BUILD_ID = "buildId01";
+    private final String NON_PRIVATE_BUILD_SCM_BRANCH ="non_private";
+    private final String FAIL_MESSAGE = "Should have thrown TeletaanInternalException: %s";
+
+    private ServiceContext createMockServiceContext() throws Exception {
+        buildDAO = mock(BuildDAO.class);
+
+        ServiceContext serviceContext = new ServiceContext();
+        serviceContext.setBuildDAO(buildDAO);
+        serviceContext.setBuildAllowlist( new BuildAllowlistImpl(new ArrayList<>(),new ArrayList<>(),new ArrayList<>()));
+        return serviceContext;
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        deployHandler = new DeployHandler(createMockServiceContext());
+    }
+
+    @Test
+    public void validateBuild() throws Exception {
+        when(buildDAO.getById(BUILD_ID)).thenReturn(genBuildBean(PRIVATE_BUILD_SCM_BRANCH));
+
+        EnvironBean envBean = genDefaultEnvBean();
+        envBean.setAllow_private_build(true);
+        try {
+            deployHandler.validateBuild(envBean, BUILD_ID);
+        } catch (Exception ex){
+            fail("Should not throw exception");
+        }
+    }
+
+    @Test
+    public void validateBuildNonPrivate() throws Exception {
+        when(buildDAO.getById(BUILD_ID)).thenReturn(genBuildBean(NON_PRIVATE_BUILD_SCM_BRANCH));
+
+        EnvironBean envBean = genDefaultEnvBean();
+        envBean.setAllow_private_build(true);
+        try {
+            deployHandler.validateBuild(envBean, BUILD_ID);
+        } catch (Exception ex){
+            fail("Should not throw exception");
+        }
+    }
+
+    @Test
+    public void validateBuildFailBuildIdEmpty() throws Exception {
+        EnvironBean envBean = genDefaultEnvBean();
+        try {
+            deployHandler.validateBuild(envBean, "");
+            fail(String.format(FAIL_MESSAGE,
+                    ERROR_EMPTY_BUILD_ID
+            ));
+        } catch (TeletaanInternalException ex){
+            assertTrue(ex.getResponse().getEntity().toString().contains(
+                    ERROR_EMPTY_BUILD_ID
+            ));
+        }
+    }
+
+    @Test
+    public void validateBuildFailBuildNotMatchStageConfig() throws Exception {
+        EnvironBean envBean = genDefaultEnvBean();
+        envBean.setBuild_name("other");
+        when(buildDAO.getById(BUILD_ID)).thenReturn(genBuildBean(NON_PRIVATE_BUILD_SCM_BRANCH));
+
+        try {
+            deployHandler.validateBuild(envBean, BUILD_ID);
+            fail(String.format(FAIL_MESSAGE,
+                    String.format(ERROR_BUILD_NAME_NOT_MATCH_STAGE_CONFIG,
+                            genBuildBean(NON_PRIVATE_BUILD_SCM_BRANCH).getBuild_name(),
+                            envBean.getBuild_name())));
+        } catch (DeployInternalException ex){
+            assertTrue(ex.getMessage().contains(
+                    String.format(ERROR_BUILD_NAME_NOT_MATCH_STAGE_CONFIG,
+                            genBuildBean(NON_PRIVATE_BUILD_SCM_BRANCH).getBuild_name(),
+                            envBean.getBuild_name())));
+        }
+    }
+
+    @Test
+    public void validateBuildFailNonPrivateFromUntrustedLocation() throws Exception {
+        BuildBean buildBean = genBuildBean(NON_PRIVATE_BUILD_SCM_BRANCH);
+        when(buildDAO.getById(BUILD_ID)).thenReturn(buildBean);
+        EnvironBean envBean = genDefaultEnvBean();
+        envBean.setEnsure_trusted_build(true);
+
+        try {
+            deployHandler.validateBuild(envBean, BUILD_ID);
+            fail(String.format(FAIL_MESSAGE,
+                    String.format(ERROR_NON_PRIVATE_UNTRUSTED_LOCATION,
+                            buildBean.getArtifact_url())));
+        } catch (TeletaanInternalException ex){
+            assertTrue(ex.getResponse().getEntity().toString().contains(
+                    String.format(ERROR_NON_PRIVATE_UNTRUSTED_LOCATION,
+                            buildBean.getArtifact_url())
+            ));
+        }
+    }
+
+    @Test
+    public void validateBuildFailErrorStageNotAllowedPrivateBuild() throws Exception {
+        BuildBean buildBean = genBuildBean(PRIVATE_BUILD_SCM_BRANCH);
+        when(buildDAO.getById(BUILD_ID)).thenReturn(buildBean);
+
+        try {
+            deployHandler.validateBuild(genDefaultEnvBean(), BUILD_ID);
+            fail(String.format(FAIL_MESSAGE,
+                    ERROR_STAGE_NOT_ALLOW_PRIVATE_BUILD));
+        } catch (TeletaanInternalException ex){
+            assertTrue(ex.getResponse().getEntity().toString().contains(
+                    ERROR_STAGE_NOT_ALLOW_PRIVATE_BUILD));
+        }
+    }
+
+    @Test
+    public void validateBuildFailErrorStageRequiresSoxBuild() throws Exception {
+        BuildBean buildBean = genBuildBean(PRIVATE_BUILD_SCM_BRANCH);
+        when(buildDAO.getById(BUILD_ID)).thenReturn(buildBean);
+
+        EnvironBean envBean = genDefaultEnvBean();
+        envBean.setIs_sox(true);
+        envBean.setAllow_private_build(true);
+
+        try {
+            deployHandler.validateBuild(envBean, BUILD_ID);
+            fail(String.format(FAIL_MESSAGE,
+                    ERROR_STAGE_REQUIRES_SOX_BUILD_COMPLIANT_STAGE));
+        } catch (TeletaanInternalException ex){
+            assertTrue(ex.getResponse().getEntity().toString().contains(
+                    ERROR_STAGE_REQUIRES_SOX_BUILD_COMPLIANT_STAGE)
+            );
+        }
+    }
+    @Test
+    public void validateBuildFailErrorStageRequiresSoxBuildCompliantSource() throws Exception {
+        BuildBean buildBean = genBuildBean(NON_PRIVATE_BUILD_SCM_BRANCH);
+        when(buildDAO.getById(BUILD_ID)).thenReturn(buildBean);
+
+        EnvironBean envBean = genDefaultEnvBean();
+        envBean.setIs_sox(true);
+        envBean.setAllow_private_build(true);
+
+        try {
+            deployHandler.validateBuild(envBean, BUILD_ID);
+            fail(String.format(FAIL_MESSAGE,
+                    ERROR_STAGE_REQUIRES_SOX_BUILD_COMPLIANT_SOURCE));
+        } catch (TeletaanInternalException ex){
+            assertTrue(ex.getResponse().getEntity().toString().contains(
+                    ERROR_STAGE_REQUIRES_SOX_BUILD_COMPLIANT_SOURCE)
+            );
+        }
+    }
+
+    private BuildBean genBuildBean(String scmBranch) {
+        BuildBean bean = new BuildBean();
+        bean.setBuild_id(BUILD_ID);
+        bean.setBuild_name("buildName");
+        bean.setArtifact_url("www.pinterest.com");
+        bean.setScm_branch(scmBranch);
+
+        return bean;
+    }
+
+    private EnvironBean genDefaultEnvBean() {
+        EnvironBean envBean = new EnvironBean();
+        envBean.setBuild_name("buildName");
+        envBean.setStage_type(EnvType.DEV);
+        envBean.setEnv_name(EnvType.DEV.toString());
+        envBean.setEnsure_trusted_build(false);
+        envBean.setIs_sox(false);
+        envBean.setAllow_private_build(false);
+
+        return envBean;
+    }
+}

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/handler/DeployHandlerTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/handler/DeployHandlerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.pinterest.deployservice.handler;
 
 import com.pinterest.deployservice.ServiceContext;
@@ -7,8 +23,8 @@ import com.pinterest.deployservice.bean.EnvType;
 import com.pinterest.deployservice.bean.EnvironBean;
 import com.pinterest.deployservice.common.DeployInternalException;
 import com.pinterest.deployservice.dao.BuildDAO;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.WebApplicationException;
 import java.util.ArrayList;
@@ -20,16 +36,18 @@ import static com.pinterest.deployservice.handler.DeployHandler.ERROR_STAGE_NOT_
 import static com.pinterest.deployservice.handler.DeployHandler.ERROR_STAGE_REQUIRES_SOX_BUILD_COMPLIANT_SOURCE;
 import static com.pinterest.deployservice.handler.DeployHandler.ERROR_STAGE_REQUIRES_SOX_BUILD_COMPLIANT_STAGE;
 import static com.pinterest.deployservice.handler.DeployHandler.PRIVATE_BUILD_SCM_BRANCH;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class DeployHandlerTest {
-    private DeployHandler deployHandler;
+    private static DeployHandler deployHandler;
     private BuildDAO buildDAO;
     private final String BUILD_ID = "buildId01";
-    private final String NON_PRIVATE_BUILD_SCM_BRANCH ="non_private";
+    private final String NON_PRIVATE_BUILD_SCM_BRANCH = "non_private";
     private final String FAIL_MESSAGE = "Should have thrown WebApplicationException: %s";
 
     private ServiceContext createMockServiceContext() throws Exception {
@@ -37,11 +55,11 @@ public class DeployHandlerTest {
 
         ServiceContext serviceContext = new ServiceContext();
         serviceContext.setBuildDAO(buildDAO);
-        serviceContext.setBuildAllowlist( new BuildAllowlistImpl(new ArrayList<>(),new ArrayList<>(),new ArrayList<>()));
+        serviceContext.setBuildAllowlist(new BuildAllowlistImpl(new ArrayList<>(), new ArrayList<>(), new ArrayList<>()));
         return serviceContext;
     }
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         deployHandler = new DeployHandler(createMockServiceContext());
     }
@@ -52,11 +70,7 @@ public class DeployHandlerTest {
 
         EnvironBean envBean = genDefaultEnvBean();
         envBean.setAllow_private_build(true);
-        try {
-            deployHandler.validateBuild(envBean, BUILD_ID);
-        } catch (Exception ex){
-            fail("Should not throw exception");
-        }
+        assertDoesNotThrow(() -> deployHandler.validateBuild(envBean, BUILD_ID));
     }
 
     @Test
@@ -65,26 +79,16 @@ public class DeployHandlerTest {
 
         EnvironBean envBean = genDefaultEnvBean();
         envBean.setAllow_private_build(true);
-        try {
-            deployHandler.validateBuild(envBean, BUILD_ID);
-        } catch (Exception ex){
-            fail("Should not throw exception");
-        }
+        assertDoesNotThrow(() -> deployHandler.validateBuild(envBean, BUILD_ID));
     }
 
     @Test
     public void validateBuildFailBuildIdEmpty() throws Exception {
         EnvironBean envBean = genDefaultEnvBean();
-        try {
-            deployHandler.validateBuild(envBean, "");
-            fail(String.format(FAIL_MESSAGE,
-                    ERROR_EMPTY_BUILD_ID
-            ));
-        } catch (WebApplicationException ex){
-            assertTrue(ex.getMessage().contains(
-                    ERROR_EMPTY_BUILD_ID
-            ));
-        }
+
+        Throwable throwable = assertThrows(WebApplicationException.class,
+                () -> deployHandler.validateBuild(envBean, ""));
+        assertTrue(throwable.getMessage().contains(ERROR_EMPTY_BUILD_ID));
     }
 
     @Test
@@ -93,18 +97,12 @@ public class DeployHandlerTest {
         envBean.setBuild_name("other");
         when(buildDAO.getById(BUILD_ID)).thenReturn(genBuildBean(NON_PRIVATE_BUILD_SCM_BRANCH));
 
-        try {
-            deployHandler.validateBuild(envBean, BUILD_ID);
-            fail(String.format(FAIL_MESSAGE,
-                    String.format(ERROR_BUILD_NAME_NOT_MATCH_STAGE_CONFIG,
-                            genBuildBean(NON_PRIVATE_BUILD_SCM_BRANCH).getBuild_name(),
-                            envBean.getBuild_name())));
-        } catch (DeployInternalException ex){
-            assertTrue(ex.getMessage().contains(
-                    String.format(ERROR_BUILD_NAME_NOT_MATCH_STAGE_CONFIG,
-                            genBuildBean(NON_PRIVATE_BUILD_SCM_BRANCH).getBuild_name(),
-                            envBean.getBuild_name())));
-        }
+        Throwable throwable = assertThrows(DeployInternalException.class,
+                () -> deployHandler.validateBuild(envBean, BUILD_ID));
+        assertTrue(throwable.getMessage().contains(
+                String.format(ERROR_BUILD_NAME_NOT_MATCH_STAGE_CONFIG,
+                        genBuildBean(NON_PRIVATE_BUILD_SCM_BRANCH).getBuild_name(),
+                        envBean.getBuild_name())));
     }
 
     @Test
@@ -113,18 +111,12 @@ public class DeployHandlerTest {
         when(buildDAO.getById(BUILD_ID)).thenReturn(buildBean);
         EnvironBean envBean = genDefaultEnvBean();
         envBean.setEnsure_trusted_build(true);
-
-        try {
-            deployHandler.validateBuild(envBean, BUILD_ID);
-            fail(String.format(FAIL_MESSAGE,
-                    String.format(ERROR_NON_PRIVATE_UNTRUSTED_LOCATION,
-                            buildBean.getArtifact_url())));
-        } catch (WebApplicationException ex){
-            assertTrue(ex.getMessage().contains(
-                    String.format(ERROR_NON_PRIVATE_UNTRUSTED_LOCATION,
-                            buildBean.getArtifact_url())
-            ));
-        }
+        Throwable throwable = assertThrows(WebApplicationException.class,
+                () -> deployHandler.validateBuild(envBean, BUILD_ID));
+        assertTrue(throwable.getMessage().contains(
+                String.format(ERROR_NON_PRIVATE_UNTRUSTED_LOCATION,
+                        buildBean.getArtifact_url()))
+        );
     }
 
     @Test
@@ -132,14 +124,9 @@ public class DeployHandlerTest {
         BuildBean buildBean = genBuildBean(PRIVATE_BUILD_SCM_BRANCH);
         when(buildDAO.getById(BUILD_ID)).thenReturn(buildBean);
 
-        try {
-            deployHandler.validateBuild(genDefaultEnvBean(), BUILD_ID);
-            fail(String.format(FAIL_MESSAGE,
-                    ERROR_STAGE_NOT_ALLOW_PRIVATE_BUILD));
-        } catch (WebApplicationException ex){
-            assertTrue(ex.getMessage().contains(
-                    ERROR_STAGE_NOT_ALLOW_PRIVATE_BUILD));
-        }
+        Throwable throwable = assertThrows(WebApplicationException.class,
+                () -> deployHandler.validateBuild(genDefaultEnvBean(), BUILD_ID));
+        assertTrue(throwable.getMessage().contains(ERROR_STAGE_NOT_ALLOW_PRIVATE_BUILD));
     }
 
     @Test
@@ -151,16 +138,11 @@ public class DeployHandlerTest {
         envBean.setIs_sox(true);
         envBean.setAllow_private_build(true);
 
-        try {
-            deployHandler.validateBuild(envBean, BUILD_ID);
-            fail(String.format(FAIL_MESSAGE,
-                    ERROR_STAGE_REQUIRES_SOX_BUILD_COMPLIANT_STAGE));
-        } catch (WebApplicationException ex){
-            assertTrue(ex.getMessage().contains(
-                    ERROR_STAGE_REQUIRES_SOX_BUILD_COMPLIANT_STAGE)
-            );
-        }
+        Throwable throwable = assertThrows(WebApplicationException.class,
+                () -> deployHandler.validateBuild(envBean, BUILD_ID));
+        assertTrue(throwable.getMessage().contains(ERROR_STAGE_REQUIRES_SOX_BUILD_COMPLIANT_STAGE));
     }
+
     @Test
     public void validateBuildFailErrorStageRequiresSoxBuildCompliantSource() throws Exception {
         BuildBean buildBean = genBuildBean(NON_PRIVATE_BUILD_SCM_BRANCH);
@@ -170,15 +152,9 @@ public class DeployHandlerTest {
         envBean.setIs_sox(true);
         envBean.setAllow_private_build(true);
 
-        try {
-            deployHandler.validateBuild(envBean, BUILD_ID);
-            fail(String.format(FAIL_MESSAGE,
-                    ERROR_STAGE_REQUIRES_SOX_BUILD_COMPLIANT_SOURCE));
-        } catch (WebApplicationException ex){
-            assertTrue(ex.getMessage().contains(
-                    ERROR_STAGE_REQUIRES_SOX_BUILD_COMPLIANT_SOURCE)
-            );
-        }
+        Throwable throwable = assertThrows(WebApplicationException.class,
+                () -> deployHandler.validateBuild(envBean, BUILD_ID));
+        assertTrue(throwable.getMessage().contains(ERROR_STAGE_REQUIRES_SOX_BUILD_COMPLIANT_SOURCE));
     }
 
     private BuildBean genBuildBean(String scmBranch) {

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/handler/DeployHandlerTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/handler/DeployHandlerTest.java
@@ -7,10 +7,10 @@ import com.pinterest.deployservice.bean.EnvType;
 import com.pinterest.deployservice.bean.EnvironBean;
 import com.pinterest.deployservice.common.DeployInternalException;
 import com.pinterest.deployservice.dao.BuildDAO;
-import com.pinterest.deployservice.exception.TeletaanInternalException;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.ws.rs.WebApplicationException;
 import java.util.ArrayList;
 
 import static com.pinterest.deployservice.handler.DeployHandler.ERROR_BUILD_NAME_NOT_MATCH_STAGE_CONFIG;
@@ -30,7 +30,7 @@ public class DeployHandlerTest {
     private BuildDAO buildDAO;
     private final String BUILD_ID = "buildId01";
     private final String NON_PRIVATE_BUILD_SCM_BRANCH ="non_private";
-    private final String FAIL_MESSAGE = "Should have thrown TeletaanInternalException: %s";
+    private final String FAIL_MESSAGE = "Should have thrown WebApplicationException: %s";
 
     private ServiceContext createMockServiceContext() throws Exception {
         buildDAO = mock(BuildDAO.class);
@@ -80,8 +80,8 @@ public class DeployHandlerTest {
             fail(String.format(FAIL_MESSAGE,
                     ERROR_EMPTY_BUILD_ID
             ));
-        } catch (TeletaanInternalException ex){
-            assertTrue(ex.getResponse().getEntity().toString().contains(
+        } catch (WebApplicationException ex){
+            assertTrue(ex.getMessage().contains(
                     ERROR_EMPTY_BUILD_ID
             ));
         }
@@ -119,8 +119,8 @@ public class DeployHandlerTest {
             fail(String.format(FAIL_MESSAGE,
                     String.format(ERROR_NON_PRIVATE_UNTRUSTED_LOCATION,
                             buildBean.getArtifact_url())));
-        } catch (TeletaanInternalException ex){
-            assertTrue(ex.getResponse().getEntity().toString().contains(
+        } catch (WebApplicationException ex){
+            assertTrue(ex.getMessage().contains(
                     String.format(ERROR_NON_PRIVATE_UNTRUSTED_LOCATION,
                             buildBean.getArtifact_url())
             ));
@@ -136,8 +136,8 @@ public class DeployHandlerTest {
             deployHandler.validateBuild(genDefaultEnvBean(), BUILD_ID);
             fail(String.format(FAIL_MESSAGE,
                     ERROR_STAGE_NOT_ALLOW_PRIVATE_BUILD));
-        } catch (TeletaanInternalException ex){
-            assertTrue(ex.getResponse().getEntity().toString().contains(
+        } catch (WebApplicationException ex){
+            assertTrue(ex.getMessage().contains(
                     ERROR_STAGE_NOT_ALLOW_PRIVATE_BUILD));
         }
     }
@@ -155,8 +155,8 @@ public class DeployHandlerTest {
             deployHandler.validateBuild(envBean, BUILD_ID);
             fail(String.format(FAIL_MESSAGE,
                     ERROR_STAGE_REQUIRES_SOX_BUILD_COMPLIANT_STAGE));
-        } catch (TeletaanInternalException ex){
-            assertTrue(ex.getResponse().getEntity().toString().contains(
+        } catch (WebApplicationException ex){
+            assertTrue(ex.getMessage().contains(
                     ERROR_STAGE_REQUIRES_SOX_BUILD_COMPLIANT_STAGE)
             );
         }
@@ -174,8 +174,8 @@ public class DeployHandlerTest {
             deployHandler.validateBuild(envBean, BUILD_ID);
             fail(String.format(FAIL_MESSAGE,
                     ERROR_STAGE_REQUIRES_SOX_BUILD_COMPLIANT_SOURCE));
-        } catch (TeletaanInternalException ex){
-            assertTrue(ex.getResponse().getEntity().toString().contains(
+        } catch (WebApplicationException ex){
+            assertTrue(ex.getMessage().contains(
                     ERROR_STAGE_REQUIRES_SOX_BUILD_COMPLIANT_SOURCE)
             );
         }


### PR DESCRIPTION
if build url is not in trusted list, it should automatically be marked as private by Teletraan and the deploy-agent should reject the build for non dev systems