### PR TITLE
Fix stopServiceOnHost AuthZ resource type 

### DIFF
--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvHosts.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvHosts.java
@@ -97,8 +97,8 @@ public class EnvHosts {
     }
 
     @DELETE
-    @RolesAllowed(TeletraanPrincipalRole.Names.DELETE)
-    @ResourceAuthZInfo(type = AuthZResource.Type.HOST, idLocation = ResourceAuthZInfo.Location.PATH)
+    @RolesAllowed(TeletraanPrincipalRole.Names.EXECUTE)
+    @ResourceAuthZInfo(type = AuthZResource.Type.ENV_STAGE, idLocation = ResourceAuthZInfo.Location.PATH)
     public void stopServiceOnHost(@Context SecurityContext sc,
             @PathParam("envName") String envName,
             @PathParam("stageName") String stageName,
@@ -114,5 +114,4 @@ public class EnvHosts {
         LOG.info("Successfully stopped {}/{} service on hosts {} by {}", envName, stageName,
                 hostIds, operator);
     }
-
 }


### PR DESCRIPTION
Discovered during validation in integ.
The authorization is based on the ENV_STAGE. Besides, terminate a host should be a part of regular operations, so DELETE -> EXECUTE. 