### PR TITLE
Improve job pool configurations

### DIFF
--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/ConfigHelper.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/ConfigHelper.java
@@ -64,16 +64,22 @@ import com.pinterest.teletraan.worker.HotfixStateTransitioner;
 import com.pinterest.teletraan.worker.MetricsEmitter;
 import com.pinterest.teletraan.worker.SimpleAgentJanitor;
 import com.pinterest.teletraan.worker.StateTransitioner;
+
+import io.dropwizard.setup.Environment;
+import io.dropwizard.util.Duration;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.TreeMap;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.ThreadPoolExecutor.AbortPolicy;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.dbcp.BasicDataSource;
@@ -98,7 +104,7 @@ public class ConfigHelper {
     private static final int DEFAULT_MAX_DAYS_TO_KEEP = 180;
     private static final int DEFAULT_MAX_BUILDS_TO_KEEP = 1000;
 
-    public static TeletraanServiceContext setupContext(TeletraanServiceConfiguration configuration)
+    public static TeletraanServiceContext setupContext(TeletraanServiceConfiguration configuration, Environment environment)
             throws Exception {
         TeletraanServiceContext context = new TeletraanServiceContext();
 
@@ -218,20 +224,18 @@ public class ConfigHelper {
             context.setAccountAllowList(configuration.getAccountAllowList());
         }
 
-        /*
-        Lastly, let us create the in-process background job executor, all transient, long
-        running background jobs can be handled by this executor
-        Currently we hard coded the parameters as:
-
-        corePoolSize - the number of threads to keep in the pool, even if they are idle, unless allowCoreThreadTimeOut is set
-        maximumPoolSize - the maximum number of threads to allow in the pool
-        keepAliveTime - when the number of threads is greater than the core, this is the maximum time that excess idle threads will wait for new tasks before terminating.
-        unit - the time unit for the keepAliveTime argument
-        workQueue - the queue to use for holding tasks before they are executed. This queue will hold only the Runnable tasks submitted by the execute method.
-        */
-        // TODO make the thread configurable
+        int poolSize = Runtime.getRuntime().availableProcessors();
+        String jobPoolName = "jobPool";
         ExecutorService jobPool =
-                new ThreadPoolExecutor(1, 10, 30, TimeUnit.SECONDS, new LinkedBlockingQueue<>());
+                environment.lifecycle().executorService(jobPoolName)
+                        .minThreads(poolSize*4)
+                        .maxThreads(poolSize*8)
+                        .keepAliveTime(Duration.seconds(30))
+                        .workQueue(new ArrayBlockingQueue<>(poolSize * 5000, false))
+                        .shutdownTime(Duration.seconds(30))
+                        .rejectedExecutionHandler(new AbortPolicy())
+                        .build();
+        new ExecutorServiceMetrics(jobPool, jobPoolName, null).bindTo(Metrics.globalRegistry);
         context.setJobPool(jobPool);
 
         context.setDeployBoardUrlPrefix(configuration.getSystemFactory().getDashboardUrl());

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/ConfigHelper.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/ConfigHelper.java
@@ -64,12 +64,10 @@ import com.pinterest.teletraan.worker.HotfixStateTransitioner;
 import com.pinterest.teletraan.worker.MetricsEmitter;
 import com.pinterest.teletraan.worker.SimpleAgentJanitor;
 import com.pinterest.teletraan.worker.StateTransitioner;
-
 import io.dropwizard.setup.Environment;
 import io.dropwizard.util.Duration;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -104,8 +102,8 @@ public class ConfigHelper {
     private static final int DEFAULT_MAX_DAYS_TO_KEEP = 180;
     private static final int DEFAULT_MAX_BUILDS_TO_KEEP = 1000;
 
-    public static TeletraanServiceContext setupContext(TeletraanServiceConfiguration configuration, Environment environment)
-            throws Exception {
+    public static TeletraanServiceContext setupContext(
+            TeletraanServiceConfiguration configuration, Environment environment) throws Exception {
         TeletraanServiceContext context = new TeletraanServiceContext();
 
         BasicDataSource dataSource = configuration.getDataSourceFactory().build();
@@ -227,9 +225,11 @@ public class ConfigHelper {
         int poolSize = Runtime.getRuntime().availableProcessors();
         String jobPoolName = "jobPool";
         ExecutorService jobPool =
-                environment.lifecycle().executorService(jobPoolName)
-                        .minThreads(poolSize*4)
-                        .maxThreads(poolSize*8)
+                environment
+                        .lifecycle()
+                        .executorService(jobPoolName)
+                        .minThreads(poolSize * 4)
+                        .maxThreads(poolSize * 8)
                         .keepAliveTime(Duration.seconds(30))
                         .workQueue(new ArrayBlockingQueue<>(poolSize * 5000, false))
                         .shutdownTime(Duration.seconds(30))

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanAgentService.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanAgentService.java
@@ -44,7 +44,7 @@ public class TeletraanAgentService extends Application<TeletraanServiceConfigura
     @Override
     public void run(TeletraanServiceConfiguration configuration, Environment environment)
             throws Exception {
-        TeletraanServiceContext context = ConfigHelper.setupContext(configuration);
+        TeletraanServiceContext context = ConfigHelper.setupContext(configuration, environment);
         environment.jersey().register(context);
         environment
                 .jersey()

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanService.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanService.java
@@ -51,7 +51,7 @@ public class TeletraanService extends Application<TeletraanServiceConfiguration>
     @Override
     public void run(TeletraanServiceConfiguration configuration, Environment environment)
             throws Exception {
-        TeletraanServiceContext context = ConfigHelper.setupContext(configuration);
+        TeletraanServiceContext context = ConfigHelper.setupContext(configuration, environment);
 
         environment.jersey().register(context);
         environment
@@ -129,6 +129,7 @@ public class TeletraanService extends Application<TeletraanServiceConfiguration>
                 "allowedHeaders",
                 "Content-Type,Authorization,X-Requested-With,Content-Length,Accept,Origin");
         filter.setInitParameter("allowCredentials", "true");
+
     }
 
     public static void main(String[] args) throws Exception {

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanService.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanService.java
@@ -129,7 +129,6 @@ public class TeletraanService extends Application<TeletraanServiceConfiguration>
                 "allowedHeaders",
                 "Content-Type,Authorization,X-Requested-With,Content-Length,Accept,Origin");
         filter.setInitParameter("allowCredentials", "true");
-
     }
 
     public static void main(String[] args) throws Exception {

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanWorker.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/TeletraanWorker.java
@@ -40,7 +40,7 @@ public class TeletraanWorker extends Application<TeletraanServiceConfiguration> 
     @Override
     public void run(TeletraanServiceConfiguration configuration, Environment environment)
             throws Exception {
-        TeletraanServiceContext context = ConfigHelper.setupContext(configuration);
+        TeletraanServiceContext context = ConfigHelper.setupContext(configuration, environment);
         ConfigHelper.scheduleWorkers(configuration, context);
         environment.healthChecks().register("generic", new WorkerHealthCheck(context));
     }


### PR DESCRIPTION
Due to misconfiguration, the job pool used in Teletraan has only one thread. Similar issue fixed in https://github.com/pinternal/rodimus/pull/110

1. `ExecutorService` used for thread pool has only 1 thread. Changed the work queue type to fix. The configuration is the same as the `regular` pool in the Rodimus. 
2. `ExecutorService` instance is not managed, so it's not properly shutdown. Use Dropwizard for lifecycle management.
3.  Bind it to Micrometer's registry so we get metrics. 

## Considerations 
I didn't have the whole change in Rodimus ported because it was not needed. There are only 3 types of tasks involved in Teletraan, ChangeFeed, NotifyJob and Webhook. They will work fine with just the regular pool configuration.

## Test plan
This change is a subset of changes we made to Rodimus and it's been working well. For sanity tests, I deployed a build with this change and verified that change feed events are published and metrics are emitted.

<img width="1611" alt="Screenshot 2024-11-08 at 14 39 52" src="https://github.com/user-attachments/assets/a0fac152-c5e6-4311-9712-7ed288d2be36">
<img width="1449" alt="Screenshot 2024-11-08 at 14 39 43" src="https://github.com/user-attachments/assets/96bc266e-81ff-4f2c-8457-f36e9ee0d900">

