### PR TITLE
Change Teletraan DB test setups

### DIFF
--- a/deploy-service/common/pom.xml
+++ b/deploy-service/common/pom.xml
@@ -20,6 +20,12 @@
     </properties>
 
     <build>
+        <testResources>
+            <testResource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/deploy-service/common/src/main/resources/sql/cleanup.sql
+++ b/deploy-service/common/src/main/resources/sql/cleanup.sql
@@ -24,4 +24,8 @@ DROP TABLE IF EXISTS tags;
 DROP TABLE IF EXISTS tokens_and_roles;
 DROP TABLE IF EXISTS user_ratings;
 DROP TABLE IF EXISTS users_and_roles;
-DROP TABLE IF EXISTS schedules
+DROP TABLE IF EXISTS schedules;
+DROP TABLE IF EXISTS hosts_and_agents;
+DROP TABLE IF EXISTS deploy_constraints;
+DROP TABLE IF EXISTS agent_counts;
+DROP TABLE IF EXISTS pindeploy;

--- a/deploy-service/common/src/main/resources/sql/schema-update-1.sql
+++ b/deploy-service/common/src/main/resources/sql/schema-update-1.sql
@@ -1,0 +1,1 @@
+../../../../../../tools/mysql/schema-update-1.sql

--- a/deploy-service/common/src/main/resources/sql/schema-update-10.sql
+++ b/deploy-service/common/src/main/resources/sql/schema-update-10.sql
@@ -1,0 +1,1 @@
+../../../../../../tools/mysql/schema-update-10.sql

--- a/deploy-service/common/src/main/resources/sql/schema-update-11.sql
+++ b/deploy-service/common/src/main/resources/sql/schema-update-11.sql
@@ -1,0 +1,1 @@
+../../../../../../tools/mysql/schema-update-11.sql

--- a/deploy-service/common/src/main/resources/sql/schema-update-12.sql
+++ b/deploy-service/common/src/main/resources/sql/schema-update-12.sql
@@ -1,0 +1,1 @@
+../../../../../../tools/mysql/schema-update-12.sql

--- a/deploy-service/common/src/main/resources/sql/schema-update-13.sql
+++ b/deploy-service/common/src/main/resources/sql/schema-update-13.sql
@@ -1,0 +1,1 @@
+../../../../../../tools/mysql/schema-update-13.sql

--- a/deploy-service/common/src/main/resources/sql/schema-update-14.sql
+++ b/deploy-service/common/src/main/resources/sql/schema-update-14.sql
@@ -1,0 +1,1 @@
+../../../../../../tools/mysql/schema-update-14.sql

--- a/deploy-service/common/src/main/resources/sql/schema-update-15.sql
+++ b/deploy-service/common/src/main/resources/sql/schema-update-15.sql
@@ -1,0 +1,1 @@
+../../../../../../tools/mysql/schema-update-15.sql

--- a/deploy-service/common/src/main/resources/sql/schema-update-16.sql
+++ b/deploy-service/common/src/main/resources/sql/schema-update-16.sql
@@ -1,0 +1,1 @@
+../../../../../../tools/mysql/schema-update-16.sql

--- a/deploy-service/common/src/main/resources/sql/schema-update-17.sql
+++ b/deploy-service/common/src/main/resources/sql/schema-update-17.sql
@@ -1,0 +1,1 @@
+../../../../../../tools/mysql/schema-update-17.sql

--- a/deploy-service/common/src/main/resources/sql/schema-update-18.sql
+++ b/deploy-service/common/src/main/resources/sql/schema-update-18.sql
@@ -1,0 +1,1 @@
+../../../../../../tools/mysql/schema-update-18.sql

--- a/deploy-service/common/src/main/resources/sql/schema-update-19.sql
+++ b/deploy-service/common/src/main/resources/sql/schema-update-19.sql
@@ -1,0 +1,1 @@
+../../../../../../tools/mysql/schema-update-19.sql

