### PR TITLE
Fix `quickstart.py` local script

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -14,3 +14,4 @@ Contributors
 * Anh Nguyen <anhn@pinterest.com>
 * Yaqin Li <yaqinli@pinterest.com>
 * Khoi Nguyen <khoinguyen@pinterest.com>
+* Ian Roquebert <iroquebert@pinterest.com>

--- a/deploy-sentinel/quickstart.py
+++ b/deploy-sentinel/quickstart.py
@@ -38,7 +38,7 @@ def main():
                                    stderr=subprocess.PIPE)
         output, error = process.communicate()
         if error:
-            print "Error: failed to publish build to /tmp directory.", error
+            print("Error: failed to publish build to /tmp directory.", error)
             return
 
         # Make deployd directory if it doesn't yet exist
@@ -50,11 +50,11 @@ def main():
                                    stderr=subprocess.PIPE)
         output, error = process.communicate()
         if error:
-            print "Error: failed to publish host_info to /tmp directory.", error
+            print("Error: failed to publish host_info to /tmp directory.", error)
             return
         publish_local_build("file://%s" % build_dest_dir)
     except Exception as e:
-        print traceback.format_exc()
+        print(traceback.format_exc())
         return None, e.message, 1
 
 
@@ -64,7 +64,7 @@ def gen_random_num(size=8, chars=string.digits):
 
 def publish_local_build(build_path, build_name='deploy-sentinel', branch='master', commit=gen_random_num(32)):
     build = {}
-    publish_build_url = "http://localhost:8080/v1/builds"
+    publish_build_url = "http://localhost:8011/v1/builds"
     headers = {'Content-type': 'application/json'}
     build['name'] = build_name
     build['repo'] = 'local'
@@ -75,11 +75,11 @@ def publish_local_build(build_path, build_name='deploy-sentinel', branch='master
     build['publishInfo'] = build_path
     r = requests.post(publish_build_url, json=build, headers=headers)
     if 200 <= r.status_code < 300:
-        print "Successfully published local deploy-sentinel build and host_info " \
-              "configuration file to local /tmp directory!"
+        print("Successfully published local deploy-sentinel build and host_info " \
+              "configuration file to local /tmp directory!")
     else:
-        print "Error publishing local deploy-sentinel build. Status code = %s, response = %s" % (str(r.status_code),
-                                                                                                 str(r.text))
+        print("Error publishing local deploy-sentinel build. Status code = %s, response = %s" % (str(r.status_code),
+                                                                                                 str(r.text)))
     return build
 
 


### PR DESCRIPTION
This script is used to publish a build to a local teletraan environment.

With Teletraan local environment up:
```
cd deploy-sentinel/
make
```