### PR TITLE
Allow script token principals to read unspecified resources

### DIFF
--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/ScriptTokenRoleAuthorizer.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/ScriptTokenRoleAuthorizer.java
@@ -47,6 +47,11 @@ public class ScriptTokenRoleAuthorizer
             return false;
         }
 
+        if (AuthZResource.Type.UNSPECIFIED.equals(requestedResource.getType())) {
+            // Always allow unspecified resources as they are READ operations
+            return true;
+        }
+
         if (AuthZResource.Type.ENV_STAGE.equals(requestedResource.getType())) {
             if (requestedResource.getEnvName().equals(principal.getResource().getName())) {
                 return true;

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/ScriptTokenRoleAuthorizerTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/ScriptTokenRoleAuthorizerTest.java
@@ -238,4 +238,18 @@ public class ScriptTokenRoleAuthorizerTest {
         checkPositive(sysOperator, build, TeletraanPrincipalRole.PUBLISHER);
         checkNegative(sysReader, build, TeletraanPrincipalRole.PUBLISHER);
     }
+
+    @Test
+    public void testUnspecified() throws Exception {
+        checkPositive(sysAdmin, AuthZResource.UNSPECIFIED_RESOURCE, TeletraanPrincipalRole.READ);
+        checkPositive(sysOperator, AuthZResource.UNSPECIFIED_RESOURCE, TeletraanPrincipalRole.READ);
+        checkPositive(sysReader, AuthZResource.UNSPECIFIED_RESOURCE, TeletraanPrincipalRole.READ);
+
+        checkPositive(envAdmin, AuthZResource.UNSPECIFIED_RESOURCE, TeletraanPrincipalRole.READ);
+        checkPositive(envOperator, AuthZResource.UNSPECIFIED_RESOURCE, TeletraanPrincipalRole.READ);
+        checkPositive(envReader, AuthZResource.UNSPECIFIED_RESOURCE, TeletraanPrincipalRole.READ);
+
+        checkPositive(pinger, AuthZResource.UNSPECIFIED_RESOURCE, TeletraanPrincipalRole.READ);
+        checkPositive(publisher, AuthZResource.UNSPECIFIED_RESOURCE, TeletraanPrincipalRole.READ);
+    }
 }


### PR DESCRIPTION
In https://github.com/pinterest/teletraan/commit/c9ed0fb09a98130ca637b21b8367fedff0f8c802 we start to authorize on all requests. Script token authorizer was not updated to accommodate the change. 