--- a/deploy-service/common/src/main/resources/sql/schema-update-2.sql
+++ b/deploy-service/common/src/main/resources/sql/schema-update-2.sql
@@ -1,0 +1,1 @@
+../../../../../../tools/mysql/schema-update-2.sql

--- a/deploy-service/common/src/main/resources/sql/schema-update-3.sql
+++ b/deploy-service/common/src/main/resources/sql/schema-update-3.sql
@@ -1,0 +1,1 @@
+../../../../../../tools/mysql/schema-update-3.sql

--- a/deploy-service/common/src/main/resources/sql/schema-update-4.sql
+++ b/deploy-service/common/src/main/resources/sql/schema-update-4.sql
@@ -1,0 +1,1 @@
+../../../../../../tools/mysql/schema-update-4.sql

--- a/deploy-service/common/src/main/resources/sql/schema-update-5.sql
+++ b/deploy-service/common/src/main/resources/sql/schema-update-5.sql
@@ -1,0 +1,1 @@
+../../../../../../tools/mysql/schema-update-5.sql

--- a/deploy-service/common/src/main/resources/sql/schema-update-6.sql
+++ b/deploy-service/common/src/main/resources/sql/schema-update-6.sql
@@ -1,0 +1,1 @@
+../../../../../../tools/mysql/schema-update-6.sql

--- a/deploy-service/common/src/main/resources/sql/schema-update-7.sql
+++ b/deploy-service/common/src/main/resources/sql/schema-update-7.sql
@@ -1,0 +1,1 @@
+../../../../../../tools/mysql/schema-update-7.sql

--- a/deploy-service/common/src/main/resources/sql/schema-update-8.sql
+++ b/deploy-service/common/src/main/resources/sql/schema-update-8.sql
@@ -1,0 +1,1 @@
+../../../../../../tools/mysql/schema-update-8.sql

