### PR TITLE
Update alarm dropdown header to be outside of collapsible content

### DIFF
--- a/deploy-board/deploy_board/templates/groups/asg_metrics.tmpl
+++ b/deploy-board/deploy_board/templates/groups/asg_metrics.tmpl
@@ -1,6 +1,6 @@
-<div id="asMetricsId" class="collapse in panel-body">
 {% load utils %}
 {% include "panel_heading.tmpl" with panel_title="Scaling Alarms" panel_body_id="asMetricsId" direction="down" %}
+<div id="asMetricsId" class="collapse in panel-body">
 <script>
 var ALARM_WARNING_THRESHOLD = 70;
 var ALARM_WARNING_TEXT = `CPUUtilization > ${ALARM_WARNING_THRESHOLD}% is recommended only for applications that are less latency sensitive. Load testing to determine an appropriate threshold is strongly encouraged.`;


### PR DESCRIPTION
Update alarm section's dropdown to be outside of collapsible content


### Previous

<img width="714" alt="Screenshot 2024-04-18 at 1 15 02 PM" src="https://github.com/pinterest/teletraan/assets/104773032/0196e205-8ba1-4fe0-866e-fde109623a94">
<img width="719" alt="Screenshot 2024-04-18 at 1 15 08 PM" src="https://github.com/pinterest/teletraan/assets/104773032/a559f476-d041-483f-8960-ec33433d2b8f">

### Now
<img width="718" alt="Screenshot 2024-04-18 at 1 15 22 PM" src="https://github.com/pinterest/teletraan/assets/104773032/8a269b08-4f4f-4b51-9a22-1c2c9a157a37">
<img width="728" alt="Screenshot 2024-04-18 at 1 20 32 PM" src="https://github.com/pinterest/teletraan/assets/104773032/71082632-ed41-4c2a-85b4-2f3ec0da1a78">

