### PR TITLE
Update UI for user and group management

### DIFF
--- a/deploy-board/deploy_board/templates/users/users_config.html
+++ b/deploy-board/deploy_board/templates/users/users_config.html
@@ -22,15 +22,6 @@
            <i class="glyphicon glyphicon-user"></i> Users
         </a>
     </div>
-    {% if pinterest %}
-	<div class="row">
-        <a type="button" class="deployToolTip btn btn-default btn-block"
-           href="/env/{{ env_name }}/get_users_config/?user_types=group_roles"
-           data-toggle="tooltip" title="Manage LDAP group permissions">
-           <i class="glyphicon glyphicon-tag"></i> LDAP Groups
-        </a>
-    </div>
-    {% endif %}
 	<div class="row">
         <a type="button" class="deployToolTip btn btn-default btn-block"
            href="/env/{{ env_name }}/get_users_config/?user_types=token_roles"
@@ -48,6 +39,10 @@
 
 {% block main %}
 <div id="usersConfigId" class="panel panel-default">
-{% include "users/users_config.tmpl" %}
+    {% if pinterest and user_types != 'token_roles'  %}
+        {% include "users/users_moved_message.html" %}
+    {% else %}
+        {% include "users/users_config.tmpl" %}
+    {% endif %}
 </div>
 {% endblock %}

--- a/deploy-board/deploy_board/templates/users/users_moved_message.html
+++ b/deploy-board/deploy_board/templates/users/users_moved_message.html
@@ -1,0 +1,14 @@
+<div class="panel-heading clearfix">
+    <h4 class="panel-title pull-left">
+        User and group management have moved
+    </h4>
+</div>
+
+<div class="panel-body">
+    <p>
+        User and group management have moved to Pastis based ACLs. Please follow the <a href="https://pinch/teletraan-pastis-acl">instructions</a> to manage users and groups.
+    </p>
+    <p>
+        Please update your bookmarks.
+    </p>
+</div>


### PR DESCRIPTION
For Pinterest devs, we show a message for the moved functionality to reduce confusions. Script token UI stays intact.

<img width="1235" alt="Screenshot 2024-05-28 at 4 27 13 PM" src="https://github.com/pinterest/teletraan/assets/8442875/61cef936-2c57-4f89-a5d6-d8832715a01e">
