### PR TITLE
Add authz to hosts endpoints

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/EnvironDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/EnvironDAO.java
@@ -62,6 +62,19 @@ public interface EnvironDAO {
 
     List<EnvironBean> getEnvsByHost(String host) throws Exception;
 
+    /**
+     * Retrieves the main environment ID for the specified host ID.
+     *
+     * <p>The main environment is where the cluster that the host belongs to is created.
+     * In case such an environment does not exist, the method will attempt to retrieve the
+     * environment that matches the first group that's known to Teletraan for the specified host.
+     *
+     * @param hostId The ID of the host.
+     * @return The bean represents the main environment for the specified host ID.
+     * @throws SQLException if an error occurs while retrieving the main environment ID.
+     */
+    EnvironBean getMainEnvByHostId(String hostId) throws SQLException;
+
     List<EnvironBean> getEnvsByGroups(Collection<String> groups) throws Exception;
 
     List<String> getCurrentDeployIds() throws Exception;

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/db/DBEnvironDAOImplTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/db/DBEnvironDAOImplTest.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.deployservice.db;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Instant;
+
+import com.pinterest.deployservice.bean.BeanUtils;
+import com.pinterest.deployservice.bean.EnvironBean;
+import com.pinterest.deployservice.bean.HostAgentBean;
+import com.pinterest.deployservice.bean.HostBean;
+import com.pinterest.deployservice.dao.EnvironDAO;
+import com.pinterest.deployservice.dao.HostAgentDAO;
+import com.pinterest.deployservice.dao.HostDAO;
+import com.pinterest.deployservice.fixture.EnvironBeanFixture;
+import org.apache.commons.dbcp.BasicDataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class DBEnvironDAOImplTest {
+    private static final String HOST_ID = "host123";
+    private static final String TEST_CLUSTER = "test-cluster";
+    private static BasicDataSource dataSource;
+    private static HostAgentDAO hostAgentDAO;
+    private static HostDAO hostDAO;
+    private EnvironDAO sut;
+
+    @BeforeAll
+    static void setUpAll() throws Exception {
+        dataSource = DBUtils.createTestDataSource();
+        hostAgentDAO = new DBHostAgentDAOImpl(dataSource);
+        hostDAO = new DBHostDAOImpl(dataSource);
+    }
+
+    @BeforeEach
+    void setUp() {
+        sut = new DBEnvironDAOImpl(dataSource);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        DBUtils.truncateAllTables(dataSource);
+    }
+
+    @Test
+    void testGetMainEnvByHostId_happyPath() throws Exception {
+        EnvironBean expectedEnvBean = EnvironBeanFixture.createRandomEnvironBean();
+        expectedEnvBean.setCluster_name(TEST_CLUSTER);
+        sut.insert(expectedEnvBean);
+
+        HostAgentBean hostAgentBean = new HostAgentBean();
+        hostAgentBean.setHost_id(HOST_ID);
+        hostAgentBean.setAuto_scaling_group(TEST_CLUSTER);
+        hostAgentDAO.insert(hostAgentBean);
+
+        HostBean hostBean = BeanUtils.createHostBean(Instant.now());
+        hostBean.setHost_id(HOST_ID);
+        hostBean.setGroup_name(TEST_CLUSTER + "sidecar");
+        hostDAO.insert(hostBean);
+
+        EnvironBean actualEnvironBean = sut.getMainEnvByHostId(HOST_ID);
+        assertEquals(expectedEnvBean.getEnv_name(), actualEnvironBean.getEnv_name());
+        assertEquals(expectedEnvBean.getStage_name(), actualEnvironBean.getStage_name());
+        assertEquals(TEST_CLUSTER, actualEnvironBean.getCluster_name());
+
+        EnvironBean nullEnvironBean = sut.getMainEnvByHostId("random-host-id");
+        assertNull(nullEnvironBean);
+    }
+
+    @Test
+    void testGetMainEnvByHostId_noHost() throws Exception {
+        EnvironBean actualEnvironBean = sut.getMainEnvByHostId(HOST_ID);
+        assertNull(actualEnvironBean);
+    }
+
+    @Test
+    void testGetMainEnvByHostId_noEnv() throws Exception {
+        HostAgentBean hostAgentBean = new HostAgentBean();
+        hostAgentBean.setHost_id(HOST_ID);
+        hostAgentBean.setAuto_scaling_group(TEST_CLUSTER);
+        hostAgentDAO.insert(hostAgentBean);
+
+        EnvironBean actualEnvironBean = sut.getMainEnvByHostId(HOST_ID);
+        assertNull(actualEnvironBean);
+    }
+
+    @Test
+    void testGetMainEnvByHostId_noHostAgent() throws Exception {
+        EnvironBean expectedEnvBean = EnvironBeanFixture.createRandomEnvironBean();
+        expectedEnvBean.setCluster_name(TEST_CLUSTER);
+        sut.insert(expectedEnvBean);
+
+        HostBean hostBean = BeanUtils.createHostBean(Instant.now());
+        hostBean.setHost_id(HOST_ID);
+        hostBean.setGroup_name(TEST_CLUSTER);
+        hostDAO.insert(hostBean);
+
+        HostBean hostBean2 = BeanUtils.createHostBean(Instant.now());
+        hostBean.setHost_id(HOST_ID);
+        hostBean.setGroup_name(TEST_CLUSTER + "2");
+        hostDAO.insert(hostBean2);
+
+        EnvironBean actualEnvironBean = sut.getMainEnvByHostId(HOST_ID);
+        assertEquals(expectedEnvBean.getEnv_name(), actualEnvironBean.getEnv_name());
+        assertEquals(expectedEnvBean.getStage_name(), actualEnvironBean.getStage_name());
+        assertEquals(TEST_CLUSTER, actualEnvironBean.getCluster_name());
+    }
+}

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/handler/EnvironHandlerTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/handler/EnvironHandlerTest.java
@@ -1,12 +1,24 @@
 package com.pinterest.deployservice.handler;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import org.junit.Before;
-import org.junit.Test;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.ws.rs.NotAllowedException;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.WebApplicationException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import com.pinterest.deployservice.ServiceContext;
@@ -18,7 +30,7 @@ import com.pinterest.deployservice.dao.AgentDAO;
 import com.pinterest.deployservice.dao.EnvironDAO;
 import com.pinterest.deployservice.dao.HostDAO;
 
-public class EnvironHandlerTest {
+class EnvironHandlerTest {
     private final static String DEFAULT_HOST_ID = "hostId";
 
     private EnvironHandler environHandler;
@@ -26,6 +38,7 @@ public class EnvironHandlerTest {
     private HostDAO mockHostDAO;
     private AgentDAO mockAgentDAO;
     private EnvironDAO environDAO;
+    private List<String> hostIds = Arrays.asList("hostId1", "hostId2");
 
     private ServiceContext createMockServiceContext() throws Exception {
         mockHostDAO = mock(HostDAO.class);
@@ -39,13 +52,13 @@ public class EnvironHandlerTest {
         return serviceContext;
     }
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    void setUp() throws Exception {
         environHandler = new EnvironHandler(createMockServiceContext());
     }
 
     @Test
-    public void stopServiceOnHost_withReplaceHost_hostBeanStateIsPendingTerminate() throws Exception {
+    void stopServiceOnHost_withReplaceHost_hostBeanStateIsPendingTerminate() throws Exception {
         ArgumentCaptor<HostBean> argument = ArgumentCaptor.forClass(HostBean.class);
 
         environHandler.stopServiceOnHost(DEFAULT_HOST_ID, true);
@@ -54,7 +67,7 @@ public class EnvironHandlerTest {
     }
 
     @Test
-    public void stopServiceOnHost_withoutReplaceHost_hostBeanStateIsPendingTerminateNoReplace() throws Exception {
+    void stopServiceOnHost_withoutReplaceHost_hostBeanStateIsPendingTerminateNoReplace() throws Exception {
         ArgumentCaptor<HostBean> argument = ArgumentCaptor.forClass(HostBean.class);
 
         environHandler.stopServiceOnHost(DEFAULT_HOST_ID, false);
@@ -63,12 +76,39 @@ public class EnvironHandlerTest {
     }
 
     @Test
-    public void updateStage_type_enables_private_build() throws Exception {
+    void updateStage_type_enables_private_build() throws Exception {
         ArgumentCaptor<EnvironBean> argument = ArgumentCaptor.forClass(EnvironBean.class);
         EnvironBean envBean = new EnvironBean();
         envBean.setStage_type(EnvType.DEV);
         environHandler.createEnvStage(envBean, "Anonymous");
         verify(environDAO).insert(argument.capture());
         assertEquals(true, argument.getValue().getAllow_private_build());
+    }
+
+    @Test
+    void ensureHostsOwnedByEnv_noMainEnv() throws Exception {
+        assertThrows(NotFoundException.class, () -> environHandler.ensureHostsOwnedByEnv(new EnvironBean(), hostIds));
+    }
+
+    @Test
+    void ensureHostsOwnedByEnv_differentMainEnv() throws Exception {
+        EnvironBean envBean = new EnvironBean();
+        envBean.setEnv_id("envId");
+        when(environDAO.getMainEnvByHostId(anyString())).thenReturn(envBean);
+        assertThrows(NotAllowedException.class, () -> environHandler.ensureHostsOwnedByEnv(new EnvironBean(), hostIds));
+    }
+
+    @Test
+    void ensureHostsOwnedByEnv_sameMainEnv() throws Exception {
+        EnvironBean envBean = new EnvironBean();
+        envBean.setEnv_id("envId");
+        when(environDAO.getMainEnvByHostId(anyString())).thenReturn(envBean);
+        assertDoesNotThrow(() -> environHandler.ensureHostsOwnedByEnv(envBean, hostIds));
+    }
+
+    @Test
+    void ensureHostsOwnedByEnv_sqlException() throws Exception {
+        when(environDAO.getMainEnvByHostId(anyString())).thenThrow(SQLException.class);
+        assertThrows(WebApplicationException.class, () -> environHandler.ensureHostsOwnedByEnv(new EnvironBean(), hostIds));
     }
 }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvAgents.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvAgents.java
@@ -98,7 +98,7 @@ public class EnvAgents {
             value = "Update host agent",
             notes = "Updates host agent specified by given environment name, stage name, and host id with given " +
                     "agent object")
-    @RolesAllowed(TeletraanPrincipalRole.Names.WRITE)
+    @RolesAllowed(TeletraanPrincipalRole.Names.EXECUTE)
     @ResourceAuthZInfo(type = AuthZResource.Type.ENV_STAGE, idLocation = ResourceAuthZInfo.Location.PATH)
     public void update(
             @Context SecurityContext sc,
@@ -118,7 +118,7 @@ public class EnvAgents {
     @ApiOperation(
             value = "Reset failed deploys",
             notes = "Resets failing deploys given an environment name, stage name, and deploy id")
-    @RolesAllowed(TeletraanPrincipalRole.Names.WRITE)
+    @RolesAllowed(TeletraanPrincipalRole.Names.EXECUTE)
     @ResourceAuthZInfo(type = AuthZResource.Type.ENV_STAGE, idLocation = ResourceAuthZInfo.Location.PATH)
     public void resetFailedDeploys(
             @Context SecurityContext sc,

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvDeploys.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvDeploys.java
@@ -154,7 +154,6 @@ public class EnvDeploys {
         response = Response.class)
     @RolesAllowed(TeletraanPrincipalRole.Names.EXECUTE)
     @ResourceAuthZInfo(type = AuthZResource.Type.ENV_STAGE, idLocation = ResourceAuthZInfo.Location.PATH)
-    // TODO: sidecar owners can perform actions on non-sidecar agents
     public void update(
             @Context SecurityContext sc,
             @ApiParam(value = "Environment name", required = true)@PathParam("envName") String envName,

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Hosts.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Hosts.java
@@ -18,9 +18,12 @@ package com.pinterest.teletraan.resource;
 import com.google.common.base.Optional;
 import com.pinterest.deployservice.bean.HostBean;
 import com.pinterest.deployservice.bean.HostState;
+import com.pinterest.deployservice.bean.TeletraanPrincipalRole;
 import com.pinterest.deployservice.dao.HostDAO;
 import com.pinterest.deployservice.handler.EnvironHandler;
 import com.pinterest.teletraan.TeletraanServiceContext;
+import com.pinterest.teletraan.universal.security.ResourceAuthZInfo;
+import com.pinterest.teletraan.universal.security.bean.AuthZResource;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import io.swagger.annotations.*;
 
 import javax.annotation.security.PermitAll;
+import javax.annotation.security.RolesAllowed;
 import javax.validation.Valid;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
@@ -47,7 +51,6 @@ import java.util.List;
 )
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
-// TODO: CDP-7701 Add authorization to hosts endpoints
 public class Hosts {
     private static final Logger LOG = LoggerFactory.getLogger(Hosts.class);
     private HostDAO hostDAO;
@@ -59,6 +62,11 @@ public class Hosts {
     }
 
     @POST
+    @RolesAllowed(TeletraanPrincipalRole.Names.EXECUTE)
+    @ResourceAuthZInfo(type = AuthZResource.Type.SYSTEM)
+    @ApiOperation(
+            value = "Add a host",
+            notes = "Add a host to the system. Should be only called by Rodimus that's why it requires SYSTEM permission.")
     public void addHost(@Context SecurityContext sc,
                         @Valid HostBean hostBean) throws Exception {
         String operator = sc.getUserPrincipal().getName();
@@ -75,6 +83,8 @@ public class Hosts {
 
     @PUT
     @Path("/{hostId : [a-zA-Z0-9\\-_]+}")
+    @RolesAllowed(TeletraanPrincipalRole.Names.EXECUTE)
+    @ResourceAuthZInfo(type = AuthZResource.Type.HOST, idLocation = ResourceAuthZInfo.Location.PATH)
     public void updateHost(@Context SecurityContext sc,
                            @PathParam("hostId") String hostId,
                            @Valid HostBean hostBean) throws Exception {
@@ -87,6 +97,8 @@ public class Hosts {
 
     @DELETE
     @Path("/{hostId : [a-zA-Z0-9\\-_]+}")
+    @RolesAllowed(TeletraanPrincipalRole.Names.EXECUTE)
+    @ResourceAuthZInfo(type = AuthZResource.Type.HOST, idLocation = ResourceAuthZInfo.Location.PATH)
     public void stopHost(@Context SecurityContext sc,
             @PathParam("hostId") String hostId,
             @ApiParam(value = "Replace the host or not") @QueryParam("replaceHost") Optional<Boolean> replaceHost)

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/HostPathExtractor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/HostPathExtractor.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.security;
+
+import com.pinterest.deployservice.ServiceContext;
+import com.pinterest.deployservice.bean.EnvironBean;
+import com.pinterest.deployservice.dao.EnvironDAO;
+import com.pinterest.teletraan.universal.security.AuthZResourceExtractor;
+import com.pinterest.teletraan.universal.security.bean.AuthZResource;
+import java.sql.SQLException;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.container.ContainerRequestContext;
+
+public class HostPathExtractor implements AuthZResourceExtractor {
+    private static final String HOST_ID = "hostId";
+    private final EnvironDAO environDAO;
+
+    public HostPathExtractor(ServiceContext context) {
+        this.environDAO = context.getEnvironDAO();
+    }
+
+    @Override
+    public AuthZResource extractResource(ContainerRequestContext requestContext)
+            throws ExtractionException {
+        String hostId = requestContext.getUriInfo().getPathParameters().getFirst(HOST_ID);
+        if (hostId == null) {
+            throw new ExtractionException("Failed to extract host id");
+        }
+
+        EnvironBean envBean;
+        try {
+            envBean = environDAO.getMainEnvByHostId(hostId);
+        } catch (SQLException e) {
+            throw new ExtractionException(
+                    "Failed to get the main environment with host ID: " + hostId, e);
+        }
+
+        if (envBean == null) {
+            throw new NotFoundException(
+                    "Failed to get the main environment with host ID: " + hostId);
+        }
+        return new AuthZResource(envBean.getEnv_name(), envBean.getStage_name());
+    }
+}

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/TeletraanAuthZResourceExtractorFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/TeletraanAuthZResourceExtractorFactory.java
@@ -30,12 +30,14 @@ public class TeletraanAuthZResourceExtractorFactory implements AuthZResourceExtr
     private static final AuthZResourceExtractor HOTFIX_BODY_EXTRACTOR = new HotfixBodyExtractor();
     private final AuthZResourceExtractor buildPathExtractor;
     private final AuthZResourceExtractor deployPathExtractor;
+    private final AuthZResourceExtractor hostPathExtractor;
     private final AuthZResourceExtractor hotfixPathExtractor;
 
     public TeletraanAuthZResourceExtractorFactory(ServiceContext serviceContext) {
         buildPathExtractor = new BuildPathExtractor(serviceContext);
         deployPathExtractor = new DeployPathExtractor(serviceContext);
         hotfixPathExtractor = new HotfixPathExtractor(serviceContext);
+        hostPathExtractor = new HostPathExtractor(serviceContext);
     }
 
     @Override
@@ -53,6 +55,8 @@ public class TeletraanAuthZResourceExtractorFactory implements AuthZResourceExtr
                         return deployPathExtractor;
                     case HOTFIX:
                         return hotfixPathExtractor;
+                    case HOST:
+                        return hostPathExtractor;
                     default:
                         throw new UnsupportedResourceInfoException(authZInfo);
                 }

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/HostPathExtractorTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/HostPathExtractorTest.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.pinterest.deployservice.ServiceContext;
+import com.pinterest.deployservice.bean.EnvironBean;
+import com.pinterest.deployservice.dao.EnvironDAO;
+import com.pinterest.teletraan.universal.security.AuthZResourceExtractor.ExtractionException;
+import com.pinterest.teletraan.universal.security.bean.AuthZResource;
+import java.sql.SQLException;
+import javax.ws.rs.NotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class HostPathExtractorTest extends BasePathExtractorTest {
+    private HostPathExtractor sut;
+    private ServiceContext serviceContext;
+    private EnvironDAO hostDAO;
+
+    @BeforeEach
+    void setUp() {
+        super.setUp();
+        hostDAO = mock(EnvironDAO.class);
+        serviceContext = new ServiceContext();
+        serviceContext.setEnvironDAO(hostDAO);
+        sut = new HostPathExtractor(serviceContext);
+    }
+
+    @Test
+    void testExtractResource_noPathParams_exception() {
+        assertThrows(ExtractionException.class, () -> sut.extractResource(context));
+    }
+
+    @Test
+    void testExtractResource_0HostId() {
+        pathParameters.add("param", "val");
+
+        assertThrows(ExtractionException.class, () -> sut.extractResource(context));
+    }
+
+    @Test
+    void testExtractResource() throws Exception {
+        String hostId = "testHostId";
+        pathParameters.add("hostId", hostId);
+
+        when(hostDAO.getMainEnvByHostId(hostId)).thenReturn(null);
+        assertThrows(NotFoundException.class, () -> sut.extractResource(context));
+
+        EnvironBean envBean = new EnvironBean();
+        envBean.setEnv_name("host_env");
+        envBean.setStage_name("host_stage");
+        when(hostDAO.getMainEnvByHostId(hostId)).thenReturn(envBean);
+
+        AuthZResource result = sut.extractResource(context);
+
+        assertNotNull(result);
+        assertTrue(result.getName().contains(envBean.getEnv_name()));
+        assertTrue(result.getName().contains(envBean.getStage_name()));
+        assertEquals(AuthZResource.Type.ENV_STAGE, result.getType());
+    }
+
+    @Test
+    void testExtractResource_sqlException() throws Exception {
+        pathParameters.add("hostId", "someId");
+        when(hostDAO.getMainEnvByHostId(any())).thenThrow(SQLException.class);
+
+        assertThrows(ExtractionException.class, () -> sut.extractResource(context));
+    }
+}

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/TeletraanAuthZResourceExtractorFactoryTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/TeletraanAuthZResourceExtractorFactoryTest.java
@@ -121,6 +121,16 @@ class TeletraanAuthZResourceExtractorFactoryTest {
     }
 
     @Test
+    void create_shouldReturnCorrectExtractorForHostPathLocation() {
+        when(authZInfo.idLocation()).thenReturn(ResourceAuthZInfo.Location.PATH);
+        when(authZInfo.type()).thenReturn(AuthZResource.Type.HOST);
+
+        AuthZResourceExtractor extractor = extractorFactory.create(authZInfo);
+
+        assertTrue(extractor instanceof HostPathExtractor);
+    }
+
+    @Test
     void create_shouldThrowExceptionForUnsupportedLocation() {
         when(authZInfo.idLocation()).thenReturn(ResourceAuthZInfo.Location.NA);
 

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/AuthZResource.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/AuthZResource.java
@@ -91,8 +91,8 @@ public class AuthZResource {
         DEPLOY,
         /** For hotfix related resources. */
         HOTFIX,
-        /** For Agent related resources. */
-        AGENT,
+        /** For Host related resources. */
+        HOST,
     }
 
     /**


### PR DESCRIPTION
Introduced a host extractor that can map hosts to their corresponding environment. This enables host level access control. 

Specifically, a host's main environment is determined by joining the tables `hosts_and_agents` and `environs` on the common field cluster. 

After deploying to dev1, I discovered an issue. If a host's agent has never pinged Teletraan, there will be no record in the hosts_and_agents table. To remedy that, the group_name in the hosts table is used to join with cluster_name in the environs table.

Besides, patched the stopServiceOnHost API so that every hosts is validated before terminating.
