### PR TITLE
Update cmdb url link when account is specified

### DIFF
--- a/deploy-board/deploy_board/templates/hosts/host_details.html
+++ b/deploy-board/deploy_board/templates/hosts/host_details.html
@@ -147,7 +147,7 @@
     {% endfor %}
     <span>For complete host details, </span>
     {% if account_id and account_id != "null" %}
-        <a href="{{ host_information_url }}/instance/{{ host_id }}?{{ account_id }}">click here</a>
+        <a href="{{ host_information_url }}/instance/{{ host_id }}?account={{ account_id }}">click here</a>
     {% else %}
         <a href="{{ host_information_url }}/instance/{{ host_id }}">click here</a>
     {% endif %}


### PR DESCRIPTION
In the UI, the linked url was missing the `account` query param name