--- a/deploy-service/common/src/main/resources/sql/schema-update-9.sql
+++ b/deploy-service/common/src/main/resources/sql/schema-update-9.sql
@@ -1,0 +1,1 @@
+../../../../../../tools/mysql/schema-update-9.sql

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/db/DBUtils.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/db/DBUtils.java
@@ -17,25 +17,62 @@ package com.pinterest.deployservice.db;
 
 import com.ibatis.common.jdbc.ScriptRunner;
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStreamReader;
 import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 import org.apache.commons.dbcp.BasicDataSource;
 import org.testcontainers.containers.MySQLContainer;
 
 public class DBUtils {
-
+    private static final String MYSQL_IMAGE_NAME = "mysql:8.0-oracle";
+    private static final String MYSQL_URL = "jdbc:mysql://0.0.0.0:3303/deploy?useSSL=false";
     public static String DATABASE_NAME = "deploy";
     public static String DATABASE_USER = "root";
     public static String DATABASE_PASSWORD = "";
+    private static MySQLContainer container;
+    private static BasicDataSource dataSource;
 
-    public static MySQLContainer getContainer() {
-        return new MySQLContainer<>()
-                .withDatabaseName(DATABASE_NAME)
-                .withUsername(DATABASE_USER)
-                .withPassword(DATABASE_PASSWORD);
+    public static BasicDataSource createTestDataSource() throws IOException, SQLException {
+        if (dataSource == null) {
+            setUpDataSource();
+        }
+        runMigrations(dataSource);
+        return dataSource;
     }
 
-    public static void runMigrations(BasicDataSource dataSource) throws Exception {
+    public static void truncateAllTables(BasicDataSource dataSource) throws Exception {
+        try (Connection conn = dataSource.getConnection();
+                Statement query = conn.createStatement();
+                Statement stmt = conn.createStatement(); ) {
+            ResultSet rs =
+                    query.executeQuery(
+                            "SELECT table_name FROM information_schema.tables WHERE table_schema = SCHEMA()");
+            stmt.addBatch("SET FOREIGN_KEY_CHECKS=0");
+            while (rs.next()) {
+                String sqlStatement = String.format("TRUNCATE `%s`", rs.getString(1));
+                stmt.addBatch(sqlStatement);
+            }
+            stmt.addBatch("SET FOREIGN_KEY_CHECKS=1");
+            stmt.executeBatch();
+        }
+    }
+
+    private static MySQLContainer getContainer() {
+        if (container == null) {
+            container =
+                    new MySQLContainer(MYSQL_IMAGE_NAME)
+                            .withDatabaseName(DATABASE_NAME)
+                            .withUsername(DATABASE_USER)
+                            .withPassword(DATABASE_PASSWORD);
+            container.start();
+        }
+        return container;
+    }
+
+    private static void runMigrations(BasicDataSource dataSource) throws IOException, SQLException {
         Connection conn = dataSource.getConnection();
         ScriptRunner runner = new ScriptRunner(conn, false, true);
         runner.runScript(
@@ -48,6 +85,34 @@ public class DBUtils {
                                 DBUtils.class.getResourceAsStream("/sql/deploy.sql"))));
         conn.prepareStatement("SET sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));")
                 .execute();
+
+        int version = 7;
+        int executed = 0;
+        while (true) {
+            String scriptName = String.format("/sql/schema-update-%d.sql", version);
+            try {
+                runner.runScript(
+                        new InputStreamReader(DBUtils.class.getResourceAsStream(scriptName)));
+            } catch (Exception e) {
+                if (executed == 0) {
+                    throw new RuntimeException(
+                            "Could not run a single update script. Check starting version is correct");
+                }
+                break;
+            }
+            version++;
+            executed++;
+        }
         conn.close();
+    }
+
+    private static void setUpDataSource() throws IOException, SQLException {
+        boolean userLocalMySQLInstance =
+                Boolean.parseBoolean(System.getenv("USE_LOCAL_MYSQL_INSTANCE"));
+        if (userLocalMySQLInstance) {
+            dataSource = DatabaseUtil.createLocalDataSource(MYSQL_URL);
+        } else {
+            dataSource = DatabaseUtil.createLocalDataSource(getContainer().getJdbcUrl());
+        }
     }
 }

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/fixture/EnvironBeanFixture.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/fixture/EnvironBeanFixture.java
@@ -13,9 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.pinterest.teletraan.fixture;
+package com.pinterest.deployservice.fixture;
 
 import com.pinterest.deployservice.bean.AcceptanceType;
+import com.pinterest.deployservice.bean.DeployPriority;
+import com.pinterest.deployservice.bean.EnvState;
+import com.pinterest.deployservice.bean.EnvType;
 import com.pinterest.deployservice.bean.EnvironBean;
 import com.pinterest.deployservice.bean.EnvironState;
 import com.pinterest.deployservice.bean.OverridePolicy;
@@ -24,29 +27,34 @@ import java.util.UUID;
 public class EnvironBeanFixture {
     public static EnvironBean createRandomEnvironBean() {
         EnvironBean environBean = new EnvironBean();
-        environBean.setEnv_name(UUID.randomUUID().toString());
-        environBean.setStage_name(UUID.randomUUID().toString());
-        environBean.setEnv_id(UUID.randomUUID().toString());
-        environBean.setDeploy_id(UUID.randomUUID().toString());
-        environBean.setState(EnvironState.NORMAL);
-        environBean.setSuccess_th(10000);
+        environBean.setAccept_type(AcceptanceType.AUTO);
+        environBean.setAdv_config_id(UUID.randomUUID().toString().substring(0, 10));
+        environBean.setAllow_private_build(false);
+        environBean.setDeploy_id(UUID.randomUUID().toString().substring(0, 10));
         environBean.setDescription(UUID.randomUUID().toString());
-        environBean.setAdv_config_id(UUID.randomUUID().toString());
-        environBean.setSc_config_id(UUID.randomUUID().toString());
+        environBean.setEnsure_trusted_build(false);
+        environBean.setEnv_id(UUID.randomUUID().toString().substring(0, 10));
+        environBean.setEnv_name(UUID.randomUUID().toString());
+        environBean.setEnv_state(EnvState.NORMAL);
+        environBean.setIs_docker(false);
+        environBean.setIs_sox(false);
         environBean.setLast_operator(UUID.randomUUID().toString());
         environBean.setLast_update(System.currentTimeMillis());
-        environBean.setAccept_type(AcceptanceType.AUTO);
-        environBean.setNotify_authors(false);
-        environBean.setWatch_recipients(UUID.randomUUID().toString());
-        environBean.setMax_deploy_num(5100);
         environBean.setMax_deploy_day(366);
-        environBean.setIs_docker(false);
+        environBean.setMax_deploy_num(5100);
         environBean.setMax_parallel_pct(0);
-        environBean.setState(EnvironState.NORMAL);
         environBean.setMax_parallel_rp(1);
+        environBean.setMax_parallel(10);
+        environBean.setNotify_authors(false);
         environBean.setOverride_policy(OverridePolicy.OVERRIDE);
-        environBean.setAllow_private_build(false);
-        environBean.setEnsure_trusted_build(false);
+        environBean.setPriority(DeployPriority.NORMAL);
+        environBean.setSc_config_id(UUID.randomUUID().toString().substring(0, 10));
+        environBean.setStage_name(UUID.randomUUID().toString());
+        environBean.setStage_type(EnvType.DEFAULT);
+        environBean.setState(EnvironState.NORMAL);
+        environBean.setStuck_th(50);
+        environBean.setSuccess_th(10000);
+        environBean.setWatch_recipients(UUID.randomUUID().toString());
         return environBean;
     }
 }

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/resource/EnvStagesTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/resource/EnvStagesTest.java
@@ -19,19 +19,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.Response;
-
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-
 import com.pinterest.deployservice.bean.EnvironBean;
 import com.pinterest.deployservice.dao.EnvironDAO;
+import com.pinterest.deployservice.fixture.EnvironBeanFixture;
 import com.pinterest.teletraan.TeletraanServiceContext;
-import com.pinterest.teletraan.fixture.EnvironBeanFixture;
-
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.dropwizard.testing.junit5.ResourceExtension;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
 class EnvStagesTest {

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/EnvStageBodyExtractorTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/EnvStageBodyExtractorTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pinterest.deployservice.bean.EnvironBean;
-import com.pinterest.teletraan.fixture.EnvironBeanFixture;
+import com.pinterest.deployservice.fixture.EnvironBeanFixture;
 import com.pinterest.teletraan.universal.security.AuthZResourceExtractor.ExtractionException;
 import com.pinterest.teletraan.universal.security.bean.AuthZResource;
 import java.io.ByteArrayInputStream;

--- a/tools/mysql/schema-update-1.sql
+++ b/tools/mysql/schema-update-1.sql
@@ -1,8 +1,8 @@
 -- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
--- ALWAYS BACKUP YOUR DATA BEFORE EXECUTING THIS SCRIPT   
+-- ALWAYS BACKUP YOUR DATA BEFORE EXECUTING THIS SCRIPT
 -- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-# This script upgrade DB schema from version 0 to version 1
+-- This script upgrade DB schema from version 0 to version 1
 
 DROP TABLE IF EXISTS groups;
 DROP TABLE IF EXISTS asg_alarms;

--- a/tools/mysql/schema-update-10.sql
+++ b/tools/mysql/schema-update-10.sql
@@ -2,7 +2,7 @@
 -- ALWAYS BACKUP YOUR DATA BEFORE EXECUTING THIS SCRIPT
 -- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-# This script upgrade DB schema from version 9 to version 10
+-- This script upgrade DB schema from version 9 to version 10
 
 CREATE INDEX cluster_name ON environs (cluster_name);
 

--- a/tools/mysql/schema-update-11.sql
+++ b/tools/mysql/schema-update-11.sql
@@ -2,7 +2,7 @@
 -- ALWAYS BACKUP YOUR DATA BEFORE EXECUTING THIS SCRIPT
 -- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-# This script upgrade DB schema from version 10 to version 11
+-- This script upgrade DB schema from version 10 to version 11
 
 ALTER TABLE environs MODIFY COLUMN stage_type VARCHAR(32) NOT NULL DEFAULT 'DEFAULT';
 

--- a/tools/mysql/schema-update-12.sql
+++ b/tools/mysql/schema-update-12.sql
@@ -2,7 +2,7 @@
 -- ALWAYS BACKUP YOUR DATA BEFORE EXECUTING THIS SCRIPT
 -- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-# This script upgrade DB schema from version 11 to version 12
+-- This script upgrade DB schema from version 11 to version 12
 
 CREATE TABLE IF NOT EXISTS agent_counts (
     env_id         VARCHAR(22)         NOT NULL,

--- a/tools/mysql/schema-update-13.sql
+++ b/tools/mysql/schema-update-13.sql
@@ -2,7 +2,7 @@
 -- ALWAYS BACKUP YOUR DATA BEFORE EXECUTING THIS SCRIPT
 -- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-# This script upgrade DB schema from version 12 to version 13
+-- This script upgrade DB schema from version 12 to version 13
 
 ALTER TABLE hosts_and_agents ADD COLUMN host_name VARCHAR(64) DEFAULT NULL;
 ALTER TABLE hosts_and_agents ADD COLUMN ip VARCHAR(64) DEFAULT NULL;

--- a/tools/mysql/schema-update-14.sql
+++ b/tools/mysql/schema-update-14.sql
@@ -2,7 +2,7 @@
 -- ALWAYS BACKUP YOUR DATA BEFORE EXECUTING THIS SCRIPT
 -- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-# This script upgrade DB schema from version 13 to version 14
+-- This script upgrade DB schema from version 13 to version 14
 
 ALTER TABLE environs ADD COLUMN is_sox TINYINT(1) NOT NULL DEFAULT 0;
 

--- a/tools/mysql/schema-update-15.sql
+++ b/tools/mysql/schema-update-15.sql
@@ -2,7 +2,7 @@
 -- ALWAYS BACKUP YOUR DATA BEFORE EXECUTING THIS SCRIPT
 -- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-# This script upgrade DB schema from version 14 to version 15
+-- This script upgrade DB schema from version 14 to version 15
 
 ALTER TABLE environs ADD UNIQUE (sc_config_id);
 

--- a/tools/mysql/schema-update-16.sql
+++ b/tools/mysql/schema-update-16.sql
@@ -2,7 +2,7 @@
 -- ALWAYS BACKUP YOUR DATA BEFORE EXECUTING THIS SCRIPT
 -- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-# This script upgrade DB schema from version 15 to version 16
+-- This script upgrade DB schema from version 15 to version 16
 
 ALTER TABLE builds ADD INDEX `build_name_publish_date` (build_name,publish_date);
 

--- a/tools/mysql/schema-update-17.sql
+++ b/tools/mysql/schema-update-17.sql
@@ -2,7 +2,7 @@
 -- ALWAYS BACKUP YOUR DATA BEFORE EXECUTING THIS SCRIPT
 -- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-# This script upgrade DB schema from version 16 to version 17
+-- This script upgrade DB schema from version 16 to version 17
 
 ALTER TABLE environs ADD COLUMN termination_limit INT DEFAULT NULL;
 

--- a/tools/mysql/schema-update-18.sql
+++ b/tools/mysql/schema-update-18.sql
@@ -2,7 +2,7 @@
 -- ALWAYS BACKUP YOUR DATA BEFORE EXECUTING THIS SCRIPT
 -- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-# This script upgrade DB schema from version 17 to version 18
+-- This script upgrade DB schema from version 17 to version 18
 
 ALTER TABLE environs ADD COLUMN group_mention_recipients VARCHAR(1024) DEFAULT NULL;
 

--- a/tools/mysql/schema-update-19.sql
+++ b/tools/mysql/schema-update-19.sql
@@ -2,7 +2,7 @@
 -- ALWAYS BACKUP YOUR DATA BEFORE EXECUTING THIS SCRIPT
 -- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-# This script upgrade DB schema from version 18 to version 19
+-- This script upgrade DB schema from version 18 to version 19
 
 CREATE TABLE `pindeploy` (
   `env_id` varchar(22) NOT NULL,

--- a/tools/mysql/schema-update-3.sql
+++ b/tools/mysql/schema-update-3.sql
@@ -2,7 +2,7 @@
 -- ALWAYS BACKUP YOUR DATA BEFORE EXECUTING THIS SCRIPT
 -- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-# This script upgrade DB schema from version 2 to version 3
+-- This script upgrade DB schema from version 2 to version 3
 
 
 ALTER TABLE environs ADD COLUMN project_id INT(11);

--- a/tools/mysql/schema-update-4.sql
+++ b/tools/mysql/schema-update-4.sql
@@ -2,7 +2,7 @@
 -- ALWAYS BACKUP YOUR DATA BEFORE EXECUTING THIS SCRIPT
 -- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-# This script upgrade DB schema from version 3 to version 4
+-- This script upgrade DB schema from version 3 to version 4
 
 ALTER TABLE environs DROP COLUMN project_id;
 ALTER TABLE environs ADD COLUMN external_id CHAR(36);

--- a/tools/mysql/schema-update-5.sql
+++ b/tools/mysql/schema-update-5.sql
@@ -2,7 +2,7 @@
 -- ALWAYS BACKUP YOUR DATA BEFORE EXECUTING THIS SCRIPT
 -- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-# This script upgrade DB schema from version 4 to version 5
+-- This script upgrade DB schema from version 4 to version 5
 
 ALTER TABLE environs ADD COLUMN allow_private_build TINYINT(1) NOT NULL DEFAULT 0;
 

--- a/tools/mysql/schema-update-6.sql
+++ b/tools/mysql/schema-update-6.sql
@@ -2,7 +2,7 @@
 -- ALWAYS BACKUP YOUR DATA BEFORE EXECUTING THIS SCRIPT
 -- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-# This script upgrade DB schema from version 5 to version 6
+-- This script upgrade DB schema from version 5 to version 6
 
 ALTER TABLE environs ADD COLUMN ensure_trusted_build TINYINT(1) NOT NULL DEFAULT 0;
 

--- a/tools/mysql/schema-update-7.sql
+++ b/tools/mysql/schema-update-7.sql
@@ -2,7 +2,7 @@
 -- ALWAYS BACKUP YOUR DATA BEFORE EXECUTING THIS SCRIPT
 -- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-# This script upgrade DB schema from version 6 to version 7
+-- This script upgrade DB schema from version 6 to version 7
 
 ALTER TABLE environs MODIFY chatroom VARCHAR(128) DEFAULT NULL;
 

--- a/tools/mysql/schema-update-8.sql
+++ b/tools/mysql/schema-update-8.sql
@@ -2,7 +2,7 @@
 -- ALWAYS BACKUP YOUR DATA BEFORE EXECUTING THIS SCRIPT
 -- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-# This script upgrade DB schema from version 7 to version 8
+-- This script upgrade DB schema from version 7 to version 8
 
 ALTER TABLE environs ADD COLUMN stage_type VARCHAR(32) NOT NULL DEFAULT 'PRODUCTION';
 ALTER TABLE groups_and_envs MODIFY group_name VARCHAR(128) NOT NULL;

--- a/tools/mysql/schema-update-9.sql
+++ b/tools/mysql/schema-update-9.sql
@@ -2,7 +2,7 @@
 -- ALWAYS BACKUP YOUR DATA BEFORE EXECUTING THIS SCRIPT
 -- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-# This script upgrade DB schema from version 8 to version 9
+-- This script upgrade DB schema from version 8 to version 9
 
 ALTER TABLE hosts MODIFY group_name VARCHAR(128) NOT NULL;
 


### PR DESCRIPTION
In order to create separate test suites for DBDAOs, it's necessary to change the Teletraan DB test set ups. 
Symlinks are created in the deploy-service/common/src/main/resources/sql/ directory so that the migration process would work.