### PR TITLE
Bug fix: For a javascript ajax call, set the return code instead of default 200 in error view exception handler

### DIFF
--- a/deploy-board/deploy_board/webapp/error_views.py
+++ b/deploy-board/deploy_board/webapp/error_views.py
@@ -41,10 +41,12 @@ class ExceptionHandlerMiddleware:
         if request.is_ajax():
             ajax_vars = {'success': False, 'error': str(exception)}
             ret = 500
-            if isinstance(exception, NotAuthorizedException):
-                ret = 403
-            elif isinstance(exception, FailedAuthenticationException):
+            if isinstance(exception, FailedAuthenticationException):
                 ret = 401
+            elif isinstance(exception, NotAuthorizedException):
+                ret = 403
+            elif isinstance(exception, NotFoundException):
+                ret = 404
             return HttpResponse(json.dumps(ajax_vars), status=ret, content_type='application/javascript')
         else:
             # Not authorized

--- a/deploy-board/deploy_board/webapp/error_views.py
+++ b/deploy-board/deploy_board/webapp/error_views.py
@@ -40,7 +40,12 @@ class ExceptionHandlerMiddleware:
         # Error is displayed as a fragment over related feature area
         if request.is_ajax():
             ajax_vars = {'success': False, 'error': str(exception)}
-            return HttpResponse(json.dumps(ajax_vars), content_type='application/javascript')
+            ret = 500
+            if isinstance(exception, NotAuthorizedException):
+                ret = 403
+            elif isinstance(exception, FailedAuthenticationException):
+                ret = 401
+            return HttpResponse(json.dumps(ajax_vars), status=ret, content_type='application/javascript')
         else:
             # Not authorized
             if isinstance(exception, NotAuthorizedException):

--- a/deploy-board/deploy_board/webapp/error_views.py
+++ b/deploy-board/deploy_board/webapp/error_views.py
@@ -41,7 +41,9 @@ class ExceptionHandlerMiddleware:
         if request.is_ajax():
             ajax_vars = {'success': False, 'error': str(exception)}
             ret = 500
-            if isinstance(exception, FailedAuthenticationException):
+            if isinstance(exception, IllegalArgumentException):
+                ret = 400
+            elif isinstance(exception, FailedAuthenticationException):
                 ret = 401
             elif isinstance(exception, NotAuthorizedException):
                 ret = 403


### PR DESCRIPTION
Customer reported a bug: https://jira.pinadmin.com/browse/CDP-8039 