### PR TITLE
Allow ENV script tokens to publish build

### DIFF
--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/ScriptTokenRoleAuthorizer.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/ScriptTokenRoleAuthorizer.java
@@ -55,6 +55,9 @@ public class ScriptTokenRoleAuthorizer
                 && !(TeletraanPrincipalRole.ADMIN.getRole().equals(principal.getRole())
                         || AuthZResource.Type.SYSTEM.equals(principal.getResource().getType()))) {
             return false;
+        } else if (AuthZResource.Type.BUILD.equals(requestedResource.getType())
+                && principal.getRole().isEqualOrSuperior(TeletraanPrincipalRole.PUBLISHER.getRole())) {
+            return true;
         }
 
         if (requestedResource.equals(principal.getResource())

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/ScriptTokenRoleAuthorizerTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/ScriptTokenRoleAuthorizerTest.java
@@ -223,8 +223,19 @@ public class ScriptTokenRoleAuthorizerTest {
     }
 
     @Test
-    public void testPublisherCanPublish() throws Exception {
+    public void testPublish() throws Exception {
+        AuthZResource build = new AuthZResource("build", AuthZResource.Type.BUILD);
         checkPositive(publisher, AuthZResource.SYSTEM_RESOURCE, TeletraanPrincipalRole.PUBLISHER);
-        checkPositive(publisher, new AuthZResource("build", AuthZResource.Type.BUILD), TeletraanPrincipalRole.PUBLISHER);
+        checkPositive(publisher, build, TeletraanPrincipalRole.PUBLISHER);
+
+        checkNegative(pinger, build, TeletraanPrincipalRole.PUBLISHER);
+
+        checkPositive(envAdmin, build, TeletraanPrincipalRole.PUBLISHER);
+        checkPositive(envOperator, build, TeletraanPrincipalRole.PUBLISHER);
+        checkNegative(envReader, build, TeletraanPrincipalRole.PUBLISHER);
+
+        checkPositive(sysAdmin, build, TeletraanPrincipalRole.PUBLISHER);
+        checkPositive(sysOperator, build, TeletraanPrincipalRole.PUBLISHER);
+        checkNegative(sysReader, build, TeletraanPrincipalRole.PUBLISHER);
     }
 }


### PR DESCRIPTION
We [didn't have authorization ](https://github.com/pinterest/teletraan/blame/381739be6f276afc9b47ae5ea846deb8a34389e5/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Builds.java)for publishing a build (what??) 

Now we do, and it's breaking some existing scenarios, so patch it to allow ENV script tokens to publish builds. 