### PR TITLE
Fix RetryInterceptor

### DIFF
--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/http/HttpClientTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/http/HttpClientTest.java
@@ -278,7 +278,7 @@ class HttpClientTest {
 
         @Override
         public MockResponse dispatch(RecordedRequest request) {
-            return new MockResponse().setResponseCode(responseCode);
+            return new MockResponse().setResponseCode(responseCode).setBody(TEST_BODY);
         }
     }
 }


### PR DESCRIPTION
Similar issue https://github.com/square/okhttp/issues/4986

```
ava.lang.IllegalStateException: cannot make a new request because the previous response is still open: please call response.close() at okhttp3.internal.connection.RealCall.enterNetworkInterceptorExchange(RealCall.kt:229) at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.kt:66) at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109) at com.pinterest.teletraan.universal.http.HttpClient.lambda$new$0(HttpClient.java:81) at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109) at com.pinterest.teletraan.universal.http.RetryInterceptor.intercept(RetryInterceptor.java:44) at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109) at io.micrometer.core.instrument.binder.okhttp3.OkHttpObservationInterceptor.intercept(OkHttpObservationInterceptor.java:98) at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109) at okhttp3.logging.HttpLoggingInterceptor.intercept(HttpLoggingInterceptor.kt:154) at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109) at okhttp3.internal.connection.RealCall.getResponseWithInterceptorChain$okhttp(RealCall.kt:201) at okhttp3.internal.connection.RealCall.execute(RealCall.kt:154) at com.pinterest.teletraan.universal.http.HttpClient.makeCall(HttpClient.java:179) at com.pinterest.teletraan.universal.http.HttpClient.post(HttpClient.java:140) at com.pinterest.deployservice.rodimus.RodimusManagerImpl.getTerminatedHosts(RodimusManagerImpl.java:129) at
```

## Test plan
Updated test cases and confirmed that the exception is thrown if `response.close();` is not called.