### PR TITLE
Fix url params getting changed erroneously

### DIFF
--- a/deploy-board/deploy_board/static/js/deploy-board.js
+++ b/deploy-board/deploy_board/static/js/deploy-board.js
@@ -55,6 +55,56 @@ function getUrlParameter(sParam) {
         }
     }
 }
+function setUrlParameter(url, name, val){
+    let searchString = url.search.substring(1);
+    let vars = searchString.split("&")
+    let modifiedString = "?"
+    let set= false;
+
+    for(let i=0; i < vars.length; i++){
+        if(i>0){
+            modifiedString+="&"
+        }
+        let currParam = vars[i].split('=');
+        if(currParam[0] === name){
+            modifiedString+=name
+            modifiedString+= "=" + encodeURIComponent(val)
+            set=true;
+        } else {
+            modifiedString+=vars[i]
+        }
+    }
+    if(!set){
+        if(modifiedString.length>1){
+            modifiedString+="&"
+        }
+        modifiedString+=name
+        modifiedString+="="+encodeURIComponent(val)
+    }
+    url.search=modifiedString;
+    return url
+}
+
+function deleteUrlParameter(url, name){
+    let searchString = url.search.substring(1);
+    let vars = searchString.split("&")
+    let modifiedString = "?"
+
+    for(let i=0; i < vars.length; i++){
+        let currParam = vars[i].split('=');
+        if(currParam[0]!==name){
+            if(modifiedString.length>1){
+                modifiedString+="&"
+            }
+            modifiedString+=vars[i]
+        }
+    }
+    url.search=modifiedString;
+    return url
+}
+
+
+
 
 function getRemainingCapacity(capacityInfo, placementList) {
     if (!capacityInfo || !placementList) {

--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -56,7 +56,6 @@
 <div id="clusterAlert">
     <in-rolling-alert v-show="showReplaceAlert" actionlink="/env/{{ env.envName }}/{{ env.stageName }}/config/cluster/config/"></in-rolling-alert>
 </div>
-{% include "environs/env_tabs.tmpl" with envTabKind="config/capacity" %}
 
 
 <div id="mainPanel" class="panel panel-default">

--- a/deploy-board/deploy_board/templates/configs/new_capacity.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity.html
@@ -46,7 +46,6 @@
     </div>
 {% endif %}
 
-{% include "environs/env_tabs.tmpl" with envTabKind="config/capacity" %}
 <script type="text/javascript" src="{% static "js/components/capacitycomponents.js"%}?changedate=2023.01.30"></script>
 <script type="text/javascript" src="{% static "js/components/clusterconfigcomponents.js"%}?changedate=2023.08.22"></script>
 <script type="text/javascript" src="{% static "js/base-image-utils.js"%}?changedate=2023.01.30"></script>

--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -33,7 +33,6 @@
 {% block new-pred-deploys-panel %}
 {% endblock %}
 {% block main%}
-{% include "environs/env_tabs.tmpl" with envTabKind="config/capacity" %}
 <script type="text/javascript" src="{% static "js/components/capacitycomponents.js"%}?changedate=2023.01.30"></script>
 <script type="text/javascript" src="{% static "js/components/clusterconfigcomponents.js"%}?changedate=2023.08.22"></script>
 <script type="text/javascript" src="{% static "js/base-image-utils.js"%}?changedate=2023.01.30"></script>

--- a/deploy-board/deploy_board/templates/configs/schedule_config.html
+++ b/deploy-board/deploy_board/templates/configs/schedule_config.html
@@ -31,7 +31,6 @@
 {% endblock %}
 
 {% block main %}
-{% include "environs/env_tabs.tmpl" with envTabKind="config/schedule" %}
 <div class="panel panel-default">
     {% include "configs/schedule_config.tmpl" %}
 </div>

--- a/deploy-board/deploy_board/templates/deploys/deploy_history.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/deploy_history.tmpl
@@ -141,7 +141,7 @@
 
     jQuery(function(){
         var maxCheckedAllowed = 2;
-        var checkboxes = $('input[type="checkbox"]');
+        var checkboxes = $("#deployHistoryTableId").find('input[type="checkbox"]');
             checkboxes.change(function(){
                 var numChecked = checkboxes.filter(':checked').length;
                 checkboxes.filter(':not(:checked)').prop('disabled', numChecked >= maxCheckedAllowed);

--- a/deploy-board/deploy_board/templates/environs/env_tabs.tmpl
+++ b/deploy-board/deploy_board/templates/environs/env_tabs.tmpl
@@ -161,59 +161,11 @@
         let url = new URL(window.location.href)
         let newUrl;
         if(filter.length < 1){
-            newUrl = deleteParam(url, "stageFilter")
+            newUrl = deleteUrlParameter(url, "stageFilter")
         } else {
-            newUrl = setParam(url, "stageFilter", JSON.stringify(filter))
+            newUrl = setUrlParameter(url, "stageFilter", JSON.stringify(filter))
         }
         window.history.replaceState(null,null,newUrl);
-    }
-
-    function setParam(url, name, val){
-        let searchString = url.search.substring(1);
-        let vars = searchString.split("&")
-        let modifiedString = "?"
-        let set= false;
-
-        for(let i=0; i < vars.length; i++){
-            if(i>0){
-                modifiedString+="&"
-            }
-            let currParam = vars[i].split('=');
-            if(currParam[0] === name){
-                modifiedString+=name
-                modifiedString+= "=" + encodeURIComponent(val)
-                set=true;
-            } else {
-                modifiedString+=vars[i]
-            }
-        }
-        if(!set){
-            if(modifiedString.length>1){
-                modifiedString+="&"
-            }
-            modifiedString+=name
-            modifiedString+="="+encodeURIComponent(val)
-        }
-        url.search=modifiedString;
-        return url
-    }
-
-    function deleteParam(url, name){
-        let searchString = url.search.substring(1);
-        let vars = searchString.split("&")
-        let modifiedString = "?"
-
-        for(let i=0; i < vars.length; i++){
-           let currParam = vars[i].split('=');
-           if(currParam[0]!==name){
-                if(modifiedString.length>1){
-                    modifiedString+="&"
-                }
-                modifiedString+=vars[i]
-           }
-        }
-        url.search=modifiedString;
-        return url
     }
 
     //intercept and add filter parameter to link
@@ -221,7 +173,7 @@
         if(!filterInactive){
             e.preventDefault();
             let url = new URL(anchor.href);
-            let newUrl = setParam(url,"stageFilter", JSON.stringify(filter));
+            let newUrl = setUrlParameter(url,"stageFilter", JSON.stringify(filter));
             window.location.href=newUrl;
         }
     }

--- a/deploy-board/deploy_board/templates/environs/env_tabs.tmpl
+++ b/deploy-board/deploy_board/templates/environs/env_tabs.tmpl
@@ -38,16 +38,15 @@
             {% endfor %}
         </ul>
     </div>
-        <ul id="stageTabs" class="nav nav-tabs" style="padding-right:40px;">
-            {% for stage in envs %}
-                <li data-stagetype="{{stage.stageType}}" {% if stage.stageName == env.stageName %}class="active"{% endif %}>
-                    <a class="deployToolTip" data-container="body" data-toggle="tooltip" title="{{stage.description}}" data-placement="bottom"
-                    onclick="callback(event, this)"
-                    href="/env/{{ env.envName }}/{{ stage.stageName }}/{{ envTabKind }}">{{ stage.stageName }}</a>
-                </li>
-            {% endfor %}
-        </ul>
-    <div id="filterOpts" data-filter="{{stagetype_filter}}" />
+    <ul id="stageTabs" class="nav nav-tabs" style="padding-right:40px;">
+        {% for stage in envs %}
+            <li data-stagetype="{{stage.stageType}}" {% if stage.stageName == env.stageName %}class="active"{% endif %}>
+                <a class="deployToolTip" data-container="body" data-toggle="tooltip" title="{{stage.description}}" data-placement="bottom"
+                onclick="callback(event, this)"
+                href="/env/{{ env.envName }}/{{ stage.stageName }}/{{ envTabKind }}">{{ stage.stageName }}</a>
+            </li>
+        {% endfor %}
+    </ul>
 </div>
 
 
@@ -56,8 +55,7 @@
     let filterInactive = true;
 
     try {
-        filter = Array.from(JSON.parse(decodeURIComponent($("#filterOpts").attr("data-filter"))));
-        console.log(filter);
+        filter = JSON.parse(getUrlParameter("stageFilter"))
         if(!Array.isArray(filter)){
             throw new Error("invalid url filter params");
         }
@@ -85,7 +83,6 @@
 
     update();
     function update() {
-        console.log(filter)
         if(filter.length < 1){
             filterInactive = true;
         } else {
@@ -161,13 +158,62 @@
 
     //update filter param in url as it changes
     function updateUrl(){
-        let url = new URL(window.location.href);
+        let url = new URL(window.location.href)
+        let newUrl;
         if(filter.length < 1){
-            url.searchParams.delete("stageFilter");
+            newUrl = deleteParam(url, "stageFilter")
         } else {
-            url.searchParams.set("stageFilter", JSON.stringify(filter));
+            newUrl = setParam(url, "stageFilter", JSON.stringify(filter))
         }
-            window.history.replaceState(null,null,url);
+        window.history.replaceState(null,null,newUrl);
+    }
+
+    function setParam(url, name, val){
+        let searchString = url.search.substring(1);
+        let vars = searchString.split("&")
+        let modifiedString = "?"
+        let set= false;
+
+        for(let i=0; i < vars.length; i++){
+            if(i>0){
+                modifiedString+="&"
+            }
+            let currParam = vars[i].split('=');
+            if(currParam[0] === name){
+                modifiedString+=name
+                modifiedString+= "=" + encodeURIComponent(val)
+                set=true;
+            } else {
+                modifiedString+=vars[i]
+            }
+        }
+        if(!set){
+            if(modifiedString.length>1){
+                modifiedString+="&"
+            }
+            modifiedString+=name
+            modifiedString+="="+encodeURIComponent(val)
+        }
+        url.search=modifiedString;
+        return url
+    }
+
+    function deleteParam(url, name){
+        let searchString = url.search.substring(1);
+        let vars = searchString.split("&")
+        let modifiedString = "?"
+
+        for(let i=0; i < vars.length; i++){
+           let currParam = vars[i].split('=');
+           if(currParam[0]!==name){
+                if(modifiedString.length>1){
+                    modifiedString+="&"
+                }
+                modifiedString+=vars[i]
+           }
+        }
+        url.search=modifiedString;
+        return url
     }
 
     //intercept and add filter parameter to link
@@ -175,8 +221,8 @@
         if(!filterInactive){
             e.preventDefault();
             let url = new URL(anchor.href);
-            url.searchParams.set("stageFilter", JSON.stringify(filter));
-            window.location.href=url;
+            let newUrl = setParam(url,"stageFilter", JSON.stringify(filter));
+            window.location.href=newUrl;
         }
     }
 </script>

--- a/deploy-board/deploy_board/webapp/alarm_views.py
+++ b/deploy-board/deploy_board/webapp/alarm_views.py
@@ -40,9 +40,11 @@ class EnvAlarmView(View):
         envs = environs_helper.get_all_env_stages(request, name)
         stages, env = common.get_all_stages(envs, stage)
         alarms = environs_helper.get_env_alarms_config(request, name, stage)
+
         return render(request, 'configs/alarm_config.html', {
             "envs": envs,
             "env": env,
+            "all_stage_types": sorted(environs_helper.STAGE_TYPES),
             "stages": stages,
             "alarms": alarms,
         })

--- a/deploy-board/deploy_board/webapp/capacity_views.py
+++ b/deploy-board/deploy_board/webapp/capacity_views.py
@@ -90,11 +90,13 @@ class EnvCapacityConfigView(View):
         stages, env = get_all_stages(envs, stage)
         hosts = environs_helper.get_env_capacity(request, name, stage, capacity_type="HOST")
         groups = get_env_groups(request, name, stage)
+
         if cluster_name in groups:
             groups.remove(cluster_name)
         data = {
             "envs": envs,
             "env": env,
+            "all_stage_types": sorted(environs_helper.STAGE_TYPES),
             "stages": stages,
             "hosts": hosts,
             "groups": groups,

--- a/deploy-board/deploy_board/webapp/config_map_views.py
+++ b/deploy-board/deploy_board/webapp/config_map_views.py
@@ -63,9 +63,11 @@ class EnvConfigMapView(View):
         # otherwise, return a page
         envs = environs_helper.get_all_env_stages(request, name)
         stages, env = get_all_stages(envs, stage)
+
         return render(request, 'configs/config_map.html', {
             "envs": envs,
             "env": env,
+            "all_stage_types": sorted(environs_helper.STAGE_TYPES),
             "stages": stages,
             "configs": configs,
             "customization": CUSTOMIZATION[flavor],

--- a/deploy-board/deploy_board/webapp/env_config_views.py
+++ b/deploy-board/deploy_board/webapp/env_config_views.py
@@ -57,6 +57,7 @@ class EnvConfigView(View):
         return render(request, 'configs/env_config.html', {
             "envs": envs,
             "env": env,
+            "all_stage_types": sorted(environs_helper.STAGE_TYPES),
             "stages": stages,
             "show_remove": show_remove,
             "pinterest": IS_PINTEREST,

--- a/deploy-board/deploy_board/webapp/env_views.py
+++ b/deploy-board/deploy_board/webapp/env_views.py
@@ -126,6 +126,7 @@ def logging_status(request, name, stage):
 
     html = render_to_string('deploys/deploy_logging_check_landing.tmpl', {
         "envs": envs,
+        "all_stage_types": sorted(environs_helper.STAGE_TYPES),
         "csrf_token": get_token(request),
         "panel_title": "Kafka logging for %s (%s)" % (name, stage),
         "env": env,
@@ -444,7 +445,6 @@ class EnvLandingView(View):
 
         asg_suspended_processes = _get_asg_suspended_processes(request, env) or []
 
-        stagetype_filter = request.GET.get('stageFilter', [])
 
         if not env['deployId']:
             capacity_hosts = deploys_helper.get_missing_hosts(request, name, stage)
@@ -454,7 +454,6 @@ class EnvLandingView(View):
                 "envs": envs,
                 "env": env,
                 "all_stage_types": sorted(environs_helper.STAGE_TYPES),
-                "stagetype_filter": stagetype_filter,
                 "env_promote": env_promote,
                 "stages": stages,
                 "metrics": metrics,
@@ -551,7 +550,6 @@ class EnvLandingView(View):
                 "envs": envs,
                 "env": env,
                 "all_stage_types": sorted(environs_helper.STAGE_TYPES),
-                "stagetype_filter": stagetype_filter,
                 "env_promote": env_promote,
                 "stages": stages,
                 "report": report,
@@ -941,6 +939,7 @@ def get_env_deploys(request, name, stage):
         return render(request, 'environs/env_history.html', {
             "envs": envs,
             "env": env,
+            "all_stage_types": sorted(environs_helper.STAGE_TYPES),
             "stages": stages,
             "deploy_summaries": [],
             "filter_title": filter_title,
@@ -976,6 +975,7 @@ def get_env_deploys(request, name, stage):
     return render(request, 'environs/env_history.html', {
         "envs": envs,
         "env": env,
+        "all_stage_types": sorted(environs_helper.STAGE_TYPES),
         "stages": stages,
         "deploy_summaries": deploy_summaries,
         "filter_title": filter_title,
@@ -1466,6 +1466,7 @@ def get_hosts(request, name, stage):
     return render(request, 'environs/env_hosts.html', {
         "envs": envs,
         "env": env,
+        "all_stage_types": sorted(environs_helper.STAGE_TYPES),
         "stage": stage,
         "stages": stages,
         "agents_wrapper": agents_wrapper,
@@ -1493,6 +1494,7 @@ def get_hosts_by_deploy(request, name, stage, deploy_id):
     return render(request, 'environs/env_hosts.html', {
         "envs": envs,
         "env": env,
+        "all_stage_types": sorted(environs_helper.STAGE_TYPES),
         "stages": stages,
         "agents_wrapper": agents_wrapper,
         "title": title,
@@ -1577,6 +1579,7 @@ def get_unknown_hosts(request, name, stage):
     return render(request, 'environs/env_hosts.html', {
         "envs": envs,
         "env": env,
+        "all_stage_types": sorted(environs_helper.STAGE_TYPES),
         "stages": stages,
         "agents_wrapper": agents_wrapper,
         "title": title,
@@ -1595,6 +1598,7 @@ def get_provisioning_hosts(request, name, stage):
     return render(request, 'environs/env_hosts.html', {
         "envs": envs,
         "env": env,
+        "all_stage_types": sorted(environs_helper.STAGE_TYPES),
         "stages": stages,
         "agents_wrapper": agents_wrapper,
         "title": title,
@@ -1613,6 +1617,7 @@ def get_all_hosts(request, name, stage):
     return render(request, 'environs/env_hosts.html', {
         "envs": envs,
         "env": env,
+        "all_stage_types": sorted(environs_helper.STAGE_TYPES),
         "stages": stages,
         "agents_wrapper": agents_wrapper,
         "title": title,
@@ -1633,6 +1638,7 @@ def get_failed_hosts(request, name, stage):
     return render(request, 'environs/env_hosts.html', {
         "envs": envs,
         "env": env,
+        "all_stage_types": sorted(environs_helper.STAGE_TYPES),
         "stages": stages,
         "agents_wrapper": agents_wrapper,
         "title": title,
@@ -1668,6 +1674,7 @@ def get_sub_account_hosts(request, name, stage):
     return render(request, 'environs/env_hosts.html', {
         "envs": envs,
         "env": env,
+        "all_stage_types": sorted(environs_helper.STAGE_TYPES),
         "stages": stages,
         "agents_wrapper": agents_wrapper,
         "title": title,

--- a/deploy-board/deploy_board/webapp/metrics_views.py
+++ b/deploy-board/deploy_board/webapp/metrics_views.py
@@ -46,6 +46,7 @@ class EnvMetricsView(View):
         return render(request, 'configs/metrics_config.html', {
             "envs": envs,
             "env": env,
+            "all_stage_types": sorted(environs_helper.STAGE_TYPES),
             "stages": stages,
             "metrics": metrics,
         })

--- a/deploy-board/deploy_board/webapp/promote_views.py
+++ b/deploy-board/deploy_board/webapp/promote_views.py
@@ -47,9 +47,11 @@ class EnvPromoteConfigView(View):
             return HttpResponse(json.dumps({'html': html}), content_type="application/json")
 
         # otherwise, return a page
+
         return render(request, 'configs/promote_config.html', {
             "envs": envs,
             "env": env,
+            "all_stage_types": sorted(environs_helper.STAGE_TYPES),
             "stages": stages,
             "stage_names": stage_names,
             "env_promote": env_promote,

--- a/deploy-board/deploy_board/webapp/webhook_views.py
+++ b/deploy-board/deploy_board/webapp/webhook_views.py
@@ -40,9 +40,11 @@ class EnvWebhooksView(View):
         envs = environs_helper.get_all_env_stages(request, name)
         stages, env = common.get_all_stages(envs, stage)
         webhooks = environs_helper.get_env_hooks_config(request, name, stage)
+
         return render(request, 'configs/webhooks_config.html', {
             "envs": envs,
             "env": env,
+            "all_stage_types": sorted(environs_helper.STAGE_TYPES),
             "stages": stages,
             "webhooks": webhooks,
         })


### PR DESCRIPTION
## Bugs:
- URL params were getting changed: a param like ?param was getting changed to ?param= due to use in a javascript URLSearchParams object in env_tabs.tmpl.
- Some pages were not getting fed the correct data to render stage type filter.
- Some pages were rendering env_tabs but not providing the correct data to render the tabs
- Deploy history page was checking all rendered components and putting a limit on checked checkboxes, interfering with stage type filter

## Fixes
- URL params are now modified with a custom parser in env_tabs.tmpl to not change url params formatting.
- Necessary pages are now fed correct data to render stage type filter.
- Pages that were previously rendering env_tabs.tmpl and not actually displaying any tabs (not providing the correct data) had the reference to env_tabs.tmpl removed.
- Changed deploy history page to only check components inside deploy history table