### PR TITLE
Emit launch latency

### DIFF
--- a/deploy-board/deploy_board/templates/groups/group_details.html
+++ b/deploy-board/deploy_board/templates/groups/group_details.html
@@ -87,29 +87,12 @@
 
     <div id="metricStatId" class="collapse in panel-body">
         <div id="tsdLinksId" style="text-align: left;">
-            <h4>Check out these links for better visualization</h4>
+            <h4>Check out the dashboard for better visualization</h4>
             <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"
-                href="{{ group_size_url }}"
-                title="" data-original-title="Click to see more group size information in TSDB">
-                <strong>Group Size</strong>
+                href="{{ teletraan_user_dashboard_url }}"
+                title="" data-original-title="Click to see more in TSDB">
+                <strong>Teletraan user dashboard</strong>
             </a>
-            <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"
-                href="{{ provision_latency_url }}"
-                title="" data-original-title="Click to see more provision latency information in TSDB">
-                <strong>Provision Latency</strong>
-            </a>
-            {% for env in envs %}
-                <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"
-                    href="{{ env.firstDeployLatencyLink }}"
-                    title="" data-original-title="Click to see more first deploy latency information in TSDB">
-                    <strong>Deploy Latency for {{ env.envName }}</strong>
-                </a>
-                <a type="button" class="deployToolTip btn btn-xs" data-toggle="tooltip"
-                    href="{{ env.firstDeploySRLink }}"
-                    title="" data-original-title="Click to see more first deploy success rate information in TSDB">
-                    <strong>First deploy SR for {{ env.envName }}</strong>
-                </a>
-            {% endfor %}
         </div>
         <div id="groupStatsId" class="collapse in panel-body" style="text-align: center;">
             <div id="container" class="chartContainer">

--- a/deploy-board/deploy_board/templates/groups/launch_rate.tmpl
+++ b/deploy-board/deploy_board/templates/groups/launch_rate.tmpl
@@ -43,7 +43,7 @@
                         lineWidth: 2}
                 },
                 vAxes: {
-                    0: {title: 'Success Rate',
+                    0: {title: 'Failure Rate',
                         titleTextStyle: {italic: false}}
                 },
                 interpolateNulls: true,
@@ -65,7 +65,6 @@
             if (metric_names != null) {
                 for (var i = 0; i < 1; ++i) {
                     var metric_name = metric_names[i];
-                    data.addColumn("number", "Launch Failure Rate");
                     data_list = response[metric_name];
                     for (j = 0; j < data_list.length; ++j) {
                         var d = new Date(data_list[j][0]);

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -1243,13 +1243,18 @@ class GroupDetailView(View):
             "launch_config": launch_config,
             "pas_enabled": pas_config['pas_state'] if pas_config else False,
             "disallow_autoscaling": _disallow_autoscaling(curr_image),
-            "teletraan_user_dashboard_url": self.generate_dashboard_url(group_name, envs),
+            "teletraan_user_dashboard_url": self.generate_dashboard_url(group_name, envs, group_info),
         })
 
-    def generate_dashboard_url(self, group, envs):
+    def generate_dashboard_url(self, group, envs, group_info):
+        launch_latency_th = (
+            group_info.get("groupInfo", {}).get("launchLatencyTh", 600)
+            if group_info
+            else 600
+        )
         env_arg = '|'.join([f'{env.get("envName")}.{env.get("stageName")}' for env in envs])
         params = {
-            "tags": f"cluster={group},envs={env_arg}",
+            "tags": f"cluster={group},envs={env_arg},th={launch_latency_th}",
         }
         params.update(self.default_params)
         return f"{self.base_dashboard_url}?{urllib.parse.urlencode(params)}"

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -1249,7 +1249,7 @@ class GroupDetailView(View):
     def generate_dashboard_url(self, group, envs):
         env_arg = '|'.join([f'{env.get("envName")}.{env.get("stageName")}' for env in envs])
         params = {
-            "tags": f"group={group},envs={env_arg}",
+            "tags": f"cluster={group},envs={env_arg}",
         }
         params.update(self.default_params)
         return f"{self.base_dashboard_url}?{urllib.parse.urlencode(params)}"

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -1247,7 +1247,7 @@ class GroupDetailView(View):
         })
 
     def generate_dashboard_url(self, group, envs):
