### PR TITLE
update cmdb to support multi-account

### DIFF
--- a/deploy-board/deploy_board/webapp/helpers/accounts_helper.py
+++ b/deploy-board/deploy_board/webapp/helpers/accounts_helper.py
@@ -1,5 +1,6 @@
 import logging
 
+from deploy_board.settings import DEFAULT_CELL, DEFAULT_PROVIDER
 from deploy_board.webapp.helpers.rodimus_client import RodimusClient
 
 log = logging.getLogger(__name__)
@@ -27,3 +28,17 @@ def get_by_cell_and_id(request, cell, account_id, provider="AWS"):
 
 def get_default_account(request, cell, provider="AWS"):
     return get_by_cell_and_id(request, cell, "default", provider)
+
+def get_aws_owner_id_for_cluster_name(request, cluster_name):
+    cluster = rodimus_client.get("/clusters/%s" % cluster_name, request.teletraan_user_id.token)
+    return get_aws_owner_id_for_cluster(request, cluster)
+
+def get_aws_owner_id_for_cluster(request, cluster):
+    account_id = cluster.get("accountId")
+    cell = cluster.get("cellName", DEFAULT_CELL)
+    provider = cluster.get("provider", DEFAULT_PROVIDER)
+    if not account_id:
+        account =  get_default_account(request, cell, provider)
+    else:
+        account = get_by_cell_and_id(request, cell, account_id, provider)
+    return account['data']['ownerId']

--- a/deploy-board/deploy_board/webapp/helpers/accounts_helper.py
+++ b/deploy-board/deploy_board/webapp/helpers/accounts_helper.py
@@ -2,6 +2,7 @@ import logging
 
 from deploy_board.settings import DEFAULT_CELL, DEFAULT_PROVIDER
 from deploy_board.webapp.helpers.rodimus_client import RodimusClient
+from . import clusters_helper
 
 log = logging.getLogger(__name__)
 
@@ -30,7 +31,7 @@ def get_default_account(request, cell, provider="AWS"):
     return get_by_cell_and_id(request, cell, "default", provider)
 
 def get_aws_owner_id_for_cluster_name(request, cluster_name):
-    cluster = rodimus_client.get("/clusters/%s" % cluster_name, request.teletraan_user_id.token)
+    cluster = clusters_helper.get_cluster(request, cluster_name)
     return get_aws_owner_id_for_cluster(request, cluster)
 
 def get_aws_owner_id_for_cluster(request, cluster):

--- a/deploy-board/deploy_board/webapp/helpers/cmdbapiclient.py
+++ b/deploy-board/deploy_board/webapp/helpers/cmdbapiclient.py
@@ -1,0 +1,23 @@
+import logging
+import requests
+from .decorators import singleton
+from . import clusters_helper
+from deploy_board.settings import CMDB_API_HOST, CMDB_INSTANCE_URL
+
+requests.packages.urllib3.disable_warnings()
+log = logging.getLogger(__name__)
+
+@singleton
+class CmdbApiClient(object):
+    def query(self, query, fields, account_id):
+        headers = {} if not account_id else {'x-aws-account-id': account_id}
+        return requests.post(CMDB_API_HOST+"/v2/query", json={
+                "query": query,
+                "fields": fields
+            },
+            headers=headers
+        )
+    
+    def get_host_details(self, host_id, account_id):
+        headers = {} if not account_id else {'x-aws-account-id': account_id}
+        return requests.get(CMDB_API_HOST+CMDB_INSTANCE_URL+ host_id, headers=headers)

--- a/deploy-board/deploy_board/webapp/helpers/hosts_helper.py
+++ b/deploy-board/deploy_board/webapp/helpers/hosts_helper.py
@@ -16,10 +16,17 @@
 """Collection of all hosts related calls
 """
 from deploy_board.webapp.helpers.deployclient import DeployClient
+from deploy_board.webapp.helpers.cmdbapiclient import CmdbApiClient
+from deploy_board.webapp.helpers.rodimus_client import RodimusClient
 
 deployclient = DeployClient()
-
+cmdbapi_client = CmdbApiClient()
 
 def get_hosts_by_name(request, host_name):
     return deployclient.get("/hosts/%s" % host_name, request.teletraan_user_id.token)
-    
+
+def query_cmdb(query, fields, account_id):
+    return cmdbapi_client.query(query, fields, account_id)
+
+def get_cmdb_host_info(host_id, account_id):
+    return cmdbapi_client.get_host_details(host_id, account_id)


### PR DESCRIPTION
Currently CMDB API supports multi-account through a header. We should update all CMDB API calls to pass the aws owner id in requests to resources in accounts besides hostmaster.

### Testing
Links to `https://phobos.pinadmin.com/phobos/<host-ip>/` instead of `https://deploy-integ.pinadmin.com/env/for-test/rzhu-integ-moka-test/host/<host-name>` for hosts outside main account.

### Regression Testing

host dist charts work for multi-accounts
<img width="443" alt="Screenshot 2024-05-21 at 4 47 27 PM" src="https://github.com/pinterest/teletraan/assets/104773032/65e21e88-8ea0-4fc8-ae55-b170a6e3cfac">