### PR TITLE
Update AuthorizationFactory interface

### DIFF
--- a/deploy-service/pom.xml
+++ b/deploy-service/pom.xml
@@ -58,7 +58,7 @@
             <dependency>
                 <groupId>com.pinterest.teletraan</groupId>
                 <artifactId>universal</artifactId>
-                <version>2.2-SNAPSHOT</version>
+                <version>2.3-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.pinterest.teletraan</groupId>

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/AuthorizationFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/AuthorizationFactory.java
@@ -17,17 +17,24 @@ package com.pinterest.teletraan.config;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.pinterest.teletraan.TeletraanServiceContext;
+import com.pinterest.teletraan.universal.security.OpenAuthorizer;
 import com.pinterest.teletraan.universal.security.TeletraanAuthorizer;
 import com.pinterest.teletraan.universal.security.bean.TeletraanPrincipal;
+import io.dropwizard.auth.Authorizer;
 import io.dropwizard.jackson.Discoverable;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 public interface AuthorizationFactory extends Discoverable {
-    <P extends TeletraanPrincipal> TeletraanAuthorizer<P> create(TeletraanServiceContext context)
-            throws Exception;
+    <P extends TeletraanPrincipal> Authorizer<P> create(TeletraanServiceContext context);
 
-    default <P extends TeletraanPrincipal> TeletraanAuthorizer<? extends TeletraanPrincipal> create(
-            TeletraanServiceContext context, Class<P> principalClass) throws Exception {
+    default <P extends TeletraanPrincipal> Authorizer<P> create(
+            TeletraanServiceContext context, Class<P> principalClass) {
         return create(context);
+    }
+
+    /** Create a secondary authorizer for on-the-fly authorization. */
+    default TeletraanAuthorizer<TeletraanPrincipal> createSecondaryAuthorizer(
+            TeletraanServiceContext context, Class<? extends TeletraanPrincipal> principalClass) {
+        return new OpenAuthorizer();
     }
 }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/OpenAuthorizationFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/OpenAuthorizationFactory.java
@@ -17,31 +17,14 @@ package com.pinterest.teletraan.config;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.pinterest.teletraan.TeletraanServiceContext;
-import com.pinterest.teletraan.universal.security.TeletraanAuthorizer;
-import com.pinterest.teletraan.universal.security.bean.AuthZResource;
+import com.pinterest.teletraan.universal.security.OpenAuthorizer;
 import com.pinterest.teletraan.universal.security.bean.TeletraanPrincipal;
-import javax.annotation.Nullable;
-import javax.ws.rs.container.ContainerRequestContext;
+import io.dropwizard.auth.Authorizer;
 
 @JsonTypeName("open")
 public class OpenAuthorizationFactory implements AuthorizationFactory {
     @Override
-    public TeletraanAuthorizer<TeletraanPrincipal> create(TeletraanServiceContext context)
-            throws Exception {
-        return new TeletraanAuthorizer<TeletraanPrincipal>() {
-            @Override
-            public boolean authorize(TeletraanPrincipal principal, String resource) {
-                return true;
-            }
-
-            @Override
-            public boolean authorize(
-                    TeletraanPrincipal principal,
-                    String role,
-                    AuthZResource requestedResource,
-                    @Nullable ContainerRequestContext context) {
-                return true;
-            }
-        };
+    public Authorizer<TeletraanPrincipal> create(TeletraanServiceContext context) {
+        return new OpenAuthorizer();
     }
 }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/OpenAuthorizationFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/OpenAuthorizationFactory.java
@@ -17,14 +17,14 @@ package com.pinterest.teletraan.config;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.pinterest.teletraan.TeletraanServiceContext;
-import com.pinterest.teletraan.universal.security.OpenAuthorizer;
 import com.pinterest.teletraan.universal.security.bean.TeletraanPrincipal;
 import io.dropwizard.auth.Authorizer;
+import io.dropwizard.auth.PermitAllAuthorizer;
 
 @JsonTypeName("open")
 public class OpenAuthorizationFactory implements AuthorizationFactory {
     @Override
     public Authorizer<TeletraanPrincipal> create(TeletraanServiceContext context) {
-        return new OpenAuthorizer();
+        return new PermitAllAuthorizer<>();
     }
 }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/RoleAuthorizationFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/RoleAuthorizationFactory.java
@@ -20,29 +20,30 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.pinterest.teletraan.TeletraanServiceContext;
 import com.pinterest.teletraan.security.ScriptTokenRoleAuthorizer;
 import com.pinterest.teletraan.security.UserRoleAuthorizer;
-import com.pinterest.teletraan.universal.security.TeletraanAuthorizer;
-import com.pinterest.teletraan.universal.security.bean.ServicePrincipal;
+import com.pinterest.teletraan.universal.security.bean.ScriptTokenPrincipal;
 import com.pinterest.teletraan.universal.security.bean.TeletraanPrincipal;
 import com.pinterest.teletraan.universal.security.bean.UserPrincipal;
+import io.dropwizard.auth.Authorizer;
 
 @JsonTypeName("role")
 public class RoleAuthorizationFactory implements AuthorizationFactory {
     @JsonProperty private String roleCacheSpec; // Unused, for backwards compatibility
 
     @Override
-    public <P extends TeletraanPrincipal> TeletraanAuthorizer<P> create(
-            TeletraanServiceContext context) throws Exception {
+    public <P extends TeletraanPrincipal> Authorizer<P> create(TeletraanServiceContext context) {
         throw new UnsupportedOperationException(
                 "RoleAuthorizationFactory does not support this method. Use create(TeletraanServiceContext, Class<P>) instead.");
     }
 
     @Override
-    public <P extends TeletraanPrincipal> TeletraanAuthorizer<? extends TeletraanPrincipal> create(
-            TeletraanServiceContext context, Class<P> principalClass) throws Exception {
-        if (ServicePrincipal.class.equals(principalClass)) {
-            return new ScriptTokenRoleAuthorizer(context.getAuthZResourceExtractorFactory());
+    public <P extends TeletraanPrincipal> Authorizer<P> create(
+            TeletraanServiceContext context, Class<P> principalClass) {
+        if (ScriptTokenPrincipal.class.equals(principalClass)) {
+            return (Authorizer<P>)
+                    new ScriptTokenRoleAuthorizer(context.getAuthZResourceExtractorFactory());
         } else if (UserPrincipal.class.equals(principalClass)) {
-            return new UserRoleAuthorizer(context, context.getAuthZResourceExtractorFactory());
+            return (Authorizer<P>)
+                    new UserRoleAuthorizer(context, context.getAuthZResourceExtractorFactory());
         }
         throw new UnsupportedOperationException("Unsupported principal class: " + principalClass);
     }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/TokenAuthenticationFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/TokenAuthenticationFactory.java
@@ -24,7 +24,6 @@ import com.pinterest.teletraan.security.TeletraanScriptTokenProvider;
 import com.pinterest.teletraan.universal.security.OAuthAuthenticator;
 import com.pinterest.teletraan.universal.security.ScriptTokenAuthenticator;
 import com.pinterest.teletraan.universal.security.bean.ScriptTokenPrincipal;
-import com.pinterest.teletraan.universal.security.bean.ServicePrincipal;
 import com.pinterest.teletraan.universal.security.bean.UserPrincipal;
 import com.pinterest.teletraan.universal.security.bean.ValueBasedRole;
 import io.dropwizard.auth.AuthFilter;
@@ -117,15 +116,15 @@ public class TokenAuthenticationFactory implements AuthenticationFactory {
                 .setAuthenticator(scriptTokenAuthenticator)
                 .setAuthorizer(
                         (Authorizer<ScriptTokenPrincipal<ValueBasedRole>>)
-                                context.getAuthorizationFactory()
-                                        .create(context, ServicePrincipal.class))
+                                (Authorizer<?>)
+                                        context.getAuthorizationFactory()
+                                                .create(context, ScriptTokenPrincipal.class))
                 .setPrefix("token")
                 .setUnauthorizedHandler(new JSONUnauthorizedHandler())
                 .buildAuthFilter();
     }
 
     // TODO: CDP-7837 remove this after all the clients are updated to use the new token scheme
-    @SuppressWarnings({"unchecked"})
     AuthFilter<String, UserPrincipal> createOauthTokenAuthFilter(TeletraanServiceContext context)
             throws Exception {
         Authenticator<String, UserPrincipal> oauthAuthenticator =
@@ -140,15 +139,12 @@ public class TokenAuthenticationFactory implements AuthenticationFactory {
         return new OAuthCredentialAuthFilter.Builder<UserPrincipal>()
                 .setAuthenticator(oauthAuthenticator)
                 .setAuthorizer(
-                        (Authorizer<UserPrincipal>)
-                                context.getAuthorizationFactory()
-                                        .create(context, UserPrincipal.class))
+                        context.getAuthorizationFactory().create(context, UserPrincipal.class))
                 .setPrefix("token")
                 .setUnauthorizedHandler(new JSONUnauthorizedHandler())
                 .buildAuthFilter();
     }
 
-    @SuppressWarnings({"unchecked"})
     AuthFilter<String, UserPrincipal> createJwtTokenAuthFilter(TeletraanServiceContext context)
             throws Exception {
         Authenticator<String, UserPrincipal> oauthJwtAuthenticator =
@@ -163,9 +159,7 @@ public class TokenAuthenticationFactory implements AuthenticationFactory {
         return new OAuthCredentialAuthFilter.Builder<UserPrincipal>()
                 .setAuthenticator(oauthJwtAuthenticator)
                 .setAuthorizer(
-                        (Authorizer<UserPrincipal>)
-                                context.getAuthorizationFactory()
-                                        .create(context, UserPrincipal.class))
+                        context.getAuthorizationFactory().create(context, UserPrincipal.class))
                 .setPrefix("Bearer")
                 .setUnauthorizedHandler(new JSONUnauthorizedHandler())
                 .buildAuthFilter();

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/TokenAuthenticationFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/TokenAuthenticationFactory.java
@@ -33,6 +33,7 @@ import io.dropwizard.auth.CachingAuthenticator;
 import io.dropwizard.auth.JSONUnauthorizedHandler;
 import io.dropwizard.auth.chained.ChainedAuthFilter;
 import io.dropwizard.auth.oauth.OAuthCredentialAuthFilter;
+import java.net.MalformedURLException;
 import java.util.Arrays;
 import javax.validation.constraints.NotEmpty;
 import javax.ws.rs.container.ContainerRequestFilter;
@@ -102,7 +103,7 @@ public class TokenAuthenticationFactory implements AuthenticationFactory {
 
     @SuppressWarnings({"unchecked"})
     AuthFilter<String, ScriptTokenPrincipal<ValueBasedRole>> createScriptTokenAuthFilter(
-            TeletraanServiceContext context) throws Exception {
+            TeletraanServiceContext context) {
         Authenticator<String, ScriptTokenPrincipal<ValueBasedRole>> scriptTokenAuthenticator =
                 new ScriptTokenAuthenticator<>(new TeletraanScriptTokenProvider(context));
         if (StringUtils.isNotBlank(getTokenCacheSpec())) {
@@ -126,7 +127,7 @@ public class TokenAuthenticationFactory implements AuthenticationFactory {
 
     // TODO: CDP-7837 remove this after all the clients are updated to use the new token scheme
     AuthFilter<String, UserPrincipal> createOauthTokenAuthFilter(TeletraanServiceContext context)
-            throws Exception {
+            throws MalformedURLException {
         Authenticator<String, UserPrincipal> oauthAuthenticator =
                 new OAuthAuthenticator(getUserDataUrl(), getGroupDataUrl());
         if (StringUtils.isNotBlank(getTokenCacheSpec())) {
@@ -146,7 +147,7 @@ public class TokenAuthenticationFactory implements AuthenticationFactory {
     }
 
     AuthFilter<String, UserPrincipal> createJwtTokenAuthFilter(TeletraanServiceContext context)
-            throws Exception {
+            throws MalformedURLException {
         Authenticator<String, UserPrincipal> oauthJwtAuthenticator =
                 new OAuthAuthenticator(getUserDataUrl(), getGroupDataUrl());
         if (StringUtils.isNotBlank(getTokenCacheSpec())) {

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvCapacities.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvCapacities.java
@@ -233,8 +233,7 @@ public class EnvCapacities {
             EnvironBean targetEnvironBean,
             Principal principal,
             CapacityType capacityType,
-            List<String> capacities)
-            throws Exception {
+            List<String> capacities) {
         if (isSidecarEnvironment(targetEnvironBean)) {
             // Allow sidecars to add capacity
             return;
@@ -243,15 +242,15 @@ public class EnvCapacities {
         if (!(principal instanceof TeletraanPrincipal)) {
             throw new UnsupportedOperationException("Only TeletraanPrincipal is allowed");
         }
-        HashSet<AuthZResource> resources = getCapacityMainEnvironments(capacityType, capacities);
+        TeletraanPrincipal teletraanPrincipal = (TeletraanPrincipal) principal;
+        TeletraanAuthorizer<TeletraanPrincipal> authorizer =
+                authorizationFactory.createSecondaryAuthorizer(
+                        context, teletraanPrincipal.getClass());
 
-        TeletraanAuthorizer<TeletraanPrincipal> authorizer = authorizationFactory.create(context);
+        HashSet<AuthZResource> resources = getCapacityMainEnvironments(capacityType, capacities);
         for (AuthZResource resource : resources) {
             if (!authorizer.authorize(
-                    (TeletraanPrincipal) principal,
-                    TeletraanPrincipalRole.Names.WRITE,
-                    resource,
-                    null)) {
+                    teletraanPrincipal, TeletraanPrincipalRole.Names.WRITE, resource, null)) {
                 throw new ForbiddenException(
                         String.format(
                                 "Principal %s is not allowed to modify capacity owned by env %s",

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/config/RoleAuthorizationFactoryTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/config/RoleAuthorizationFactoryTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.pinterest.teletraan.TeletraanServiceContext;
 import com.pinterest.teletraan.security.ScriptTokenRoleAuthorizer;
 import com.pinterest.teletraan.security.UserRoleAuthorizer;
+import com.pinterest.teletraan.universal.security.bean.ScriptTokenPrincipal;
 import com.pinterest.teletraan.universal.security.bean.ServicePrincipal;
 import com.pinterest.teletraan.universal.security.bean.TeletraanPrincipal;
 import com.pinterest.teletraan.universal.security.bean.UserPrincipal;
@@ -40,19 +41,28 @@ class RoleAuthorizationFactoryTest {
     }
 
     @Test
-    void testCreate_servicePrincipal() throws Exception {
-        assertEquals(
-                ScriptTokenRoleAuthorizer.class,
-                sut.create(context, ServicePrincipal.class).getClass());
+    void testCreate_servicePrincipal() {
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> {
+                    sut.create(context, ServicePrincipal.class);
+                });
     }
 
     @Test
-    void testCreate_userPrincipal() throws Exception {
+    void testCreate_scriptTokenPrincipal() {
+        assertEquals(
+                ScriptTokenRoleAuthorizer.class,
+                sut.create(context, ScriptTokenPrincipal.class).getClass());
+    }
+
+    @Test
+    void testCreate_userPrincipal() {
         assertEquals(UserRoleAuthorizer.class, sut.create(context, UserPrincipal.class).getClass());
     }
 
     @Test
-    void testCreate_otherPrincipal() throws Exception {
+    void testCreate_otherPrincipal() {
         assertThrows(
                 UnsupportedOperationException.class,
                 () -> {

--- a/deploy-service/universal/pom.xml
+++ b/deploy-service/universal/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>com.pinterest.teletraan</groupId>
   <artifactId>universal</artifactId>
-  <version>2.2-SNAPSHOT</version>
+  <version>2.3-SNAPSHOT</version>
 
   <name>Teletraan platform universal components</name>
   <url>https://github.com/pinterest/teletraan/</url>

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/BaseAuthorizer.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/BaseAuthorizer.java
@@ -19,6 +19,7 @@ import com.pinterest.teletraan.universal.security.AuthZResourceExtractor.BeanCla
 import com.pinterest.teletraan.universal.security.AuthZResourceExtractor.ExtractionException;
 import com.pinterest.teletraan.universal.security.bean.AuthZResource;
 import com.pinterest.teletraan.universal.security.bean.TeletraanPrincipal;
+import io.dropwizard.auth.Authorizer;
 import javax.annotation.Nullable;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.ContainerRequestContext;
@@ -34,7 +35,7 @@ import lombok.extern.slf4j.Slf4j;
 @AllArgsConstructor
 @Slf4j
 public abstract class BaseAuthorizer<P extends TeletraanPrincipal>
-        implements TeletraanAuthorizer<P> {
+        implements TeletraanAuthorizer<P>, Authorizer<P> {
     protected final AuthZResourceExtractor.Factory extractorFactory;
 
     @Override

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/BasePastisAuthorizer.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/BasePastisAuthorizer.java
@@ -36,7 +36,7 @@ import lombok.extern.slf4j.Slf4j;
  * @param <P> the principal type
  */
 @Slf4j
-public class BasePastisAuthorizer<P extends TeletraanPrincipal> extends BaseAuthorizer<P> {
+public class BasePastisAuthorizer extends BaseAuthorizer<TeletraanPrincipal> {
     private static final String INPUT = "input";
     protected final PastisAuthorizer pastis;
 
@@ -62,7 +62,7 @@ public class BasePastisAuthorizer<P extends TeletraanPrincipal> extends BaseAuth
 
     @Override
     public boolean authorize(
-            P principal,
+            TeletraanPrincipal principal,
             String role,
             AuthZResource requestedResource,
             @Nullable ContainerRequestContext context) {

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/DenyAllAuthorizer.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/DenyAllAuthorizer.java
@@ -17,13 +17,23 @@ package com.pinterest.teletraan.universal.security;
 
 import com.pinterest.teletraan.universal.security.bean.AuthZResource;
 import com.pinterest.teletraan.universal.security.bean.TeletraanPrincipal;
+import io.dropwizard.auth.Authorizer;
 import javax.annotation.Nullable;
 import javax.ws.rs.container.ContainerRequestContext;
 
-public interface TeletraanAuthorizer<P extends TeletraanPrincipal> {
-    boolean authorize(
-            P principal,
+public class DenyAllAuthorizer
+        implements TeletraanAuthorizer<TeletraanPrincipal>, Authorizer<TeletraanPrincipal> {
+    @Override
+    public boolean authorize(
+            TeletraanPrincipal principal,
             String role,
             AuthZResource requestedResource,
-            @Nullable ContainerRequestContext context);
+            @Nullable ContainerRequestContext context) {
+        return false;
+    }
+
+    @Override
+    public boolean authorize(TeletraanPrincipal principal, String role) {
+        return false;
+    }
 }

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/DenyAllAuthorizer.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/DenyAllAuthorizer.java
@@ -17,23 +17,16 @@ package com.pinterest.teletraan.universal.security;
 
 import com.pinterest.teletraan.universal.security.bean.AuthZResource;
 import com.pinterest.teletraan.universal.security.bean.TeletraanPrincipal;
-import io.dropwizard.auth.Authorizer;
 import javax.annotation.Nullable;
 import javax.ws.rs.container.ContainerRequestContext;
 
-public class DenyAllAuthorizer
-        implements TeletraanAuthorizer<TeletraanPrincipal>, Authorizer<TeletraanPrincipal> {
+public class DenyAllAuthorizer implements TeletraanAuthorizer<TeletraanPrincipal> {
     @Override
     public boolean authorize(
             TeletraanPrincipal principal,
             String role,
             AuthZResource requestedResource,
             @Nullable ContainerRequestContext context) {
-        return false;
-    }
-
-    @Override
-    public boolean authorize(TeletraanPrincipal principal, String role) {
         return false;
     }
 }

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/OpenAuthorizer.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/OpenAuthorizer.java
@@ -17,23 +17,16 @@ package com.pinterest.teletraan.universal.security;
 
 import com.pinterest.teletraan.universal.security.bean.AuthZResource;
 import com.pinterest.teletraan.universal.security.bean.TeletraanPrincipal;
-import io.dropwizard.auth.Authorizer;
 import javax.annotation.Nullable;
 import javax.ws.rs.container.ContainerRequestContext;
 
-public class OpenAuthorizer
-        implements TeletraanAuthorizer<TeletraanPrincipal>, Authorizer<TeletraanPrincipal> {
+public class OpenAuthorizer implements TeletraanAuthorizer<TeletraanPrincipal> {
     @Override
     public boolean authorize(
             TeletraanPrincipal principal,
             String role,
             AuthZResource requestedResource,
             @Nullable ContainerRequestContext context) {
-        return true;
-    }
-
-    @Override
-    public boolean authorize(TeletraanPrincipal principal, String role) {
         return true;
     }
 }

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/OpenAuthorizer.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/OpenAuthorizer.java
@@ -17,13 +17,23 @@ package com.pinterest.teletraan.universal.security;
 
 import com.pinterest.teletraan.universal.security.bean.AuthZResource;
 import com.pinterest.teletraan.universal.security.bean.TeletraanPrincipal;
+import io.dropwizard.auth.Authorizer;
 import javax.annotation.Nullable;
 import javax.ws.rs.container.ContainerRequestContext;
 
-public interface TeletraanAuthorizer<P extends TeletraanPrincipal> {
-    boolean authorize(
-            P principal,
+public class OpenAuthorizer
+        implements TeletraanAuthorizer<TeletraanPrincipal>, Authorizer<TeletraanPrincipal> {
+    @Override
+    public boolean authorize(
+            TeletraanPrincipal principal,
             String role,
             AuthZResource requestedResource,
-            @Nullable ContainerRequestContext context);
+            @Nullable ContainerRequestContext context) {
+        return true;
+    }
+
+    @Override
+    public boolean authorize(TeletraanPrincipal principal, String role) {
+        return true;
+    }
 }

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/BasePastisAuthorizerTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/BasePastisAuthorizerTest.java
@@ -60,17 +60,19 @@ class BasePastisAuthorizerTest {
     private static PastisAuthorizer pastis;
     private static AuthZResourceExtractor.Factory factory;
 
+    private BasePastisAuthorizer sut;
+
     @BeforeEach
     public void setUp() {
         context = mock(ContainerRequestContext.class);
         pastis = mock(PastisAuthorizer.class);
         factory = mock(AuthZResourceExtractor.Factory.class);
+        sut = new BasePastisAuthorizer(pastis, factory);
     }
 
     @ParameterizedTest
     @ValueSource(strings = {ACTION_READ, ACTION_WRITE})
     void testAuthorize_userPrincipal(String action) {
-        BasePastisAuthorizer<UserPrincipal> sut = new BasePastisAuthorizer<>(pastis, factory);
         UserPrincipal principal = new UserPrincipal(PRINCIPAL_NAME, Arrays.asList(GROUP_NAME));
         sut.authorize(principal, action, resource, context);
         verify(pastis)
@@ -87,7 +89,6 @@ class BasePastisAuthorizerTest {
 
     @Test
     void testAuthorize_userPrincipal_failure() {
-        BasePastisAuthorizer<UserPrincipal> sut = new BasePastisAuthorizer<>(pastis, factory);
         UserPrincipal principal = new UserPrincipal(PRINCIPAL_NAME, Arrays.asList(GROUP_NAME));
         when(pastis.authorize(anyString())).thenThrow(new RuntimeException());
         assertFalse(sut.authorize(principal, ACTION_READ, resource, context));
@@ -96,7 +97,6 @@ class BasePastisAuthorizerTest {
     @ParameterizedTest
     @ValueSource(strings = {ACTION_READ, ACTION_WRITE})
     void testAuthorize_servicePrincipal(String action) {
-        BasePastisAuthorizer<ServicePrincipal> sut = new BasePastisAuthorizer<>(pastis, factory);
         ServicePrincipal principal = new ServicePrincipal(SPIFFE_ID);
         sut.authorize(principal, action, resource, context);
         verify(pastis)
@@ -120,7 +120,6 @@ class BasePastisAuthorizerTest {
     @ParameterizedTest
     @ValueSource(strings = {ACTION_READ, ACTION_WRITE})
     void testAuthorize_payloadContainsOptionalFields(String action) {
-        BasePastisAuthorizer<UserPrincipal> sut = new BasePastisAuthorizer<>(pastis, factory);
         UserPrincipal principal = new UserPrincipal(PRINCIPAL_NAME, Arrays.asList(GROUP_NAME));
         sut.authorize(principal, action, resourceWithOptionalFields, context);
         verify(pastis)


### PR DESCRIPTION
Update `AuthorizationFactory` interface to make it more secure.

## The issues

### Wrong method invoked during on-the-fly authorization
```java
TeletraanAuthorizer<TeletraanPrincipal> authorizer = authorizationFactory.create(context);
```
When `CompositeAuthorizationFactory` is configured, this always returns the `BasePastisAuthorizer`. It is a problem because `ScriptTokenPrincipal` can only be authorized by `ScriptTokenRoleAuthorizer`, otherwise illegal access is possible. It was prevented before the introduction of on-the-fly authorization via bundling the authenticator and the authorizer in the auth filter creation. 

### `AuthorizationFactory` interface
The interface of `AuthorizationFactory` makes it possible get wrong authorizer. 
```java
<P extends TeletraanPrincipal> TeletraanAuthorizer<P> create(TeletraanServiceContext context)
            throws Exception;
```

## Fixes

### Dissociate `TeletraanAuthorizer` and `Authorizer` interfaces. 
`TeletraanAuthorizer` stops extending `Authorizer`. All authorizers implementing `TeletraanAuthorizer` now need to implement `TeletraanAuthorizer` and `Authorizer` respectively.

### New method in `AuthorizationFactory`
The existing methods are updated to return `Authorizer`.
```java
<P extends TeletraanPrincipal> Authorizer<P> create(TeletraanServiceContext context);
```

Introduced a new method to return `TeletraanAuthorizer`.

### Call new method in `EnvCapacities`
```java
authorizationFactory.createSecondaryAuthorizer(
                        context, teletraanPrincipal.getClass());
```
And it's the only option now, no way to be mistaken.