-        env_arg = '|'.join([f'{env.get('envName')}.{env.get('stageName')}' for env in envs])
+        env_arg = '|'.join([f'{env.get("envName")}.{env.get("stageName")}' for env in envs])
         params = {
             "tags": f"group={group},envs={env_arg}",
         }

--- a/deploy-board/deploy_board/webapp/util_views.py
+++ b/deploy-board/deploy_board/webapp/util_views.py
@@ -160,7 +160,7 @@ def get_latency_metrics(request, group_name):
                                                                              "LAUNCH", settings.DEFAULT_START_TIME)
             json_data = []
             for data_point in launch_data_points:
-                timestamp, value = data_point["timestamp"], data_point["value"] / 1000
+                timestamp, value = data_point["timestamp"], data_point["value"]
                 json_data.append([timestamp, value])
             util_data[metric_name1] = json_data
 
@@ -169,7 +169,7 @@ def get_latency_metrics(request, group_name):
                                                                              "DEPLOY", settings.DEFAULT_START_TIME)
             json_data2 = []
             for data_point in deploy_data_points:
-                timestamp, value = data_point["timestamp"], data_point["value"] / 1000
+                timestamp, value = data_point["timestamp"], data_point["value"]
                 json_data2.append([timestamp, value])
             util_data[metric_name2] = json_data2
 
@@ -189,13 +189,13 @@ def get_launch_rate(request, group_name):
     try:
         util_data["metric_names"] = []
         for env in envs:
-            metric_name = "mimmax:rate:teletraan.{}.{}.first_deploy{{success=false}}".format(
+            metric_name = "zimsum:rate:teletraan.{}.{}.first_deploy{{success=false}}".format(
                 env["envName"], env["stageName"])
             rate_data_points = autoscaling_metrics_helper.get_raw_metrics(request, metric_name,
                                                                           settings.DEFAULT_START_TIME)
             json_data = []
             for data_point in rate_data_points:
-                timestamp, value = data_point["timestamp"], data_point["value"]
+                timestamp, value = data_point["timestamp"], data_point["value"] * 60
                 json_data.append([timestamp, value])
 
             util_data[metric_name] = json_data

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java
@@ -492,7 +492,7 @@ public class GoalAnalyst {
                 return hosts.get(0).getCreate_date();
             }
         } catch (Exception ex) {
-            LOG.info("Failed to get host with id {}", agent.getHost_id(), ex);
+            LOG.warn("Failed to get host with id {}", agent.getHost_id(), ex);
         }
 
         return null;

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java
@@ -435,7 +435,9 @@ public class GoalAnalyst {
             updateBean.setStart_date(agent.getStart_date());
         }
 
