### PR TITLE
Fix resource name typo in auth schema

### DIFF
--- a/docs/auth/teletraan_auth.yaml
+++ b/docs/auth/teletraan_auth.yaml
@@ -77,7 +77,7 @@ definitions:
           - ENV_STAGE
           - GROUP
           - SYSTEM
-          - PLACEMENTS
+          - PLACEMENT
           - BASE_IMAGE
           - SECURITY_ZONE
           - IAM_ROLE


### PR DESCRIPTION
It should be `PLACEMENT`: https://github.com/pinterest/teletraan/blob/a74e37d058bffa4dbcb1c9f8e20736492b153203/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/AuthZResource.java#L105