### PR TITLE
CDP-8544: Added an endpoint to get active host ids

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostDAO.java
@@ -58,6 +58,8 @@ public interface HostDAO {
 
     List<HostBean> getHostsByHostId(String hostId) throws Exception;
 
+    List<String> getActiveHostIdsByHostIds(Collection<String> hostId) throws Exception;
+
     List<HostBean> getTerminatingHosts() throws Exception;
 
     List<String> getStaleAgentlessHostIds(long lastUpdateBefore, int limit) throws SQLException;

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/db/DBDAOTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/db/DBDAOTest.java
@@ -861,6 +861,77 @@ public class DBDAOTest {
     }
 
     @Test
+    public void returnActiveHostIdsIfThemExists() throws Exception {
+        // GIVEN
+        Set<String> groups = new HashSet<>(Arrays.asList("group1", "group2"));
+        String activeHostId1 = "id-active-1";
+        String activeHostId2 = "id-active-2";
+        String terminatedHostId = "id-terminated-1";
+
+        hostDAO.insertOrUpdate(
+                "host-active-1",
+                "1.1.1.1",
+                activeHostId1,
+                HostState.ACTIVE.toString(),
+                groups,
+                "test");
+        hostDAO.insertOrUpdate(
+                "host-active-2",
+                "1.1.1.1",
+                activeHostId2,
+                HostState.ACTIVE.toString(),
+                groups,
+                "test");
+        hostDAO.insertOrUpdate(
+                "host-terminated-1",
+                "1.1.1.1",
+                terminatedHostId,
+                HostState.TERMINATED.toString(),
+                groups,
+                "test");
+
+        // WHEN
+        List<String> actual =
+                hostDAO.getActiveHostIdsByHostIds(Arrays.asList(activeHostId1, activeHostId2));
+
+        // THEN
+        assertEquals(2, actual.size());
+        assertTrue(actual.contains(activeHostId1));
+        assertTrue(actual.contains(activeHostId2));
+    }
+
+    @Test
+    public void returnEmptyHostIdsIfThemNotExists() throws Exception {
+        // GIVEN
+        Set<String> groups = new HashSet<>(Arrays.asList("group1", "group2"));
+        String terminatedHostId = "id-terminated-2";
+        String terminatingHostId = "id-terminating-1";
+
+        hostDAO.insertOrUpdate(
+                "host-terminated-2",
+                "1.1.1.1",
+                terminatedHostId,
+                HostState.TERMINATED.toString(),
+                groups,
+                "test");
+        hostDAO.insertOrUpdate(
+                "host-terminating-1",
+                "1.1.1.1",
+                terminatingHostId,
+                HostState.TERMINATING.toString(),
+                groups,
+                "test");
+
+        // WHEN
+        List<String> actual =
+                hostDAO.getActiveHostIdsByHostIds(
+                        Arrays.asList(terminatedHostId, terminatingHostId));
+
+        // THEN
+        assertTrue(actual.isEmpty());
+    }
+
+    @Test
     public void testDataDAO() throws Exception {
         DataBean dataBean = genDefaultDataBean("foo1", "name1=value1,name2=value2");
         dataDAO.insert(dataBean);

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Hosts.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Hosts.java
@@ -128,4 +128,14 @@ public class Hosts {
     public Collection<HostBean> getById(@PathParam("hostId") String hostId) throws Exception {
         return hostDAO.getHostsByHostId(hostId);
     }
+
+    @POST
+    @Path("/active")
+    @ApiOperation(
+            value = "Get active host ids by host ids",
+            notes =
+                    "Checks if hosts are active in the Teletraan service by it's id. POST operation because host ids may be too long for a GET request.")
+    public Collection<String> getActiveHostsIdsByIds(Collection<String> hostIds) throws Exception {
+        return hostDAO.getActiveHostIdsByHostIds(hostIds);
+    }
 }


### PR DESCRIPTION
# Context

Rodimus should have a possibility to fallback to check running hosts in the Teletraan service. This PR adds a new endpoint which returns active (running) hosts from the Teletraan database.

# Tests

## Test Script
```Bash
#!/bin/bash

TOKEN=''

curl -i -X POST --location 'https://<teletraan_url>/v1/hosts/active' \
    --header 'Content-Type: application/json' \
    --header "Authorization: token $TOKEN" \
    --data '["i-00ed0c81d932f4038", "i-045152ef8256fcb18"]'
```

## Results

### Active Hosts

```
["i-00ed0c81d932f4038","i-045152ef8256fcb18"]
```

### Not Active Hosts

```
[]
```