### PR TITLE
Return 404 if no current deploy exists

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/BaseBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/BaseBean.java
@@ -1,16 +1,31 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.pinterest.deployservice.bean;
 
 public class BaseBean {
 
     /**
-     * Trims the input string to the specified size limit. If the input string's length
-     * exceeds the limit, the method returns the substring from the end of the string
-     * with the specified limit. Otherwise returns the original string.
+     * Trims the input string to the specified size limit. If the input string's length exceeds the
+     * limit, the method returns the substring from the end of the string with the specified limit.
+     * Otherwise returns the original string.
      *
      * @param value the input string to be trimmed
      * @param limit the maximum length of the returned string
-     * @return the trimmed string if the input string's length exceeds the limit,
-     *         otherwise the original string
+     * @return the trimmed string if the input string's length exceeds the limit, otherwise the
+     *     original string
      */
     protected String getStringWithinSizeLimit(String value, int limit) {
         if (value != null && value.length() > limit) {

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/bean/BaseBeanTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/bean/BaseBeanTest.java
@@ -1,5 +1,19 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.pinterest.deployservice.bean;
-
 
 import static org.junit.Assert.assertSame;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -22,6 +36,7 @@ public class BaseBeanTest {
         String result = baseBean.getStringWithinSizeLimit(input, 10);
         assertSame(input, result);
     }
+
     @Test
     void testGetStringWithinSizeLimitInputExceedsLimit() {
         BaseBean baseBean = new BaseBean();

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvDeploys.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvDeploys.java
@@ -40,6 +40,7 @@ import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.*;
 import javax.ws.rs.core.*;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -95,7 +96,7 @@ public class EnvDeploys {
                     String stageName)
             throws Exception {
         EnvironBean envBean = Utils.getEnvStage(environDAO, envName, stageName);
-        if (envBean.getDeploy_id() == null) {
+        if (StringUtils.isNotBlank(envBean.getDeploy_id())) {
             throw new NotFoundException(
                     String.format("%s/%s doesn't have any deploys", envName, stageName));
         }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvDeploys.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvDeploys.java
@@ -95,6 +95,10 @@ public class EnvDeploys {
                     String stageName)
             throws Exception {
         EnvironBean envBean = Utils.getEnvStage(environDAO, envName, stageName);
+        if (envBean.getDeploy_id() == null) {
+            throw new NotFoundException(
+                    String.format("%s/%s doesn't have any deploys", envName, stageName));
+        }
         return deployHandler.getDeploySafely(envBean.getDeploy_id());
     }
 
@@ -269,7 +273,8 @@ public class EnvDeploys {
         return Response.created(deployUri).entity(deployBean).build();
     }
 
-    // Even though this is PUT, but it really just update progress, no check is needed
+    // Even though this is PUT, but it really just update progress, no check is
+    // needed
     @PUT
     @Timed
     @ExceptionMetered

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvDeploys.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvDeploys.java
@@ -96,7 +96,7 @@ public class EnvDeploys {
                     String stageName)
             throws Exception {
         EnvironBean envBean = Utils.getEnvStage(environDAO, envName, stageName);
-        if (StringUtils.isNotBlank(envBean.getDeploy_id())) {
+        if (StringUtils.isBlank(envBean.getDeploy_id())) {
             throw new NotFoundException(
                     String.format("%s/%s doesn't have any deploys", envName, stageName));
         }


### PR DESCRIPTION
The current implementation let `getDeploySafely` handle `deployId` being null and throws an exception that will eventually be mapped to 500. To improve the usability of this API, explicitly throw 404 if `deployId` is blank. 