### PR TITLE
Deduplicate hosts in UI

### DIFF
--- a/deploy-board/deploy_board/webapp/env_views.py
+++ b/deploy-board/deploy_board/webapp/env_views.py
@@ -446,7 +446,7 @@ class EnvLandingView(View):
 
         if not env['deployId']:
             capacity_hosts = deploys_helper.get_missing_hosts(request, name, stage)
-            provisioning_hosts = environ_hosts_helper.get_hosts(request, name, stage)
+            provisioning_hosts = deduplicate_hosts(environ_hosts_helper.get_hosts(request, name, stage))
 
             response = render(request, 'environs/env_landing.html', {
                 "envs": envs,
@@ -588,6 +588,17 @@ class EnvLandingView(View):
         response.set_cookie(STATUS_COOKIE_NAME, sortByStatus)
 
         return response
+
+
+def deduplicate_hosts(hosts):
+    results = []
+    seen = set()
+    for h in hosts:
+        host_id = h['hostId']
+        if host_id not in seen:
+            seen.add(host_id)
+            results.append(h)
+    return results
 
 def _get_asg_suspended_processes(request, env):
     try:


### PR DESCRIPTION
## Bug
After creating a new stage without a deploy, if you add a single existing host to the capacity, it will show that host 16 times.  To recreate:1.  Create stage (do not create deploy)
2.  Go to Capacity -> Existing Capacity and add a single host
3.  Stage now shows 16 hosts with the same name3

## Analysis 
When there is a deployment, the service code path actually only takes the first host https://github.com/pinterest/teletraan/blob/3ea3478c62a73f5c3b0921517c9bb41c3b16a30a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/EnvironHandler.java#L492-L492, so we are safe to do so in the UI when there is no deployment. 

## Validations

### Before
<img width="1340" alt="Screenshot 2024-07-16 at 14 57 42" src="https://github.com/user-attachments/assets/11f36dd9-a8be-4ad4-a5f0-20b98f3450ad">

### After
<img width="1628" alt="Screenshot 2024-07-22 at 13 35 16" src="https://github.com/user-attachments/assets/dccdd18a-3dbc-4502-9eb9-a358de04bdfb">
