### PR TITLE
Add metrics that help monitoring AuthN usages

### DIFF
--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/resource/ResourceAuthorizationTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/resource/ResourceAuthorizationTest.java
@@ -19,8 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.Collections;
-
 import com.codahale.metrics.SharedMetricRegistries;
 import com.pinterest.deployservice.bean.BuildBean;
 import com.pinterest.deployservice.bean.EnvironBean;
@@ -42,6 +40,7 @@ import com.pinterest.teletraan.universal.security.bean.AuthZResource;
 import io.dropwizard.auth.AuthDynamicFeature;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.dropwizard.testing.junit5.ResourceExtension;
+import java.util.Collections;
 import javax.annotation.security.DenyAll;
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
@@ -131,12 +130,15 @@ public class ResourceAuthorizationTest {
         tokenRolesBean.setRole(TeletraanPrincipalRole.OPERATOR);
         tokenRolesBean.setResource_id("testEnv");
         tokenRolesBean.setResource_type(AuthZResource.Type.ENV);
+        tokenRolesBean.setScript_name(SCRIPT_TOKEN);
         pingerRolesBean.setRole(TeletraanPrincipalRole.PINGER);
         pingerRolesBean.setResource_id(AuthZResource.ALL);
         pingerRolesBean.setResource_type(AuthZResource.Type.SYSTEM);
+        pingerRolesBean.setScript_name(PINGER_TOKEN);
         publisherRolesBean.setRole(TeletraanPrincipalRole.PUBLISHER);
         publisherRolesBean.setResource_id(AuthZResource.ALL);
         publisherRolesBean.setResource_type(AuthZResource.Type.SYSTEM);
+        publisherRolesBean.setScript_name(PUBLISHER_TOKEN);
         buildBean.setBuild_name(TEST_BUILD_ID);
 
         context.setAuthorizationFactory(authorizationFactory);
@@ -155,7 +157,8 @@ public class ResourceAuthorizationTest {
             when(tokenRolesDAO.getByToken(SCRIPT_TOKEN)).thenReturn(tokenRolesBean);
             when(tokenRolesDAO.getByToken(PINGER_TOKEN)).thenReturn(pingerRolesBean);
             when(tokenRolesDAO.getByToken(PUBLISHER_TOKEN)).thenReturn(publisherRolesBean);
-            when(environDAO.getByName(TEST_ENV_ID)).thenReturn(Collections.singletonList(new EnvironBean()));
+            when(environDAO.getByName(TEST_ENV_ID))
+                    .thenReturn(Collections.singletonList(new EnvironBean()));
             when(buildDAO.getById(TEST_BUILD_ID)).thenReturn(buildBean);
             EXT =
                     ResourceExtension.builder()
@@ -315,7 +318,6 @@ public class ResourceAuthorizationTest {
         assertEquals(Status.OK.getStatusCode(), response.getStatus());
     }
 
-
     @Test
     void validPublisherToken_buildResource_200() {
         Response response =
@@ -410,7 +412,9 @@ public class ResourceAuthorizationTest {
         @GET
         @Path(Targets.build + BUILD_SUFFIX)
         @RolesAllowed(TeletraanPrincipalRole.Names.PUBLISHER)
-        @ResourceAuthZInfo(type = AuthZResource.Type.BUILD, idLocation = ResourceAuthZInfo.Location.PATH)
+        @ResourceAuthZInfo(
+                type = AuthZResource.Type.BUILD,
+                idLocation = ResourceAuthZInfo.Location.PATH)
         public Response buildResource() {
             return Response.ok().build();
         }

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/AuthMetricsFactory.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/AuthMetricsFactory.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.universal.security;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Metrics;
+
+public class AuthMetricsFactory {
+    private static final String AUTHN_METRICS_NAME_TEMPLATE = "authn.%s";
+    public static final String SUCCESS = "success";
+    public static final String TYPE = "type";
+
+    private AuthMetricsFactory() {}
+
+    public static Counter.Builder createAuthNCounterBuilder(
+            Class<?> clazz, Boolean success, PrincipalType type, String... extraTags) {
+        return Counter.builder(String.format(AUTHN_METRICS_NAME_TEMPLATE, clazz.getSimpleName()))
+                .tag(SUCCESS, success.toString())
+                .tag(TYPE, type.toString())
+                .tags(extraTags);
+    }
+
+    public static Counter createAuthNCounter(
+            Class<?> clazz, Boolean success, PrincipalType type, String... extraTags) {
+        return createAuthNCounterBuilder(clazz, success, type, extraTags)
+                .register(Metrics.globalRegistry);
+    }
+
+    public enum PrincipalType {
+        USER,
+        SERVICE,
+        NA
+    }
+}

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/AuthMetricsFactoryTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/AuthMetricsFactoryTest.java
@@ -20,8 +20,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.pinterest.teletraan.universal.security.AuthMetricsFactory.PrincipalType;
 import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -30,10 +32,18 @@ import org.junit.jupiter.params.provider.ValueSource;
 class AuthMetricsFactoryTest {
     private static final String AUTHN_AUTH_METRICS_FACTORY_TEST = "authn.AuthMetricsFactoryTest";
     private static final String[] EXTRA_TAGS = {"tagK", "tagV"};
+    private static MeterRegistry registry;
 
     @BeforeAll
-    public static void setup() {
-        Metrics.globalRegistry.add(new SimpleMeterRegistry());
+    public static void setUpClass() {
+        registry = new SimpleMeterRegistry();
+        Metrics.addRegistry(registry);
+    }
+
+    @AfterAll
+    public static void tearDownClass() {
+        registry.close();
+        Metrics.removeRegistry(registry);
     }
 
     @Test
@@ -51,8 +61,7 @@ class AuthMetricsFactoryTest {
         AuthMetricsFactory.createAuthNCounter(
                 AuthMetricsFactoryTest.class, success, PrincipalType.USER, EXTRA_TAGS);
         Counter counter =
-                Metrics.globalRegistry
-                        .find(AUTHN_AUTH_METRICS_FACTORY_TEST)
+                registry.find(AUTHN_AUTH_METRICS_FACTORY_TEST)
                         .tag(AuthMetricsFactory.SUCCESS, success.toString())
                         .tag(
                                 AuthMetricsFactory.TYPE,

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/AuthMetricsFactoryTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/AuthMetricsFactoryTest.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.universal.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.pinterest.teletraan.universal.security.AuthMetricsFactory.PrincipalType;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class AuthMetricsFactoryTest {
+    private static final String AUTHN_AUTH_METRICS_FACTORY_TEST = "authn.AuthMetricsFactoryTest";
+    private static final String[] EXTRA_TAGS = {"tagK", "tagV"};
+
+    @BeforeAll
+    public static void setup() {
+        Metrics.globalRegistry.add(new SimpleMeterRegistry());
+    }
+
+    @Test
+    void testCreateAuthNCounterBuilder() {
+        Counter.Builder counterBuilder =
+                AuthMetricsFactory.createAuthNCounterBuilder(
+                        AuthMetricsFactoryTest.class, false, PrincipalType.USER, EXTRA_TAGS);
+
+        assertNotNull(counterBuilder);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testCreateAuthNCounter(Boolean success) {
+        AuthMetricsFactory.createAuthNCounter(
+                AuthMetricsFactoryTest.class, success, PrincipalType.USER, EXTRA_TAGS);
+        Counter counter =
+                Metrics.globalRegistry
+                        .find(AUTHN_AUTH_METRICS_FACTORY_TEST)
+                        .tag(AuthMetricsFactory.SUCCESS, success.toString())
+                        .tag(
+                                AuthMetricsFactory.TYPE,
+                                AuthMetricsFactory.PrincipalType.USER.toString())
+                        .counter();
+
+        assertNotNull(counter);
+        assertEquals(AUTHN_AUTH_METRICS_FACTORY_TEST, counter.getId().getName());
+        assertEquals(success.toString(), counter.getId().getTag(AuthMetricsFactory.SUCCESS));
+        assertEquals("USER", counter.getId().getTag(AuthMetricsFactory.TYPE));
+        assertEquals(EXTRA_TAGS[1], counter.getId().getTag(EXTRA_TAGS[0]));
+
+        counter.increment();
+        assertEquals(1.0, counter.count());
+    }
+}

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/EnvoyAuthFilterTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/EnvoyAuthFilterTest.java
@@ -15,11 +15,11 @@
  */
 package com.pinterest.teletraan.universal.security;
 
-import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/EnvoyAuthenticatorTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/EnvoyAuthenticatorTest.java
@@ -48,7 +48,7 @@ class EnvoyAuthenticatorTest {
 
     @AfterEach
     public void tearDown() {
-        Metrics.globalRegistry.clear();;
+        Metrics.globalRegistry.clear();
     }
 
     @Test

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/EnvoyAuthenticatorTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/EnvoyAuthenticatorTest.java
@@ -26,7 +26,6 @@ import com.pinterest.teletraan.universal.security.bean.TeletraanPrincipal;
 import com.pinterest.teletraan.universal.security.bean.UserPrincipal;
 import io.dropwizard.auth.AuthenticationException;
 import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.Optional;
@@ -39,19 +38,17 @@ class EnvoyAuthenticatorTest {
     private static final String USER_NAME = "testUser";
 
     private EnvoyAuthenticator authenticator;
-    private MeterRegistry meterRegistry;
     private String COUNTER_NAME = "authn.EnvoyAuthenticator";
 
     @BeforeEach
     public void setUp() {
-        meterRegistry = new SimpleMeterRegistry();
-        Metrics.globalRegistry.add(meterRegistry);
+        Metrics.globalRegistry.add(new SimpleMeterRegistry());
         authenticator = new EnvoyAuthenticator();
     }
 
     @AfterEach
     public void tearDown() {
-        Metrics.globalRegistry.remove(meterRegistry);
+        Metrics.globalRegistry.clear();;
     }
 
     @Test

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/EnvoyAuthenticatorTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/EnvoyAuthenticatorTest.java
@@ -30,6 +30,7 @@ import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -40,9 +41,13 @@ class EnvoyAuthenticatorTest {
     private EnvoyAuthenticator authenticator;
     private String COUNTER_NAME = "authn.EnvoyAuthenticator";
 
+    @BeforeAll
+    public static void setUpClass() {
+        Metrics.globalRegistry.add(new SimpleMeterRegistry());
+    }
+
     @BeforeEach
     public void setUp() {
-        Metrics.globalRegistry.add(new SimpleMeterRegistry());
         authenticator = new EnvoyAuthenticator();
     }
 

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/EnvoyAuthenticatorTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/EnvoyAuthenticatorTest.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.universal.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.pinterest.teletraan.universal.security.AuthMetricsFactory.PrincipalType;
+import com.pinterest.teletraan.universal.security.bean.EnvoyCredentials;
+import com.pinterest.teletraan.universal.security.bean.ServicePrincipal;
+import com.pinterest.teletraan.universal.security.bean.TeletraanPrincipal;
+import com.pinterest.teletraan.universal.security.bean.UserPrincipal;
+import io.dropwizard.auth.AuthenticationException;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class EnvoyAuthenticatorTest {
+    private static final String SPIFFE_ID = "testSpiffeId";
+    private static final String USER_NAME = "testUser";
+
+    private EnvoyAuthenticator authenticator;
+    private MeterRegistry meterRegistry;
+    private String COUNTER_NAME = "authn.EnvoyAuthenticator";
+
+    @BeforeEach
+    public void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        Metrics.globalRegistry.add(meterRegistry);
+        authenticator = new EnvoyAuthenticator();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        Metrics.globalRegistry.remove(meterRegistry);
+    }
+
+    @Test
+    void testAuthenticate_withUserCredentials() throws AuthenticationException {
+        EnvoyCredentials credentials = new EnvoyCredentials(USER_NAME, null, null);
+        Optional<TeletraanPrincipal> result = authenticator.authenticate(credentials);
+
+        assertTrue(result.isPresent());
+        assertTrue(result.get() instanceof UserPrincipal);
+
+        UserPrincipal userPrincipal = (UserPrincipal) result.get();
+        assertEquals(USER_NAME, userPrincipal.getName());
+        assertEquals(null, userPrincipal.getGroups());
+
+        assertCounterValue(true, 1.0, PrincipalType.USER);
+    }
+
+    @Test
+    void testAuthenticate_withServiceCredentials() throws AuthenticationException {
+        EnvoyCredentials credentials = new EnvoyCredentials(null, SPIFFE_ID, null);
+        Optional<TeletraanPrincipal> result = authenticator.authenticate(credentials);
+
+        assertTrue(result.isPresent());
+        assertTrue(result.get() instanceof ServicePrincipal);
+
+        ServicePrincipal servicePrincipal = (ServicePrincipal) result.get();
+        assertEquals(SPIFFE_ID, servicePrincipal.getName());
+
+        assertCounterValue(true, 1.0, PrincipalType.SERVICE);
+    }
+
+    @Test
+    void testAuthenticate_withEmptyCredentials() throws AuthenticationException {
+        EnvoyCredentials credentials = new EnvoyCredentials(null, null, null);
+        Optional<TeletraanPrincipal> result = authenticator.authenticate(credentials);
+        assertFalse(result.isPresent());
+
+        assertCounterValue(false, 1.0, PrincipalType.NA);
+    }
+
+    private void assertCounterValue(Boolean success, double expected, PrincipalType type) {
+        Counter counter =
+                Metrics.globalRegistry
+                        .find(COUNTER_NAME)
+                        .tag(AuthMetricsFactory.SUCCESS, success.toString())
+                        .tag(AuthMetricsFactory.TYPE, type.toString())
+                        .counter();
+        assertEquals(expected, counter.count());
+    }
+}

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/OAuthAuthenticatorTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/OAuthAuthenticatorTest.java
@@ -23,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.pinterest.teletraan.universal.security.bean.UserPrincipal;
 import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
@@ -64,19 +63,17 @@ class OAuthAuthenticatorTest {
     private MockWebServer mockWebServer;
     private MockResponse baseResponse =
             new MockResponse().setHeader("Content-Type", "application/json");
-    private MeterRegistry meterRegistry;
 
     @BeforeEach
     void setUp() throws IOException {
         mockWebServer = new MockWebServer();
         mockWebServer.start();
-        meterRegistry = new SimpleMeterRegistry();
-        Metrics.globalRegistry.add(meterRegistry);
+        Metrics.globalRegistry.add(new SimpleMeterRegistry());
     }
 
     @AfterEach
     void tearDown() {
-        Metrics.globalRegistry.remove(meterRegistry);
+        Metrics.globalRegistry.clear();;
     }
 
     @ParameterizedTest

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/OAuthAuthenticatorTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/OAuthAuthenticatorTest.java
@@ -73,7 +73,8 @@ class OAuthAuthenticatorTest {
 
     @AfterEach
     void tearDown() {
-        Metrics.globalRegistry.clear();;
+        Metrics.globalRegistry.clear();
+        ;
     }
 
     @ParameterizedTest

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/OAuthAuthenticatorTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/OAuthAuthenticatorTest.java
@@ -34,6 +34,7 @@ import java.util.stream.Stream;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -64,17 +65,20 @@ class OAuthAuthenticatorTest {
     private MockResponse baseResponse =
             new MockResponse().setHeader("Content-Type", "application/json");
 
+    @BeforeAll
+    public static void setUpClass() {
+        Metrics.globalRegistry.add(new SimpleMeterRegistry());
+    }
+
     @BeforeEach
     void setUp() throws IOException {
         mockWebServer = new MockWebServer();
         mockWebServer.start();
-        Metrics.globalRegistry.add(new SimpleMeterRegistry());
     }
 
     @AfterEach
     void tearDown() {
         Metrics.globalRegistry.clear();
-        ;
     }
 
     @ParameterizedTest

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/ScriptTokenAuthenticatorTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/ScriptTokenAuthenticatorTest.java
@@ -68,7 +68,8 @@ class ScriptTokenAuthenticatorTest {
         Optional<ScriptTokenPrincipal<ValueBasedRole>> principal = sut.authenticate(CREDENTIALS);
         assertTrue(principal.isPresent());
         assertEquals(PRINCIPAL_NAME, principal.get().getName());
-        assertCounterValue(true, 1.0);
+        Counter counter = assertCounterValue(true, 1.0);
+        assertEquals(PRINCIPAL_NAME, counter.getId().getTag("principal"));
     }
 
     @Test
@@ -86,7 +87,7 @@ class ScriptTokenAuthenticatorTest {
         assertCounterValue(false, 1.0);
     }
 
-    private void assertCounterValue(Boolean success, double expected) {
+    private Counter assertCounterValue(Boolean success, double expected) {
         Counter counter =
                 Metrics.globalRegistry
                         .find("authn.ScriptTokenAuthenticator")
@@ -96,5 +97,6 @@ class ScriptTokenAuthenticatorTest {
                                 AuthMetricsFactory.PrincipalType.SERVICE.toString())
                         .counter();
         assertEquals(expected, counter.count());
+        return counter;
     }
 }

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/ScriptTokenAuthenticatorTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/ScriptTokenAuthenticatorTest.java
@@ -15,9 +15,10 @@
  */
 package com.pinterest.teletraan.universal.security;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -25,15 +26,22 @@ import static org.mockito.Mockito.when;
 import com.pinterest.teletraan.universal.security.bean.ScriptTokenPrincipal;
 import com.pinterest.teletraan.universal.security.bean.ValueBasedRole;
 import io.dropwizard.auth.AuthenticationException;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class ScriptTokenAuthenticatorTest {
+    private static final String PRINCIPAL_NAME = "testPrincipal";
     private static final String CREDENTIALS = "credentials";
     private ScriptTokenProvider<ValueBasedRole> scriptTokenProvider;
     private ScriptTokenPrincipal<ValueBasedRole> scriptTokenPrincipal;
     private ScriptTokenAuthenticator<ValueBasedRole> sut;
+    private MeterRegistry meterRegistry;
 
     @SuppressWarnings("unchecked")
     @BeforeEach
@@ -43,14 +51,24 @@ class ScriptTokenAuthenticatorTest {
         when(scriptTokenProvider.getPrincipal(anyString())).thenReturn(Optional.empty());
         when(scriptTokenProvider.getPrincipal(CREDENTIALS))
                 .thenReturn(Optional.of(scriptTokenPrincipal));
+        when(scriptTokenPrincipal.getName()).thenReturn(PRINCIPAL_NAME);
 
+        meterRegistry = new SimpleMeterRegistry();
+        Metrics.globalRegistry.add(meterRegistry);
         sut = new ScriptTokenAuthenticator<>(scriptTokenProvider);
+    }
+
+    @AfterEach
+    void tearDown() {
+        Metrics.globalRegistry.remove(meterRegistry);
     }
 
     @Test
     void testAuthenticate() throws Exception {
         Optional<ScriptTokenPrincipal<ValueBasedRole>> principal = sut.authenticate(CREDENTIALS);
         assertTrue(principal.isPresent());
+        assertEquals(PRINCIPAL_NAME, principal.get().getName());
+        assertCounterValue(true, 1.0);
     }
 
     @Test
@@ -58,11 +76,25 @@ class ScriptTokenAuthenticatorTest {
         Optional<ScriptTokenPrincipal<ValueBasedRole>> principal =
                 sut.authenticate("bad-credentials");
         assertFalse(principal.isPresent());
+        assertCounterValue(false, 1.0);
     }
 
     @Test
     void testAuthenticateWithException() throws Exception {
         when(scriptTokenProvider.getPrincipal(anyString())).thenThrow(new RuntimeException());
         assertThrows(AuthenticationException.class, () -> sut.authenticate(CREDENTIALS));
+        assertCounterValue(false, 1.0);
+    }
+
+    private void assertCounterValue(Boolean success, double expected) {
+        Counter counter =
+                Metrics.globalRegistry
+                        .find("authn.ScriptTokenAuthenticator")
+                        .tag(AuthMetricsFactory.SUCCESS, success.toString())
+                        .tag(
+                                AuthMetricsFactory.TYPE,
+                                AuthMetricsFactory.PrincipalType.SERVICE.toString())
+                        .counter();
+        assertEquals(expected, counter.count());
     }
 }

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/ScriptTokenAuthenticatorTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/ScriptTokenAuthenticatorTest.java
@@ -31,6 +31,7 @@ import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -40,6 +41,11 @@ class ScriptTokenAuthenticatorTest {
     private ScriptTokenProvider<ValueBasedRole> scriptTokenProvider;
     private ScriptTokenPrincipal<ValueBasedRole> scriptTokenPrincipal;
     private ScriptTokenAuthenticator<ValueBasedRole> sut;
+
+    @BeforeAll
+    public static void setUpClass() {
+        Metrics.globalRegistry.add(new SimpleMeterRegistry());
+    }
 
     @SuppressWarnings("unchecked")
     @BeforeEach
@@ -51,7 +57,6 @@ class ScriptTokenAuthenticatorTest {
                 .thenReturn(Optional.of(scriptTokenPrincipal));
         when(scriptTokenPrincipal.getName()).thenReturn(PRINCIPAL_NAME);
 
-        Metrics.globalRegistry.add(new SimpleMeterRegistry());
         sut = new ScriptTokenAuthenticator<>(scriptTokenProvider);
     }
 

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/ScriptTokenAuthenticatorTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/ScriptTokenAuthenticatorTest.java
@@ -27,7 +27,6 @@ import com.pinterest.teletraan.universal.security.bean.ScriptTokenPrincipal;
 import com.pinterest.teletraan.universal.security.bean.ValueBasedRole;
 import io.dropwizard.auth.AuthenticationException;
 import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.Optional;
@@ -41,7 +40,6 @@ class ScriptTokenAuthenticatorTest {
     private ScriptTokenProvider<ValueBasedRole> scriptTokenProvider;
     private ScriptTokenPrincipal<ValueBasedRole> scriptTokenPrincipal;
     private ScriptTokenAuthenticator<ValueBasedRole> sut;
-    private MeterRegistry meterRegistry;
 
     @SuppressWarnings("unchecked")
     @BeforeEach
@@ -53,14 +51,13 @@ class ScriptTokenAuthenticatorTest {
                 .thenReturn(Optional.of(scriptTokenPrincipal));
         when(scriptTokenPrincipal.getName()).thenReturn(PRINCIPAL_NAME);
 
-        meterRegistry = new SimpleMeterRegistry();
-        Metrics.globalRegistry.add(meterRegistry);
+        Metrics.globalRegistry.add(new SimpleMeterRegistry());
         sut = new ScriptTokenAuthenticator<>(scriptTokenProvider);
     }
 
     @AfterEach
     void tearDown() {
-        Metrics.globalRegistry.remove(meterRegistry);
+        Metrics.globalRegistry.clear();
     }
 
     @Test


### PR DESCRIPTION
Add a few counters for different authentication methods that will help us monitor the usages. 

## Tests
Unit tests.
Deployed to dev1 and verified that metrics exist in statsboard. 