### PR TITLE
Pass pageSize (200) to call to get AMIs to get more images by default

### DIFF
--- a/deploy-board/deploy_board/webapp/helpers/baseimages_helper.py
+++ b/deploy-board/deploy_board/webapp/helpers/baseimages_helper.py
@@ -97,7 +97,7 @@ def get_by_name(request, name, cell_name):
     return rodimus_client.get("/base_images/names/%s" % name, request.teletraan_user_id.token, params=params)
 
 def get_acceptance_by_name(request, name, cell_name):
-    params = [('cellName', cell_name)]
+    params = [('cellName', cell_name), ('pageSize', 200)]
     return rodimus_client.get("/base_images/acceptances/%s" % name, request.teletraan_user_id.token, params=params)
 
 


### PR DESCRIPTION
The API used takes pageSize. Default page size is 100. Users not able to select 102th image, for example. Use bigger page size. Need to support paging (multiple requests) if the list is long. For now, increasing to 200.