### PR TITLE
Bump deploy-agent version (again)

### DIFF
--- a/deploy-agent/deployd/__init__.py
+++ b/deploy-agent/deployd/__init__.py
@@ -27,4 +27,4 @@ REDEPLOY_MAX_RETRY = 3
 # 2: puppet applied successfully with changes
 PUPPET_SUCCESS_EXIT_CODES = [0, 2]
 
-__version__ = '1.2.62'
+__version__ = '1.2.63'


### PR DESCRIPTION
The previously published version did not include "noble" in the package metadata.

Bump the version again after updating the metadata