### PR TITLE
Only log State transition result when state changes

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/CommonHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/CommonHandler.java
@@ -374,10 +374,12 @@ public class CommonHandler {
                 }
             }
             newDeployBean.setState(DeployState.SUCCEEDING);
-            LOG.info(
-                    "Set deploy {} as SUCCEEDING since {} agents are succeeded.",
-                    deployId,
-                    succeeded);
+            if (!DeployState.SUCCEEDING.equals(oldState)) {
+                LOG.info(
+                        "Set deploy {} as SUCCEEDING since {} agents are succeeded.",
+                        deployId,
+                        succeeded);
+            }
             return;
         }
 


### PR DESCRIPTION
This log line is about 60% of total worker log volume. For most of the time, this line is not very helpful unless there is a change. 