### PR TITLE
CDP-8328: deploy-agent: enable unit tests in bazel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,11 @@ MANIFEST
 # Virtual Environments
 .venv
 docs/docs_generator/bin/
+
+# Bazel
+bazel-bin
+bazel-out
+bazel-testlogs
+bazel-weave
+bazel-deploy-agent
+MODULE.bazel*

--- a/deploy-agent/README.md
+++ b/deploy-agent/README.md
@@ -1,7 +1,39 @@
 Deploy-agent is a python script runs on every host and execute deploy scripts.
 See https://github.com/pinterest/teletraan/wiki for more details.
 
-To run unit tests (debian comapatible):
+# Before you commit new code
+
+1. Install [pre-commit](https://pre-commit.com/#install)
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+# Using Bazel
+## Prerequisites
+Ensure that your python version is at least python3.8.
+
+## Building
+```bash
+sudo bazel build //deployd:deploy-agent
+```
+
+## Testing
+```bash
+cd teletraan/deploy-agent/
+sudo bazel test //tests:*
+
+```
+
+# FAQ
+
+## Run pre-commit on the last commit only
+```bash
+cd teletraan
+pre-commit run --files $(git diff --name-only HEAD^1...HEAD)
+```
+
+## To run unit tests (debian comapatible):
 
 1. Install `tox` with apt.
 2.  `> tox`

--- a/deploy-agent/tests/BUILD.bazel
+++ b/deploy-agent/tests/BUILD.bazel
@@ -8,6 +8,13 @@ py_test(
 )
 
 py_test(
+    name = "test_client",
+    srcs = ['unit/deploy/client/test_client.py'],
+    deps = ["test_lib"],
+    python_version = "PY3",
+)
+
+py_test(
     name = "test_serverless_client",
     srcs = ['unit/deploy/client/test_serverless_client.py'],
     deps = ["test_lib"],
@@ -15,8 +22,22 @@ py_test(
 )
 
 py_test(
-    name = "test_agent",
-    srcs = ['unit/deploy/server/test_agent.py'],
+    name = "test_config",
+    srcs = ['unit/deploy/common/test_config.py'],
+    deps = ["test_lib"],
+    python_version = "PY3",
+)
+
+py_test(
+    name = "test_helper",
+    srcs = ['unit/deploy/common/test_helper.py'],
+    deps = ["test_lib"],
+    python_version = "PY3",
+)
+
+py_test(
+    name = "test_stats",
+    srcs = ['unit/deploy/common/test_stats.py'],
     deps = ["test_lib"],
     python_version = "PY3",
 )
@@ -29,8 +50,8 @@ py_test(
 )
 
 py_test(
-    name = "test_s3_download_helper",
-    srcs = ['unit/deploy/download/test_s3_download_helper.py'],
+    name = "test_download_helper",
+    srcs = ['unit/deploy/download/test_download_helper.py'],
     deps = ["test_lib"],
     python_version = "PY3",
 )
@@ -38,6 +59,41 @@ py_test(
 py_test(
     name = "test_http_download_helper",
     srcs = ['unit/deploy/download/test_http_download_helper.py'],
+    deps = ["test_lib"],
+    python_version = "PY3",
+)
+
+py_test(
+    name = "test_local_download_helper",
+    srcs = ['unit/deploy/download/test_local_download_helper.py'],
+    deps = ["test_lib"],
+    python_version = "PY3",
+)
+
+py_test(
+    name = "test_s3_download_helper",
+    srcs = ['unit/deploy/download/test_s3_download_helper.py'],
+    deps = ["test_lib"],
+    python_version = "PY3",
+)
+
+py_test(
+    name = "test_agent",
+    srcs = ['unit/deploy/server/test_agent.py'],
+    deps = ["test_lib"],
+    python_version = "PY3",
+)
+
+py_test(
+    name = "test_staging_helper",
+    srcs = ['unit/deploy/staging/test_staging_helper.py'],
+    deps = ["test_lib"],
+    python_version = "PY3",
+)
+
+py_test(
+    name = "test_transformer",
+    srcs = ['unit/deploy/staging/test_transformer.py'],
     deps = ["test_lib"],
     python_version = "PY3",
 )

--- a/deploy-agent/tests/unit/deploy/common/test_config.py
+++ b/deploy-agent/tests/unit/deploy/common/test_config.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
+from unittest import mock
 import os
 import os.path
 import tempfile
@@ -78,10 +78,10 @@ class TestConfigFunctions(tests.TestCase):
     def test_get_config_filename(self):
         filename = os.path.join(self.dirname, "test_file1.conf")
         open(os.path.join(self.dirname, "test_file1.conf"), "w")
-            
-        config = Config(filenames=filename) 
+
+        config = Config(filenames=filename)
         self.assertEqual(config.get_config_filename(), filename)
-    
+
     def test_get_deploy_type_from_op_code(self):
         config = Config()
         self.assertEqual(config._get_deploy_type_from_opcode(opCode="NOOP"), DeployType.REGULAR)

--- a/deploy-agent/tests/unit/deploy/common/test_helper.py
+++ b/deploy-agent/tests/unit/deploy/common/test_helper.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import getpass
-import mock
+from unittest import mock
 import os.path
 import shutil
 import tests

--- a/deploy-agent/tests/unit/deploy/download/test_download_helper.py
+++ b/deploy-agent/tests/unit/deploy/download/test_download_helper.py
@@ -14,7 +14,7 @@
 
 from deployd.download.s3_download_helper import S3DownloadHelper
 import os
-import mock
+from unittest import mock
 import shutil
 import tempfile
 import unittest

--- a/deploy-agent/tests/unit/deploy/server/test_agent.py
+++ b/deploy-agent/tests/unit/deploy/server/test_agent.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -499,7 +499,6 @@ class TestDeployAgent(TestCase):
         status.report = PingReport(jsonValue=self.deploy_goal1)
 
         envs = {'abc': status}
-        client = mock.Mock()
         estatus = mock.Mock()
         estatus.load_envs = mock.Mock(return_value=envs)
         ping_response_list = [
@@ -513,8 +512,14 @@ class TestDeployAgent(TestCase):
         agent = DeployAgent(client=client, estatus=estatus, conf=self.config,
                             executor=self.executor, helper=self.helper)
         agent.serve_build()
-        mock_create_sc.assert_called_once_with('deployd.stats.deploy.status.sum', tags={
-                                               'first_run': False, 'deploy_stage': 'PRE_DOWNLOAD', 'env_name': 'abc', 'stage_name': 'beta', 'status_code': 'SUCCEEDED'})
+        mock_create_sc.assert_called_once_with(
+            'deployd.stats.deploy.status.sum',
+            tags={
+                'first_run': False,
+                'deploy_stage': 'PRE_DOWNLOAD',
+                'env_name': 'abc',
+                'stage_name': 'beta',
+                'status_code': 'SUCCEEDED'})
         self.assertEqual(agent._curr_report.report.deployStage, DeployStage.PRE_DOWNLOAD)
         self.assertEqual(agent._curr_report.report.status, AgentStatus.SUCCEEDED)
 

--- a/deploy-agent/tests/unit/deploy/staging/test_staging_helper.py
+++ b/deploy-agent/tests/unit/deploy/staging/test_staging_helper.py
@@ -3,16 +3,16 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
+from unittest import mock
 import os.path
 import shutil
 import unittest
@@ -23,7 +23,7 @@ from deployd.common.status_code import Status
 from deployd.staging.stager import Stager
 
 
-class TestHelper(unittest.TestCase):
+class TestStagingHelper(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.base_dir = tempfile.mkdtemp()


### PR DESCRIPTION
# Description
Just enabling existing unit tests in bazel before making changes to the agent

# Execution on `devapp`
```
jpierre@devrestricted-jpierre:~/code/teletraan/deploy-agent$ sudo bazel test //tests:*
[...]
INFO: Analyzed 31 targets (1 packages loaded, 31 targets configured).
INFO: Found 17 targets and 14 test targets...
INFO: Elapsed time: 1.382s, Critical Path: 0.51s
INFO: 15 processes: 28 processwrapper-sandbox.
INFO: Build completed successfully, 15 total actions
//tests:test_agent                                                       PASSED in 0.4s
//tests:test_base_client                                                 PASSED in 0.2s
//tests:test_client                                                      PASSED in 0.3s
//tests:test_config                                                      PASSED in 0.3s
//tests:test_download_helper                                             PASSED in 0.4s
//tests:test_helper                                                      PASSED in 0.2s
//tests:test_http_download_helper                                        PASSED in 0.3s
//tests:test_local_download_helper                                       PASSED in 0.1s
//tests:test_s3_download_helper                                          PASSED in 0.5s
//tests:test_serverless_client                                           PASSED in 0.3s
//tests:test_staging_helper                                              PASSED in 0.3s
//tests:test_stats                                                       PASSED in 0.2s
//tests:test_transformer                                                 PASSED in 0.2s
//tests:test_utils                                                       PASSED in 0.3s

Executed 14 out of 14 tests: 14 tests pass.
```