### PR TITLE
Set default `AuthZResource` when `ResourceAuthZInfo` is null 

### DIFF
--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/BaseAuthorizer.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/BaseAuthorizer.java
@@ -54,8 +54,7 @@ public abstract class BaseAuthorizer<P extends TeletraanPrincipal> implements Au
 
         Object authZInfo = context.getProperty(ResourceAuthZInfo.class.getName());
         if (authZInfo == null) {
-            log.warn("ResourceAuthZInfo is required for authorization");
-            return false;
+            return authorize(principal, role, AuthZResource.UNSPECIFIED_RESOURCE, context);
         }
 
         if (!(authZInfo instanceof ResourceAuthZInfo)) {

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/AuthZResource.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/AuthZResource.java
@@ -32,7 +32,9 @@ public class AuthZResource {
     private String accountId;
 
     public static final String ALL = "*";
+    public static final String NA = "NA";
     public static final AuthZResource SYSTEM_RESOURCE = new AuthZResource(ALL, Type.SYSTEM);
+    public static final AuthZResource UNSPECIFIED_RESOURCE = new AuthZResource(NA, Type.UNSPECIFIED);
 
     public AuthZResource(@Nonnull String name, Type type) {
         this(name, type, null);
@@ -93,6 +95,8 @@ public class AuthZResource {
         HOTFIX,
         /** For Host related resources. */
         HOST,
+        /* For anything else */
+        UNSPECIFIED,
     }
 
     /**

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/BaseAuthorizerTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/BaseAuthorizerTest.java
@@ -66,7 +66,7 @@ class BaseAuthorizerTest {
 
     @Test
     void testAuthorize_contextHasNoResourceAuthZInfo() {
-        assertFalse(sut.authorize(principal, TEST_ROLE, context));
+        assertTrue(sut.authorize(principal, TEST_ROLE, context));
     }
 
     @Test


### PR DESCRIPTION
This makes authorization possible without providing the `ResourceAuthZInfo` annotation. It's useful for things like READ authorization. 