### PR TITLE
 Hide 'Backup host types in order: None' text if the feature is disabled

### DIFF
--- a/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
+++ b/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
@@ -579,7 +579,7 @@ Vue.component('backup-hosttypes', {
     template: '<div class="form-group" v-if="isVisible">\
     <div class="col-xs-2"></div>\
     <div class="col-xs-8">\
-        <span class="col-xs-8" style="padding:0;" v-if="isVisible">Backup Host Types In Order: {{backuphosttypes}}</span>\
+        <span class="col-xs-8" style="padding:0;">Backup Host Types In Order: {{backuphosttypes}}</span>\
     </div>\
     </div>',
     props: ['backuphosttypes'],

--- a/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
+++ b/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
@@ -579,11 +579,13 @@ Vue.component('backup-hosttypes', {
     template: '<div class="form-group" v-if="isVisible">\
     <div class="col-xs-2"></div>\
     <div class="col-xs-8">\
-        <span class="col-xs-8" style="padding:0;">Backup Host Types In Order: {{backuphosttypes}}</span>\
+        <span class="col-xs-8" style="padding:0;" v-if="isVisible">Backup Host Types In Order: {{backuphosttypes}}</span>\
     </div>\
     </div>',
     props: ['backuphosttypes'],
     data: function () {
+        console.log(this.backuphosttypes);
+        console.log(this.backuphosttypes === 'None');
         return {
             isVisible: this.backuphosttypes === 'None' ? false : true
         }

--- a/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
+++ b/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
@@ -576,13 +576,18 @@ Vue.component('remaining-capacity', {
 });
 
 Vue.component('backup-hosttypes', {
-    template: '<div class="form-group">\
+    template: '<div class="form-group" v-if="isVisible">\
     <div class="col-xs-2"></div>\
     <div class="col-xs-8">\
         <span class="col-xs-8" style="padding:0;">Backup Host Types In Order: {{backuphosttypes}}</span>\
     </div>\
     </div>',
-    props: ['backuphosttypes']
+    props: ['backuphosttypes'],
+    data: function () {
+        return {
+            isVisible: this.backuphosttypes === 'None' ? false : true
+        }
+    }
 });
 
 Vue.component("accessrole-input", {

--- a/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
+++ b/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
@@ -583,11 +583,11 @@ Vue.component('backup-hosttypes', {
     </div>\
     </div>',
     props: ['backuphosttypes'],
-    data: function () {
-        console.log(this.backuphosttypes);
-        console.log(this.backuphosttypes === 'None');
-        return {
-            isVisible: this.backuphosttypes === 'None' ? false : true
+    computed: {
+        isVisible: function () {
+            console.log(this.backuphosttypes);
+            console.log(this.backuphosttypes === 'None');
+            return this.backuphosttypes === 'None' ? false : true
         }
     }
 });

--- a/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
+++ b/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
@@ -585,8 +585,6 @@ Vue.component('backup-hosttypes', {
     props: ['backuphosttypes'],
     computed: {
         isVisible: function () {
-            console.log(this.backuphosttypes);
-            console.log(this.backuphosttypes === 'None');
             return this.backuphosttypes === 'None' ? false : true
         }
     }

--- a/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
+++ b/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
@@ -585,7 +585,7 @@ Vue.component('backup-hosttypes', {
     props: ['backuphosttypes'],
     computed: {
         isVisible: function () {
-            return this.backuphosttypes === 'None' ? false : true
+            return this.backuphosttypes !== 'None'
         }
     }
 });


### PR DESCRIPTION
Reasoning: Not many users will have this enabled
