### PR TITLE
Show `publish_info` in base image UI

### DIFF
--- a/deploy-board/deploy_board/templates/clusters/base_image_info.tmpl
+++ b/deploy-board/deploy_board/templates/clusters/base_image_info.tmpl
@@ -34,6 +34,24 @@
             </td>
         </tr>
         <tr>
+            <td>Publish Info</td>
+            <td>
+                {% if current_image.publish_info  %}
+                    <a class="deployToolTip" data-toggle="tooltip"
+                        title="Click to see the details of jenkins build job"
+                        href='{{ current_image.publish_info }}'
+                    >
+                        <i class="fa fa-wrench"></i>
+                        Publisher Information
+                    </a>
+                {% else %}
+                    <span> <i class="fa fa-wrench"></i>
+                    Publisher Information
+                    </span>
+                {% endif %}
+            </td>
+        </tr>
+        <tr>
             <td>Golden Tags</td>
             <td>
                 {%if golden_latest %}


### PR DESCRIPTION
## Summary

The API for base images can expose a `publish_info` field. Display it if it exists.

This is similar to the "Publish Info" for Teletraan builds


## Screenshots

**Before**

![before](https://github.com/user-attachments/assets/3ed05d56-c367-449c-9a97-1cccc679c6b3)


**After**

![Screenshot 2024-08-15 at 8 22 32 AM](https://github.com/user-attachments/assets/117c7ce6-7cc3-4dbd-84c9-799458616e93)

