### PR TITLE
Address deploy-agent lint errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,6 @@ repos:
     hooks:
       - id: ruff
         args: [ --fix ]
-      - id: ruff-format
   - repo: https://github.com/djlint/djLint
     rev: v1.34.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,5 @@ repos:
   - repo: https://github.com/djlint/djLint
     rev: v1.34.1
     hooks:
-      - id: djlint-reformat-django
       - id: djlint-django
         args: [--ignore="H031"]

--- a/deploy-agent/deployd/agent.py
+++ b/deploy-agent/deployd/agent.py
@@ -132,7 +132,7 @@ class DeployAgent(object):
                 # for each service, we check the container health status
                 log.info(f"the current service is: {status.report.envName}")
                 try:
-                    if status.report.redeploy == None:
+                    if status.report.redeploy is None:
                         status.report.redeploy = 0
                     healthStatus = get_container_health_info(status.build_info.build_commit, status.report.envName, status.report.redeploy)
                     if healthStatus:
@@ -145,7 +145,7 @@ class DeployAgent(object):
                             status.report.containerHealthStatus = healthStatus
                             status.report.state = None
                             if "unhealthy" not in healthStatus:
-                                if status.report.wait == None or status.report.wait > 5:
+                                if status.report.wait is None or status.report.wait > 5:
                                     status.report.redeploy = 0
                                     status.report.wait = 0
                                 else:
@@ -228,7 +228,7 @@ class DeployAgent(object):
         while True:
             try:
                 self.serve_build()
-            except:
+            except Exception:
                 log.exception("Deploy Agent got exception: {}".format(traceback.format_exc()))
             finally:
                 time.sleep(self._config.get_daemon_sleep_time())

--- a/deploy-agent/deployd/common/types.py
+++ b/deploy-agent/deployd/common/types.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -52,11 +52,11 @@ class DeployType(object):
     RESTART = 'RESTART'
     STOP = 'STOP'
 
-class DeployErrorSource(object): 
+class DeployErrorSource(object):
     TELEFIG = 'TELEFIG'
     UNKNOWN = 'UNKNOWN'
 
-class DeployError(object): 
+class DeployError(object):
     TELEFIG_UNAVAILABLE = 'TELEFIG_UNAVAILABLE'
     UNKNOWN = 'UNKNOWN'
 
@@ -197,7 +197,7 @@ class DeployStatus(object):
     def to_json(self) -> dict:
         json = {}
         for key, value in self.__dict__.items():
-            if type(value) is dict:
+            if isinstance(value, dict):
                 json[key] = {k: v for k, v in value.items()}
             elif value:
                 if hasattr(value, "__dict__"):

--- a/deploy-agent/deployd/download/downloader.py
+++ b/deploy-agent/deployd/download/downloader.py
@@ -119,10 +119,10 @@ class Downloader(object):
             with open(extracted_file, 'w'):
                 pass
             log.info("Successfully extracted {} to {}".format(local_full_fn, working_dir))
-        except tarfile.TarError as e:
+        except tarfile.TarError:
             status = Status.FAILED
             log.exception("Failed to extract tar files")
-        except OSError as e:
+        except OSError:
             status = Status.FAILED
             log.exception("Failed to extract files. OSError:")
         except Exception:

--- a/deploy-agent/deployd/staging/transformer.py
+++ b/deploy-agent/deployd/staging/transformer.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -70,7 +70,7 @@ class Transformer(object):
             res = s.safe_substitute(self._dictionary)
             with open(to_path, 'w') as f:
                 f.write(res)
-        except:
+        except Exception:
             log.error('Fail to translate script {}, stacktrace: {}'.format(from_path,
                                                                            traceback.format_exc()))
 

--- a/deploy-agent/tests/unit/deploy/client/test_base_client.py
+++ b/deploy-agent/tests/unit/deploy/client/test_base_client.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,7 +28,7 @@ class TestBaseClient(TestCase):
             pass
 
         with self.assertRaises(TypeError):
-            myclient = MyClient()
+            MyClient()
 
     def test_abc_equivalent_to_old(self):
         """

--- a/deploy-agent/tests/unit/deploy/client/test_client.py
+++ b/deploy-agent/tests/unit/deploy/client/test_client.py
@@ -1,8 +1,7 @@
-import mock
 import unittest
 from tests import TestCase
 
-from deployd.client.client import Client 
+from deployd.client.client import Client
 from deployd.client.base_client import BaseClient
 from deployd.common.config import Config
 

--- a/deploy-agent/tests/unit/deploy/download/test_s3_download_helper.py
+++ b/deploy-agent/tests/unit/deploy/download/test_s3_download_helper.py
@@ -49,13 +49,5 @@ class TestS3DownloadHelper(unittest.TestCase):
         self.assertTrue(result)
         mock_get_s3_download_allow_list.assert_called_once()
 
-    @mock.patch('deployd.common.config.Config.get_s3_download_allow_list')
-    def test_validate_url_without_allow_list(self, mock_get_s3_download_allow_list):
-        mock_get_s3_download_allow_list.return_value = []
-        result = self.downloader.validate_source()
-
-        self.assertTrue(result)
-        mock_get_s3_download_allow_list.assert_called_once()
-
 if __name__ == '__main__':
     unittest.main()

--- a/deploy-agent/tests/unit/deploy/staging/test_transformer.py
+++ b/deploy-agent/tests/unit/deploy/staging/test_transformer.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -100,7 +100,6 @@ class TransformTest(unittest.TestCase):
         transformer.transform_scripts(self.template_dir, self.template_dir, self.script_dir)
 
         fn1 = os.path.join(self.script_dir, 'test1')
-        fn2 = os.path.join(self.script_dir, 'test2')
 
         value1 = "foo-foo-foo"
         values = {

--- a/deploy-agent/tests/unit/deploy/utils/test_exec.py
+++ b/deploy-agent/tests/unit/deploy/utils/test_exec.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import time
 import signal
 import tempfile
 import unittest
@@ -142,7 +141,7 @@ class TestUtilsFunctions(tests.TestCase):
         executor.MAX_SLEEP_INTERVAL = 5
         executor.MAX_TAIL_BYTES = 10240
         executor.TERMINATE_TIMEOUT = 0
-        deploy_report = executor.run_cmd(cmd=cmd)
+        executor.run_cmd(cmd=cmd)
         self.assertEqual(os.killpg.call_count, 2)
         calls = [mock.call(mock.ANY, signal.SIGTERM), mock.call(mock.ANY, signal.SIGKILL)]
         os.killpg.assert_has_calls(calls)

--- a/deploy-agent/tox.ini
+++ b/deploy-agent/tox.ini
@@ -6,6 +6,11 @@ recreate=True
 deps=-rrequirements_test.txt
 commands=py.test --cov=deployd {posargs}
 
+[testenv:ruff]
+description = run ruff
+deps = ruff
+commands = ruff {posargs}
+
 [gh-actions]
 python =
     3.6: py36


### PR DESCRIPTION
`ruff` was recently introduced to the precommit checks.

This PR addresses the existing checks for deploy-agent:

* Add `ruff` command to `tox.ini`
* Run `ruff check --fix`
* Run `ruff check --fix --unsafe-fixes`
  * Verified the fixes were safe
* Use explicit exceptions
* Remove unused variables and methods
* Remove trailing ws