### PR TITLE
Fix auth filter sequence

### DIFF
--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/CompositeAuthenticationFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/CompositeAuthenticationFactory.java
@@ -28,8 +28,7 @@ import io.dropwizard.auth.AuthFilter;
 import io.dropwizard.auth.Authenticator;
 import io.dropwizard.auth.CachingAuthenticator;
 import io.dropwizard.auth.chained.ChainedAuthFilter;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Arrays;
 import javax.ws.rs.container.ContainerRequestFilter;
 import org.apache.commons.lang3.StringUtils;
 
@@ -38,7 +37,6 @@ public class CompositeAuthenticationFactory extends TokenAuthenticationFactory {
     @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public ContainerRequestFilter create(TeletraanServiceContext context) throws Exception {
-        List<AuthFilter> tokenFilters = createAuthFilters(context);
         Authenticator<EnvoyCredentials, TeletraanPrincipal> authenticator =
                 new EnvoyAuthenticator();
 
@@ -54,10 +52,7 @@ public class CompositeAuthenticationFactory extends TokenAuthenticationFactory {
                         .setAuthorizer(context.getAuthorizationFactory().create(context))
                         .buildAuthFilter();
 
-        List<AuthFilter> filters = new ArrayList<>();
-        filters.addAll(tokenFilters);
-        filters.add(envoyAuthFilter);
-
-        return new ChainedAuthFilter(filters);
+        return new ChainedAuthFilter(Arrays.asList(createScriptTokenAuthFilter(context),
+                createOauthTokenAuthFilter(context), envoyAuthFilter, createJwtTokenAuthFilter(context)));
     }
 }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/TokenAuthenticationFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/TokenAuthenticationFactory.java
@@ -94,18 +94,13 @@ public class TokenAuthenticationFactory implements AuthenticationFactory {
     @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public ContainerRequestFilter create(TeletraanServiceContext context) throws Exception {
-        List<AuthFilter> filters = createAuthFilters(context);
-
-        return new ChainedAuthFilter(filters);
-    }
-
-    @SuppressWarnings("rawtypes")
-    List<AuthFilter> createAuthFilters(TeletraanServiceContext context) throws Exception {
-        return Arrays.asList(createScriptTokenAuthFilter(context), createOauthTokenAuthFilter(context), createJwtTokenAuthFilter(context));
+        return new ChainedAuthFilter(Arrays.asList(createScriptTokenAuthFilter(context),
+                createOauthTokenAuthFilter(context), createJwtTokenAuthFilter(context)));
     }
 
     @SuppressWarnings({ "unchecked" })
-    private AuthFilter<String, ScriptTokenPrincipal<ValueBasedRole>> createScriptTokenAuthFilter(TeletraanServiceContext context) throws Exception {
+    AuthFilter<String, ScriptTokenPrincipal<ValueBasedRole>> createScriptTokenAuthFilter(
+            TeletraanServiceContext context) throws Exception {
         Authenticator<String, ScriptTokenPrincipal<ValueBasedRole>> scriptTokenAuthenticator =
                 new ScriptTokenAuthenticator<>(new TeletraanScriptTokenProvider(context));
         if (StringUtils.isNotBlank(getTokenCacheSpec())) {
@@ -125,7 +120,7 @@ public class TokenAuthenticationFactory implements AuthenticationFactory {
 
     // TODO: CDP-7837 remove this after all the clients are updated to use the new token scheme
     @SuppressWarnings({ "unchecked" })
-    private AuthFilter<String, UserPrincipal> createOauthTokenAuthFilter(TeletraanServiceContext context) throws Exception {
+    AuthFilter<String, UserPrincipal> createOauthTokenAuthFilter(TeletraanServiceContext context) throws Exception {
         Authenticator<String, UserPrincipal> oauthAuthenticator =
                 new OAuthAuthenticator(getUserDataUrl(), getGroupDataUrl());
         if (StringUtils.isNotBlank(getTokenCacheSpec())) {
@@ -144,7 +139,7 @@ public class TokenAuthenticationFactory implements AuthenticationFactory {
     }
 
     @SuppressWarnings({ "unchecked" })
-    private AuthFilter<String, UserPrincipal> createJwtTokenAuthFilter(TeletraanServiceContext context) throws Exception {
+    AuthFilter<String, UserPrincipal> createJwtTokenAuthFilter(TeletraanServiceContext context) throws Exception {
         Authenticator<String, UserPrincipal> oauthJwtAuthenticator = new OAuthAuthenticator(getUserDataUrl(),
                 getGroupDataUrl());
         if (StringUtils.isNotBlank(getTokenCacheSpec())) {


### PR DESCRIPTION
Since Envoy will pass through the `Authorization` header, having the OAuth filter before Envoy auth filter is effectively disaling Envoy auth filter. This PR changes the evaluation order. 

## Validation
Deployed to dev1 and validated that requests with `Authorization: Bearer <jwt token>` were indeed processed by the Envoy auth filter and Pastis was invoked for authorization. And when requests were sent with with `Authorization: token <jwt token>`, the Oauth auth filter is involved. 