### PR TITLE
Add extra tag for env

### DIFF
--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/handler/EnvStagesTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/handler/EnvStagesTest.java
@@ -67,7 +67,7 @@ public class EnvStagesTest {
         origBean.setStage_type(EnvType.DEV);
         envBean.setStage_type(EnvType.STAGING);
         Mockito.when(environDAO.getByStage(Mockito.anyString(), Mockito.anyString()))
-            .thenReturn(origBean);
+                .thenReturn(origBean);
         SecurityContext mockSC = mock(SecurityContext.class);
         Principal mockPrincipal = mock(Principal.class);
         Mockito.when(mockSC.getUserPrincipal()).thenReturn(mockPrincipal);

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/ScriptTokenAuthenticator.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/ScriptTokenAuthenticator.java
@@ -22,6 +22,7 @@ import io.dropwizard.auth.AuthenticationException;
 import io.dropwizard.auth.Authenticator;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Metrics;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -55,7 +56,7 @@ public class ScriptTokenAuthenticator<R extends Role<R>>
                                 "principal",
                                 principal.get().getName(),
                                 "env",
-                                principal.get().getResource().getEnvName())
+                                Objects.toString(principal.get().getResource().getEnvName(), "NA"))
                         .register(Metrics.globalRegistry)
                         .increment();
             } else {

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/ScriptTokenAuthenticator.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/ScriptTokenAuthenticator.java
@@ -51,7 +51,11 @@ public class ScriptTokenAuthenticator<R extends Role<R>>
             Optional<ScriptTokenPrincipal<R>> principal = tokenProvider.getPrincipal(credentials);
             if (principal.isPresent()) {
                 scriptTokenSuccessCounterBuilder
-                        .tags("principal", principal.get().getName())
+                        .tags(
+                                "principal",
+                                principal.get().getName(),
+                                "env",
+                                principal.get().getResource().getEnvName())
                         .register(Metrics.globalRegistry)
                         .increment();
             } else {

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/ScriptTokenAuthenticatorTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/ScriptTokenAuthenticatorTest.java
@@ -23,6 +23,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.pinterest.teletraan.universal.security.bean.AuthZResource;
 import com.pinterest.teletraan.universal.security.bean.ScriptTokenPrincipal;
 import com.pinterest.teletraan.universal.security.bean.ValueBasedRole;
 import io.dropwizard.auth.AuthenticationException;
@@ -50,12 +51,14 @@ class ScriptTokenAuthenticatorTest {
         registry = new SimpleMeterRegistry();
         Metrics.addRegistry(registry);
 
+        scriptTokenPrincipal =
+                new ScriptTokenPrincipal<ValueBasedRole>(
+                        PRINCIPAL_NAME, new ValueBasedRole(1), new AuthZResource("rId", "rType"));
+
         scriptTokenProvider = mock(ScriptTokenProvider.class);
-        scriptTokenPrincipal = mock(ScriptTokenPrincipal.class);
         when(scriptTokenProvider.getPrincipal(anyString())).thenReturn(Optional.empty());
         when(scriptTokenProvider.getPrincipal(CREDENTIALS))
                 .thenReturn(Optional.of(scriptTokenPrincipal));
-        when(scriptTokenPrincipal.getName()).thenReturn(PRINCIPAL_NAME);
 
         sut = new ScriptTokenAuthenticator<>(scriptTokenProvider);
     }


### PR DESCRIPTION
Script tokens can have the same name, add env tag to differentiate. 