### PR TITLE
change number to string for cluster config value

### DIFF
--- a/deploy-board/deploy_board/webapp/cluster_view.py
+++ b/deploy-board/deploy_board/webapp/cluster_view.py
@@ -1020,11 +1020,11 @@ def get_aws_config_name_list_by_image(image_name):
         config_map['raid_device'] = '/dev/md0'
         config_map['raid_fs'] = 'xfs'
         config_map['ebs'] = 'true'
-        config_map['ebs_size'] = 500
+        config_map['ebs_size'] = '500'
         config_map['ebs_mount'] = '/backup'
         config_map['ebs_volume_type'] = 'gp3'
         config_map['root_volume_type'] = 'gp3'
-        config_map['root_volume_size'] = 100
+        config_map['root_volume_size'] = '100'
         if image_name == DEFAULT_CMP_IMAGE or image_name == DEFAULT_CMP_ARM_IMAGE:
             config_map['pinfo_role'] = 'cmp_base'
             config_map['pinfo_team'] = 'cloudeng'


### PR DESCRIPTION
Fix error when trying to add a config that uses a number (eg root_volume_size or ebs_size) on the [advanced cluster setttings]