### PR TITLE
Use Pastis for all user authorizations.

### DIFF
--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/CompositeAuthenticationFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/CompositeAuthenticationFactory.java
@@ -52,7 +52,11 @@ public class CompositeAuthenticationFactory extends TokenAuthenticationFactory {
                         .setAuthorizer(context.getAuthorizationFactory().create(context))
                         .buildAuthFilter();
 
-        return new ChainedAuthFilter(Arrays.asList(createScriptTokenAuthFilter(context),
-                createOauthTokenAuthFilter(context), envoyAuthFilter, createJwtTokenAuthFilter(context)));
+        return new ChainedAuthFilter(
+                Arrays.asList(
+                        createScriptTokenAuthFilter(context),
+                        envoyAuthFilter,
+                        createOauthTokenAuthFilter(context),
+                        createJwtTokenAuthFilter(context)));
     }
 }

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/config/CompositeAuthorizationFactoryTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/config/CompositeAuthorizationFactoryTest.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.config;
+
+import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.pinterest.teletraan.TeletraanServiceContext;
+import com.pinterest.teletraan.security.TeletraanAuthZResourceExtractorFactory;
+import com.pinterest.teletraan.universal.security.BasePastisAuthorizer;
+import io.dropwizard.auth.Authorizer;
+import org.junit.jupiter.api.Test;
+
+class CompositeAuthorizationFactoryTest {
+    @Test
+    void testCreate() throws Exception {
+        TeletraanServiceContext context = new TeletraanServiceContext();
+        context.setAuthZResourceExtractorFactory(
+                new TeletraanAuthZResourceExtractorFactory(context));
+        CompositeAuthorizationFactory factory = new CompositeAuthorizationFactory();
+
+        Authorizer<?> authorizer = factory.create(context);
+        assertNotNull(authorizer);
+        assertTrue(authorizer instanceof BasePastisAuthorizer);
+
+        Authorizer<?> authorizer2 = factory.create(context);
+        assertSame(authorizer, authorizer2);
+    }
+}


### PR DESCRIPTION
1. When `CompositeAuthorizationFactory` is used, only return Pastis authorizer for `UserPrincipal`.
2. Only create 1 `BasePastisAuthorizer` instance.
3. Change the order of authenticators to favor `envoyAuthFilter`.

# Tests
Added unit test cases.