### PR TITLE
Change log level of noisy worker logs

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/CommonHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/CommonHandler.java
@@ -487,12 +487,12 @@ public class CommonHandler {
         String lockName = String.format("STATE_TRANSITION-%s", deployId);
         Connection connection = utilDAO.getLock(lockName);
         if (connection != null) {
-            LOG.info(String.format("DB lock operation is successful: get lock %s", lockName));
+            LOG.trace(String.format("DB lock operation is successful: get lock %s", lockName));
             try {
                 internalTransition(deployId, envBean);
             } finally {
                 utilDAO.releaseLock(lockName, connection);
-                LOG.info(
+                LOG.trace(
                         String.format(
                                 "DB lock operation is successful: release lock %s", lockName));
             }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AutoPromoter.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AutoPromoter.java
@@ -536,7 +536,7 @@ public class AutoPromoter implements Runnable {
                 if (buildTagBean.getTag() != null
                         && buildTagBean.getTag().getValue() == TagValue.BAD_BUILD) {
                     // bad build,  do not include
-                    LOG.info(
+                    LOG.debug(
                             "Env {} Build {} is tagged as BAD_BUILD, ignore",
                             envBean.getEnv_id(),
                             buildTagBean.getBuild());


### PR DESCRIPTION
These logs will be gone unless log level trace is enabled. This will get rid of 60%+ logs.