-        if (report.getDeployStage() == DeployStage.SERVING_BUILD && updateBean.getFirst_deploy()) {
+        if (Boolean.TRUE.equals(updateBean.getFirst_deploy())
+                && (report.getDeployStage() == DeployStage.SERVING_BUILD
+                        || updateBean.getState() == AgentState.PAUSED_BY_SYSTEM)) {
             // turn off first deploy flag
             updateBean.setFirst_deploy(false);
             updateBean.setFirst_deploy_time(currentTime);

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java
@@ -58,7 +58,8 @@ public class GoalAnalyst {
     private static final int ROLL_BACK_PRIORITY = DeployPriority.HIGHER.getValue() - 10;
     private static final String DEPLOY_LATENCY_TIMER_NAME =
             CUSTOM_NAME_PREFIX + "teletraan.%s.%s.deploy_latency";
-    private static final String LAUNCH_LATENCY_TIMER_NAME = "teletraan.%s.%s.launch_latency";
+    private static final String LAUNCH_LATENCY_TIMER_NAME =
+            CUSTOM_NAME_PREFIX + "teletraan.%s.%s.launch_latency";
     private static final String FIRST_DEPLOY_COUNTER_NAME =
             CUSTOM_NAME_PREFIX + "teletraan.%s.%s.first_deploy";
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java
@@ -436,8 +436,8 @@ public class GoalAnalyst {
         }
 
         if (Boolean.TRUE.equals(updateBean.getFirst_deploy())
-                && (report.getDeployStage() == DeployStage.SERVING_BUILD
-                        || updateBean.getState() == AgentState.PAUSED_BY_SYSTEM)) {
+                && (DeployStage.SERVING_BUILD.equals(report.getDeployStage())
+                        || AgentState.PAUSED_BY_SYSTEM.equals(updateBean.getState()))) {
             // turn off first deploy flag
             updateBean.setFirst_deploy(false);
             updateBean.setFirst_deploy_time(currentTime);

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/GoalAnalyst.java
@@ -466,7 +466,7 @@ public class GoalAnalyst {
                                     env.getEnv_name(),
                                     env.getStage_name()),
                             "success",
-                            String.valueOf(updateBean.getStatus().equals(AgentStatus.SUCCEEDED)))
+                            String.valueOf(AgentStatus.SUCCEEDED.equals(updateBean.getStatus())))
                     .increment();
 
             Long hostStartTime = estimateHostStartTime(updateBean);

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
@@ -861,6 +861,7 @@ public class PingHandler {
                         hostTagDAO,
                         deployDAO,
                         environDAO,
+                        hostDAO,
                         hostName,
                         hostId,
                         envs,

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/db/DBUtils.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/db/DBUtils.java
@@ -27,7 +27,7 @@ import org.apache.commons.dbcp.BasicDataSource;
 import org.testcontainers.containers.MySQLContainer;
 
 public class DBUtils {
-    private static final String MYSQL_IMAGE_NAME = "mysql:8.0";
+    private static final String MYSQL_IMAGE_NAME = "mysql:8.0-oracle";
     private static final String MYSQL_URL = "jdbc:mysql://0.0.0.0:3303/deploy?useSSL=false";
     public static String DATABASE_NAME = "deploy";
     public static String DATABASE_USER = "root";

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/db/DBUtils.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/db/DBUtils.java
@@ -27,7 +27,7 @@ import org.apache.commons.dbcp.BasicDataSource;
 import org.testcontainers.containers.MySQLContainer;
 
 public class DBUtils {
-    private static final String MYSQL_IMAGE_NAME = "mysql:8.0-oracle";
+    private static final String MYSQL_IMAGE_NAME = "mysql:8.0";
     private static final String MYSQL_URL = "jdbc:mysql://0.0.0.0:3303/deploy?useSSL=false";
     public static String DATABASE_NAME = "deploy";
     public static String DATABASE_USER = "root";

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/handler/GoalAnalystTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/handler/GoalAnalystTest.java
@@ -100,7 +100,8 @@ public class GoalAnalystTest {
         envs.put(envBean.getEnv_id(), envBean);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(
+                        null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 0);
@@ -120,7 +121,8 @@ public class GoalAnalystTest {
         reports.put(report.getEnvId(), report);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(
+                        null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 1);
@@ -143,7 +145,8 @@ public class GoalAnalystTest {
         agents.put(envBean.getEnv_id(), agent);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(
+                        null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 1);
@@ -161,7 +164,8 @@ public class GoalAnalystTest {
         reports.put(report.getEnvId(), report);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(
+                        null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 1);
@@ -180,7 +184,8 @@ public class GoalAnalystTest {
         reports.put(report.getEnvId(), report);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(
+                        null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 1);
@@ -208,7 +213,8 @@ public class GoalAnalystTest {
         agents.put(agent.getEnv_id(), agent);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(
+                        null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 1);
@@ -227,7 +233,8 @@ public class GoalAnalystTest {
         envs.put(envBean.getEnv_id(), envBean);
         // no report, no agents
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(
+                        null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 0);
@@ -251,7 +258,17 @@ public class GoalAnalystTest {
         Mockito.when(environDAO.getById("foo2")).thenReturn(envBean);
         GoalAnalyst analyst =
                 new GoalAnalyst(
-                        null, null, null, environDAO, null, "foo", "id-1", envs, reports, agents, null);
+                        null,
+                        null,
+                        null,
+                        environDAO,
+                        null,
+                        "foo",
+                        "id-1",
+                        envs,
+                        reports,
+                        agents,
+                        null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 0);
@@ -276,7 +293,17 @@ public class GoalAnalystTest {
         Mockito.when(environDAO.getById("foo2")).thenReturn(envBean2);
         GoalAnalyst analyst =
                 new GoalAnalyst(
-                        null, null, null, environDAO, null, "foo", "id-1", envs, reports, agents, null);
+                        null,
+                        null,
+                        null,
+                        environDAO,
+                        null,
+                        "foo",
+                        "id-1",
+                        envs,
+                        reports,
+                        agents,
+                        null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 0);
@@ -301,7 +328,8 @@ public class GoalAnalystTest {
         agent.setFirst_deploy(true);
         agents.put(agent.getEnv_id(), agent);
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(
+                        null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 1);
@@ -327,7 +355,8 @@ public class GoalAnalystTest {
         agent.setStart_date(0L);
         agents.put(agent.getEnv_id(), agent);
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(
+                        null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 1);
@@ -340,7 +369,8 @@ public class GoalAnalystTest {
 
         reports.get(report.getEnvId()).setDeployStage(DeployStage.SERVING_BUILD);
         GoalAnalyst analyst1 =
-                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(
+                        null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst1.analysis();
         assertEquals(analyst1.getNeedUpdateAgents().size(), 1);
         assertEquals(analyst1.getNeedDeleteAgentEnvIds().size(), 0);
@@ -363,7 +393,8 @@ public class GoalAnalystTest {
         agent.setStart_date(0L);
         agents.put(agent.getEnv_id(), agent);
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(
+                        null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 1);
@@ -390,7 +421,8 @@ public class GoalAnalystTest {
         agents.put(agent.getEnv_id(), agent);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(
+                        null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 1);
@@ -415,7 +447,8 @@ public class GoalAnalystTest {
         reports.put(report.getEnvId(), report);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(
+                        null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 1);
@@ -440,7 +473,8 @@ public class GoalAnalystTest {
         reports.put(report.getEnvId(), report);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(
+                        null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 1);
@@ -470,7 +504,8 @@ public class GoalAnalystTest {
         agents.put(agent.getEnv_id(), agent);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(
+                        null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 1);
@@ -496,7 +531,8 @@ public class GoalAnalystTest {
         reports.put(report.getEnvId(), report);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(
+                        null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 1);
@@ -527,7 +563,8 @@ public class GoalAnalystTest {
         agents.put(agent.getEnv_id(), agent);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(
+                        null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 1);
@@ -547,7 +584,8 @@ public class GoalAnalystTest {
         envs.put(envBean.getEnv_id(), envBean);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(
+                        null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 0);
@@ -569,7 +607,8 @@ public class GoalAnalystTest {
         agents.put(report.getEnvId(), agent);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(
+                        null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 1);
@@ -585,7 +624,8 @@ public class GoalAnalystTest {
         agents.put(agent.getEnv_id(), agent);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(
+                        null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 0);
@@ -610,7 +650,8 @@ public class GoalAnalystTest {
         Mockito.when(deployDAO.getById("bar")).thenReturn(deployBean);
         GoalAnalyst analyst =
                 new GoalAnalyst(
-                        null, null, deployDAO, null, null, "foo", "id-1", envs, reports, agents, null);
+                        null, null, deployDAO, null, null, "foo", "id-1", envs, reports, agents,
+                        null);
         analyst.analysis();
         Mockito.verify(deployDAO).getById("bar");
 
@@ -640,7 +681,8 @@ public class GoalAnalystTest {
         Mockito.when(deployDAO.getById("bar")).thenReturn(deployBean);
         GoalAnalyst analyst =
                 new GoalAnalyst(
-                        null, null, deployDAO, null, null, "foo", "id-1", envs, reports, agents, null);
+                        null, null, deployDAO, null, null, "foo", "id-1", envs, reports, agents,
+                        null);
         analyst.analysis();
 
         Mockito.verify(deployDAO).getById("bar");
@@ -829,7 +871,8 @@ public class GoalAnalystTest {
         agents.put(agent66.getEnv_id(), agent66);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(
+                        null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 13);
@@ -875,7 +918,8 @@ public class GoalAnalystTest {
         agents.put(agent1.getEnv_id(), agent1);
         agent1.setFirst_deploy(true);
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(
+                        null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         // Making sure the candidates are sorted as expected
@@ -886,7 +930,8 @@ public class GoalAnalystTest {
 
         envBean3.setDeploy_type(DeployType.ROLLBACK);
         analyst =
-                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(
+                        null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         // First deploy
@@ -898,7 +943,8 @@ public class GoalAnalystTest {
         agent1.setFirst_deploy(false);
 
         analyst =
-                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(
+                        null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
         candidates = analyst.getInstallCandidates();
         assertEquals(candidates.get(0).env.getEnv_id(), "e3");
@@ -996,7 +1042,8 @@ public class GoalAnalystTest {
         agents.put(agent24.getEnv_id(), agent24);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(
+                        null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
         assertEquals(analyst.getInstallCandidates().size(), 6);
 
@@ -1021,7 +1068,8 @@ public class GoalAnalystTest {
         reports.put(report.getEnvId(), report);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(
+                        null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 1);
@@ -1048,7 +1096,8 @@ public class GoalAnalystTest {
         reports.put(report.getEnvId(), report);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(
+                        null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 1);
@@ -1074,7 +1123,8 @@ public class GoalAnalystTest {
         reports.put(report.getEnvId(), report);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(
+                        null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 1);

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/handler/GoalAnalystTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/handler/GoalAnalystTest.java
@@ -100,7 +100,7 @@ public class GoalAnalystTest {
         envs.put(envBean.getEnv_id(), envBean);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 0);
@@ -120,7 +120,7 @@ public class GoalAnalystTest {
         reports.put(report.getEnvId(), report);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 1);
@@ -143,7 +143,7 @@ public class GoalAnalystTest {
         agents.put(envBean.getEnv_id(), agent);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 1);
@@ -161,7 +161,7 @@ public class GoalAnalystTest {
         reports.put(report.getEnvId(), report);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 1);
@@ -180,7 +180,7 @@ public class GoalAnalystTest {
         reports.put(report.getEnvId(), report);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 1);
@@ -208,7 +208,7 @@ public class GoalAnalystTest {
         agents.put(agent.getEnv_id(), agent);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 1);
@@ -227,7 +227,7 @@ public class GoalAnalystTest {
         envs.put(envBean.getEnv_id(), envBean);
         // no report, no agents
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 0);
@@ -251,7 +251,7 @@ public class GoalAnalystTest {
         Mockito.when(environDAO.getById("foo2")).thenReturn(envBean);
         GoalAnalyst analyst =
                 new GoalAnalyst(
-                        null, null, null, environDAO, "foo", "id-1", envs, reports, agents, null);
+                        null, null, null, environDAO, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 0);
@@ -276,7 +276,7 @@ public class GoalAnalystTest {
         Mockito.when(environDAO.getById("foo2")).thenReturn(envBean2);
         GoalAnalyst analyst =
                 new GoalAnalyst(
-                        null, null, null, environDAO, "foo", "id-1", envs, reports, agents, null);
+                        null, null, null, environDAO, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 0);
@@ -301,7 +301,7 @@ public class GoalAnalystTest {
         agent.setFirst_deploy(true);
         agents.put(agent.getEnv_id(), agent);
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 1);
@@ -327,7 +327,7 @@ public class GoalAnalystTest {
         agent.setStart_date(0L);
         agents.put(agent.getEnv_id(), agent);
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 1);
@@ -340,7 +340,7 @@ public class GoalAnalystTest {
 
         reports.get(report.getEnvId()).setDeployStage(DeployStage.SERVING_BUILD);
         GoalAnalyst analyst1 =
-                new GoalAnalyst(null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst1.analysis();
         assertEquals(analyst1.getNeedUpdateAgents().size(), 1);
         assertEquals(analyst1.getNeedDeleteAgentEnvIds().size(), 0);
@@ -363,7 +363,7 @@ public class GoalAnalystTest {
         agent.setStart_date(0L);
         agents.put(agent.getEnv_id(), agent);
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 1);
@@ -390,7 +390,7 @@ public class GoalAnalystTest {
         agents.put(agent.getEnv_id(), agent);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 1);
@@ -415,7 +415,7 @@ public class GoalAnalystTest {
         reports.put(report.getEnvId(), report);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 1);
@@ -440,7 +440,7 @@ public class GoalAnalystTest {
         reports.put(report.getEnvId(), report);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 1);
@@ -470,7 +470,7 @@ public class GoalAnalystTest {
         agents.put(agent.getEnv_id(), agent);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 1);
@@ -496,7 +496,7 @@ public class GoalAnalystTest {
         reports.put(report.getEnvId(), report);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 1);
@@ -527,7 +527,7 @@ public class GoalAnalystTest {
         agents.put(agent.getEnv_id(), agent);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 1);
@@ -547,7 +547,7 @@ public class GoalAnalystTest {
         envs.put(envBean.getEnv_id(), envBean);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 0);
@@ -569,7 +569,7 @@ public class GoalAnalystTest {
         agents.put(report.getEnvId(), agent);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 1);
@@ -585,7 +585,7 @@ public class GoalAnalystTest {
         agents.put(agent.getEnv_id(), agent);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 0);
@@ -610,7 +610,7 @@ public class GoalAnalystTest {
         Mockito.when(deployDAO.getById("bar")).thenReturn(deployBean);
         GoalAnalyst analyst =
                 new GoalAnalyst(
-                        null, null, deployDAO, null, "foo", "id-1", envs, reports, agents, null);
+                        null, null, deployDAO, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
         Mockito.verify(deployDAO).getById("bar");
 
@@ -640,7 +640,7 @@ public class GoalAnalystTest {
         Mockito.when(deployDAO.getById("bar")).thenReturn(deployBean);
         GoalAnalyst analyst =
                 new GoalAnalyst(
-                        null, null, deployDAO, null, "foo", "id-1", envs, reports, agents, null);
+                        null, null, deployDAO, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         Mockito.verify(deployDAO).getById("bar");
@@ -829,7 +829,7 @@ public class GoalAnalystTest {
         agents.put(agent66.getEnv_id(), agent66);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 13);
@@ -875,7 +875,7 @@ public class GoalAnalystTest {
         agents.put(agent1.getEnv_id(), agent1);
         agent1.setFirst_deploy(true);
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         // Making sure the candidates are sorted as expected
@@ -886,7 +886,7 @@ public class GoalAnalystTest {
 
         envBean3.setDeploy_type(DeployType.ROLLBACK);
         analyst =
-                new GoalAnalyst(null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         // First deploy
@@ -898,7 +898,7 @@ public class GoalAnalystTest {
         agent1.setFirst_deploy(false);
 
         analyst =
-                new GoalAnalyst(null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
         candidates = analyst.getInstallCandidates();
         assertEquals(candidates.get(0).env.getEnv_id(), "e3");
@@ -996,7 +996,7 @@ public class GoalAnalystTest {
         agents.put(agent24.getEnv_id(), agent24);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
         assertEquals(analyst.getInstallCandidates().size(), 6);
 
@@ -1021,7 +1021,7 @@ public class GoalAnalystTest {
         reports.put(report.getEnvId(), report);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 1);
@@ -1048,7 +1048,7 @@ public class GoalAnalystTest {
         reports.put(report.getEnvId(), report);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 1);
@@ -1074,7 +1074,7 @@ public class GoalAnalystTest {
         reports.put(report.getEnvId(), report);
 
         GoalAnalyst analyst =
-                new GoalAnalyst(null, null, null, null, "foo", "id-1", envs, reports, agents, null);
+                new GoalAnalyst(null, null, null, null, null, "foo", "id-1", envs, reports, agents, null);
         analyst.analysis();
 
         assertEquals(analyst.getNeedUpdateAgents().size(), 1);


### PR DESCRIPTION
## Changes

## TAS
Previously launch latency was emitted by a Rodimus worker. This PR implements the same measure in the TAS. 

Launch latency is defined as the duration from host launch to the the complete of the first deployment. It measures for all environments deployed on new hosts. The configuration **Launch grace period** is the user set threshold for this latency and it's used for AgentJanitor and Rodimus health check.

Another fix is that I found all first deploy metrics were success. So I updated the condition when the `first_deploy` flag should be turned off. 

## UI
While updating the group status page to include the launch latency, I realized I forgot that the original plan was to create a dashboard. So I removed the links added in #1694, created a dashboard including the changes in a new Teletraan user dashboard.

Fixed launch failure rate graph and updated some metrics calculations.

<img width="1641" alt="image" src="https://github.com/user-attachments/assets/ef62bb3b-7748-4afa-b66a-f0a89111f8b6">

## Test plan
### TAS
1. Deploy this PR to TAS dev1
2. Launch a new host in tyler/test
    - [x] Launch latency should be emitted 
    - [x] First deploy counter should increment with success=true.
4. Deploy a bad build to tyler/test
5. Launch a new host
    - [x] Launch latency should be emitted
    - [x] First deploy counter should increment with success=false.

### UI
1. Deploy this PR to deploy-board dev1
2. Visit group status page /groups/tyler-test/
    - [x] verify the link is updated and working