### PR TITLE
CDP-8328: deploy-agent: emit normandie and knox status inside PingRequest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,9 +82,5 @@ MANIFEST
 docs/docs_generator/bin/
 
 # Bazel
-bazel-bin
-bazel-out
-bazel-testlogs
-bazel-weave
-bazel-deploy-agent
+bazel-*
 MODULE.bazel*

--- a/deploy-agent/README.md
+++ b/deploy-agent/README.md
@@ -5,6 +5,7 @@ See https://github.com/pinterest/teletraan/wiki for more details.
 
 1. Install [pre-commit](https://pre-commit.com/#install)
 ```bash
+cd teletraan
 pip install pre-commit
 pre-commit install
 ```
@@ -15,6 +16,7 @@ Ensure that your python version is at least python3.8.
 
 ## Building
 ```bash
+cd teletraan/deploy-agent/
 sudo bazel build //deployd:deploy-agent
 ```
 

--- a/deploy-agent/deployd/__init__.py
+++ b/deploy-agent/deployd/__init__.py
@@ -27,4 +27,4 @@ REDEPLOY_MAX_RETRY = 3
 # 2: puppet applied successfully with changes
 PUPPET_SUCCESS_EXIT_CODES = [0, 2]
 
-__version__ = '1.2.65'
+__version__ = '1.2.66'

--- a/deploy-agent/deployd/types/ping_request.py
+++ b/deploy-agent/deployd/types/ping_request.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#  
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-#    
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,7 +20,8 @@ from deployd.types.agent_status import AgentStatus
 class PingRequest(object):
 
     def __init__(self, hostId=None, hostName=None, hostIp=None, groups=None, reports=None,
-                agentVersion=None, autoscalingGroup=None, availabilityZone=None, ec2Tags=None, stageType=None, accountId=None):
+                agentVersion=None, autoscalingGroup=None, availabilityZone=None, ec2Tags=None, stageType=None,
+                 accountId=None, normandieStatus=None, knoxStatus=None):
         self.hostId = hostId
         self.hostName = hostName
         self.hostIp = hostIp
@@ -32,6 +33,8 @@ class PingRequest(object):
         self.ec2Tags = ec2Tags
         self.stageType = stageType
         self.accountId = accountId
+        self.normandieStatus = normandieStatus
+        self.knoxStatus = knoxStatus
 
     def to_json(self):
         ping_requests = {}
@@ -52,6 +55,10 @@ class PingRequest(object):
             ping_requests["accountId"] = self.accountId
         if self.ec2Tags:
             ping_requests["ec2Tags"] = self.ec2Tags
+        if self.normandieStatus:
+            ping_requests["normandieStatus"] = self.normandieStatus
+        if self.knoxStatus:
+            ping_requests["knoxStatus"] = self.knoxStatus
 
         ping_requests["reports"] = []
         for report in self.reports:
@@ -76,16 +83,16 @@ class PingRequest(object):
             ping_report["deployAlias"] = report.deployAlias
             ping_report["containerHealthStatus"] = report.containerHealthStatus
             ping_report["agentState"] = report.state
-            
+
             if report.extraInfo:
                 ping_report["extraInfo"] = \
                     json.dumps(report.extraInfo, ensure_ascii=False).encode('utf8')
-            
+
             ping_requests["reports"].append(ping_report)
         return ping_requests
 
     def __str__(self):
         return "PingRequest(hostId={}, hostName={}, hostIp={}, agentVersion={}, autoscalingGroup={}, " \
-            "availabilityZone={}, ec2Tags={}, stageType={}, groups={}, accountId={}, reports={})".format(self.hostId, self.hostName, 
+            "availabilityZone={}, ec2Tags={}, stageType={}, groups={}, accountId={}, normandieStatus={}, knoxStatus={}, reports={})".format(self.hostId, self.hostName,
             self.hostIp, self.agentVersion, self.autoscalingGroup, self.availabilityZone, self.ec2Tags, self.stageType,
-            self.groups, self.accountId, ",".join(str(v) for v in self.reports))
+            self.groups, self.accountId, self.normandieStatus, self.knoxStatus, ",".join(str(v) for v in self.reports))

--- a/deploy-agent/tests/unit/deploy/client/test_client.py
+++ b/deploy-agent/tests/unit/deploy/client/test_client.py
@@ -23,6 +23,30 @@ class TestClient(TestCase):
         self.assertIsNotNone(client._ip)
         self.assertTrue(return_value)
 
+    def test_read_host_info_normandie(self):
+        client = Client(config=Config())
+        client._ec2_tags = {}
+        client._availability_zone = "us-east-1"
+        return_value: bool = client._read_host_info()
+        self.assertTrue(return_value)
+
+        # On a host with normandie, the normandie status should be set to OK
+        # On a host without, such as build agents, the normandie status should be ERROR
+        self.assertIsNotNone(client._normandie_status)
+        self.assertTrue(client._normandie_status == "OK" or client._normandie_status == "ERROR")
+
+    def test_read_host_info_knox(self):
+        client = Client(config=Config())
+        client._ec2_tags = {}
+        client._availability_zone = "us-east-1"
+        return_value: bool = client._read_host_info()
+        self.assertTrue(return_value)
+
+        # On a host with knox, the knox status should be set to OK
+        # On a host without, such as build agents, the knox status should be ERROR
+        self.assertIsNotNone(client._knox_status)
+        self.assertTrue(client._knox_status == "OK" or client._knox_status == "ERROR")
+
     def test_read_host_info_no_ec2_tags_provided(self):
         client = Client(config=Config())
         with self.assertRaises(AttributeError):


### PR DESCRIPTION
# Description
Add normandie status and knox status to ping requests 
[CDP-8328](https://jira.pinadmin.com/browse/CDP-8328)

# Development status
* Normandie status is defined by the presence of a valid normandie's certificate.
* Knox status is defined by knox deamon running successfully 
* Both fields are emitted in ping requests and stored in `hosts_and_agents` SQL table

## Associated PRs
* deploy-service changes: https://github.com/pinterest/teletraan/pull/1760

## Previous version of this PR
https://github.com/pinterest/teletraan/pull/1745