### PR TITLE
Fix `create_env.py` script to use non-DEFAULT stage type

### DIFF
--- a/deploy-board/tools/commons.py
+++ b/deploy-board/tools/commons.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -37,13 +37,13 @@ def gen_random_num(size=8, chars=string.digits):
     return ''.join(random.choice(chars) for _ in range(size))
 
 
-def create_env(name, stage):
+def create_env(name: str, stage: str):
     request = {}
     request["envName"] = name
     request["stageName"] = stage
-    request["stageType"]= "DEFAULT"
+    request["stageType"]= "PRODUCTION"
     env = environs_helper.create_env(REQUEST, request)
-    print("Successfully created env %s." % env['id'])
+    print(f"Successfully created env {env['id']}")
     return env
 
 

--- a/deploy-board/tools/create_env.py
+++ b/deploy-board/tools/create_env.py
@@ -13,27 +13,21 @@
 # limitations under the License.
 
 #!/usr/bin/env python3
-import commons
-
-environs_helper = commons.get_environ_helper()
-
-
-def main():
-    for x in range(1, 3):
-        name = "sample-service-%d" % x
-        stage = "canary"
-        commons.create_env(name, stage)
-        hosts = ["sample-host1", "sample-host2"]
-        environs_helper.update_env_capacity(commons.REQUEST, name, stage,
-                                            capacity_type="HOST", data=hosts)
-        stage = "prod"
-        commons.create_env(name, stage)
-        groups = ["sample-group1", "sample-group2"]
-        environs_helper.update_env_capacity(commons.REQUEST, name, stage, data=groups)
-
+from deploy_board.webapp.helpers import environs_helper
+from commons import create_env, REQUEST
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as e:
-        print(e.message)
+    for x in range(1, 3):
+        name = f"sample-service-{x}"
+        stage = "canary"
+        try:
+            create_env(name, stage)
+            hosts = ["sample-host1", "sample-host2"]
+            environs_helper.update_env_capacity(REQUEST, name, stage,
+                                                capacity_type="HOST", data=hosts)
+            stage = "prod"
+            create_env(name, stage)
+            groups = ["sample-group1", "sample-group2"]
+            environs_helper.update_env_capacity(REQUEST, name, stage, data=groups)
+        except Exception as e:
+            print(e)

--- a/deploy-board/tools/run.sh
+++ b/deploy-board/tools/run.sh
@@ -1,7 +1,11 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
 export TELETRAAN_SERVICE_URL=http://localhost:8011
 export TELETRAAN_SERVICE_VERSION=v1
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 TARGET=$DIR/$1
 shift
-PYTHONPATH=$DIR/.. python $TARGET $*
+PYTHONPATH=$DIR/.. python3 $TARGET $*


### PR DESCRIPTION
# Summary

- Update the stage type for the local script that creates environments
- Small python3 and bash improvements

# Test Plan

```bash
./run.sh create_env.py
Successfully created env 3XyZf7SHSLGdG30N6FEYWg
Successfully created env vnH5BixBRQefm80yA8tAxA
Successfully created env H3MjI_uTR52aN81gtqxkbw
Successfully created env rdMTMYZ1Siike2cN4jcpGA
```
