### PR TITLE
Use bearer instead of token

### DIFF
--- a/deploy-board/deploy_board/templates/swagger-ui/dist/index.html
+++ b/deploy-board/deploy_board/templates/swagger-ui/dist/index.html
@@ -11,7 +11,7 @@
             render-style="read"
             api-key-name="Authorization"
             api-key-location="header"
-            api-key-value="token {{ token }}"
+            api-key-value="Bearer {{ token }}"
             fetch-credentials="same-origin"
             allow-server-selection="false"
             allow-authentication="false"


### PR DESCRIPTION
Now teletraan supports `Authorization: Bearer <>`.