### PR TITLE
Fix termination policies not matching from backend API

### DIFF
--- a/deploy-board/deploy_board/webapp/helpers/autoscaling_groups_helper.py
+++ b/deploy-board/deploy_board/webapp/helpers/autoscaling_groups_helper.py
@@ -19,7 +19,7 @@ from deploy_board.webapp.helpers.rodimus_client import RodimusClient
 rodimus_client = RodimusClient()
 
 
-TerminationPolicy = ['DEFAULT', 'OLDEST_INSTANCE', 'NEWEST_INSTANCE', 'CLOSEST_TO_NEXT_INSTANCE_HOUR', 'ALLOCATION_STRATEGY', 'OLDEST_LAUNCH_TEMPLATE']
+TerminationPolicy = ["Default", "OldestInstance", "NewestInstance", "ClosestToNextInstanceHour", 'OldestLaunchTemplate', 'AllocationStrategy']
 
 
 Comparator = [{"value": "GreaterThanOrEqualToThreshold", "symbol": "≥"},


### PR DESCRIPTION
Currently, these values are not matching with values returned from backend. Updated to match.