### PR TITLE
Add a new AuthZ resource type

### DIFF
--- a/deploy-service/pom.xml
+++ b/deploy-service/pom.xml
@@ -58,7 +58,7 @@
             <dependency>
                 <groupId>com.pinterest.teletraan</groupId>
                 <artifactId>universal</artifactId>
-                <version>2.1-SNAPSHOT</version>
+                <version>2.2-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.pinterest.teletraan</groupId>

--- a/deploy-service/universal/pom.xml
+++ b/deploy-service/universal/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>com.pinterest.teletraan</groupId>
   <artifactId>universal</artifactId>
-  <version>2.1-SNAPSHOT</version>
+  <version>2.2-SNAPSHOT</version>
 
   <name>Teletraan platform universal components</name>
   <url>https://github.com/pinterest/teletraan/</url>

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/AuthZResource.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/AuthZResource.java
@@ -115,8 +115,10 @@ public class AuthZResource {
         DEPLOY,
         /** For hotfix related resources. */
         HOTFIX,
-        /** For Host related resources. */
+        /** For host related resources. */
         HOST,
+        /** For cluster provision prefix resource. */
+        PROVISION_PREFIX,
         /* For anything else */
         UNSPECIFIED,
     }

--- a/docs/auth/teletraan_auth.yaml
+++ b/docs/auth/teletraan_auth.yaml
@@ -85,6 +85,7 @@ definitions:
           - BUILD
           - HOTFIX
           - HOST
+          - PROVISION_PREFIX
           - UNSPECIFIED
       resourceName:
         type: string


### PR DESCRIPTION
This new resource type represents the config `provision_prefix` in the cluster configuration. It's similar to IAM_ROLE. Clusters with this configuration will have hostnames with this configuration as the prefix.