### PR TITLE
Fix long task timer implementation

### DIFF
--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/metrics/micrometer/PinStatsLongTaskTimer.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/metrics/micrometer/PinStatsLongTaskTimer.java
@@ -1,59 +1,71 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.pinterest.teletraan.universal.metrics.micrometer;
-
-import java.lang.reflect.Field;
-import java.time.Instant;
-import java.util.concurrent.TimeUnit;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.LongTaskTimer;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
-import io.micrometer.core.instrument.internal.CumulativeHistogramLongTaskTimer;
+import io.micrometer.core.instrument.internal.DefaultLongTaskTimer;
+import java.lang.reflect.Field;
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-/**
- * This is a custom implementation of {@link LongTaskTimer}
- * to support user supplied start time.
- */
-public class PinStatsLongTaskTimer extends CumulativeHistogramLongTaskTimer {
-  private static final Logger LOG = LoggerFactory.getLogger(PinStatsLongTaskTimer.class);
+/** This is a custom implementation of {@link LongTaskTimer} to support user supplied start time. */
+public class PinStatsLongTaskTimer extends DefaultLongTaskTimer {
+    private static final Logger LOG = LoggerFactory.getLogger(PinStatsLongTaskTimer.class);
 
-  private final Clock clock;
+    private final Clock clock;
 
-  public PinStatsLongTaskTimer(Id id, Clock clock, TimeUnit baseTimeUnit,
-      DistributionStatisticConfig distributionStatisticConfig) {
-    super(id, clock, baseTimeUnit, distributionStatisticConfig);
-    this.clock = clock;
-  }
-
-  /**
-   * Start the timer with user supplied start time.
-   *
-   * This method can only provide an approximation of the start time. Therefore it
-   * is not suitable for high precision use cases. You shouldn't use a
-   * {@link LongTaskTimer} for tracking high precision durations anyways.
-   *
-   * If for any reason the start time cannot be set, the current time will be
-   * used.
-   *
-   * @param startTime start time
-   * @return the sample with specified start time
-   */
-  public Sample start(Instant startTime) {
-    Sample sample = start();
-    try {
-      long timeLapsed = clock.wallTime() - startTime.toEpochMilli();
-      long monotonicStartTime = clock.monotonicTime() - timeLapsed * 1000000;
-      // The class `SampleImpl` is not visible, so we have to use reflection to set
-      // the start time.
-      Class<?> sampleImplClass = sample.getClass();
-      Field field = sampleImplClass.getDeclaredField("startTime");
-      field.setAccessible(true);
-      field.set(sample, monotonicStartTime);
-    } catch (Exception e) {
-      LOG.error("Failed to set start time, use current time instead", e);
+    public PinStatsLongTaskTimer(
+            Id id,
+            Clock clock,
+            TimeUnit baseTimeUnit,
+            DistributionStatisticConfig distributionStatisticConfig) {
+        super(id, clock, baseTimeUnit, distributionStatisticConfig, false);
+        this.clock = clock;
     }
-    return sample;
-  }
+
+    /**
+     * Start the timer with user supplied start time.
+     *
+     * <p>This method can only provide an approximation of the start time. Therefore it is not
+     * suitable for high precision use cases. You shouldn't use a {@link LongTaskTimer} for tracking
+     * high precision durations anyways.
+     *
+     * <p>If for any reason the start time cannot be set, the current time will be used.
+     *
+     * @param startTime start time
+     * @return the sample with specified start time
+     */
+    public Sample start(Instant startTime) {
+        Sample sample = start();
+        try {
+            long timeLapsed = clock.wallTime() - startTime.toEpochMilli();
+            long monotonicStartTime = clock.monotonicTime() - timeLapsed * 1000000;
+            // The class `SampleImpl` is not visible, so we have to use reflection to set
+            // the start time.
+            Class<?> sampleImplClass = sample.getClass();
+            Field field = sampleImplClass.getDeclaredField("startTime");
+            field.setAccessible(true);
+            field.set(sample, monotonicStartTime);
+        } catch (Exception e) {
+            LOG.error("Failed to set start time, use current time instead", e);
+        }
+        return sample;
+    }
 }


### PR DESCRIPTION
The implementation of `CumulativeHistogramLongTaskTimer` in micrometer has a known [issue](https://github.com/micrometer-metrics/micrometer/issues/2744). Besides, the implementation of `writeLongTaskTimer` is not compatible with `CumulativeHistogramLongTaskTimer` and results in non-sense histogram. The +Inf bucket should be the total counts of elements in the histogram, but it's set to the active count. 

https://github.com/pinterest/teletraan/blob/cddbb726abe2377ddc3601c8928020c6739d93f8/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/metrics/micrometer/PinStatsPublisher.java#L213-L228

Because PinStats supports GaugeHistogram, this PR adopts the second recommendation in the micrometer issue. 

> Alternatively, [GaugeHistogram](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#gaugehistogram) is exactly what we want and doesn't require the logic of adding the previous snapshot to maintain monotonicity. Unfortunately, GaugeHistogram is not available in Prometheus' text format; it's only defined in OpenMetrics.

GaugeHistogram works for Teletraan's use case because the purpose of this metrics is to allow users to detect out of SLA host launches immediately. It's not intended to provide the histogram of actual host launch durations. 

The fix is simply to inherit from `DefaultLongTaskTimer` instead of `CumulativeHistogramLongTaskTimer`. 