### PR TITLE
added stage-type badges to teletraan environments page

### DIFF
--- a/deploy-board/deploy_board/static/css/deploy-board.css
+++ b/deploy-board/deploy_board/static/css/deploy-board.css
@@ -343,6 +343,16 @@ body {
   margin-top: 3px;
 }
 
+.stage-type-badge {
+  display: inline-block;
+  border-style: solid;
+  border-radius: 25px;
+  border-color: #ccc;
+  padding-left: 5px;
+  padding-right: 5px;
+  background-color: #fff;
+}
+
 .mr-1 {
   margin-right: 5px;
 }

--- a/deploy-board/deploy_board/templates/environs/env_landing.html
+++ b/deploy-board/deploy_board/templates/environs/env_landing.html
@@ -372,6 +372,9 @@ $('#privateBldUploadBtnId button').click(function () {
                 </div>
                 {% endif %}
             {% endif %}
+            <h6 class="stage-type-badge">
+                {{env.stageType|default:"NO STAGE TYPE"}}
+            </h6>
             <div class="btn-group pull-right">
                 {% if has_deploy and env|isEnvEnabled %}
                 <a href="/env/{{ env.envName }}/{{ env.stageName }}/rollback"


### PR DESCRIPTION
canary: 
* <img width="1415" alt="canary badge" src="https://github.com/user-attachments/assets/74bc5aa3-af5b-42d6-bb09-e98e6499302b">

control:
* <img width="1418" alt="control badge" src="https://github.com/user-attachments/assets/a5282de6-677d-4848-8c3e-d24510145a82">

dev:
* <img width="1434" alt="dev badge" src="https://github.com/user-attachments/assets/bb63778b-6190-48db-8dc8-6d272d0c74ba">

latest:
* <img width="1428" alt="latest badge" src="https://github.com/user-attachments/assets/4103caf4-b6a5-4afe-8d4a-4f5ecc292117">

production:
* <img width="1429" alt="production badge" src="https://github.com/user-attachments/assets/183dcf9d-f295-4f0a-abf7-2d96357ecb17">


staging: 
* <img width="1428" alt="staging badge" src="https://github.com/user-attachments/assets/ac34ce9e-feb0-44a8-8a10-cbd59c92fb03">
