### PR TITLE
Address an AuthZ flaw

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/EnvironDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/EnvironDAO.java
@@ -18,6 +18,7 @@ package com.pinterest.deployservice.dao;
 import com.pinterest.deployservice.bean.EnvironBean;
 import com.pinterest.deployservice.bean.UpdateStatement;
 
+import java.sql.SQLException;
 import java.util.Collection;
 import java.util.List;
 
@@ -43,6 +44,8 @@ public interface EnvironDAO {
 
     EnvironBean getById(String envId) throws Exception;
 
+    EnvironBean getByDeployId(String deployId) throws SQLException;
+
     List<EnvironBean> getByName(String envName) throws Exception;
 
     EnvironBean getByStage(String envName, String envStage) throws Exception;
@@ -65,7 +68,7 @@ public interface EnvironDAO {
 
     // Return all
     List<String> getAllEnvIds() throws Exception;
-    
+
     List<EnvironBean> getAllEnvs() throws Exception;
     List<EnvironBean> getAllSidecarEnvs() throws Exception;
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBEnvironDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBEnvironDAOImpl.java
@@ -28,6 +28,7 @@ import org.apache.commons.lang.StringUtils;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -47,6 +48,8 @@ public class DBEnvironDAOImpl implements EnvironDAO {
         "UPDATE environs SET external_id=? WHERE env_name=? AND stage_name=?";
     private static final String GET_ENV_BY_ID =
         "SELECT * FROM environs WHERE env_id=?";
+    private static final String GET_ENV_BY_DEPLOY_ID =
+        "SELECT e.* FROM environs e INNER JOIN deploys d ON e.env_id = d.env_id WHERE d.deploy_id=?";
     private static final String GET_ENV_BY_NAME =
         "SELECT * FROM environs WHERE env_name=?";
     private static final String GET_ENV_BY_STAGE =
@@ -180,8 +183,14 @@ public class DBEnvironDAOImpl implements EnvironDAO {
 
     @Override
     public EnvironBean getById(String envId) throws Exception {
-        ResultSetHandler<EnvironBean> h = new BeanHandler<EnvironBean>(EnvironBean.class);
+        ResultSetHandler<EnvironBean> h = new BeanHandler<>(EnvironBean.class);
         return new QueryRunner(dataSource).query(GET_ENV_BY_ID, h, envId);
+    }
+
+    @Override
+    public EnvironBean getByDeployId(String deployId) throws SQLException {
+        ResultSetHandler<EnvironBean> h = new BeanHandler<>(EnvironBean.class);
+        return new QueryRunner(dataSource).query(GET_ENV_BY_DEPLOY_ID, h, deployId);
     }
 
     @Override

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/db/DBDAOTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/db/DBDAOTest.java
@@ -289,6 +289,8 @@ public class DBDAOTest {
         assertEquals(beans.size(), 1);
         assertEquals(beans.get(0).getDeploy_id(), "d-5");
 
+        assertEquals(envBean1.getEnv_id(), environDAO.getByDeployId(deployBean1.getDeploy_id()).getEnv_id());
+
         buildDAO.delete("bbb-1");
         buildDAO.delete("bbb-2");
         buildDAO.delete("bbb-3");

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Deploys.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Deploys.java
@@ -146,7 +146,7 @@ public class Deploys {
             notes = "Update deploy given a deploy id and a deploy object. Current only "
                     + "acceptanceStatus and description are allowed to change.")
     @RolesAllowed(TeletraanPrincipalRole.Names.WRITE)
-    @ResourceAuthZInfo(type = AuthZResource.Type.ENV_STAGE, idLocation = Location.BODY, beanClass = DeployBean.class)
+    @ResourceAuthZInfo(type = AuthZResource.Type.DEPLOY, idLocation = Location.PATH)
     public void update(
             @Context SecurityContext sc,
             @ApiParam(value = "Deploy id", required = true)@PathParam("id") String id,
@@ -166,7 +166,7 @@ public class Deploys {
             value = "Delete deploy info",
             notes = "Delete deploy info given a deploy id")
     @RolesAllowed(TeletraanPrincipalRole.Names.WRITE)
-    @ResourceAuthZInfo(type = AuthZResource.Type.ENV_STAGE, idLocation = Location.BODY, beanClass = DeployBean.class)
+    @ResourceAuthZInfo(type = AuthZResource.Type.DEPLOY, idLocation = Location.PATH)
     public void delete(
             @Context SecurityContext sc,
             @ApiParam(value = "Deploy id", required = true)@PathParam("id") String id) throws Exception {

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Environs.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Environs.java
@@ -148,7 +148,7 @@ public class Environs {
             notes = "Creates a new environment given an environment object",
             response = Response.class)
     @RolesAllowed(TeletraanPrincipalRole.Names.WRITE)
-    @ResourceAuthZInfo(type = AuthZResource.Type.ENV_STAGE, idLocation = Location.BODY, beanClass = EnvironBean.class)
+    @ResourceAuthZInfo(type = AuthZResource.Type.ENV_STAGE, idLocation = Location.BODY)
     public Response create(
             @Context SecurityContext sc,
             @Context UriInfo uriInfo,

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Hotfixs.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Hotfixs.java
@@ -83,7 +83,7 @@ public class Hotfixs {
     @PUT
     @Path("/{id : [a-zA-Z0-9\\-_]+}")
     @RolesAllowed(TeletraanPrincipalRole.Names.WRITE)
-    @ResourceAuthZInfo(type = AuthZResource.Type.ENV_STAGE, idLocation = Location.BODY, beanClass = HotfixBean.class)
+    @ResourceAuthZInfo(type = AuthZResource.Type.HOTFIX, idLocation = Location.PATH)
     public void update(@PathParam("id") String id,
         HotfixBean hotfixBean) throws Exception {
         hotfixDAO.update(id, hotfixBean);

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Hotfixs.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Hotfixs.java
@@ -101,7 +101,7 @@ public class Hotfixs {
 
     @POST
     @RolesAllowed(TeletraanPrincipalRole.Names.EXECUTE)
-    @ResourceAuthZInfo(type = AuthZResource.Type.ENV_STAGE, idLocation = Location.BODY, beanClass = HotfixBean.class)
+    @ResourceAuthZInfo(type = AuthZResource.Type.HOTFIX, idLocation = Location.BODY)
     public Response create(@Context SecurityContext sc, @Context UriInfo uriInfo, @Valid HotfixBean hotfixBean)
             throws Exception {
         String hotfixId = CommonUtils.getBase64UUID();

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/DeployPathExtractor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/DeployPathExtractor.java
@@ -15,22 +15,19 @@
  */
 package com.pinterest.teletraan.security;
 
-import java.sql.SQLException;
-
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.container.ContainerRequestContext;
-
 import com.pinterest.deployservice.ServiceContext;
 import com.pinterest.deployservice.bean.EnvironBean;
 import com.pinterest.deployservice.dao.EnvironDAO;
 import com.pinterest.teletraan.universal.security.AuthZResourceExtractor;
 import com.pinterest.teletraan.universal.security.bean.AuthZResource;
+import java.sql.SQLException;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.container.ContainerRequestContext;
 
 /**
- * The authentication and authorization resource is extracted based on the deploy ID
- * present in the request's path parameters. It retrieves the corresponding environment
- * bean from the EnvironDAO and creates an AuthZResource object using the environment's
- * name and stage name.
+ * The authentication and authorization resource is extracted based on the deploy ID present in the
+ * request's path parameters. It retrieves the corresponding environment bean from the EnvironDAO
+ * and creates an AuthZResource object using the environment's name and stage name.
  */
 public class DeployPathExtractor implements AuthZResourceExtractor {
     private static final String DEPLOY_ID = "id";
@@ -55,8 +52,8 @@ public class DeployPathExtractor implements AuthZResourceExtractor {
             throw new ExtractionException("Failed to get environment bean", e);
         }
         if (envBean == null) {
-            throw new NotFoundException(String.format("Environment not found, referenced by deploy(%s)",
-                    deployID));
+            throw new NotFoundException(
+                    String.format("Environment not found, referenced by deploy(%s)", deployID));
         }
         return new AuthZResource(envBean.getEnv_name(), envBean.getStage_name());
     }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/DeployPathExtractor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/DeployPathExtractor.java
@@ -15,6 +15,8 @@
  */
 package com.pinterest.teletraan.security;
 
+import java.sql.SQLException;
+
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.container.ContainerRequestContext;
 
@@ -29,8 +31,6 @@ import com.pinterest.teletraan.universal.security.bean.AuthZResource;
  * present in the request's path parameters. It retrieves the corresponding environment
  * bean from the EnvironDAO and creates an AuthZResource object using the environment's
  * name and stage name.
- *
- * This class is used to enforce access control and permissions for the Teletraan service.
  */
 public class DeployPathExtractor implements AuthZResourceExtractor {
     private static final String DEPLOY_ID = "id";
@@ -45,13 +45,13 @@ public class DeployPathExtractor implements AuthZResourceExtractor {
             throws ExtractionException {
         String deployID = requestContext.getUriInfo().getPathParameters().getFirst(DEPLOY_ID);
         if (deployID == null) {
-            throw new ExtractionException("Failed to extract build id");
+            throw new ExtractionException("Failed to extract deploy id");
         }
 
         EnvironBean envBean;
         try {
             envBean = environDAO.getByDeployId(deployID);
-        } catch (Exception e) {
+        } catch (SQLException e) {
             throw new ExtractionException("Failed to get environment bean", e);
         }
         if (envBean == null) {

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/DeployPathExtractor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/DeployPathExtractor.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.security;
+
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.container.ContainerRequestContext;
+
+import com.pinterest.deployservice.ServiceContext;
+import com.pinterest.deployservice.bean.EnvironBean;
+import com.pinterest.deployservice.dao.EnvironDAO;
+import com.pinterest.teletraan.universal.security.AuthZResourceExtractor;
+import com.pinterest.teletraan.universal.security.bean.AuthZResource;
+
+/**
+ * The authentication and authorization resource is extracted based on the deploy ID
+ * present in the request's path parameters. It retrieves the corresponding environment
+ * bean from the EnvironDAO and creates an AuthZResource object using the environment's
+ * name and stage name.
+ *
+ * This class is used to enforce access control and permissions for the Teletraan service.
+ */
+public class DeployPathExtractor implements AuthZResourceExtractor {
+    private static final String DEPLOY_ID = "id";
+    private final EnvironDAO environDAO;
+
+    public DeployPathExtractor(ServiceContext context) {
+        this.environDAO = context.getEnvironDAO();
+    }
+
+    @Override
+    public AuthZResource extractResource(ContainerRequestContext requestContext)
+            throws ExtractionException {
+        String deployID = requestContext.getUriInfo().getPathParameters().getFirst(DEPLOY_ID);
+        if (deployID == null) {
+            throw new ExtractionException("Failed to extract build id");
+        }
+
+        EnvironBean envBean;
+        try {
+            envBean = environDAO.getByDeployId(deployID);
+        } catch (Exception e) {
+            throw new ExtractionException("Failed to get environment bean", e);
+        }
+        if (envBean == null) {
+            throw new NotFoundException(String.format("Environment not found, referenced by deploy(%s)",
+                    deployID));
+        }
+        return new AuthZResource(envBean.getEnv_name(), envBean.getStage_name());
+    }
+}

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/EnvStageBodyExtractor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/EnvStageBodyExtractor.java
@@ -19,12 +19,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pinterest.deployservice.bean.EnvironBean;
 import com.pinterest.teletraan.universal.security.AuthZResourceExtractor;
 import com.pinterest.teletraan.universal.security.bean.AuthZResource;
-
 import java.io.IOException;
 import java.io.InputStream;
-
 import javax.ws.rs.container.ContainerRequestContext;
-
 import org.glassfish.jersey.server.ContainerRequest;
 
 public class EnvStageBodyExtractor implements AuthZResourceExtractor {

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/EnvStageBodyExtractor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/EnvStageBodyExtractor.java
@@ -18,7 +18,6 @@ package com.pinterest.teletraan.security;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pinterest.deployservice.ServiceContext;
 import com.pinterest.deployservice.bean.AgentBean;
-import com.pinterest.deployservice.bean.DeployBean;
 import com.pinterest.deployservice.bean.EnvironBean;
 import com.pinterest.deployservice.bean.HotfixBean;
 import com.pinterest.deployservice.dao.EnvironDAO;
@@ -71,19 +70,6 @@ public class EnvStageBodyExtractor implements AuthZResourceExtractor {
             }
         }
 
-        if (DeployBean.class.equals(beanClass) || tryAll) {
-            try {
-                return extractDeployResource(inputStream);
-            } catch (Exception e) {
-                if (!tryAll) {
-                    if (e instanceof NotFoundException) {
-                        throw (NotFoundException) e;
-                    }
-                    throw new BeanClassExtractionException(beanClass, e);
-                }
-            }
-        }
-
         if (HotfixBean.class.equals(beanClass) || tryAll) {
             try {
                 return extractHotfixResource(inputStream);
@@ -116,21 +102,6 @@ public class EnvStageBodyExtractor implements AuthZResourceExtractor {
 
     private AuthZResource extractEnvironResource(InputStream inputStream) throws IOException {
         EnvironBean envBean = new ObjectMapper().readValue(inputStream, EnvironBean.class);
-        return new AuthZResource(envBean.getEnv_name(), envBean.getStage_name());
-    }
-
-    private AuthZResource extractDeployResource(InputStream inputStream) throws IOException, ExtractionException, NotFoundException {
-        DeployBean deployBean = new ObjectMapper().readValue(inputStream, DeployBean.class);
-        EnvironBean envBean;
-        try {
-            envBean = environDAO.getById(deployBean.getEnv_id());
-        } catch (Exception e) {
-            throw new ExtractionException("Failed to get environment bean", e);
-        }
-        if (envBean == null) {
-            throw new NotFoundException(String.format("Environment(%s) not found, referenced by deploy(%s)",
-                    deployBean.getEnv_id(), deployBean.getDeploy_id()));
-        }
         return new AuthZResource(envBean.getEnv_name(), envBean.getStage_name());
     }
 

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/HotfixBodyExtractor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/HotfixBodyExtractor.java
@@ -15,17 +15,14 @@
  */
 package com.pinterest.teletraan.security;
 
-import java.io.InputStream;
-
-import javax.ws.rs.container.ContainerRequestContext;
-
-import org.glassfish.jersey.server.ContainerRequest;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pinterest.deployservice.bean.BuildBean;
 import com.pinterest.deployservice.bean.HotfixBean;
 import com.pinterest.teletraan.universal.security.AuthZResourceExtractor;
 import com.pinterest.teletraan.universal.security.bean.AuthZResource;
+import java.io.InputStream;
+import javax.ws.rs.container.ContainerRequestContext;
+import org.glassfish.jersey.server.ContainerRequest;
 
 public class HotfixBodyExtractor implements AuthZResourceExtractor {
     @Override

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/HotfixBodyExtractor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/HotfixBodyExtractor.java
@@ -15,19 +15,19 @@
  */
 package com.pinterest.teletraan.security;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.pinterest.deployservice.bean.EnvironBean;
-import com.pinterest.teletraan.universal.security.AuthZResourceExtractor;
-import com.pinterest.teletraan.universal.security.bean.AuthZResource;
-
-import java.io.IOException;
 import java.io.InputStream;
 
 import javax.ws.rs.container.ContainerRequestContext;
 
 import org.glassfish.jersey.server.ContainerRequest;
 
-public class EnvStageBodyExtractor implements AuthZResourceExtractor {
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pinterest.deployservice.bean.BuildBean;
+import com.pinterest.deployservice.bean.HotfixBean;
+import com.pinterest.teletraan.universal.security.AuthZResourceExtractor;
+import com.pinterest.teletraan.universal.security.bean.AuthZResource;
+
+public class HotfixBodyExtractor implements AuthZResourceExtractor {
     @Override
     public AuthZResource extractResource(ContainerRequestContext requestContext)
             throws ExtractionException {
@@ -35,10 +35,10 @@ public class EnvStageBodyExtractor implements AuthZResourceExtractor {
         request.bufferEntity();
         InputStream inputStream = request.getEntityStream();
         try {
-            EnvironBean envBean = new ObjectMapper().readValue(inputStream, EnvironBean.class);
-            return new AuthZResource(envBean.getEnv_name(), envBean.getStage_name());
-        } catch (IOException e) {
-            throw new BeanClassExtractionException(EnvironBean.class, e);
+            HotfixBean hotfixBean = new ObjectMapper().readValue(inputStream, HotfixBean.class);
+            return new AuthZResource(hotfixBean.getEnv_name(), "");
+        } catch (Exception e) {
+            throw new BeanClassExtractionException(BuildBean.class, e);
         }
     }
 }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/HotfixPathExtractor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/HotfixPathExtractor.java
@@ -15,20 +15,18 @@
  */
 package com.pinterest.teletraan.security;
 
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.container.ContainerRequestContext;
-
 import com.pinterest.deployservice.ServiceContext;
 import com.pinterest.deployservice.bean.HotfixBean;
 import com.pinterest.deployservice.dao.HotfixDAO;
 import com.pinterest.teletraan.universal.security.AuthZResourceExtractor;
 import com.pinterest.teletraan.universal.security.bean.AuthZResource;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.container.ContainerRequestContext;
 
 /**
- * The authentication and authorization resource is extracted based on the
- * hotfix ID present in the request's path parameters. It retrieves the
- * corresponding environment bean from the EnvironDAO and creates an
- * AuthZResource object using the environment's name and stage name.
+ * The authentication and authorization resource is extracted based on the hotfix ID present in the
+ * request's path parameters. It retrieves the corresponding environment bean from the EnvironDAO
+ * and creates an AuthZResource object using the environment's name and stage name.
  */
 public class HotfixPathExtractor implements AuthZResourceExtractor {
     private static final String HOTFIX_ID = "id";
@@ -53,8 +51,8 @@ public class HotfixPathExtractor implements AuthZResourceExtractor {
             throw new ExtractionException("Failed to get environment bean", e);
         }
         if (hotfixBean == null) {
-            throw new NotFoundException(String.format("Environment not found, referenced by hotfix(%s)",
-                    hotfixID));
+            throw new NotFoundException(
+                    String.format("Environment not found, referenced by hotfix(%s)", hotfixID));
         }
         return new AuthZResource(hotfixBean.getEnv_name(), "");
     }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/HotfixPathExtractor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/HotfixPathExtractor.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.security;
+
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.container.ContainerRequestContext;
+
+import com.pinterest.deployservice.ServiceContext;
+import com.pinterest.deployservice.bean.HotfixBean;
+import com.pinterest.deployservice.dao.HotfixDAO;
+import com.pinterest.teletraan.universal.security.AuthZResourceExtractor;
+import com.pinterest.teletraan.universal.security.bean.AuthZResource;
+
+/**
+ * The authentication and authorization resource is extracted based on the
+ * hotfix ID present in the request's path parameters. It retrieves the
+ * corresponding environment bean from the EnvironDAO and creates an
+ * AuthZResource object using the environment's name and stage name.
+ */
+public class HotfixPathExtractor implements AuthZResourceExtractor {
+    private static final String HOTFIX_ID = "id";
+    private final HotfixDAO hotfixDAO;
+
+    public HotfixPathExtractor(ServiceContext context) {
+        this.hotfixDAO = context.getHotfixDAO();
+    }
+
+    @Override
+    public AuthZResource extractResource(ContainerRequestContext requestContext)
+            throws ExtractionException {
+        String hotfixID = requestContext.getUriInfo().getPathParameters().getFirst(HOTFIX_ID);
+        if (hotfixID == null) {
+            throw new ExtractionException("Failed to extract hotfix id");
+        }
+
+        HotfixBean hotfixBean;
+        try {
+            hotfixBean = hotfixDAO.getByHotfixId(hotfixID);
+        } catch (Exception e) {
+            throw new ExtractionException("Failed to get environment bean", e);
+        }
+        if (hotfixBean == null) {
+            throw new NotFoundException(String.format("Environment not found, referenced by hotfix(%s)",
+                    hotfixID));
+        }
+        return new AuthZResource(hotfixBean.getEnv_name(), "");
+    }
+}

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/TeletraanAuthZResourceExtractorFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/TeletraanAuthZResourceExtractorFactory.java
@@ -23,14 +23,14 @@ public class TeletraanAuthZResourceExtractorFactory implements AuthZResourceExtr
 
     private static final AuthZResourceExtractor BUILD_BODY_EXTRACTOR = new BuildBodyExtractor();
     private static final AuthZResourceExtractor ENV_PATH_EXTRACTOR = new EnvPathExtractor();
+    private static final AuthZResourceExtractor ENV_STAGE_BODY_EXTRACTOR = new EnvStageBodyExtractor();
     private static final AuthZResourceExtractor ENV_STAGE_PATH_EXTRACTOR = new EnvStagePathExtractor();
+    private static final AuthZResourceExtractor HOTFIX_BODY_EXTRACTOR = new HotfixBodyExtractor();
     private final AuthZResourceExtractor buildPathExtractor;
     private final AuthZResourceExtractor deployPathExtractor;
-    private final AuthZResourceExtractor envStageBodyExtractor;
     private final AuthZResourceExtractor hotfixPathExtractor;
 
     public TeletraanAuthZResourceExtractorFactory(ServiceContext serviceContext) {
-        envStageBodyExtractor = new EnvStageBodyExtractor(serviceContext);
         buildPathExtractor = new BuildPathExtractor(serviceContext);
         deployPathExtractor = new DeployPathExtractor(serviceContext);
         hotfixPathExtractor = new HotfixPathExtractor(serviceContext);
@@ -59,7 +59,9 @@ public class TeletraanAuthZResourceExtractorFactory implements AuthZResourceExtr
                     case BUILD:
                         return BUILD_BODY_EXTRACTOR;
                     case ENV_STAGE:
-                        return envStageBodyExtractor;
+                        return ENV_STAGE_BODY_EXTRACTOR;
+                    case HOTFIX:
+                        return HOTFIX_BODY_EXTRACTOR;
                     default:
                         throw new UnsupportedResourceInfoException(authZInfo);
                 }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/TeletraanAuthZResourceExtractorFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/TeletraanAuthZResourceExtractorFactory.java
@@ -23,8 +23,10 @@ public class TeletraanAuthZResourceExtractorFactory implements AuthZResourceExtr
 
     private static final AuthZResourceExtractor BUILD_BODY_EXTRACTOR = new BuildBodyExtractor();
     private static final AuthZResourceExtractor ENV_PATH_EXTRACTOR = new EnvPathExtractor();
-    private static final AuthZResourceExtractor ENV_STAGE_BODY_EXTRACTOR = new EnvStageBodyExtractor();
-    private static final AuthZResourceExtractor ENV_STAGE_PATH_EXTRACTOR = new EnvStagePathExtractor();
+    private static final AuthZResourceExtractor ENV_STAGE_BODY_EXTRACTOR =
+            new EnvStageBodyExtractor();
+    private static final AuthZResourceExtractor ENV_STAGE_PATH_EXTRACTOR =
+            new EnvStagePathExtractor();
     private static final AuthZResourceExtractor HOTFIX_BODY_EXTRACTOR = new HotfixBodyExtractor();
     private final AuthZResourceExtractor buildPathExtractor;
     private final AuthZResourceExtractor deployPathExtractor;

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/TeletraanAuthZResourceExtractorFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/TeletraanAuthZResourceExtractorFactory.java
@@ -24,12 +24,14 @@ public class TeletraanAuthZResourceExtractorFactory implements AuthZResourceExtr
     private static final AuthZResourceExtractor BUILD_BODY_EXTRACTOR = new BuildBodyExtractor();
     private static final AuthZResourceExtractor ENV_PATH_EXTRACTOR = new EnvPathExtractor();
     private static final AuthZResourceExtractor ENV_STAGE_PATH_EXTRACTOR = new EnvStagePathExtractor();
-    private final AuthZResourceExtractor BUILD_PATH_EXTRACTOR;
-    private final AuthZResourceExtractor ENV_STAGE_BODY_EXTRACTOR;
+    private final AuthZResourceExtractor buildPathExtractor;
+    private final AuthZResourceExtractor envStageBodyExtractor;
+    private final AuthZResourceExtractor deployPathExtractor;
 
     public TeletraanAuthZResourceExtractorFactory(ServiceContext serviceContext) {
-        ENV_STAGE_BODY_EXTRACTOR = new EnvStageBodyExtractor(serviceContext);
-        BUILD_PATH_EXTRACTOR = new BuildPathExtractor(serviceContext);
+        envStageBodyExtractor = new EnvStageBodyExtractor(serviceContext);
+        buildPathExtractor = new BuildPathExtractor(serviceContext);
+        deployPathExtractor = new DeployPathExtractor(serviceContext);
     }
 
     @Override
@@ -47,16 +49,23 @@ public class TeletraanAuthZResourceExtractorFactory implements AuthZResourceExtr
                     case PATH:
                         return ENV_STAGE_PATH_EXTRACTOR;
                     case BODY:
-                        return ENV_STAGE_BODY_EXTRACTOR;
+                        return envStageBodyExtractor;
                     default:
                         throw new UnsupportedResourceIDLocationException(authZInfo);
                 }
             case BUILD:
                 switch (authZInfo.idLocation()) {
                     case PATH:
-                        return BUILD_PATH_EXTRACTOR;
+                        return buildPathExtractor;
                     case BODY:
                         return BUILD_BODY_EXTRACTOR;
+                    default:
+                        throw new UnsupportedResourceIDLocationException(authZInfo);
+                }
+            case DEPLOY:
+                switch (authZInfo.idLocation()) {
+                    case PATH:
+                        return deployPathExtractor;
                     default:
                         throw new UnsupportedResourceIDLocationException(authZInfo);
                 }

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/BuildPathExtractorTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/BuildPathExtractorTest.java
@@ -22,18 +22,15 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.sql.SQLException;
-
-import javax.ws.rs.NotFoundException;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import com.pinterest.deployservice.ServiceContext;
 import com.pinterest.deployservice.bean.BuildBean;
 import com.pinterest.deployservice.dao.BuildDAO;
-import com.pinterest.teletraan.universal.security.bean.AuthZResource;
 import com.pinterest.teletraan.universal.security.AuthZResourceExtractor.ExtractionException;
+import com.pinterest.teletraan.universal.security.bean.AuthZResource;
+import java.sql.SQLException;
+import javax.ws.rs.NotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 class BuildPathExtractorTest extends BasePathExtractorTest {
     private BuildPathExtractor sut;

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/DeployPathExtractorTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/DeployPathExtractorTest.java
@@ -22,18 +22,15 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.sql.SQLException;
-
-import javax.ws.rs.NotFoundException;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import com.pinterest.deployservice.ServiceContext;
 import com.pinterest.deployservice.bean.EnvironBean;
 import com.pinterest.deployservice.dao.EnvironDAO;
 import com.pinterest.teletraan.universal.security.AuthZResourceExtractor.ExtractionException;
 import com.pinterest.teletraan.universal.security.bean.AuthZResource;
+import java.sql.SQLException;
+import javax.ws.rs.NotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 class DeployPathExtractorTest extends BasePathExtractorTest {
     private DeployPathExtractor sut;
@@ -77,7 +74,9 @@ class DeployPathExtractorTest extends BasePathExtractorTest {
         AuthZResource result = sut.extractResource(context);
 
         assertNotNull(result);
-        assertEquals(String.format("%s/%s", envBean.getEnv_name(), envBean.getStage_name()), result.getName());
+        assertEquals(
+                String.format("%s/%s", envBean.getEnv_name(), envBean.getStage_name()),
+                result.getName());
         assertEquals(AuthZResource.Type.ENV_STAGE, result.getType());
     }
 

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/EnvStageBodyExtractorTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/EnvStageBodyExtractorTest.java
@@ -20,22 +20,19 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-
-import javax.ws.rs.container.ContainerRequestContext;
-
-import org.glassfish.jersey.server.ContainerRequest;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pinterest.deployservice.bean.EnvironBean;
 import com.pinterest.teletraan.fixture.EnvironBeanFixture;
 import com.pinterest.teletraan.universal.security.AuthZResourceExtractor.ExtractionException;
 import com.pinterest.teletraan.universal.security.bean.AuthZResource;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import javax.ws.rs.container.ContainerRequestContext;
+import org.glassfish.jersey.server.ContainerRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 class EnvStageBodyExtractorTest {
 
@@ -43,7 +40,6 @@ class EnvStageBodyExtractorTest {
     private EnvStageBodyExtractor sut;
     private InputStream inputStream;
     private ObjectMapper objectMapper = new ObjectMapper();
-
 
     @BeforeEach
     void setUp() {
@@ -71,7 +67,9 @@ class EnvStageBodyExtractorTest {
 
         AuthZResource resource = sut.extractResource(context);
 
-        assertEquals(String.format("%s/%s", envBean.getEnv_name(), envBean.getStage_name()), resource.getName());
+        assertEquals(
+                String.format("%s/%s", envBean.getEnv_name(), envBean.getStage_name()),
+                resource.getName());
         assertEquals(AuthZResource.Type.ENV_STAGE, resource.getType());
     }
 

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/HotfixBodyExtractorTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/HotfixBodyExtractorTest.java
@@ -32,46 +32,35 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.pinterest.deployservice.bean.EnvironBean;
-import com.pinterest.teletraan.fixture.EnvironBeanFixture;
+import com.pinterest.deployservice.bean.HotfixBean;
 import com.pinterest.teletraan.universal.security.AuthZResourceExtractor.ExtractionException;
 import com.pinterest.teletraan.universal.security.bean.AuthZResource;
 
-class EnvStageBodyExtractorTest {
-
-    private ContainerRequestContext context;
-    private EnvStageBodyExtractor sut;
-    private InputStream inputStream;
+class HotfixBodyExtractorTest {
+    private HotfixBodyExtractor sut;
+    private ContainerRequestContext requestContext;
     private ObjectMapper objectMapper = new ObjectMapper();
-
 
     @BeforeEach
     void setUp() {
-        sut = new EnvStageBodyExtractor();
-        context = mock(ContainerRequest.class);
-    }
-
-    @Test
-    void testExtractResource_nothing_exception() throws Exception {
-        inputStream = mock(InputStream.class);
-        when(context.getEntityStream()).thenReturn(inputStream);
-
-        assertThrows(ExtractionException.class, () -> sut.extractResource(context));
+        sut = new HotfixBodyExtractor();
+        requestContext = mock(ContainerRequest.class);
     }
 
     @Test
     void testExtractResource() throws ExtractionException, IOException {
-        EnvironBean envBean = EnvironBeanFixture.createRandomEnvironBean();
+        HotfixBean hotfixBean = new HotfixBean();
+        hotfixBean.setEnv_name("test-env");
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        objectMapper.writeValue(out, envBean);
+        objectMapper.writeValue(out, hotfixBean);
         InputStream inputStream = new ByteArrayInputStream(out.toByteArray());
 
-        when(context.getEntityStream()).thenReturn(inputStream);
+        when(requestContext.getEntityStream()).thenReturn(inputStream);
 
-        AuthZResource resource = sut.extractResource(context);
+        AuthZResource resource = sut.extractResource(requestContext);
 
-        assertEquals(String.format("%s/%s", envBean.getEnv_name(), envBean.getStage_name()), resource.getName());
+        assertEquals(hotfixBean.getEnv_name() + "/", resource.getName());
         assertEquals(AuthZResource.Type.ENV_STAGE, resource.getType());
     }
 
@@ -80,8 +69,8 @@ class EnvStageBodyExtractorTest {
         String invalidJson = "{ xyz }";
         InputStream inputStream = new ByteArrayInputStream(invalidJson.getBytes());
 
-        when(context.getEntityStream()).thenReturn(inputStream);
+        when(requestContext.getEntityStream()).thenReturn(inputStream);
 
-        assertThrows(ExtractionException.class, () -> sut.extractResource(context));
+        assertThrows(ExtractionException.class, () -> sut.extractResource(requestContext));
     }
 }

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/HotfixBodyExtractorTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/HotfixBodyExtractorTest.java
@@ -20,21 +20,18 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-
-import javax.ws.rs.container.ContainerRequestContext;
-
-import org.glassfish.jersey.server.ContainerRequest;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pinterest.deployservice.bean.HotfixBean;
 import com.pinterest.teletraan.universal.security.AuthZResourceExtractor.ExtractionException;
 import com.pinterest.teletraan.universal.security.bean.AuthZResource;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import javax.ws.rs.container.ContainerRequestContext;
+import org.glassfish.jersey.server.ContainerRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 class HotfixBodyExtractorTest {
     private HotfixBodyExtractor sut;

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/HotfixPathExtractorTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/HotfixPathExtractorTest.java
@@ -22,18 +22,15 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.sql.SQLException;
-
-import javax.ws.rs.NotFoundException;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import com.pinterest.deployservice.ServiceContext;
 import com.pinterest.deployservice.bean.HotfixBean;
 import com.pinterest.deployservice.dao.HotfixDAO;
 import com.pinterest.teletraan.universal.security.AuthZResourceExtractor.ExtractionException;
 import com.pinterest.teletraan.universal.security.bean.AuthZResource;
+import java.sql.SQLException;
+import javax.ws.rs.NotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 class HotfixPathExtractorTest extends BasePathExtractorTest {
     private HotfixPathExtractor sut;

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/HotfixPathExtractorTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/HotfixPathExtractorTest.java
@@ -30,23 +30,23 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.pinterest.deployservice.ServiceContext;
-import com.pinterest.deployservice.bean.BuildBean;
-import com.pinterest.deployservice.dao.BuildDAO;
-import com.pinterest.teletraan.universal.security.bean.AuthZResource;
+import com.pinterest.deployservice.bean.HotfixBean;
+import com.pinterest.deployservice.dao.HotfixDAO;
 import com.pinterest.teletraan.universal.security.AuthZResourceExtractor.ExtractionException;
+import com.pinterest.teletraan.universal.security.bean.AuthZResource;
 
-class BuildPathExtractorTest extends BasePathExtractorTest {
-    private BuildPathExtractor sut;
+class HotfixPathExtractorTest extends BasePathExtractorTest {
+    private HotfixPathExtractor sut;
     private ServiceContext serviceContext;
-    private BuildDAO buildDAO;
+    private HotfixDAO hotfixDAO;
 
     @BeforeEach
     void setUp() {
         super.setUp();
-        buildDAO = mock(BuildDAO.class);
+        hotfixDAO = mock(HotfixDAO.class);
         serviceContext = new ServiceContext();
-        serviceContext.setBuildDAO(buildDAO);
-        sut = new BuildPathExtractor(serviceContext);
+        serviceContext.setHotfixDAO(hotfixDAO);
+        sut = new HotfixPathExtractor(serviceContext);
     }
 
     @Test
@@ -55,7 +55,7 @@ class BuildPathExtractorTest extends BasePathExtractorTest {
     }
 
     @Test
-    void testExtractResource_0BuildId() {
+    void testExtractResource_0HotfixId() {
         pathParameters.add("param", "val");
 
         assertThrows(ExtractionException.class, () -> sut.extractResource(context));
@@ -63,27 +63,27 @@ class BuildPathExtractorTest extends BasePathExtractorTest {
 
     @Test
     void testExtractResource() throws Exception {
-        String buildId = "testBuildId";
-        pathParameters.add("id", buildId);
+        String hotfixId = "testHotfixId";
+        pathParameters.add("id", hotfixId);
 
-        when(buildDAO.getById(buildId)).thenReturn(null);
+        when(hotfixDAO.getByHotfixId(hotfixId)).thenReturn(null);
         assertThrows(NotFoundException.class, () -> sut.extractResource(context));
 
-        BuildBean buildBean = new BuildBean();
-        buildBean.setBuild_name("Test Build");
-        when(buildDAO.getById(buildId)).thenReturn(buildBean);
+        HotfixBean hotfixBean = new HotfixBean();
+        hotfixBean.setEnv_name("hotfix_env");
+        when(hotfixDAO.getByHotfixId(hotfixId)).thenReturn(hotfixBean);
 
         AuthZResource result = sut.extractResource(context);
 
         assertNotNull(result);
-        assertEquals("Test Build", result.getName());
-        assertEquals(AuthZResource.Type.BUILD, result.getType());
+        assertEquals(hotfixBean.getEnv_name() + "/", result.getName());
+        assertEquals(AuthZResource.Type.ENV_STAGE, result.getType());
     }
 
     @Test
     void testExtractResource_sqlException() throws Exception {
         pathParameters.add("id", "someId");
-        when(buildDAO.getById(any())).thenThrow(SQLException.class);
+        when(hotfixDAO.getByHotfixId(any())).thenThrow(SQLException.class);
 
         assertThrows(ExtractionException.class, () -> sut.extractResource(context));
     }

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/TeletraanAuthZResourceExtractorFactoryTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/TeletraanAuthZResourceExtractorFactoryTest.java
@@ -1,0 +1,128 @@
+package com.pinterest.teletraan.security;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.pinterest.deployservice.ServiceContext;
+import com.pinterest.teletraan.security.TeletraanAuthZResourceExtractorFactory.UnsupportedResourceInfoException;
+import com.pinterest.teletraan.universal.security.AuthZResourceExtractor;
+import com.pinterest.teletraan.universal.security.ResourceAuthZInfo;
+import com.pinterest.teletraan.universal.security.bean.AuthZResource;
+
+class TeletraanAuthZResourceExtractorFactoryTest {
+    private ServiceContext serviceContext;
+    private ResourceAuthZInfo authZInfo;
+    private TeletraanAuthZResourceExtractorFactory extractorFactory;
+
+    @BeforeEach
+    void setUp() {
+        serviceContext = mock(ServiceContext.class);
+        authZInfo = mock(ResourceAuthZInfo.class);
+        extractorFactory = new TeletraanAuthZResourceExtractorFactory(serviceContext);
+    }
+
+    @Test
+    void create_shouldReturnCorrectExtractorForPathLocation() {
+        when(authZInfo.idLocation()).thenReturn(ResourceAuthZInfo.Location.PATH);
+        when(authZInfo.type()).thenReturn(AuthZResource.Type.BUILD);
+
+        AuthZResourceExtractor extractor = extractorFactory.create(authZInfo);
+
+        assertTrue(extractor instanceof BuildPathExtractor);
+    }
+
+    @Test
+    void create_shouldReturnCorrectExtractorForBodyLocation() {
+        when(authZInfo.idLocation()).thenReturn(ResourceAuthZInfo.Location.BODY);
+        when(authZInfo.type()).thenReturn(AuthZResource.Type.BUILD);
+
+        AuthZResourceExtractor extractor = extractorFactory.create(authZInfo);
+
+        assertTrue(extractor instanceof BuildBodyExtractor);
+    }
+
+    @Test
+    void create_shouldReturnCorrectExtractorForEnvPathLocation() {
+        when(authZInfo.idLocation()).thenReturn(ResourceAuthZInfo.Location.PATH);
+        when(authZInfo.type()).thenReturn(AuthZResource.Type.ENV);
+
+        AuthZResourceExtractor extractor = extractorFactory.create(authZInfo);
+
+        assertTrue(extractor instanceof EnvPathExtractor);
+    }
+
+    @Test
+    void create_shouldReturnCorrectExtractorForEnvStageBodyLocation() {
+        when(authZInfo.idLocation()).thenReturn(ResourceAuthZInfo.Location.BODY);
+        when(authZInfo.type()).thenReturn(AuthZResource.Type.ENV_STAGE);
+
+        AuthZResourceExtractor extractor = extractorFactory.create(authZInfo);
+
+        assertTrue(extractor instanceof EnvStageBodyExtractor);
+    }
+
+    @Test
+    void create_shouldReturnCorrectExtractorForHotfixPathLocation() {
+        when(authZInfo.idLocation()).thenReturn(ResourceAuthZInfo.Location.PATH);
+        when(authZInfo.type()).thenReturn(AuthZResource.Type.HOTFIX);
+
+        AuthZResourceExtractor extractor = extractorFactory.create(authZInfo);
+
+        assertTrue(extractor instanceof HotfixPathExtractor);
+    }
+
+    @Test
+    void create_shouldReturnCorrectExtractorForHotfixBodyLocation() {
+        when(authZInfo.idLocation()).thenReturn(ResourceAuthZInfo.Location.BODY);
+        when(authZInfo.type()).thenReturn(AuthZResource.Type.HOTFIX);
+
+        AuthZResourceExtractor extractor = extractorFactory.create(authZInfo);
+
+        assertTrue(extractor instanceof HotfixBodyExtractor);
+    }
+
+    @Test
+    void create_shouldReturnCorrectExtractorForDeployPathLocation() {
+        when(authZInfo.idLocation()).thenReturn(ResourceAuthZInfo.Location.PATH);
+        when(authZInfo.type()).thenReturn(AuthZResource.Type.DEPLOY);
+
+        AuthZResourceExtractor extractor = extractorFactory.create(authZInfo);
+
+        assertTrue(extractor instanceof DeployPathExtractor);
+    }
+
+    @Test
+    void create_shouldReturnCorrectExtractorForEnvStagePathLocation() {
+        when(authZInfo.idLocation()).thenReturn(ResourceAuthZInfo.Location.PATH);
+        when(authZInfo.type()).thenReturn(AuthZResource.Type.ENV_STAGE);
+
+        AuthZResourceExtractor extractor = extractorFactory.create(authZInfo);
+
+        assertTrue(extractor instanceof EnvStagePathExtractor);
+    }
+
+    @Test
+    void create_shouldThrowExceptionForUnsupportedLocation() {
+        when(authZInfo.idLocation()).thenReturn(ResourceAuthZInfo.Location.NA);
+
+        assertThrows(IllegalArgumentException.class, () -> extractorFactory.create(authZInfo));
+    }
+
+    @Test
+    void create_shouldThrowExceptionForUnsupportedType() {
+        when(authZInfo.idLocation()).thenReturn(ResourceAuthZInfo.Location.BODY);
+        when(authZInfo.type()).thenReturn(AuthZResource.Type.SYSTEM);
+
+        assertThrows(UnsupportedResourceInfoException.class, () -> extractorFactory.create(authZInfo));
+
+        when(authZInfo.idLocation()).thenReturn(ResourceAuthZInfo.Location.PATH);
+        when(authZInfo.type()).thenReturn(AuthZResource.Type.SYSTEM);
+
+        assertThrows(UnsupportedResourceInfoException.class, () -> extractorFactory.create(authZInfo));
+    }
+}

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/TeletraanAuthZResourceExtractorFactoryTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/TeletraanAuthZResourceExtractorFactoryTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.pinterest.teletraan.security;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -5,14 +20,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import com.pinterest.deployservice.ServiceContext;
 import com.pinterest.teletraan.security.TeletraanAuthZResourceExtractorFactory.UnsupportedResourceInfoException;
 import com.pinterest.teletraan.universal.security.AuthZResourceExtractor;
 import com.pinterest.teletraan.universal.security.ResourceAuthZInfo;
 import com.pinterest.teletraan.universal.security.bean.AuthZResource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 class TeletraanAuthZResourceExtractorFactoryTest {
     private ServiceContext serviceContext;
@@ -118,11 +132,13 @@ class TeletraanAuthZResourceExtractorFactoryTest {
         when(authZInfo.idLocation()).thenReturn(ResourceAuthZInfo.Location.BODY);
         when(authZInfo.type()).thenReturn(AuthZResource.Type.SYSTEM);
 
-        assertThrows(UnsupportedResourceInfoException.class, () -> extractorFactory.create(authZInfo));
+        assertThrows(
+                UnsupportedResourceInfoException.class, () -> extractorFactory.create(authZInfo));
 
         when(authZInfo.idLocation()).thenReturn(ResourceAuthZInfo.Location.PATH);
         when(authZInfo.type()).thenReturn(AuthZResource.Type.SYSTEM);
 
-        assertThrows(UnsupportedResourceInfoException.class, () -> extractorFactory.create(authZInfo));
+        assertThrows(
+                UnsupportedResourceInfoException.class, () -> extractorFactory.create(authZInfo));
     }
 }

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/TeletraanScriptTokenProviderTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/TeletraanScriptTokenProviderTest.java
@@ -15,8 +15,10 @@
  */
 package com.pinterest.teletraan.security;
 
+import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -27,6 +29,8 @@ import com.pinterest.deployservice.dao.TokenRolesDAO;
 import com.pinterest.teletraan.universal.security.bean.AuthZResource;
 import com.pinterest.teletraan.universal.security.bean.ScriptTokenPrincipal;
 import com.pinterest.teletraan.universal.security.bean.ValueBasedRole;
+
+import java.sql.SQLException;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -69,5 +73,13 @@ class TeletraanScriptTokenProviderTest {
         assertEquals(AuthZResource.Type.SYSTEM, principal.getResource().getType());
         assertEquals(tokenRolesBean.getResource_id(), principal.getResource().getName());
         assertEquals(tokenRolesBean.getScript_name(), principal.getName());
+    }
+
+    @Test
+    void testGetPrincipal_tokenRolesDAOException() throws Exception {
+        String token = "exceptionToken";
+        when(tokenRolesDAO.getByToken(token)).thenThrow(SQLException.class);
+        Optional<?> principal = sut.getPrincipal(token);
+        assertFalse(principal.isPresent());
     }
 }

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/TeletraanScriptTokenProviderTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/TeletraanScriptTokenProviderTest.java
@@ -15,10 +15,8 @@
  */
 package com.pinterest.teletraan.security;
 
-import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -29,7 +27,6 @@ import com.pinterest.deployservice.dao.TokenRolesDAO;
 import com.pinterest.teletraan.universal.security.bean.AuthZResource;
 import com.pinterest.teletraan.universal.security.bean.ScriptTokenPrincipal;
 import com.pinterest.teletraan.universal.security.bean.ValueBasedRole;
-
 import java.sql.SQLException;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/AuthZResourceExtractor.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/AuthZResourceExtractor.java
@@ -19,12 +19,12 @@ import com.pinterest.teletraan.universal.security.bean.AuthZResource;
 import javax.ws.rs.container.ContainerRequestContext;
 
 /**
- * This interface represents an AuthZResourceExtractor, which is responsible for extracting
- * an AuthZResource from a ContainerRequestContext.
+ * This interface represents an AuthZResourceExtractor, which is responsible for extracting an
+ * AuthZResource from a ContainerRequestContext.
  *
- * Note that the extractor can map the input resource type to a different AuthZResource type.
- * And thus the authorization will be based on the mapped AuthZResource type. This can help
- * reduce the complexity of the authorization logic.
+ * <p>Note that the extractor can map the input resource type to a different AuthZResource type. And
+ * thus the authorization will be based on the mapped AuthZResource type. This can help reduce the
+ * complexity of the authorization logic.
  */
 public interface AuthZResourceExtractor {
     /**
@@ -50,9 +50,7 @@ public interface AuthZResourceExtractor {
         return extractResource(requestContext);
     }
 
-    /**
-     * This interface represents a Factory for creating AuthZResourceExtractors.
-     */
+    /** This interface represents a Factory for creating AuthZResourceExtractors. */
     interface Factory {
         /**
          * Creates an AuthZResourceExtractor based on the given ResourceAuthZInfo.
@@ -75,7 +73,11 @@ public interface AuthZResourceExtractor {
 
     class BeanClassExtractionException extends ExtractionException {
         public BeanClassExtractionException(Class<?> beanClass, Throwable cause) {
-            super(String.format("failed to extract as %s. Check if request body is valid", beanClass.getName()), cause);
+            super(
+                    String.format(
+                            "failed to extract as %s. Check if request body is valid",
+                            beanClass.getName()),
+                    cause);
         }
     }
 }

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/AuthZResourceExtractor.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/AuthZResourceExtractor.java
@@ -18,12 +18,20 @@ package com.pinterest.teletraan.universal.security;
 import com.pinterest.teletraan.universal.security.bean.AuthZResource;
 import javax.ws.rs.container.ContainerRequestContext;
 
+/**
+ * This interface represents an AuthZResourceExtractor, which is responsible for extracting
+ * an AuthZResource from a ContainerRequestContext.
+ *
+ * Note that the extractor can map the input resource type to a different AuthZResource type.
+ * And thus the authorization will be based on the mapped AuthZResource type. This can help
+ * reduce the complexity of the authorization logic.
+ */
 public interface AuthZResourceExtractor {
     /**
      * Extracts AuthZResource from the requestContext.
      *
-     * @param requestContext
-     * @return
+     * @param requestContext the ContainerRequestContext from which to extract the AuthZResource
+     * @return the extracted AuthZResource
      * @throws ExtractionException if no resource can be extracted
      */
     AuthZResource extractResource(ContainerRequestContext requestContext)
@@ -32,9 +40,9 @@ public interface AuthZResourceExtractor {
     /**
      * Extracts AuthZResource from the requestContext.
      *
-     * @param requestContext
-     * @param beanClass is the class of the expected resource bean
-     * @return
+     * @param requestContext the ContainerRequestContext from which to extract the AuthZResource
+     * @param beanClass the class of the expected input resource bean
+     * @return the extracted AuthZResource
      * @throws ExtractionException if no resource can be extracted
      */
     default AuthZResource extractResource(
@@ -42,7 +50,16 @@ public interface AuthZResourceExtractor {
         return extractResource(requestContext);
     }
 
+    /**
+     * This interface represents a Factory for creating AuthZResourceExtractors.
+     */
     interface Factory {
+        /**
+         * Creates an AuthZResourceExtractor based on the given ResourceAuthZInfo.
+         *
+         * @param authZInfo the ResourceAuthZInfo used to create the AuthZResourceExtractor
+         * @return the created AuthZResourceExtractor
+         */
         AuthZResourceExtractor create(ResourceAuthZInfo authZInfo);
     }
 

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/ResourceAuthZInfo.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/ResourceAuthZInfo.java
@@ -25,6 +25,7 @@ import java.lang.annotation.Target;
 @Target({ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ResourceAuthZInfo {
+    /** The type of the original resource for authorization purpose. */
     AuthZResource.Type type();
 
     /** The location of the resource identifier in the request. */

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/AuthZResource.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/AuthZResource.java
@@ -77,16 +77,22 @@ public class AuthZResource {
         SYSTEM,
         /** For resources related to a specific environment-stage. The most common resource type. */
         ENV_STAGE,
-        /** For placement related to a specific environment. */
+        /** For placement related resources. */
         PLACEMENT,
-        /** For base image related to a specific environment. */
+        /** For base image related resources. */
         BASE_IMAGE,
-        /** For security zone related to a specific environment. */
+        /** For security zone related resources. */
         SECURITY_ZONE,
-        /** For IAM role related to a specific environment. */
+        /** For IAM role related resources. */
         IAM_ROLE,
         /** For build related resources. */
-        BUILD
+        BUILD,
+        /** For deploy related resources. */
+        DEPLOY,
+        /** For hotfix related resources. */
+        HOTFIX,
+        /** For Agent related resources. */
+        AGENT,
     }
 
     /**


### PR DESCRIPTION
Previously Teletraan looks for the request body for AuthZ resource identifier. However it has a security flaw for some endpoints. This PR address the issue by using the identifier from request path parameter for those affected resources.

## Details of the issue
Some Teletraan endpoints follows a pattern that requires the resource identifier in the path parameter, while the request body also contains the same ID field. The ID in the path parameter is used for later processing. Therefore it's possible for a request to contain 2 resource IDs and the one used for authorization can be different from the resource being changed. 

## Changes
First of all some interface change. Previously the annotation `ResourceAuthZInfo.type` expects the type of the extracted resource. Now it's the type of the input resource. This will reduce some confusion because it matches the method it annotates. 

When appropriate, a path resource extractor replaces the previously used body resource extractor. New implementations of resource extractors are added.

The most change happen in the [EnvStageBodyExtractor.java](https://github.com/pinterest/teletraan/pull/1610/files#diff-a49e40979c111009fe3e8ecb19415406d092e63d99033e04077178dd4ec45f81). This is the result of the interface change. The implementation are split into individual extractors. 

## Tests and validation
Close to 100% test coverage for this change. 