### PR TITLE
Allow hosts added as existing capacity when main environment is not found

### DIFF
--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/db/DBEnvironDAOImplTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/db/DBEnvironDAOImplTest.java
@@ -129,10 +129,34 @@ class DBEnvironDAOImplTest {
         sut.insert(expectedEnvBean);
 
         setUpHostBean(TEST_CLUSTER);
-        setUpHostBean(TEST_CLUSTER + "2");
+        setUpHostBean(TEST_CLUSTER + "3");
 
         EnvironBean actualEnvironBean = sut.getMainEnvByHostName(HOST_NAME);
         assertEnvironBean(expectedEnvBean, actualEnvironBean);
+    }
+
+    @Test
+    void testGetMainEnvByHostId_noMainEnv() throws Exception {
+        EnvironBean envBean = EnvironBeanFixture.createRandomEnvironBean();
+        envBean.setCluster_name(null);
+        sut.insert(envBean);
+
+        setUpHostBean(TEST_CLUSTER);
+
+        EnvironBean actualEnvironBean = sut.getMainEnvByHostId(HOST_ID);
+        assertNull(actualEnvironBean);
+    }
+
+    @Test
+    void testGetMainEnvByHostName_noMainEnv() throws Exception {
+        EnvironBean envBean = EnvironBeanFixture.createRandomEnvironBean();
+        envBean.setCluster_name(null);
+        sut.insert(envBean);
+
+        setUpHostBean(TEST_CLUSTER);
+
+        EnvironBean actualEnvironBean = sut.getMainEnvByHostId(HOST_NAME);
+        assertNull(actualEnvironBean);
     }
 
     private void setUpHostAgentBean() throws Exception {

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvCapacities.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvCapacities.java
@@ -231,8 +231,7 @@ public class EnvCapacities {
             CapacityType capacityType,
             List<String> capacities)
             throws Exception {
-        if (targetEnvironBean.getSystem_priority() != null
-                && targetEnvironBean.getSystem_priority() > 0) {
+        if (isSidecarEnvironment(targetEnvironBean)) {
             // Allow sidecars to add capacity
             return;
         }
@@ -272,12 +271,16 @@ public class EnvCapacities {
                 throw new InternalServerErrorException(e);
             }
 
-            if (envBean == null) {
-                throw new ForbiddenException(
-                        "Failed to get the main environment with capacity name: " + capacity);
+            if (envBean != null) {
+                resources.add(new AuthZResource(envBean.getEnv_name(), envBean.getStage_name()));
+            } else {
+                LOG.info("Failed to find main environment for capacity {}, skip authorization", capacity);
             }
-            resources.add(new AuthZResource(envBean.getEnv_name(), envBean.getStage_name()));
         }
         return resources;
+    }
+
+    private boolean isSidecarEnvironment(EnvironBean environBean) {
+        return environBean.getSystem_priority() != null && environBean.getSystem_priority() > 0;
     }
 }

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/resource/EnvCapacitiesTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/resource/EnvCapacitiesTest.java
@@ -118,16 +118,14 @@ class EnvCapacitiesTest {
 
     @ParameterizedTest
     @MethodSource("capacityTypes")
-    void authorizeThrowsExceptionWhenNoMainEnvFound(CapacityType type) throws Exception {
+    void authorizeSucceedsWhenNoMainEnvFound(CapacityType type) throws Exception {
         EnvironBean envBean = EnvironBeanFixture.createRandomEnvironBean();
 
         for (String capacity : capacities) {
             when(environDAO.getMainEnvByHostName(capacity)).thenReturn(null);
             when(environDAO.getByCluster(capacity)).thenReturn(null);
         }
-        assertThrows(
-                ForbiddenException.class,
-                () -> sut.authorize(envBean, principal, type, capacities));
+        assertDoesNotThrow(() -> sut.authorize(envBean, principal, type, capacities));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Hots added as existing capacities may not have an owning env. For those hosts, allow them to be added.