### PR TITLE
Surface current deployment dropdown values in env landing page

### DIFF
--- a/deploy-board/deploy_board/templates/environs/env_landing.html
+++ b/deploy-board/deploy_board/templates/environs/env_landing.html
@@ -405,7 +405,17 @@ $('#privateBldUploadBtnId button').click(function () {
                 <button class="deployToolTip btn btn-default btn-sm dropdown-toggle"
                         title="Change how the hosts are displayed"
                         data-toggle="dropdown" type="button">
-                    Display Mode <span class="caret"></span>
+                    Display Mode:
+                    {% if report.showMode == "simple" %}
+                        Simple
+                    {% elif report.showMode == "compact" %}
+                        Compact
+                    {% elif report.showMode == "complete" %}
+                        Complete
+                    {% elif report.showMode == "containerStatus" %}
+                        Health Check Status
+                    {% endif %}
+                    <span class="caret"></span>
                 </button>
                 <ul class="dropdown-menu" role="menu">
                     <form id="updateModeFormId">
@@ -464,7 +474,9 @@ $('#privateBldUploadBtnId button').click(function () {
                         <button class="deployToolTip btn btn-default btn-sm dropdown-toggle"
                                 title="Change how the hosts are displayed based on Account"
                                 data-toggle="dropdown" type="button">
-                            Account <span class="caret"></span>
+                            Account:
+                            {{ report.account|capfirst }}
+                            <span class="caret"></span>
                         </button>
                         <ul class="dropdown-menu dropdown-menu-right" role="menu">
                             <form id="accountFormId">

--- a/deploy-board/deploy_board/templates/environs/env_landing.html
+++ b/deploy-board/deploy_board/templates/environs/env_landing.html
@@ -338,11 +338,7 @@ $('#privateBldUploadBtnId button').click(function () {
 {% include "environs/site_health.tmpl" with metricsKind="service" %}
 
 {% if has_deploy %}
-    {%  if env|canResume %}
-    <div class="panel panel-danger">
-    {% else %}
-    <div class="panel panel-default">
-    {%  endif %}
+    <div class="panel {% if env|canResume %}panel-danger{% else %}panel-default{% endif %}">
         <div class="panel-heading clearfix">
             <h4 class="panel-title pull-left pointer-cursor">
                 <a data-toggle="collapse" data-target="#activeDeployId">

--- a/deploy-board/deploy_board/templates/environs/env_landing.html
+++ b/deploy-board/deploy_board/templates/environs/env_landing.html
@@ -27,7 +27,7 @@
 {% else %}
     {% include "feedbacks/feedback_banner.tmpl" with hidden='display: none;'%}
 {% endif %}
-{% endblock %}
+{% endblock breadcrumb-items %}
 
 
 {% block side-panel-actions %}
@@ -268,7 +268,7 @@ $('#privateBldUploadBtnId button').click(function () {
 </script>
 {% endif %}
 
-{% endblock %}
+{% endblock side-panel-actions %}
 
 {% block main %}
 
@@ -621,4 +621,4 @@ $('#privateBldUploadBtnId button').click(function () {
 {% endif %}
 {% endif %}
 
-{% endblock %}
+{% endblock main %}

--- a/deploy-board/deploy_board/templates/environs/env_landing.html
+++ b/deploy-board/deploy_board/templates/environs/env_landing.html
@@ -490,15 +490,6 @@ $('#privateBldUploadBtnId button').click(function () {
                                         </label></div>
                                     </li>
                                 {% endfor %}
-                                <li>
-                                    <div class="radio"><label>&nbsp;
-                                        <input type="radio" name="account" value="others"
-                                               {% if report.account == "others" %}
-                                        checked
-                                        {% endif %}
-                                        > Others
-                                    </label></div>
-                                </li>
                             </form>
                         </ul>
                     </div>

--- a/deploy-board/deploy_board/templates/environs/env_landing.html
+++ b/deploy-board/deploy_board/templates/environs/env_landing.html
@@ -86,12 +86,6 @@
             <span class="glyphicon glyphicon-time"></span> Deploy Constraint
         </a>
     </div>
-    <!--div class="row">
-        <a href="/builds/{{ env.envName }}/{{ env.stageName }}/start_build/" type="button" class="deployToolTip btn btn-default btn-block"
-           data-toggle="tooltip" title="Create a private build for current environment">
-            <span class="glyphicon glyphicon-pencil"></span> Branch Build
-           </a>
-    </div-->
 
     {% if has_deploy %}
 	<div class="row">


### PR DESCRIPTION
## Summary

If the wrong option is set it's possible for no hosts to appear, which can be confusing for users. We should display the values of display mode and account without having to access the dropdown to make these more visible.

- https://jira.pinadmin.com/browse/CDP-7722

## Test Plan
<details>
<summary>before</summary>
<img width="199" alt="image" src="https://github.com/pinterest/teletraan/assets/72234714/4d43e4b0-7704-4133-a072-26859faaf0e7">

</details>

<details>
<summary>after</summary>
<img width="280" alt="image" src="https://github.com/pinterest/teletraan/assets/72234714/fc2364c5-00c4-4886-ac4c-4a5ca36bf983">
</details>

