### PR TITLE
Add an auth filter for PinDeploy pipeline

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/AgentBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/AgentBean.java
@@ -161,7 +161,7 @@ public class AgentBean extends BaseBean implements Updatable {
     }
 
     public void setLast_operator(String last_operator) {
-        this.last_operator = getStringWithSizeLimit(last_operator, 64);
+        this.last_operator = getStringWithinSizeLimit(last_operator, 64);
     }
 
     public Boolean getFirst_deploy() {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/AgentBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/AgentBean.java
@@ -18,7 +18,7 @@ package com.pinterest.deployservice.bean;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
-public class AgentBean implements Updatable {
+public class AgentBean extends BaseBean implements Updatable {
 
     @JsonProperty("hostId")
     private String host_id;
@@ -161,7 +161,7 @@ public class AgentBean implements Updatable {
     }
 
     public void setLast_operator(String last_operator) {
-        this.last_operator = last_operator;
+        this.last_operator = getStringWithSizeLimit(last_operator, 64);
     }
 
     public Boolean getFirst_deploy() {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/BaseBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/BaseBean.java
@@ -12,7 +12,7 @@ public class BaseBean {
      * @return the trimmed string if the input string's length exceeds the limit,
      *         otherwise the original string
      */
-    protected String getStringWithSizeLimit(String value, int limit) {
+    protected String getStringWithinSizeLimit(String value, int limit) {
         if (value != null && value.length() > limit) {
             return value.substring(value.length() - limit, value.length());
         }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/BaseBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/BaseBean.java
@@ -1,0 +1,21 @@
+package com.pinterest.deployservice.bean;
+
+public class BaseBean {
+
+    /**
+     * Trims the input string to the specified size limit. If the input string's length
+     * exceeds the limit, the method returns the substring from the end of the string
+     * with the specified limit. Otherwise returns the original string.
+     *
+     * @param value the input string to be trimmed
+     * @param limit the maximum length of the returned string
+     * @return the trimmed string if the input string's length exceeds the limit,
+     *         otherwise the original string
+     */
+    protected String getStringWithSizeLimit(String value, int limit) {
+        if (value != null && value.length() > limit) {
+            return value.substring(value.length() - limit, value.length());
+        }
+        return value;
+    }
+}

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/ConfigHistoryBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/ConfigHistoryBean.java
@@ -62,7 +62,7 @@ public class ConfigHistoryBean extends BaseBean implements Updatable {
     }
 
     public void setOperator(String operator) {
-        this.operator = getStringWithSizeLimit(operator, 64);
+        this.operator = getStringWithinSizeLimit(operator, 64);
     }
 
     public String getOperator() {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/ConfigHistoryBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/ConfigHistoryBean.java
@@ -18,7 +18,7 @@ package com.pinterest.deployservice.bean;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
-public class ConfigHistoryBean implements Updatable {
+public class ConfigHistoryBean extends BaseBean implements Updatable {
     @JsonProperty("id")
     private String config_id;
 
@@ -62,7 +62,7 @@ public class ConfigHistoryBean implements Updatable {
     }
 
     public void setOperator(String operator) {
-        this.operator = operator;
+        this.operator = getStringWithSizeLimit(operator, 64);
     }
 
     public String getOperator() {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/DataBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/DataBean.java
@@ -17,7 +17,7 @@ package com.pinterest.deployservice.bean;
 
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
-public class DataBean implements Updatable {
+public class DataBean extends BaseBean implements Updatable {
     private String data_id;
     // TODO deprecate data_kind, we should use json all the time
     private String data_kind;
@@ -46,7 +46,7 @@ public class DataBean implements Updatable {
     }
 
     public void setOperator(String operator) {
-        this.operator = operator;
+        this.operator = getStringWithSizeLimit(operator, 64);
     }
 
     public String getData() {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/DataBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/DataBean.java
@@ -46,7 +46,7 @@ public class DataBean extends BaseBean implements Updatable {
     }
 
     public void setOperator(String operator) {
-        this.operator = getStringWithSizeLimit(operator, 64);
+        this.operator = getStringWithinSizeLimit(operator, 64);
     }
 
     public String getData() {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/DeployBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/DeployBean.java
@@ -18,7 +18,7 @@ package com.pinterest.deployservice.bean;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
-public class DeployBean implements Updatable {
+public class DeployBean extends BaseBean implements Updatable {
     @JsonProperty("id")
     private String deploy_id;
 
@@ -107,7 +107,7 @@ public class DeployBean implements Updatable {
     }
 
     public void setOperator(String operator) {
-        this.operator = operator;
+        this.operator = getStringWithSizeLimit(operator, 64);
     }
 
     public Long getLast_update() {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/DeployBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/DeployBean.java
@@ -107,7 +107,7 @@ public class DeployBean extends BaseBean implements Updatable {
     }
 
     public void setOperator(String operator) {
-        this.operator = getStringWithSizeLimit(operator, 64);
+        this.operator = getStringWithinSizeLimit(operator, 64);
     }
 
     public Long getLast_update() {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironBean.java
@@ -22,7 +22,7 @@ import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.commons.text.StringEscapeUtils;
 import org.hibernate.validator.constraints.Range;
 
-public class EnvironBean implements Updatable, Serializable {
+public class EnvironBean extends BaseBean implements Updatable, Serializable {
     @JsonProperty("id")
     private String env_id;
 
@@ -309,7 +309,7 @@ public class EnvironBean implements Updatable, Serializable {
     }
 
     public void setLast_operator(String last_operator) {
-        this.last_operator = last_operator;
+        this.last_operator = getStringWithSizeLimit(last_operator, 64);
     }
 
     public Long getLast_update() {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironBean.java
@@ -309,7 +309,7 @@ public class EnvironBean extends BaseBean implements Updatable, Serializable {
     }
 
     public void setLast_operator(String last_operator) {
-        this.last_operator = getStringWithSizeLimit(last_operator, 64);
+        this.last_operator = getStringWithinSizeLimit(last_operator, 64);
     }
 
     public Long getLast_update() {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/HotfixBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/HotfixBean.java
@@ -145,7 +145,7 @@ public class HotfixBean extends BaseBean implements Updatable {
     }
 
     public void setOperator(String operator) {
-        this.operator = getStringWithSizeLimit(operator, 32);
+        this.operator = getStringWithinSizeLimit(operator, 32);
     }
 
     public Long getStart_time() {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/HotfixBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/HotfixBean.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import javax.validation.constraints.NotEmpty;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
-public class HotfixBean implements Updatable {
+public class HotfixBean extends BaseBean implements Updatable {
     private String id;
 
     @NotEmpty
@@ -145,7 +145,7 @@ public class HotfixBean implements Updatable {
     }
 
     public void setOperator(String operator) {
-        this.operator = operator;
+        this.operator = getStringWithSizeLimit(operator, 32);
     }
 
     public Long getStart_time() {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/PromoteBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/PromoteBean.java
@@ -71,7 +71,7 @@ public class PromoteBean extends BaseBean implements Updatable, Serializable {
     }
 
     public void setLast_operator(String last_operator) {
-        this.last_operator = getStringWithSizeLimit(last_operator, 64);
+        this.last_operator = getStringWithinSizeLimit(last_operator, 64);
     }
 
     public Long getLast_update() {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/PromoteBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/PromoteBean.java
@@ -27,7 +27,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.quartz.CronExpression;
 
-public class PromoteBean implements Updatable, Serializable {
+public class PromoteBean extends BaseBean implements Updatable, Serializable {
     @JsonProperty("envId")
     private String env_id;
 
@@ -71,7 +71,7 @@ public class PromoteBean implements Updatable, Serializable {
     }
 
     public void setLast_operator(String last_operator) {
-        this.last_operator = last_operator;
+        this.last_operator = getStringWithSizeLimit(last_operator, 64);
     }
 
     public Long getLast_update() {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/TagBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/TagBean.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.beans.Transient;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
-public class TagBean implements Updatable {
+public class TagBean extends BaseBean implements Updatable {
 
     private static final ObjectMapper mapper = new ObjectMapper();
 

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/bean/BaseBeanTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/bean/BaseBeanTest.java
@@ -1,0 +1,31 @@
+package com.pinterest.deployservice.bean;
+
+
+import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+public class BaseBeanTest {
+    @Test
+    void testGetStringWithSizeLimitInputNull() {
+        BaseBean baseBean = new BaseBean();
+        String result = baseBean.getStringWithSizeLimit(null, 10);
+        assertNull(result);
+    }
+
+    @Test
+    void testGetStringWithSizeLimitInputWithinLimit() {
+        BaseBean baseBean = new BaseBean();
+        String input = "test";
+        String result = baseBean.getStringWithSizeLimit(input, 10);
+        assertSame(input, result);
+    }
+    @Test
+    void testGetStringWithSizeLimitInputExceedsLimit() {
+        BaseBean baseBean = new BaseBean();
+        String result = baseBean.getStringWithSizeLimit("0123456789", 5);
+        assertEquals("56789", result);
+    }
+}

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/bean/BaseBeanTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/bean/BaseBeanTest.java
@@ -9,23 +9,23 @@ import org.junit.jupiter.api.Test;
 
 public class BaseBeanTest {
     @Test
-    void testGetStringWithSizeLimitInputNull() {
+    void testGetStringWithinSizeLimitInputNull() {
         BaseBean baseBean = new BaseBean();
-        String result = baseBean.getStringWithSizeLimit(null, 10);
+        String result = baseBean.getStringWithinSizeLimit(null, 10);
         assertNull(result);
     }
 
     @Test
-    void testGetStringWithSizeLimitInputWithinLimit() {
+    void testGetStringWithinSizeLimitInputWithinLimit() {
         BaseBean baseBean = new BaseBean();
         String input = "test";
-        String result = baseBean.getStringWithSizeLimit(input, 10);
+        String result = baseBean.getStringWithinSizeLimit(input, 10);
         assertSame(input, result);
     }
     @Test
-    void testGetStringWithSizeLimitInputExceedsLimit() {
+    void testGetStringWithinSizeLimitInputExceedsLimit() {
         BaseBean baseBean = new BaseBean();
-        String result = baseBean.getStringWithSizeLimit("0123456789", 5);
+        String result = baseBean.getStringWithinSizeLimit("0123456789", 5);
         assertEquals("56789", result);
     }
 }

--- a/deploy-service/teletraanservice/bin/server.yaml
+++ b/deploy-service/teletraanservice/bin/server.yaml
@@ -98,6 +98,14 @@ db:
   # (Optional)OAuth token cache
   #tokenCacheSpec: maximumSize=1000,expireAfterWrite=10m
 
+  # pinDeploySpiffeIds:
+  #   - spiffe://pin220.com/teletraan/spin-orca/dev
+  #   - spiffe://pin220.com/teletraan/spin-orca/staging
+  #   - spiffe://pin220.com/teletraan/spin-orca/prod
+  #   - spiffe://pin220.com/teletraan/spin-keel/dev
+  #   - spiffe://pin220.com/teletraan/spin-keel/staging
+  #   - spiffe://pin220.com/teletraan/spin-keel/prod
+
 #
 # Token based Authorization: by default is disabled.
 #

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/CompositeAuthenticationFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/CompositeAuthenticationFactory.java
@@ -25,7 +25,6 @@ import com.pinterest.teletraan.TeletraanServiceContext;
 import com.pinterest.teletraan.universal.security.EnvoyAuthFilter;
 import com.pinterest.teletraan.universal.security.EnvoyAuthenticator;
 import com.pinterest.teletraan.universal.security.PinDeployPipelinePrincipalReplacer;
-import com.pinterest.teletraan.universal.security.PrincipalReplacer;
 import com.pinterest.teletraan.universal.security.bean.EnvoyCredentials;
 import com.pinterest.teletraan.universal.security.bean.TeletraanPrincipal;
 import io.dropwizard.auth.AuthFilter;
@@ -45,10 +44,16 @@ public class CompositeAuthenticationFactory extends TokenAuthenticationFactory {
     @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public ContainerRequestFilter create(TeletraanServiceContext context) throws Exception {
-        PrincipalReplacer principalReplacer =
-                new PinDeployPipelinePrincipalReplacer(ImmutableList.copyOf(pinDeploySpiffeIds));
-        Authenticator<EnvoyCredentials, TeletraanPrincipal> authenticator =
-                new EnvoyAuthenticator(ImmutableList.of(principalReplacer));
+        Authenticator<EnvoyCredentials, TeletraanPrincipal> authenticator;
+        if (pinDeploySpiffeIds != null && !pinDeploySpiffeIds.isEmpty()) {
+            authenticator =
+                    new EnvoyAuthenticator(
+                            ImmutableList.of(
+                                    new PinDeployPipelinePrincipalReplacer(
+                                            ImmutableList.copyOf(pinDeploySpiffeIds))));
+        } else {
+            authenticator = new EnvoyAuthenticator();
+        }
 
         if (StringUtils.isNotBlank(getTokenCacheSpec())) {
             MetricRegistry registry = SharedMetricRegistries.getDefault();

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/CompositeAuthenticationFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/CompositeAuthenticationFactory.java
@@ -65,8 +65,8 @@ public class CompositeAuthenticationFactory extends TokenAuthenticationFactory {
 
         return new ChainedAuthFilter(
                 Arrays.asList(
-                        envoyAuthFilter,
                         createScriptTokenAuthFilter(context),
+                        envoyAuthFilter,
                         createOauthTokenAuthFilter(context),
                         createJwtTokenAuthFilter(context)));
     }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/CompositeAuthenticationFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/CompositeAuthenticationFactory.java
@@ -17,11 +17,15 @@ package com.pinterest.teletraan.config;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.SharedMetricRegistries;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.common.collect.ImmutableList;
 import com.pinterest.teletraan.TeletraanServiceContext;
 import com.pinterest.teletraan.universal.security.EnvoyAuthFilter;
 import com.pinterest.teletraan.universal.security.EnvoyAuthenticator;
+import com.pinterest.teletraan.universal.security.PinDeployPipelinePrincipalReplacer;
+import com.pinterest.teletraan.universal.security.PrincipalReplacer;
 import com.pinterest.teletraan.universal.security.bean.EnvoyCredentials;
 import com.pinterest.teletraan.universal.security.bean.TeletraanPrincipal;
 import io.dropwizard.auth.AuthFilter;
@@ -30,16 +34,21 @@ import io.dropwizard.auth.CachingAuthenticator;
 import io.dropwizard.auth.JSONUnauthorizedHandler;
 import io.dropwizard.auth.chained.ChainedAuthFilter;
 import java.util.Arrays;
+import java.util.List;
 import javax.ws.rs.container.ContainerRequestFilter;
 import org.apache.commons.lang3.StringUtils;
 
 @JsonTypeName("composite")
 public class CompositeAuthenticationFactory extends TokenAuthenticationFactory {
+    @JsonProperty private List<String> pinDeploySpiffeIds;
+
     @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public ContainerRequestFilter create(TeletraanServiceContext context) throws Exception {
+        PrincipalReplacer principalReplacer =
+                new PinDeployPipelinePrincipalReplacer(ImmutableList.copyOf(pinDeploySpiffeIds));
         Authenticator<EnvoyCredentials, TeletraanPrincipal> authenticator =
-                new EnvoyAuthenticator();
+                new EnvoyAuthenticator(ImmutableList.of(principalReplacer));
 
         if (StringUtils.isNotBlank(getTokenCacheSpec())) {
             MetricRegistry registry = SharedMetricRegistries.getDefault();

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/CompositeAuthenticationFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/CompositeAuthenticationFactory.java
@@ -65,8 +65,8 @@ public class CompositeAuthenticationFactory extends TokenAuthenticationFactory {
 
         return new ChainedAuthFilter(
                 Arrays.asList(
-                        createScriptTokenAuthFilter(context),
                         envoyAuthFilter,
+                        createScriptTokenAuthFilter(context),
                         createOauthTokenAuthFilter(context),
                         createJwtTokenAuthFilter(context)));
     }

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/Constants.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/Constants.java
@@ -22,6 +22,7 @@ public final class Constants {
     public static final String USER_HEADER = "x-forwarded-user";
     public static final String GROUPS_HEADER = "x-forwarded-groups";
     public static final String CLIENT_CERT_HEADER = "x-forwarded-client-cert";
-    public static final String PIPELINE_HEADER = "x-pipeline-identifier";
+    public static final String PINDEPLOY_PIPELINE_HEADER = "Pindeploy-Pipeline-Identifier";
+
     public static final String AUTHZ_ATTR_REQ_CXT_KEY = "AuthZAttributes";
 }

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/EnvoyAuthFilter.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/EnvoyAuthFilter.java
@@ -63,7 +63,7 @@ public class EnvoyAuthFilter<P extends Principal> extends AuthFilter<EnvoyCreden
         String user = headers.getFirst(Constants.USER_HEADER);
         String spiffeId = getSpiffeId(headers.getFirst(Constants.CLIENT_CERT_HEADER));
         List<String> groups = getGroups(headers.getFirst(Constants.GROUPS_HEADER));
-        String pipelineId = headers.getFirst(Constants.PIPELINE_HEADER);
+        String pipelineId = headers.getFirst(Constants.PINDEPLOY_PIPELINE_HEADER);
 
         if (StringUtils.isBlank(spiffeId) && StringUtils.isBlank(user)) {
             return null;

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/EnvoyAuthFilter.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/EnvoyAuthFilter.java
@@ -25,6 +25,7 @@ import javax.annotation.Nullable;
 import javax.annotation.Priority;
 import javax.ws.rs.Priorities;
 import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.SecurityContext;
 import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
@@ -58,17 +59,17 @@ public class EnvoyAuthFilter<P extends Principal> extends AuthFilter<EnvoyCreden
      */
     @Nullable
     private EnvoyCredentials getCredentials(ContainerRequestContext requestContext) {
-        String user = requestContext.getHeaders().getFirst(Constants.USER_HEADER);
-        String spiffeId =
-                getSpiffeId(requestContext.getHeaders().getFirst(Constants.CLIENT_CERT_HEADER));
-        List<String> groups =
-                getGroups(requestContext.getHeaders().getFirst(Constants.GROUPS_HEADER));
+        MultivaluedMap<String, String> headers = requestContext.getHeaders();
+        String user = headers.getFirst(Constants.USER_HEADER);
+        String spiffeId = getSpiffeId(headers.getFirst(Constants.CLIENT_CERT_HEADER));
+        List<String> groups = getGroups(headers.getFirst(Constants.GROUPS_HEADER));
+        String pipelineId = headers.getFirst(Constants.PIPELINE_HEADER);
 
         if (StringUtils.isBlank(spiffeId) && StringUtils.isBlank(user)) {
             return null;
         }
 
-        return new EnvoyCredentials(user, spiffeId, groups);
+        return new EnvoyCredentials(user, spiffeId, groups, pipelineId);
     }
 
     /**

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/PinDeployPipelinePrincipalReplacer.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/PinDeployPipelinePrincipalReplacer.java
@@ -33,8 +33,7 @@ public class PinDeployPipelinePrincipalReplacer implements PrincipalReplacer {
             if (pinDeploySpiffeIds.contains(servicePrincipal.getName())
                     && StringUtils.isNotEmpty(credentials.getPipelineId())) {
                 return new ServicePrincipal(
-                        StringUtils.join(
-                                servicePrincipal.getName(), credentials.getPipelineId(), "/"));
+                        String.join("/", servicePrincipal.getName(), credentials.getPipelineId()));
             }
         }
         return principal;

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/PinDeployPipelinePrincipalReplacer.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/PinDeployPipelinePrincipalReplacer.java
@@ -32,7 +32,7 @@ public class PinDeployPipelinePrincipalReplacer implements PrincipalReplacer {
             ServicePrincipal servicePrincipal = (ServicePrincipal) principal;
             if (pinDeploySpiffeIds.contains(servicePrincipal.getName())
                     && StringUtils.isNotEmpty(credentials.getPipelineId())) {
-                return new ServicePrincipal(credentials.getPipelineId());
+                return new ServicePrincipal(StringUtils.join(servicePrincipal.getName(), credentials.getPipelineId(), "/"));
             }
         }
         return principal;

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/PinDeployPipelinePrincipalReplacer.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/PinDeployPipelinePrincipalReplacer.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.universal.security;
+
+import com.google.common.collect.ImmutableList;
+import com.pinterest.teletraan.universal.security.bean.EnvoyCredentials;
+import com.pinterest.teletraan.universal.security.bean.ServicePrincipal;
+import com.pinterest.teletraan.universal.security.bean.TeletraanPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+
+@RequiredArgsConstructor
+public class PinDeployPipelinePrincipalReplacer implements PrincipalReplacer {
+    private final ImmutableList<String> pinDeploySpiffeIds;
+
+    @Override
+    public TeletraanPrincipal replace(TeletraanPrincipal principal, EnvoyCredentials credentials) {
+        if (principal != null && ServicePrincipal.class.isAssignableFrom(principal.getClass())) {
+            ServicePrincipal servicePrincipal = (ServicePrincipal) principal;
+            if (pinDeploySpiffeIds.contains(servicePrincipal.getName())
+                    && StringUtils.isNotEmpty(credentials.getPipelineId())) {
+                return new ServicePrincipal(credentials.getPipelineId());
+            }
+        }
+        return principal;
+    }
+}

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/PinDeployPipelinePrincipalReplacer.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/PinDeployPipelinePrincipalReplacer.java
@@ -32,7 +32,9 @@ public class PinDeployPipelinePrincipalReplacer implements PrincipalReplacer {
             ServicePrincipal servicePrincipal = (ServicePrincipal) principal;
             if (pinDeploySpiffeIds.contains(servicePrincipal.getName())
                     && StringUtils.isNotEmpty(credentials.getPipelineId())) {
-                return new ServicePrincipal(StringUtils.join(servicePrincipal.getName(), credentials.getPipelineId(), "/"));
+                return new ServicePrincipal(
+                        StringUtils.join(
+                                servicePrincipal.getName(), credentials.getPipelineId(), "/"));
             }
         }
         return principal;

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/PrincipalReplacer.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/PrincipalReplacer.java
@@ -15,13 +15,9 @@
  */
 package com.pinterest.teletraan.universal.security;
 
-import lombok.NoArgsConstructor;
+import com.pinterest.teletraan.universal.security.bean.EnvoyCredentials;
+import com.pinterest.teletraan.universal.security.bean.TeletraanPrincipal;
 
-@NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
-public final class Constants {
-    public static final String USER_HEADER = "x-forwarded-user";
-    public static final String GROUPS_HEADER = "x-forwarded-groups";
-    public static final String CLIENT_CERT_HEADER = "x-forwarded-client-cert";
-    public static final String PIPELINE_HEADER = "x-pipeline-identifier";
-    public static final String AUTHZ_ATTR_REQ_CXT_KEY = "AuthZAttributes";
+public interface PrincipalReplacer {
+    TeletraanPrincipal replace(TeletraanPrincipal principal, EnvoyCredentials credentials);
 }

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/EnvoyCredentials.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/EnvoyCredentials.java
@@ -25,4 +25,12 @@ public class EnvoyCredentials {
     String user;
     String spiffeId;
     List<String> groups;
+    String pipelineId;
+
+    public EnvoyCredentials(String user, String spiffeId, List<String> groups) {
+        this.user = user;
+        this.spiffeId = spiffeId;
+        this.groups = groups;
+        this.pipelineId = null; // Default value for backward compatibility
+    }
 }

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/PinDeployPipelinePrincipalReplacerTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/PinDeployPipelinePrincipalReplacerTest.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.universal.security;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import com.google.common.collect.ImmutableList;
+import com.pinterest.teletraan.universal.security.bean.EnvoyCredentials;
+import com.pinterest.teletraan.universal.security.bean.ServicePrincipal;
+import com.pinterest.teletraan.universal.security.bean.TeletraanPrincipal;
+import com.pinterest.teletraan.universal.security.bean.UserPrincipal;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class PinDeployPipelinePrincipalReplacerTest {
+    private static final String PIPELINE_ID_1 = "pipeline123";
+    private static final String PINDEPLOY_SPIFFE_1 = "spiffe://example.org/service1";
+    private static final String PINDEPLOY_SPIFFE_2 = "spiffe://example.org/service2";
+    private static final ImmutableList<String> pinDeploySpiffeIds =
+            ImmutableList.of(PINDEPLOY_SPIFFE_1, PINDEPLOY_SPIFFE_2);
+    private PinDeployPipelinePrincipalReplacer sut;
+
+    @BeforeEach
+    void setUp() {
+        sut = new PinDeployPipelinePrincipalReplacer(pinDeploySpiffeIds);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {PINDEPLOY_SPIFFE_1, PINDEPLOY_SPIFFE_2})
+    void replaceShouldReturnModifiedPrincipalWhenConditionsMet(String spiffe) {
+        ServicePrincipal principal = new ServicePrincipal(spiffe);
+        EnvoyCredentials credentials = new EnvoyCredentials(null, spiffe, null, PIPELINE_ID_1);
+
+        TeletraanPrincipal result = sut.replace(principal, credentials);
+
+        assertInstanceOf(ServicePrincipal.class, result);
+        assertEquals(spiffe + "/" + PIPELINE_ID_1, ((ServicePrincipal) result).getName());
+    }
+
+    @Test
+    void replaceShouldReturnOriginalPrincipalWhenNotServicePrincipal() {
+        TeletraanPrincipal principal = new UserPrincipal("user", null);
+        EnvoyCredentials credentials = new EnvoyCredentials("user", null, null);
+
+        TeletraanPrincipal result = sut.replace(principal, credentials);
+
+        assertSame(principal, result);
+    }
+
+    @Test
+    void replaceShouldReturnOriginalPrincipalWhenSpiffeIdNotInList() {
+        String unknownSpiffe = "spiffe://example.org/unknown";
+        ServicePrincipal principal = new ServicePrincipal(unknownSpiffe);
+        EnvoyCredentials credentials =
+                new EnvoyCredentials(null, unknownSpiffe, null, PIPELINE_ID_1);
+
+        TeletraanPrincipal result = sut.replace(principal, credentials);
+
+        assertSame(principal, result);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {PINDEPLOY_SPIFFE_1, PINDEPLOY_SPIFFE_2})
+    void replaceShouldReturnOriginalPrincipalWhenPipelineIdIsEmpty(String spiffe) {
+        ServicePrincipal principal = new ServicePrincipal(spiffe);
+        EnvoyCredentials credentials = new EnvoyCredentials(null, spiffe, null, null);
+
+        TeletraanPrincipal result = sut.replace(principal, credentials);
+
+        assertSame(principal, result);
+    }
+
+    @Test
+    void replaceShouldReturnOriginalPrincipalWhenPrincipalIsNull() {
+        EnvoyCredentials credentials = new EnvoyCredentials(null, PINDEPLOY_SPIFFE_1, null, null);
+        TeletraanPrincipal result = sut.replace(null, credentials);
+
+        assertNull(result);
+    }
+}


### PR DESCRIPTION
This PR implements an auth filter that will replace the principal if both of the conditions are met
1. Request is sent from a list of spiffe ids
2. Request contains a special header.
3. Because the principal name has a SPIFFE prefix, it's more likely to exceed the DB column limit. Introduced a method to trim the string to avoid updating the DB. 

## Test and validations
test coverage and some manual tests
1. Start the service with updated configuration
2. Craft a request with the spiffe ID and special header
4. Verify in the debugger that the principal is replaced. 