### PR TITLE
Reduce batch size 

### DIFF
--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AgentJanitor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AgentJanitor.java
@@ -82,7 +82,7 @@ public class AgentJanitor extends SimpleAgentJanitor {
     }
 
     private Set<String> getTerminatedHostsFromSource(List<String> staleHostIds) {
-        int batchSize = 10;
+        int batchSize = 5;
         Set<String> terminatedHosts = new HashSet<>();
         for (int i = 0; i < staleHostIds.size(); i += batchSize) {
             try {


### PR DESCRIPTION
The Rodimus API is being slow and sometime time out. Reduce the batch size so it can succeed. 