### PR TITLE
allow none for the third priority backup instance type

### DIFF
--- a/deploy-board/deploy_board/templates/clusters/host_types_mapping.html
+++ b/deploy-board/deploy_board/templates/clusters/host_types_mapping.html
@@ -99,6 +99,7 @@
                         </label>
                         <div class="col-md-6">
                             <select class="form-control" name="thirdHostType" required id="thirdHostType">
+                                <option value="None">None</option>
                                 {% for type in hosttype_list %}
                                     <option value="{{ type.provider_name }}" >{{ type.provider_name }}</option>
                                 {% endfor %}

--- a/deploy-board/deploy_board/templates/clusters/modify_host_type_mapping_modal.tmpl
+++ b/deploy-board/deploy_board/templates/clusters/modify_host_type_mapping_modal.tmpl
@@ -33,6 +33,7 @@
                     </label>
                     <div class="col-md-6">
                         <select class="form-control" name="thirdHostType" required id="thirdHostType">
+                            <option value="None">None</option>
                             {% for type in hosttype_list %}
                                 <option value="{{ type.provider_name }}" >{{ type.provider_name }}</option>
                             {% endfor %}

--- a/deploy-board/deploy_board/webapp/cluster_view.py
+++ b/deploy-board/deploy_board/webapp/cluster_view.py
@@ -665,7 +665,10 @@ def create_host_type_mapping(request):
     params = request.POST
     host_type_mapping_info = {}
     host_type_mapping_info['defaultId'] = params['defaultHostType']
-    host_type_mapping_info['backupIds'] = [params['secondHostType'], params['thirdHostType']]
+    if params["thirdHostType"] == "None":
+        host_type_mapping_info['backupIds'] = [params['secondHostType']]
+    else:
+        host_type_mapping_info['backupIds'] = [params['secondHostType'], params['thirdHostType']]
     hosttypesmapping_helper.create_host_type_mapping(request, host_type_mapping_info)
     return redirect('/clouds/hosttypesmapping/')
 
@@ -674,7 +677,10 @@ def modify_host_type_mapping(request):
     try:
         host_type_mapping_info = json.loads(request.body)
         updated_info = {}
-        updated_info['backupIds'] = [host_type_mapping_info['secondHostType'], host_type_mapping_info['thirdHostType']]
+        if host_type_mapping_info['thirdHostType'] == "None":
+            updated_info['backupIds'] = [host_type_mapping_info['secondHostType']]
+        else:
+            updated_info['backupIds'] = [host_type_mapping_info['secondHostType'], host_type_mapping_info['thirdHostType']]
         host_type_id = host_type_mapping_info['id']
         updated_info['defaultId'] = host_type_mapping_info['id']
 


### PR DESCRIPTION
The capacity team has requested a mapping of instance types, which includes only one backup option.