### PR TITLE
Add extra authorization to EnvCapacities

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/EnvironDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/EnvironDAO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,14 +17,11 @@ package com.pinterest.deployservice.dao;
 
 import com.pinterest.deployservice.bean.EnvironBean;
 import com.pinterest.deployservice.bean.UpdateStatement;
-
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.List;
 
-/**
- * A collection of methods to help interact with Environments tables
- */
+/** A collection of methods to help interact with Environments tables */
 public interface EnvironDAO {
     void insert(EnvironBean bean) throws Exception;
 
@@ -56,7 +53,8 @@ public interface EnvironDAO {
 
     long countTotalCapacity(String envId, String envName, String envStage) throws Exception;
 
-    List<String> getTotalCapacityHosts(String envId, String envName, String envStage) throws Exception;
+    List<String> getTotalCapacityHosts(String envId, String envName, String envStage)
+            throws Exception;
 
     Collection<String> getMissingHosts(String envId) throws Exception;
 
@@ -65,15 +63,28 @@ public interface EnvironDAO {
     /**
      * Retrieves the main environment ID for the specified host ID.
      *
-     * <p>The main environment is where the cluster that the host belongs to is created.
-     * In case such an environment does not exist, the method will attempt to retrieve the
-     * environment that matches the first group that's known to Teletraan for the specified host.
+     * <p>The main environment is where the cluster that the host belongs to is created. In case
+     * such an environment does not exist, the method will attempt to retrieve the environment that
+     * matches the first group that's known to Teletraan for the specified host.
      *
      * @param hostId The ID of the host.
      * @return The bean represents the main environment for the specified host ID.
      * @throws SQLException if an error occurs while retrieving the main environment ID.
      */
     EnvironBean getMainEnvByHostId(String hostId) throws SQLException;
+
+    /**
+     * Retrieves the main environment ID for the specified host name.
+     *
+     * <p>The main environment is where the cluster that the host belongs to is created. In case
+     * such an environment does not exist, the method will attempt to retrieve the environment that
+     * matches the first group that's known to Teletraan for the specified host.
+     *
+     * @param hostName The host name.
+     * @return The bean represents the main environment for the specified host name.
+     * @throws SQLException if an error occurs while retrieving the main environment ID.
+     */
+    EnvironBean getMainEnvByHostName(String hostName) throws SQLException;
 
     List<EnvironBean> getEnvsByGroups(Collection<String> groups) throws Exception;
 
@@ -83,6 +94,7 @@ public interface EnvironDAO {
     List<String> getAllEnvIds() throws Exception;
 
     List<EnvironBean> getAllEnvs() throws Exception;
+
     List<EnvironBean> getAllSidecarEnvs() throws Exception;
 
     void deleteSchedule(String envName, String stageName) throws Exception;

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/AuthorizationFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/AuthorizationFactory.java
@@ -17,16 +17,16 @@ package com.pinterest.teletraan.config;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.pinterest.teletraan.TeletraanServiceContext;
+import com.pinterest.teletraan.universal.security.TeletraanAuthorizer;
 import com.pinterest.teletraan.universal.security.bean.TeletraanPrincipal;
-import io.dropwizard.auth.Authorizer;
 import io.dropwizard.jackson.Discoverable;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 public interface AuthorizationFactory extends Discoverable {
-    <P extends TeletraanPrincipal> Authorizer<P> create(TeletraanServiceContext context)
+    <P extends TeletraanPrincipal> TeletraanAuthorizer<P> create(TeletraanServiceContext context)
             throws Exception;
 
-    default <P extends TeletraanPrincipal> Authorizer<? extends TeletraanPrincipal> create(
+    default <P extends TeletraanPrincipal> TeletraanAuthorizer<? extends TeletraanPrincipal> create(
             TeletraanServiceContext context, Class<P> principalClass) throws Exception {
         return create(context);
     }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/CompositeAuthorizationFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/CompositeAuthorizationFactory.java
@@ -20,16 +20,16 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.pinterest.teletraan.TeletraanServiceContext;
 import com.pinterest.teletraan.security.ScriptTokenRoleAuthorizer;
 import com.pinterest.teletraan.universal.security.BasePastisAuthorizer;
+import com.pinterest.teletraan.universal.security.TeletraanAuthorizer;
 import com.pinterest.teletraan.universal.security.bean.ServicePrincipal;
 import com.pinterest.teletraan.universal.security.bean.TeletraanPrincipal;
-import io.dropwizard.auth.Authorizer;
 
 @JsonTypeName("composite")
 public class CompositeAuthorizationFactory implements AuthorizationFactory {
     private static final String DEFAULT_PASTIS_SERVICE_NAME = "teletraan_dev";
 
     @JsonProperty private String pastisServiceName = DEFAULT_PASTIS_SERVICE_NAME;
-    private Authorizer<TeletraanPrincipal> pastisAuthorizer;
+    private TeletraanAuthorizer<TeletraanPrincipal> pastisAuthorizer;
 
     public void setPastisServiceName(String pastisServiceName) {
         this.pastisServiceName = pastisServiceName;
@@ -40,8 +40,8 @@ public class CompositeAuthorizationFactory implements AuthorizationFactory {
     }
 
     @Override
-    public <P extends TeletraanPrincipal> Authorizer<P> create(TeletraanServiceContext context)
-            throws Exception {
+    public <P extends TeletraanPrincipal> TeletraanAuthorizer<P> create(
+            TeletraanServiceContext context) throws Exception {
         if (pastisAuthorizer == null) {
             pastisAuthorizer =
                     BasePastisAuthorizer.builder()
@@ -49,11 +49,11 @@ public class CompositeAuthorizationFactory implements AuthorizationFactory {
                             .serviceName(pastisServiceName)
                             .build();
         }
-        return (Authorizer<P>) pastisAuthorizer;
+        return (TeletraanAuthorizer<P>) pastisAuthorizer;
     }
 
     @Override
-    public <P extends TeletraanPrincipal> Authorizer<? extends TeletraanPrincipal> create(
+    public <P extends TeletraanPrincipal> TeletraanAuthorizer<? extends TeletraanPrincipal> create(
             TeletraanServiceContext context, Class<P> principalClass) throws Exception {
         if (ServicePrincipal.class.equals(principalClass)) {
             return new ScriptTokenRoleAuthorizer(context.getAuthZResourceExtractorFactory());

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/OpenAuthorizationFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/OpenAuthorizationFactory.java
@@ -17,14 +17,31 @@ package com.pinterest.teletraan.config;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.pinterest.teletraan.TeletraanServiceContext;
+import com.pinterest.teletraan.universal.security.TeletraanAuthorizer;
+import com.pinterest.teletraan.universal.security.bean.AuthZResource;
 import com.pinterest.teletraan.universal.security.bean.TeletraanPrincipal;
-import io.dropwizard.auth.Authorizer;
-import io.dropwizard.auth.PermitAllAuthorizer;
+import javax.annotation.Nullable;
+import javax.ws.rs.container.ContainerRequestContext;
 
 @JsonTypeName("open")
 public class OpenAuthorizationFactory implements AuthorizationFactory {
     @Override
-    public Authorizer<TeletraanPrincipal> create(TeletraanServiceContext context) throws Exception {
-        return new PermitAllAuthorizer<>();
+    public TeletraanAuthorizer<TeletraanPrincipal> create(TeletraanServiceContext context)
+            throws Exception {
+        return new TeletraanAuthorizer<TeletraanPrincipal>() {
+            @Override
+            public boolean authorize(TeletraanPrincipal principal, String resource) {
+                return true;
+            }
+
+            @Override
+            public boolean authorize(
+                    TeletraanPrincipal principal,
+                    String role,
+                    AuthZResource requestedResource,
+                    @Nullable ContainerRequestContext context) {
+                return true;
+            }
+        };
     }
 }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/RoleAuthorizationFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/RoleAuthorizationFactory.java
@@ -20,25 +20,24 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.pinterest.teletraan.TeletraanServiceContext;
 import com.pinterest.teletraan.security.ScriptTokenRoleAuthorizer;
 import com.pinterest.teletraan.security.UserRoleAuthorizer;
+import com.pinterest.teletraan.universal.security.TeletraanAuthorizer;
 import com.pinterest.teletraan.universal.security.bean.ServicePrincipal;
 import com.pinterest.teletraan.universal.security.bean.TeletraanPrincipal;
 import com.pinterest.teletraan.universal.security.bean.UserPrincipal;
-import io.dropwizard.auth.Authorizer;
 
 @JsonTypeName("role")
 public class RoleAuthorizationFactory implements AuthorizationFactory {
-    @JsonProperty
-    private String roleCacheSpec; // Unused, for backwards compatibility
+    @JsonProperty private String roleCacheSpec; // Unused, for backwards compatibility
 
     @Override
-    public <P extends TeletraanPrincipal> Authorizer<P> create(TeletraanServiceContext context)
-            throws Exception {
+    public <P extends TeletraanPrincipal> TeletraanAuthorizer<P> create(
+            TeletraanServiceContext context) throws Exception {
         throw new UnsupportedOperationException(
                 "RoleAuthorizationFactory does not support this method. Use create(TeletraanServiceContext, Class<P>) instead.");
     }
 
     @Override
-    public <P extends TeletraanPrincipal> Authorizer<? extends TeletraanPrincipal> create(
+    public <P extends TeletraanPrincipal> TeletraanAuthorizer<? extends TeletraanPrincipal> create(
             TeletraanServiceContext context, Class<P> principalClass) throws Exception {
         if (ServicePrincipal.class.equals(principalClass)) {
             return new ScriptTokenRoleAuthorizer(context.getAuthZResourceExtractorFactory());

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvCapacities.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvCapacities.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2016 Pinterest, Inc.
+/**
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package com.pinterest.teletraan.resource;
 
+import com.google.common.base.Optional;
 import com.pinterest.deployservice.bean.EnvironBean;
 import com.pinterest.deployservice.bean.TeletraanPrincipalRole;
 import com.pinterest.deployservice.common.Constants;
@@ -23,23 +24,25 @@ import com.pinterest.deployservice.dao.GroupDAO;
 import com.pinterest.deployservice.handler.ConfigHistoryHandler;
 import com.pinterest.deployservice.handler.EnvironHandler;
 import com.pinterest.teletraan.TeletraanServiceContext;
+import com.pinterest.teletraan.config.AuthorizationFactory;
 import com.pinterest.teletraan.universal.security.ResourceAuthZInfo;
+import com.pinterest.teletraan.universal.security.TeletraanAuthorizer;
 import com.pinterest.teletraan.universal.security.bean.AuthZResource;
-import com.google.common.base.Optional;
-
+import com.pinterest.teletraan.universal.security.bean.TeletraanPrincipal;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
-import org.apache.commons.lang3.StringUtils;
-import javax.validation.constraints.NotEmpty;
-import javax.annotation.security.RolesAllowed;
-import javax.validation.constraints.NotNull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import java.security.Principal;
+import java.sql.SQLException;
+import java.util.HashSet;
 import java.util.List;
+import javax.annotation.security.RolesAllowed;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.GET;
+import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -49,6 +52,9 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.SecurityContext;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @RolesAllowed(TeletraanPrincipalRole.Names.READ)
 @Path("/v1/envs/{envName : [a-zA-Z0-9\\-_]+}/{stageName : [a-zA-Z0-9\\-_]+}/capacity")
@@ -57,122 +63,217 @@ import javax.ws.rs.core.SecurityContext;
 @Consumes(MediaType.APPLICATION_JSON)
 public class EnvCapacities {
 
-  private static final Logger LOG = LoggerFactory.getLogger(EnvCapacities.class);
+    private static final Logger LOG = LoggerFactory.getLogger(EnvCapacities.class);
 
-  private EnvironHandler environHandler;
-  private ConfigHistoryHandler configHistoryHandler;
-  private EnvironDAO environDAO;
-  private GroupDAO groupDAO;
+    private EnvironHandler environHandler;
+    private ConfigHistoryHandler configHistoryHandler;
+    private EnvironDAO environDAO;
+    private GroupDAO groupDAO;
+    private AuthorizationFactory authorizationFactory;
+    private TeletraanServiceContext context;
 
-  public EnvCapacities(@Context TeletraanServiceContext context) {
-    environHandler = new EnvironHandler(context);
-    configHistoryHandler = new ConfigHistoryHandler(context);
-    environDAO = context.getEnvironDAO();
-    groupDAO = context.getGroupDAO();
-  }
-
-  @GET
-  @ApiOperation(
-      value = "Get the capacities for Group and hosts",
-      notes = "Get the capacities for Group and hosts")
-  public List<String> get(@PathParam("envName") String envName,
-                          @PathParam("stageName") String stageName,
-                          @QueryParam("capacityType") Optional<CapacityType> capacityType)
-      throws Exception {
-    EnvironBean envBean = Utils.getEnvStage(environDAO, envName, stageName);
-    if (capacityType.or(CapacityType.GROUP) == CapacityType.GROUP) {
-      return groupDAO.getCapacityGroups(envBean.getEnv_id());
-    } else {
-      return groupDAO.getCapacityHosts(envBean.getEnv_id());
+    public EnvCapacities(@Context TeletraanServiceContext context) {
+        environHandler = new EnvironHandler(context);
+        configHistoryHandler = new ConfigHistoryHandler(context);
+        environDAO = context.getEnvironDAO();
+        groupDAO = context.getGroupDAO();
+        authorizationFactory = context.getAuthorizationFactory();
+        this.context = context;
     }
-  }
 
-  @PUT
-  @ApiOperation(
-      value = "Update the capacities for Group and hosts",
-      notes = "Update the capacities for Group and hosts")
-  @RolesAllowed(TeletraanPrincipalRole.Names.WRITE)
-  @ResourceAuthZInfo(type = AuthZResource.Type.ENV_STAGE, idLocation = ResourceAuthZInfo.Location.PATH)
-  public void update(@PathParam("envName") String envName,
-                     @PathParam("stageName") String stageName,
-                     @QueryParam("capacityType") Optional<CapacityType> capacityType,
-                     @NotNull List<String> names, @Context SecurityContext sc) throws Exception {
-    EnvironBean envBean = Utils.getEnvStage(environDAO, envName, stageName);
-    String operator = sc.getUserPrincipal().getName();
-    if (capacityType.or(CapacityType.GROUP) == CapacityType.GROUP) {
-      environHandler.updateGroups(envBean, names, operator);
-      configHistoryHandler
-          .updateConfigHistory(envBean.getEnv_id(), Constants.TYPE_ENV_GROUP_CAPACITY, names,
-              operator);
-      configHistoryHandler.updateChangeFeed(Constants.CONFIG_TYPE_ENV, envBean.getEnv_id(),
-          Constants.TYPE_ENV_GROUP_CAPACITY, operator, envBean.getExternal_id());
-    } else {
-      environHandler.updateHosts(envBean, names, operator);
-      configHistoryHandler
-          .updateConfigHistory(envBean.getEnv_id(), Constants.TYPE_ENV_HOST_CAPACITY, names,
-              operator);
-      configHistoryHandler.updateChangeFeed(Constants.CONFIG_TYPE_ENV, envBean.getEnv_id(),
-          Constants.TYPE_ENV_HOST_CAPACITY, operator, envBean.getExternal_id());
+    @GET
+    @ApiOperation(
+            value = "Get the capacities for Group and hosts",
+            notes = "Get the capacities for Group and hosts")
+    public List<String> get(
+            @PathParam("envName") String envName,
+            @PathParam("stageName") String stageName,
+            @QueryParam("capacityType") Optional<CapacityType> capacityType)
+            throws Exception {
+        EnvironBean envBean = Utils.getEnvStage(environDAO, envName, stageName);
+        if (capacityType.or(CapacityType.GROUP) == CapacityType.GROUP) {
+            return groupDAO.getCapacityGroups(envBean.getEnv_id());
+        } else {
+            return groupDAO.getCapacityHosts(envBean.getEnv_id());
+        }
     }
-    LOG.info("Successfully updated env {}/{} capacity config as {} by {}.",
-        envName, stageName, names, operator);
-  }
 
-  @POST
-  @ApiOperation(
-      value = "Create the capacities for Group and hosts",
-      notes = "Create the capacities for Group and hosts")
-  @RolesAllowed(TeletraanPrincipalRole.Names.WRITE)
-  @ResourceAuthZInfo(type = AuthZResource.Type.ENV_STAGE, idLocation = ResourceAuthZInfo.Location.PATH)
-  public void add(@PathParam("envName") String envName,
-                  @PathParam("stageName") String stageName,
-                  @QueryParam("capacityType") Optional<CapacityType> capacityType,
-                  @NotEmpty String name, @Context SecurityContext sc) throws Exception {
-    EnvironBean envBean = Utils.getEnvStage(environDAO, envName, stageName);
-    String operator = sc.getUserPrincipal().getName();
-    name = name.replaceAll("\"", "");
-    if (capacityType.or(CapacityType.GROUP) == CapacityType.GROUP) {
-      groupDAO.addGroupCapacity(envBean.getEnv_id(), name);
-    } else {
-      groupDAO.addHostCapacity(envBean.getEnv_id(), name);
+    @PUT
+    @ApiOperation(
+            value = "Update the capacities for Group and hosts",
+            notes = "Update the capacities for Group and hosts")
+    @RolesAllowed(TeletraanPrincipalRole.Names.WRITE)
+    @ResourceAuthZInfo(
+            type = AuthZResource.Type.ENV_STAGE,
+            idLocation = ResourceAuthZInfo.Location.PATH)
+    public void update(
+            @PathParam("envName") String envName,
+            @PathParam("stageName") String stageName,
+            @QueryParam("capacityType") Optional<CapacityType> capacityType,
+            @NotNull List<String> names,
+            @Context SecurityContext sc)
+            throws Exception {
+        EnvironBean envBean = Utils.getEnvStage(environDAO, envName, stageName);
+        String operator = sc.getUserPrincipal().getName();
+        authorize(envBean, sc.getUserPrincipal(), capacityType.or(CapacityType.GROUP), names);
+
+        if (capacityType.or(CapacityType.GROUP) == CapacityType.GROUP) {
+            environHandler.updateGroups(envBean, names, operator);
+            configHistoryHandler.updateConfigHistory(
+                    envBean.getEnv_id(), Constants.TYPE_ENV_GROUP_CAPACITY, names, operator);
+            configHistoryHandler.updateChangeFeed(
+                    Constants.CONFIG_TYPE_ENV,
+                    envBean.getEnv_id(),
+                    Constants.TYPE_ENV_GROUP_CAPACITY,
+                    operator,
+                    envBean.getExternal_id());
+        } else {
+            environHandler.updateHosts(envBean, names, operator);
+            configHistoryHandler.updateConfigHistory(
+                    envBean.getEnv_id(), Constants.TYPE_ENV_HOST_CAPACITY, names, operator);
+            configHistoryHandler.updateChangeFeed(
+                    Constants.CONFIG_TYPE_ENV,
+                    envBean.getEnv_id(),
+                    Constants.TYPE_ENV_HOST_CAPACITY,
+                    operator,
+                    envBean.getExternal_id());
+        }
+        LOG.info(
+                "Successfully updated env {}/{} capacity config as {} by {}.",
+                envName,
+                stageName,
+                names,
+                operator);
     }
-    LOG.info("Successfully added {} to env {}/{} capacity config by {}.",
-        name, envName, stageName, operator);
-  }
 
-  @DELETE
-  @ApiOperation(
-      value = "Delete the capacities for Group and hosts",
-      notes = "Delete the capacities for Group and hosts")
-  @RolesAllowed(TeletraanPrincipalRole.Names.DELETE)
-  @ResourceAuthZInfo(type = AuthZResource.Type.ENV_STAGE, idLocation = ResourceAuthZInfo.Location.PATH)
-  public void delete(@PathParam("envName") String envName,
-                     @PathParam("stageName") String stageName,
-                     @QueryParam("capacityType") Optional<CapacityType> capacityType,
-                     @NotEmpty String name, @Context SecurityContext sc) throws Exception {
-    EnvironBean envBean = Utils.getEnvStage(environDAO, envName, stageName);
-    String operator = sc.getUserPrincipal().getName();
-    name = name.replaceAll("\"", "");
-    if (capacityType.or(CapacityType.GROUP) == CapacityType.GROUP) {
-      LOG.info("Delete group {} from environment {} stage {} capacity", name,
-          envName, stageName);
-      groupDAO.removeGroupCapacity(envBean.getEnv_id(), name);
-      if (StringUtils.equalsIgnoreCase(envBean.getCluster_name(), name)) {
-        LOG.info("Delete cluster {} from environment {} stage {}", name, envName, stageName);
-        //The group is set to be the cluster
-        environDAO.deleteCluster(envName, stageName);
-      }
-    } else {
-      LOG.info("Delete host {} from environment {} stage {} capacity", name,
-          envName, stageName);
-      groupDAO.removeHostCapacity(envBean.getEnv_id(), name);
+    @POST
+    @ApiOperation(
+            value = "Create the capacities for Group and hosts",
+            notes = "Create the capacities for Group and hosts")
+    @RolesAllowed(TeletraanPrincipalRole.Names.WRITE)
+    @ResourceAuthZInfo(
+            type = AuthZResource.Type.ENV_STAGE,
+            idLocation = ResourceAuthZInfo.Location.PATH)
+    public void add(
+            @PathParam("envName") String envName,
+            @PathParam("stageName") String stageName,
+            @QueryParam("capacityType") Optional<CapacityType> capacityType,
+            @NotEmpty String name,
+            @Context SecurityContext sc)
+            throws Exception {
+        EnvironBean envBean = Utils.getEnvStage(environDAO, envName, stageName);
+        String operator = sc.getUserPrincipal().getName();
+        name = name.replaceAll("\"", "");
+        if (capacityType.or(CapacityType.GROUP) == CapacityType.GROUP) {
+            groupDAO.addGroupCapacity(envBean.getEnv_id(), name);
+        } else {
+            groupDAO.addHostCapacity(envBean.getEnv_id(), name);
+        }
+        LOG.info(
+                "Successfully added {} to env {}/{} capacity config by {}.",
+                name,
+                envName,
+                stageName,
+                operator);
     }
-    LOG.info("Successfully deleted {} from env {}/{} capacity config by {}.",
-        name, envName, stageName, operator);
-  }
 
-  public enum CapacityType {
-    GROUP,
-    HOST
-  }
+    @DELETE
+    @ApiOperation(
+            value = "Delete the capacities for Group and hosts",
+            notes = "Delete the capacities for Group and hosts")
+    @RolesAllowed(TeletraanPrincipalRole.Names.DELETE)
+    @ResourceAuthZInfo(
+            type = AuthZResource.Type.ENV_STAGE,
+            idLocation = ResourceAuthZInfo.Location.PATH)
+    public void delete(
+            @PathParam("envName") String envName,
+            @PathParam("stageName") String stageName,
+            @QueryParam("capacityType") Optional<CapacityType> capacityType,
+            @NotEmpty String name,
+            @Context SecurityContext sc)
+            throws Exception {
+        EnvironBean envBean = Utils.getEnvStage(environDAO, envName, stageName);
+        String operator = sc.getUserPrincipal().getName();
+        name = name.replaceAll("\"", "");
+        if (capacityType.or(CapacityType.GROUP) == CapacityType.GROUP) {
+            LOG.info(
+                    "Delete group {} from environment {} stage {} capacity",
+                    name,
+                    envName,
+                    stageName);
+            groupDAO.removeGroupCapacity(envBean.getEnv_id(), name);
+            if (StringUtils.equalsIgnoreCase(envBean.getCluster_name(), name)) {
+                LOG.info(
+                        "Delete cluster {} from environment {} stage {}", name, envName, stageName);
+                // The group is set to be the cluster
+                environDAO.deleteCluster(envName, stageName);
+            }
+        } else {
+            LOG.info(
+                    "Delete host {} from environment {} stage {} capacity",
+                    name,
+                    envName,
+                    stageName);
+            groupDAO.removeHostCapacity(envBean.getEnv_id(), name);
+        }
+        LOG.info(
+                "Successfully deleted {} from env {}/{} capacity config by {}.",
+                name,
+                envName,
+                stageName,
+                operator);
+    }
+
+    public enum CapacityType {
+        GROUP,
+        HOST
+    }
+
+    void authorize(
+            EnvironBean targetEnvironBean,
+            Principal principal,
+            CapacityType capacityType,
+            List<String> capacities)
+            throws Exception {
+        if (targetEnvironBean.getSystem_priority() != null
+                && targetEnvironBean.getSystem_priority() > 0) {
+            // Allow sidecars to add capacity
+            return;
+        }
+
+        if (!(principal instanceof TeletraanPrincipal)) {
+            throw new UnsupportedOperationException("Only TeletraanPrincipal is allowed");
+        }
+        TeletraanPrincipal p = (TeletraanPrincipal) principal;
+        TeletraanAuthorizer<TeletraanPrincipal> authorizer = authorizationFactory.create(context);
+
+        HashSet<AuthZResource> resources = new HashSet<>();
+        for (String capacity : capacities) {
+            EnvironBean envBean;
+            try {
+                if (capacityType == CapacityType.GROUP) {
+                    envBean = environDAO.getByCluster(capacity);
+                } else {
+                    envBean = environDAO.getMainEnvByHostName(capacity);
+                }
+            } catch (SQLException e) {
+                throw new InternalServerErrorException(e);
+            }
+
+            if (envBean == null) {
+                throw new ForbiddenException(
+                        "Failed to get the main environment with capacity name: " + capacity);
+            }
+            resources.add(new AuthZResource(envBean.getEnv_name(), envBean.getStage_name()));
+        }
+
+        for (AuthZResource resource : resources) {
+            if (!authorizer.authorize(p, TeletraanPrincipalRole.Names.WRITE, resource, null)) {
+                throw new ForbiddenException(
+                        String.format(
+                                "Principal %s is now allowed to modify capacity owned by env %s",
+                                p.getName(), resource.getName()));
+            }
+        }
+    }
 }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvCapacities.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvCapacities.java
@@ -15,7 +15,6 @@
  */
 package com.pinterest.teletraan.resource;
 
-import com.google.common.base.Optional;
 import com.pinterest.deployservice.bean.EnvironBean;
 import com.pinterest.deployservice.bean.TeletraanPrincipalRole;
 import com.pinterest.deployservice.common.Constants;
@@ -35,6 +34,7 @@ import java.security.Principal;
 import java.sql.SQLException;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import javax.annotation.security.RolesAllowed;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
@@ -91,7 +91,7 @@ public class EnvCapacities {
             @QueryParam("capacityType") Optional<CapacityType> capacityType)
             throws Exception {
         EnvironBean envBean = Utils.getEnvStage(environDAO, envName, stageName);
-        if (capacityType.or(CapacityType.GROUP) == CapacityType.GROUP) {
+        if (capacityType.orElse(CapacityType.GROUP) == CapacityType.GROUP) {
             return groupDAO.getCapacityGroups(envBean.getEnv_id());
         } else {
             return groupDAO.getCapacityHosts(envBean.getEnv_id());
@@ -115,9 +115,9 @@ public class EnvCapacities {
             throws Exception {
         EnvironBean envBean = Utils.getEnvStage(environDAO, envName, stageName);
         String operator = sc.getUserPrincipal().getName();
-        authorize(envBean, sc.getUserPrincipal(), capacityType.or(CapacityType.GROUP), names);
+        authorize(envBean, sc.getUserPrincipal(), capacityType.orElse(CapacityType.GROUP), names);
 
-        if (capacityType.or(CapacityType.GROUP) == CapacityType.GROUP) {
+        if (capacityType.orElse(CapacityType.GROUP) == CapacityType.GROUP) {
             environHandler.updateGroups(envBean, names, operator);
             configHistoryHandler.updateConfigHistory(
                     envBean.getEnv_id(), Constants.TYPE_ENV_GROUP_CAPACITY, names, operator);
@@ -163,8 +163,8 @@ public class EnvCapacities {
             throws Exception {
         EnvironBean envBean = Utils.getEnvStage(environDAO, envName, stageName);
         String operator = sc.getUserPrincipal().getName();
-        name = name.replaceAll("\"", "");
-        if (capacityType.or(CapacityType.GROUP) == CapacityType.GROUP) {
+        name = name.replace("\"", "");
+        if (capacityType.orElse(CapacityType.GROUP) == CapacityType.GROUP) {
             groupDAO.addGroupCapacity(envBean.getEnv_id(), name);
         } else {
             groupDAO.addHostCapacity(envBean.getEnv_id(), name);
@@ -194,8 +194,8 @@ public class EnvCapacities {
             throws Exception {
         EnvironBean envBean = Utils.getEnvStage(environDAO, envName, stageName);
         String operator = sc.getUserPrincipal().getName();
-        name = name.replaceAll("\"", "");
-        if (capacityType.or(CapacityType.GROUP) == CapacityType.GROUP) {
+        name = name.replace("\"", "");
+        if (capacityType.orElse(CapacityType.GROUP) == CapacityType.GROUP) {
             LOG.info(
                     "Delete group {} from environment {} stage {} capacity",
                     name,

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/resource/EnvCapacitiesTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/resource/EnvCapacitiesTest.java
@@ -1,0 +1,167 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.resource;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.pinterest.deployservice.bean.EnvironBean;
+import com.pinterest.deployservice.bean.TeletraanPrincipalRole;
+import com.pinterest.deployservice.dao.EnvironDAO;
+import com.pinterest.deployservice.fixture.EnvironBeanFixture;
+import com.pinterest.teletraan.TeletraanServiceContext;
+import com.pinterest.teletraan.config.AuthorizationFactory;
+import com.pinterest.teletraan.resource.EnvCapacities.CapacityType;
+import com.pinterest.teletraan.universal.security.TeletraanAuthorizer;
+import com.pinterest.teletraan.universal.security.bean.AuthZResource;
+import com.pinterest.teletraan.universal.security.bean.TeletraanPrincipal;
+import java.security.Principal;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import javax.ws.rs.ForbiddenException;
+import javax.ws.rs.InternalServerErrorException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class EnvCapacitiesTest {
+    private EnvCapacities sut;
+    private List<String> capacities;
+
+    @Mock private EnvironDAO environDAO;
+    @Mock private TeletraanAuthorizer<TeletraanPrincipal> authorizer;
+    @Mock private TeletraanPrincipal principal;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        MockitoAnnotations.openMocks(this);
+
+        TeletraanServiceContext serviceContext = new TeletraanServiceContext();
+        AuthorizationFactory authorizationFactory = mock(AuthorizationFactory.class);
+
+        when(authorizationFactory.create(any())).thenReturn(authorizer);
+        serviceContext.setAuthorizationFactory(authorizationFactory);
+        serviceContext.setEnvironDAO(environDAO);
+
+        sut = new EnvCapacities(serviceContext);
+        capacities = new ArrayList<>();
+        capacities.add("cap1");
+        capacities.add("cap2");
+    }
+
+    @ParameterizedTest
+    @MethodSource("capacityTypes")
+    void authorizeShouldAllowSidecarEnvsToAddCapacities(CapacityType type) throws Exception {
+        EnvironBean envBean = EnvironBeanFixture.createRandomEnvironBean();
+        envBean.setSystem_priority(1);
+
+        assertDoesNotThrow(() -> sut.authorize(envBean, principal, type, capacities));
+    }
+
+    @ParameterizedTest
+    @MethodSource("capacityTypes")
+    void authorizeShouldAllowEmptyCapacities(CapacityType type) throws Exception {
+        EnvironBean envBean = EnvironBeanFixture.createRandomEnvironBean();
+
+        assertDoesNotThrow(() -> sut.authorize(envBean, principal, type, new ArrayList<>()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("capacityTypes")
+    void authorizeShouldThrowExceptionForNonTeletraanPrincipal(CapacityType type) {
+        EnvironBean envBean = EnvironBeanFixture.createRandomEnvironBean();
+        Principal nonTeletraanPrincipal = mock(Principal.class);
+
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> sut.authorize(envBean, nonTeletraanPrincipal, type, capacities));
+    }
+
+    @ParameterizedTest
+    @MethodSource("capacityTypes")
+    void authorizeSuccess(CapacityType type) throws Exception {
+        EnvironBean envBean = EnvironBeanFixture.createRandomEnvironBean();
+
+        for (String capacity : capacities) {
+            when(environDAO.getMainEnvByHostName(capacity)).thenReturn(envBean);
+            when(environDAO.getByCluster(capacity)).thenReturn(envBean);
+        }
+        when(authorizer.authorize(
+                        (TeletraanPrincipal) principal,
+                        TeletraanPrincipalRole.Names.WRITE,
+                        new AuthZResource(envBean.getEnv_name(), envBean.getStage_name()),
+                        null))
+                .thenReturn(true);
+        assertDoesNotThrow(() -> sut.authorize(envBean, principal, type, capacities));
+    }
+
+    @ParameterizedTest
+    @MethodSource("capacityTypes")
+    void authorizeThrowsExceptionWhenNoMainEnvFound(CapacityType type) throws Exception {
+        EnvironBean envBean = EnvironBeanFixture.createRandomEnvironBean();
+
+        for (String capacity : capacities) {
+            when(environDAO.getMainEnvByHostName(capacity)).thenReturn(null);
+            when(environDAO.getByCluster(capacity)).thenReturn(null);
+        }
+        assertThrows(
+                ForbiddenException.class,
+                () -> sut.authorize(envBean, principal, type, capacities));
+    }
+
+    @ParameterizedTest
+    @MethodSource("capacityTypes")
+    void authorizeThrowsExceptionWhenDBException(CapacityType type) throws Exception {
+        EnvironBean envBean = EnvironBeanFixture.createRandomEnvironBean();
+
+        for (String capacity : capacities) {
+            when(environDAO.getMainEnvByHostName(capacity)).thenThrow(SQLException.class);
+            when(environDAO.getByCluster(capacity)).thenThrow(SQLException.class);
+        }
+        assertThrows(
+                InternalServerErrorException.class,
+                () -> sut.authorize(envBean, principal, type, capacities));
+    }
+
+    @ParameterizedTest
+    @MethodSource("capacityTypes")
+    void authorizeThrowsExceptionWhenAccessDenied(CapacityType type) throws Exception {
+        EnvironBean envBean = EnvironBeanFixture.createRandomEnvironBean();
+
+        for (String capacity : capacities) {
+            when(environDAO.getMainEnvByHostName(capacity)).thenReturn(envBean);
+            when(environDAO.getByCluster(capacity)).thenReturn(envBean);
+        }
+        when(authorizer.authorize(any(), any(), any(), any())).thenReturn(false);
+        assertThrows(
+                ForbiddenException.class,
+                () -> sut.authorize(envBean, principal, type, capacities));
+    }
+
+    static Stream<Arguments> capacityTypes() {
+        return Stream.of(
+                Arguments.of(EnvCapacities.CapacityType.GROUP),
+                Arguments.of(EnvCapacities.CapacityType.HOST));
+    }
+}

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/BaseAuthorizer.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/BaseAuthorizer.java
@@ -19,7 +19,6 @@ import com.pinterest.teletraan.universal.security.AuthZResourceExtractor.BeanCla
 import com.pinterest.teletraan.universal.security.AuthZResourceExtractor.ExtractionException;
 import com.pinterest.teletraan.universal.security.bean.AuthZResource;
 import com.pinterest.teletraan.universal.security.bean.TeletraanPrincipal;
-import io.dropwizard.auth.Authorizer;
 import javax.annotation.Nullable;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.ContainerRequestContext;
@@ -34,7 +33,8 @@ import lombok.extern.slf4j.Slf4j;
  */
 @AllArgsConstructor
 @Slf4j
-public abstract class BaseAuthorizer<P extends TeletraanPrincipal> implements Authorizer<P> {
+public abstract class BaseAuthorizer<P extends TeletraanPrincipal>
+        implements TeletraanAuthorizer<P> {
     protected final AuthZResourceExtractor.Factory extractorFactory;
 
     @Override
@@ -86,10 +86,4 @@ public abstract class BaseAuthorizer<P extends TeletraanPrincipal> implements Au
             return authorize(principal, role, requestedResource, context);
         }
     }
-
-    public abstract boolean authorize(
-            P principal,
-            String role,
-            AuthZResource requestedResource,
-            @Nullable ContainerRequestContext context);
 }

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/TeletraanAuthorizer.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/TeletraanAuthorizer.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.universal.security;
+
+import com.pinterest.teletraan.universal.security.bean.AuthZResource;
+import com.pinterest.teletraan.universal.security.bean.TeletraanPrincipal;
+import io.dropwizard.auth.Authorizer;
+import javax.annotation.Nullable;
+import javax.ws.rs.container.ContainerRequestContext;
+
+public interface TeletraanAuthorizer<P extends TeletraanPrincipal> extends Authorizer<P> {
+    boolean authorize(
+            P principal,
+            String role,
+            AuthZResource requestedResource,
+            @Nullable ContainerRequestContext context);
+}


### PR DESCRIPTION
Updates the EnvCapacities to support comprehensive authorization on capacity updates.

Previously users can can add arbitrary capacities to their environments. Now they can only do so if they own the capacity. Before updating capacities, Teletraan now makes sure the principal has `WRITE` permission to the capacities being added. 