### PR TITLE
disable the ability to delete deploys through api

### DIFF
--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Deploys.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Deploys.java
@@ -152,14 +152,7 @@ public class Deploys {
         LOG.info("{} successfully updated deploy {} with {}", userName, id, deployBean);
     }
 
-    @DELETE
-    @Timed
-    @ExceptionMetered
-    @Path("/{id : [a-zA-Z0-9\\-_]+}")
-    @ApiOperation(value = "Delete deploy info", notes = "Delete deploy info given a deploy id")
-    @RolesAllowed(TeletraanPrincipalRole.Names.WRITE)
-    @ResourceAuthZInfo(type = AuthZResource.Type.DEPLOY, idLocation = Location.PATH)
-    public void delete(
+    private void delete(
             @Context SecurityContext sc,
             @ApiParam(value = "Deploy id", required = true) @PathParam("id") String id)
             throws Exception {


### PR DESCRIPTION
prevent deleting deploys through the teletraan api