### PR TITLE
update teletraan api to disable keel pipeline by pipeline link instead of env/stage name

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/PindeployDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/PindeployDAO.java
@@ -23,7 +23,7 @@ import com.pinterest.deployservice.bean.PindeployBean;
 public interface PindeployDAO {
     PindeployBean get(String envId) throws Exception;
 
-    void delete(String envId) throws Exception;
+    void delete(String pipeline) throws Exception;
 
     void insertOrUpdate(PindeployBean pindeployBean) throws Exception;
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBPindeployDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBPindeployDAOImpl.java
@@ -46,8 +46,7 @@ public class DBPindeployDAOImpl implements PindeployDAO {
 
     @Override
     public void delete(String pipeline) throws Exception {
-        ResultSetHandler<PindeployBean> h = new BeanHandler<PindeployBean>(PindeployBean.class);
-        new QueryRunner(dataSource).query(DELETE_PINDEPLOY, h, pipeline);
+        new QueryRunner(dataSource).update(DELETE_PINDEPLOY, pipeline);
     }
 
     @Override

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBPindeployDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBPindeployDAOImpl.java
@@ -28,7 +28,7 @@ public class DBPindeployDAOImpl implements PindeployDAO {
     private static final String GET_PINDEPLOY =
         "SELECT * FROM pindeploy WHERE env_id=?";
     private static final String DELETE_PINDEPLOY =
-        "DELETE * FROM pindeploy WHERE pipeline=?";
+        "DELETE FROM pindeploy WHERE pipeline=?";
     private static final String INSERT_OR_UPDATE_PINDEPLOY =
         "INSERT INTO pindeploy SET %s ON DUPLICATE KEY UPDATE pipeline=?, is_pindeploy=?";
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBPindeployDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBPindeployDAOImpl.java
@@ -28,7 +28,7 @@ public class DBPindeployDAOImpl implements PindeployDAO {
     private static final String GET_PINDEPLOY =
         "SELECT * FROM pindeploy WHERE env_id=?";
     private static final String DELETE_PINDEPLOY =
-        "DELETE * FROM pindeploy WHERE env_id=?";
+        "DELETE * FROM pindeploy WHERE pipeline=?";
     private static final String INSERT_OR_UPDATE_PINDEPLOY =
         "INSERT INTO pindeploy SET %s ON DUPLICATE KEY UPDATE pipeline=?, is_pindeploy=?";
 
@@ -45,9 +45,9 @@ public class DBPindeployDAOImpl implements PindeployDAO {
     }
 
     @Override
-    public void delete(String envId) throws Exception {
+    public void delete(String pipeline) throws Exception {
         ResultSetHandler<PindeployBean> h = new BeanHandler<PindeployBean>(PindeployBean.class);
-        new QueryRunner(dataSource).query(DELETE_PINDEPLOY, h, envId);
+        new QueryRunner(dataSource).query(DELETE_PINDEPLOY, h, pipeline);
     }
 
     @Override

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/EnvironHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/EnvironHandler.java
@@ -336,10 +336,6 @@ public class EnvironHandler {
         }
     }
 
-    public void updatePindeploy(PindeployBean pindeployBean) throws Exception {
-        pindeployDAO.insertOrUpdate(pindeployBean);
-    }
-
     public String resume(EnvironBean envBean, String operator) throws Exception {
         envBean.setEnv_state(EnvState.NORMAL);
         updateStage(envBean, operator);

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanService.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanService.java
@@ -90,6 +90,7 @@ public class TeletraanService extends Application<TeletraanServiceConfiguration>
         environment.jersey().register(EnvGroupRoles.class);
         environment.jersey().register(Hosts.class);
         environment.jersey().register(Systems.class);
+        environment.jersey().register(Pindeploy.class);
 
         // Support pings as well
         environment.jersey().register(Pings.class);

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
@@ -266,32 +266,32 @@ public class EnvStages {
     }
 
     @POST
-    @Path("/pindeployPipeline/action")
+    @Path("/pindeployPipeline/enable")
     @RolesAllowed(TeletraanPrincipalRole.Names.EXECUTE)
     @ResourceAuthZInfo(type = AuthZResource.Type.ENV_STAGE, idLocation = Location.PATH)
     public void pindeployPipelineAction(@Context SecurityContext sc,
                        @PathParam("envName") String envName,
                        @PathParam("stageName") String stageName,
-                       @NotNull @QueryParam("actionType") ActionType actionType,
                        @NotEmpty @QueryParam("pipeline") String pipeline) throws Exception {
         EnvironBean envBean = Utils.getEnvStage(environDAO, envName, stageName);
         String operator = sc.getUserPrincipal().getName();
-
         PindeployBean pindeployBean = new PindeployBean();
         pindeployBean.setEnv_id(envBean.getEnv_id());
         pindeployBean.setPipeline(pipeline);
-        switch (actionType) {
-            case ENABLE:
-                pindeployBean.setIs_pindeploy(true);
-                break;
-            case DISABLE:
-                pindeployBean.setIs_pindeploy(false);
-                break;
-            default:
-                throw new WebApplicationException("No action found.", Response.Status.BAD_REQUEST);
-        }
-        environHandler.updatePindeploy(pindeployBean);
-        LOG.info(String.format("Successfully updated pindeploy pipeline action %s for %s/%s by %s", actionType, envName, stageName, operator));
+        pindeployBean.setIs_pindeploy(true);
+        pindeployDAO.insertOrUpdate(pindeployBean);
+        LOG.info(String.format("Successfully updated pindeploy pipeline for %s/%s by %s", envName, stageName, operator));
+    }
+
+    @POST
+    @Path("/pindeployPipeline/disable")
+    @RolesAllowed(TeletraanPrincipalRole.Names.EXECUTE)
+    @ResourceAuthZInfo(type = AuthZResource.Type.ENV_STAGE, idLocation = Location.PATH)
+    public void pindeployPipelineAction(@Context SecurityContext sc,
+                       @NotEmpty @QueryParam("pipeline") String pipeline) throws Exception {
+        String operator = sc.getUserPrincipal().getName();
+        pindeployDAO.delete(pipeline);
+        LOG.info(String.format("Successfully disabled pindeploy pipeline %s by %s", pipeline, operator));
     }
 
     private void stageTypeValidate(EnvironBean origBean, EnvironBean newBean) throws Exception {

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
@@ -283,17 +283,6 @@ public class EnvStages {
         LOG.info(String.format("Successfully updated pindeploy pipeline for %s/%s by %s", envName, stageName, operator));
     }
 
-    @POST
-    @Path("/pindeployPipeline/disable")
-    @RolesAllowed(TeletraanPrincipalRole.Names.EXECUTE)
-    @ResourceAuthZInfo(type = AuthZResource.Type.ENV_STAGE, idLocation = Location.PATH)
-    public void pindeployPipelineAction(@Context SecurityContext sc,
-                       @NotEmpty @QueryParam("pipeline") String pipeline) throws Exception {
-        String operator = sc.getUserPrincipal().getName();
-        pindeployDAO.delete(pipeline);
-        LOG.info(String.format("Successfully disabled pindeploy pipeline %s by %s", pipeline, operator));
-    }
-
     private void stageTypeValidate(EnvironBean origBean, EnvironBean newBean) throws Exception {
         Map<EnvType, String> stageTypeCategory = new HashMap<>();
         stageTypeCategory.put(EnvType.DEFAULT, "PRODUCTION");

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
@@ -43,15 +43,12 @@ import org.slf4j.LoggerFactory;
 
 import com.pinterest.deployservice.bean.EnvType;
 import com.pinterest.deployservice.bean.EnvironBean;
-import com.pinterest.deployservice.bean.PindeployBean;
 import com.pinterest.deployservice.bean.TagBean;
-import com.pinterest.deployservice.bean.PindeployBean;
 import com.pinterest.deployservice.bean.TagTargetType;
 import com.pinterest.deployservice.bean.TagValue;
 import com.pinterest.deployservice.bean.TeletraanPrincipalRole;
 import com.pinterest.deployservice.common.Constants;
 import com.pinterest.deployservice.dao.EnvironDAO;
-import com.pinterest.deployservice.dao.PindeployDAO;
 import com.pinterest.deployservice.handler.ConfigHistoryHandler;
 import com.pinterest.deployservice.handler.EnvTagHandler;
 import com.pinterest.deployservice.handler.EnvironHandler;
@@ -78,7 +75,6 @@ public class EnvStages {
 
     private static final Logger LOG = LoggerFactory.getLogger(EnvStages.class);
     private EnvironDAO environDAO;
-    private PindeployDAO pindeployDAO;
     private EnvironHandler environHandler;
     private ConfigHistoryHandler configHistoryHandler;
     private TagHandler tagHandler;
@@ -86,7 +82,6 @@ public class EnvStages {
 
     public EnvStages(@Context TeletraanServiceContext context) {
         environDAO = context.getEnvironDAO();
-        pindeployDAO = context.getPindeployDAO();
         environHandler = new EnvironHandler(context);
         configHistoryHandler = new ConfigHistoryHandler(context);
         tagHandler = new EnvTagHandler(context);
@@ -101,19 +96,6 @@ public class EnvStages {
             @ApiParam(value = "Environment name", required = true)@PathParam("envName") String envName,
             @ApiParam(value = "Stage name", required = true)@PathParam("stageName") String stageName) throws Exception {
         return Utils.getEnvStage(environDAO, envName, stageName);
-    }
-
-    @GET
-    @Path("/pindeployPipeline")
-    @ApiOperation(
-            value = "Get pindeploy related info",
-            notes = "Return is_pindeploy and pipeline given the environment id",
-            response = PindeployBean.class)
-    public PindeployBean getPindeployInfo(
-            @ApiParam(value = "Environment name", required = true)@PathParam("envName") String envName,
-            @ApiParam(value = "Stage name", required = true)@PathParam("stageName") String stageName) throws Exception {
-        EnvironBean envBean = Utils.getEnvStage(environDAO, envName, stageName);
-        return pindeployDAO.get(envBean.getEnv_id());
     }
 
     @PUT
@@ -263,24 +245,6 @@ public class EnvStages {
         tagBean.setComments(description);
         tagHandler.createTag(tagBean, operator);
         LOG.info(String.format("Successfully updated action %s for %s/%s by %s", actionType, envName, stageName, operator));
-    }
-
-    @POST
-    @Path("/pindeployPipeline/enable")
-    @RolesAllowed(TeletraanPrincipalRole.Names.EXECUTE)
-    @ResourceAuthZInfo(type = AuthZResource.Type.ENV_STAGE, idLocation = Location.PATH)
-    public void pindeployPipelineAction(@Context SecurityContext sc,
-                       @PathParam("envName") String envName,
-                       @PathParam("stageName") String stageName,
-                       @NotEmpty @QueryParam("pipeline") String pipeline) throws Exception {
-        EnvironBean envBean = Utils.getEnvStage(environDAO, envName, stageName);
-        String operator = sc.getUserPrincipal().getName();
-        PindeployBean pindeployBean = new PindeployBean();
-        pindeployBean.setEnv_id(envBean.getEnv_id());
-        pindeployBean.setPipeline(pipeline);
-        pindeployBean.setIs_pindeploy(true);
-        pindeployDAO.insertOrUpdate(pindeployBean);
-        LOG.info(String.format("Successfully updated pindeploy pipeline for %s/%s by %s", envName, stageName, operator));
     }
 
     private void stageTypeValidate(EnvironBean origBean, EnvironBean newBean) throws Exception {

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Environs.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Environs.java
@@ -210,8 +210,6 @@ public class Environs {
 
     @POST
     @Path("/pindeployPipeline/disable")
-    @RolesAllowed(TeletraanPrincipalRole.Names.EXECUTE)
-    @ResourceAuthZInfo(type = AuthZResource.Type.ENV_STAGE, idLocation = Location.PATH)
     public void pindeployPipelineAction(@Context SecurityContext sc,
                        @NotEmpty @QueryParam("pipeline") String pipeline) throws Exception {
         LOG.info("yaqin-test-1");

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Environs.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Environs.java
@@ -25,7 +25,6 @@ import com.pinterest.deployservice.bean.UserRolesBean;
 import com.pinterest.deployservice.bean.EnvType;
 import com.pinterest.deployservice.dao.EnvironDAO;
 import com.pinterest.deployservice.dao.UserRolesDAO;
-import com.pinterest.deployservice.dao.PindeployDAO;
 import com.pinterest.deployservice.handler.EnvTagHandler;
 import com.pinterest.deployservice.handler.EnvironHandler;
 import com.pinterest.deployservice.handler.TagHandler;
@@ -76,14 +75,12 @@ public class Environs {
     private EnvironHandler environHandler;
     private TagHandler tagHandler;
     private UserRolesDAO userRolesDAO;
-    private PindeployDAO pindeployDAO;
 
     public Environs(@Context TeletraanServiceContext context) throws Exception {
         environDAO = context.getEnvironDAO();
         environHandler = new EnvironHandler(context);
         tagHandler = new EnvTagHandler(context);
         userRolesDAO = context.getUserRolesDAO();
-        pindeployDAO = context.getPindeployDAO();
     }
 
     @GET
@@ -206,16 +203,5 @@ public class Environs {
         tagBean.setComments(description);
         tagHandler.createTag(tagBean, operator);
         LOG.info(String.format("Successfully updated actions %s for all envs by %s", actionType, operator));
-    }
-
-    @POST
-    @Path("/pindeployPipeline/disable")
-    public void pindeployPipelineAction(@Context SecurityContext sc,
-                       @NotEmpty @QueryParam("pipeline") String pipeline) throws Exception {
-        LOG.info("yaqin-test-1");
-        String operator = sc.getUserPrincipal().getName();
-        LOG.info("yaqin-test-2");
-        pindeployDAO.delete(pipeline);
-        LOG.info(String.format("Successfully disabled pindeploy pipeline %s by %s", pipeline, operator));
     }
 }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Environs.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Environs.java
@@ -214,9 +214,9 @@ public class Environs {
     @ResourceAuthZInfo(type = AuthZResource.Type.ENV_STAGE, idLocation = Location.PATH)
     public void pindeployPipelineAction(@Context SecurityContext sc,
                        @NotEmpty @QueryParam("pipeline") String pipeline) throws Exception {
-        LOG.info(String.format("yaqin-test"));
+        LOG.info("yaqin-test-1");
         String operator = sc.getUserPrincipal().getName();
-        LOG.info(String.format("yaqin-test-2"));
+        LOG.info("yaqin-test-2");
         pindeployDAO.delete(pipeline);
         LOG.info(String.format("Successfully disabled pindeploy pipeline %s by %s", pipeline, operator));
     }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Environs.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Environs.java
@@ -214,7 +214,9 @@ public class Environs {
     @ResourceAuthZInfo(type = AuthZResource.Type.ENV_STAGE, idLocation = Location.PATH)
     public void pindeployPipelineAction(@Context SecurityContext sc,
                        @NotEmpty @QueryParam("pipeline") String pipeline) throws Exception {
+        LOG.info(String.format("yaqin-test"));
         String operator = sc.getUserPrincipal().getName();
+        LOG.info(String.format("yaqin-test-2"));
         pindeployDAO.delete(pipeline);
         LOG.info(String.format("Successfully disabled pindeploy pipeline %s by %s", pipeline, operator));
     }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Environs.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Environs.java
@@ -25,6 +25,7 @@ import com.pinterest.deployservice.bean.UserRolesBean;
 import com.pinterest.deployservice.bean.EnvType;
 import com.pinterest.deployservice.dao.EnvironDAO;
 import com.pinterest.deployservice.dao.UserRolesDAO;
+import com.pinterest.deployservice.dao.PindeployDAO;
 import com.pinterest.deployservice.handler.EnvTagHandler;
 import com.pinterest.deployservice.handler.EnvironHandler;
 import com.pinterest.deployservice.handler.TagHandler;
@@ -75,12 +76,14 @@ public class Environs {
     private EnvironHandler environHandler;
     private TagHandler tagHandler;
     private UserRolesDAO userRolesDAO;
+    private PindeployDAO pindeployDAO;
 
     public Environs(@Context TeletraanServiceContext context) throws Exception {
         environDAO = context.getEnvironDAO();
         environHandler = new EnvironHandler(context);
         tagHandler = new EnvTagHandler(context);
         userRolesDAO = context.getUserRolesDAO();
+        pindeployDAO = context.getPindeployDAO();
     }
 
     @GET
@@ -203,5 +206,16 @@ public class Environs {
         tagBean.setComments(description);
         tagHandler.createTag(tagBean, operator);
         LOG.info(String.format("Successfully updated actions %s for all envs by %s", actionType, operator));
+    }
+
+    @POST
+    @Path("/pindeployPipeline/disable")
+    @RolesAllowed(TeletraanPrincipalRole.Names.EXECUTE)
+    @ResourceAuthZInfo(type = AuthZResource.Type.ENV_STAGE, idLocation = Location.PATH)
+    public void pindeployPipelineAction(@Context SecurityContext sc,
+                       @NotEmpty @QueryParam("pipeline") String pipeline) throws Exception {
+        String operator = sc.getUserPrincipal().getName();
+        pindeployDAO.delete(pipeline);
+        LOG.info(String.format("Successfully disabled pindeploy pipeline %s by %s", pipeline, operator));
     }
 }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Pindeploy.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Pindeploy.java
@@ -81,9 +81,7 @@ public class Pindeploy {
     @Path("/disable")
     public void disablePindeployPipeline(@Context SecurityContext sc,
                        @NotEmpty @QueryParam("pipeline") String pipeline) throws Exception {
-        LOG.info("yaqin-test-1");
         String operator = sc.getUserPrincipal().getName();
-        LOG.info("yaqin-test-2");
         pindeployDAO.delete(pipeline);
         LOG.info(String.format("Successfully disabled pindeploy pipeline %s by %s", pipeline, operator));
     }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Pindeploy.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Pindeploy.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2016 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.resource;
+
+import com.google.common.base.Optional;
+import com.pinterest.deployservice.bean.TeletraanPrincipalRole;
+import com.pinterest.deployservice.bean.PindeployBean;
+import com.pinterest.deployservice.bean.EnvironBean;
+import com.pinterest.deployservice.dao.PindeployDAO;
+import com.pinterest.deployservice.dao.EnvironDAO;
+import com.pinterest.teletraan.TeletraanServiceContext;
+import com.pinterest.teletraan.universal.security.ResourceAuthZInfo;
+import com.pinterest.teletraan.universal.security.ResourceAuthZInfo.Location;
+import com.pinterest.teletraan.universal.security.bean.AuthZResource;
+import com.pinterest.teletraan.universal.security.bean.UserPrincipal;
+
+import io.swagger.annotations.*;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.security.PermitAll;
+import javax.annotation.security.RolesAllowed;
+import javax.validation.Valid;
+import javax.ws.rs.*;
+import javax.ws.rs.core.*;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+@PermitAll
+@Path("/v1/pindeploy")
+@Api(tags = "Pindeploy")
+@SwaggerDefinition(
+        tags = {
+                @Tag(name = "Pindeploy", description = "Pindeploy related APIs"),
+        }
+)
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class Pindeploy {
+    private static final Logger LOG = LoggerFactory.getLogger(Pindeploy.class);
+    private PindeployDAO pindeployDAO;
+    private EnvironDAO environDAO;
+
+    public Pindeploy(@Context TeletraanServiceContext context) throws Exception {
+        pindeployDAO = context.getPindeployDAO();
+        environDAO = context.getEnvironDAO();
+    }
+
+    @GET
+    @ApiOperation(
+            value = "Get pindeploy related info",
+            notes = "Return is_pindeploy and pipeline given the environment id",
+            response = PindeployBean.class)
+    public PindeployBean getPindeployInfo(
+            @NotEmpty @QueryParam("envName") String envName,
+            @NotEmpty @QueryParam("stageName") String stageName) throws Exception {
+        EnvironBean envBean = Utils.getEnvStage(environDAO, envName, stageName);
+        return pindeployDAO.get(envBean.getEnv_id());
+    }
+
+    @DELETE
+    @Path("/disable")
+    public void disablePindeployPipeline(@Context SecurityContext sc,
+                       @NotEmpty @QueryParam("pipeline") String pipeline) throws Exception {
+        LOG.info("yaqin-test-1");
+        String operator = sc.getUserPrincipal().getName();
+        LOG.info("yaqin-test-2");
+        pindeployDAO.delete(pipeline);
+        LOG.info(String.format("Successfully disabled pindeploy pipeline %s by %s", pipeline, operator));
+    }
+
+    @POST
+    @Path("/enable")
+    public void enablePindeployPipeline(@Context SecurityContext sc,
+                       @NotEmpty @QueryParam("envName") String envName,
+                       @NotEmpty @QueryParam("stageName") String stageName,
+                       @NotEmpty @QueryParam("pipeline") String pipeline) throws Exception {
+        EnvironBean envBean = Utils.getEnvStage(environDAO, envName, stageName);
+        String operator = sc.getUserPrincipal().getName();
+        PindeployBean pindeployBean = new PindeployBean();
+        pindeployBean.setEnv_id(envBean.getEnv_id());
+        pindeployBean.setPipeline(pipeline);
+        pindeployBean.setIs_pindeploy(true);
+        pindeployDAO.insertOrUpdate(pindeployBean);
+        LOG.info(String.format("Successfully updated pindeploy pipeline for %s/%s by %s", envName, stageName, operator));
+    }
+}


### PR DESCRIPTION
Moved the pindeploy related API to one file.
When marking a pindeploy pipeline, we use env/stage name; when unmarking a pindeploy pipeline, we use pipeline link.
In Pindeploy side, when creating/updating a pipeline, we first unmark and then mark to make sure the consistency between pindeploy and teletraan.