### PR TITLE
Set `isManagedResource` to false on any cluster updates

### DIFF
--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -1006,7 +1006,6 @@
                            delete clusterInfo['configs']['cmp_group']
                        }
                     }
-                    clusterInfo['isManagedResource'] = false
 
                     if (this.validateInput(clusterInfo, this.imageNameValue)) {
                         //Send request

--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -1006,6 +1006,7 @@
                            delete clusterInfo['configs']['cmp_group']
                        }
                     }
+                    clusterInfo['isManagedResource'] = false
 
                     if (this.validateInput(clusterInfo, this.imageNameValue)) {
                         //Send request

--- a/deploy-board/deploy_board/webapp/cluster_view.py
+++ b/deploy-board/deploy_board/webapp/cluster_view.py
@@ -335,6 +335,7 @@ class ClusterConfigurationView(View):
                         log.error("Teletraan does not support user to remove %s %s" % (field, cluster_info[field]))
                         raise TeletraanException("Teletraan does not support user to remove %s" % field)
             cluster_info['statefulStatus'] = clusters_helper.StatefulStatuses.get_status(cluster_info['statefulStatus'])
+            cluster_info['isManagedResource'] = False
             clusters_helper.update_cluster(request, cluster_name, cluster_info)
         except NotAuthorizedException as e:
             log.error("Have an NotAuthorizedException error {}".format(e))
@@ -357,6 +358,9 @@ class ClusterCapacityUpdateView(View):
             maxSize = int(settings['maxsize'])
             clusters_helper.update_cluster_capacity(
                 request, cluster_name, minSize, maxSize)
+            cluster_info = clusters_helper.get_cluster(request, cluster_name)
+            cluster_info['isManagedResource'] = False
+            clusters_helper.update_cluster(request, cluster_name, cluster_info)
         except NotAuthorizedException as e:
             log.error("Have an NotAuthorizedException error {}".format(e))
             return HttpResponse(e, status=403, content_type="application/json")


### PR DESCRIPTION
## Test Plan

### `isManagedResource` is persisted as `false` when updating cluster with backend change

https://www.loom.com/share/c89443b35aae4c36bb0aef70831b810b

### `isManagedResource` is persisted as `false` when creating cluster with backend change

https://www.loom.com/share/bfa3315843bb40f3894f94a3e00f8e81

### `isManagedResource` is persisted as `false` when updating cluster capacity with backend change

https://www.loom.com/share/bd240f05641f4198ac17f5d4be638a94?sid=3e69f69e-9698-49ba-a02e-605c3b712503

### Cluster update still works without backend change

https://www.loom.com/share/a6158ed5feb44c8c8e077744ee33209f?sid=95f4700f-14a2-48cf-9c70-045b710a13da

### Cluster creation still works without backend change

https://www.loom.com/share/18ca52987d754dff889d105187fd3d67

### Cluster capacity update still works without backend change

https://www.loom.com/share/74d9ef456e2f403ca5622757d0b70401?sid=0d631b28-8a9f-4e35-8f22-861d454bf53e


