### PR TITLE
CDP-8328: deploy-service: add normandie and knox statuses to PingRequest and hosts_and_agents table

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ Check out [Integrate with Teletraan](https://github.com/pinterest/teletraan/wiki
 
 [Quick start guide!](https://github.com/pinterest/teletraan/wiki/Quickstart-Guide)
 
+#### Before you commit new code
+
+1. Install [pre-commit](https://pre-commit.com/#install)
+```bash
+cd teletraan
+pip install pre-commit
+pre-commit install
+```
+
+
 ### Documentation
 
 [Check out our wiki!](https://github.com/pinterest/teletraan/wiki)

--- a/deploy-service/common/pom.xml
+++ b/deploy-service/common/pom.xml
@@ -208,6 +208,12 @@
             <artifactId>quartz</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.28</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>
             <version>${okhttp.version}</version>

--- a/deploy-service/common/pom.xml
+++ b/deploy-service/common/pom.xml
@@ -210,7 +210,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.28</version>
+            <version>${lombok.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/HostAgentBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/HostAgentBean.java
@@ -50,10 +50,10 @@ public class HostAgentBean implements Updatable {
     private String auto_scaling_group;
 
     @JsonProperty("normandieStatus")
-    private String normandie_status;
+    private NormandieStatus normandie_status;
 
     @JsonProperty("knoxStatus")
-    private String knox_status;
+    private KnoxStatus knox_status;
 
     @Override
     public SetClause genSetClause() {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/HostAgentBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/HostAgentBean.java
@@ -16,8 +16,17 @@
 package com.pinterest.deployservice.bean;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
+import lombok.Data;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
 public class HostAgentBean implements Updatable {
     @JsonProperty("hostName")
     private String host_name;
@@ -40,61 +49,11 @@ public class HostAgentBean implements Updatable {
     @JsonProperty("autoScalingGroup")
     private String auto_scaling_group;
 
-    public String getHost_name() {
-        return host_name;
-    }
+    @JsonProperty("normandieStatus")
+    private String normandie_status;
 
-    public void setHost_name(String host_name) {
-        this.host_name = host_name;
-    }
-
-    public String getIp() {
-        return ip;
-    }
-
-    public void setIp(String ip) {
-        this.ip = ip;
-    }
-
-    public String getHost_id() {
-        return host_id;
-    }
-
-    public void setHost_id(String host_id) {
-        this.host_id = host_id;
-    }
-
-    public Long getCreate_date() {
-        return create_date;
-    }
-
-    public void setCreate_date(Long create_date) {
-        this.create_date = create_date;
-    }
-
-    public Long getLast_update() {
-        return last_update;
-    }
-
-    public void setLast_update(Long last_update) {
-        this.last_update = last_update;
-    }
-
-    public String getAgent_Version() {
-        return agent_version;
-    }
-
-    public void setAgent_Version(String agent_version) {
-        this.agent_version = agent_version;
-    }
-
-    public String getAuto_scaling_group() {
-        return this.auto_scaling_group;
-    }
-
-    public void setAuto_scaling_group(String asg) {
-        this.auto_scaling_group = asg;
-    }
+    @JsonProperty("knoxStatus")
+    private String knox_status;
 
     @Override
     public SetClause genSetClause() {
@@ -106,6 +65,8 @@ public class HostAgentBean implements Updatable {
         clause.addColumn("last_update", last_update);
         clause.addColumn("agent_version", agent_version);
         clause.addColumn("auto_scaling_group", auto_scaling_group);
+        clause.addColumn("normandie_status", normandie_status);
+        clause.addColumn("knox_status", knox_status);
         return clause;
     }
 
@@ -115,7 +76,9 @@ public class HostAgentBean implements Updatable {
                     + "host_id=VALUES(host_id),"
                     + "last_update=VALUES(last_update),"
                     + "agent_version=VALUES(agent_version),"
-                    + "auto_scaling_group=VALUES(auto_scaling_group)";
+                    + "auto_scaling_group=VALUES(auto_scaling_group),"
+                    + "normandie_status=VALUES(normandie_status),"
+                    + "knox_status=VALUES(knox_status)";
 
     @Override
     public String toString() {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/KnoxStatus.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/KnoxStatus.java
@@ -1,0 +1,7 @@
+package com.pinterest.deployservice.bean;
+
+public enum KnoxStatus {
+    OK,
+    ERROR,
+    UNKNOWN,
+}

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/NormandieStatus.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/NormandieStatus.java
@@ -1,0 +1,7 @@
+package com.pinterest.deployservice.bean;
+
+public enum NormandieStatus {
+    OK,
+    ERROR,
+    UNKNOWN,
+}

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/PingRequestBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/PingRequestBean.java
@@ -50,9 +50,9 @@ public class PingRequestBean {
 
     private String accountId;
 
-    private String normandieStatus;
+    private NormandieStatus normandieStatus;
 
-    private String knoxStatus;
+    private KnoxStatus knoxStatus;
 
     private List<PingReportBean> reports;
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/PingRequestBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/PingRequestBean.java
@@ -55,4 +55,9 @@ public class PingRequestBean {
     private KnoxStatus knoxStatus;
 
     private List<PingReportBean> reports;
+
+    @Override
+    public String toString() {
+        return ReflectionToStringBuilder.toString(this);
+    }
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/PingRequestBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/PingRequestBean.java
@@ -41,6 +41,10 @@ public class PingRequestBean {
 
     private String accountId;
 
+    private String normandieStatus;
+
+    private String knoxStatus;
+
     private List<PingReportBean> reports;
 
     public String getHostId() {
@@ -126,6 +130,14 @@ public class PingRequestBean {
     public void setAccountId(String accountId) {
         this.accountId = accountId;
     }
+
+    public String getNormandieStatus() { return normandieStatus; }
+
+    public void setNormandieStatus(String normandieStatus) { this.normandieStatus = normandieStatus; }
+
+    public String getKnoxStatus() { return knoxStatus; }
+
+    public void setKnoxStatus(String knoxStatus) { this.knoxStatus = knoxStatus; }
 
     public void setReports(List<PingReportBean> reports) {
         this.reports = reports;

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/PingRequestBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/PingRequestBean.java
@@ -18,8 +18,17 @@ package com.pinterest.deployservice.bean;
 import java.util.List;
 import java.util.Set;
 import javax.validation.constraints.NotEmpty;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
 public class PingRequestBean {
     @NotEmpty private String hostId;
 
@@ -46,105 +55,4 @@ public class PingRequestBean {
     private String knoxStatus;
 
     private List<PingReportBean> reports;
-
-    public String getHostId() {
-        return hostId;
-    }
-
-    public void setHostId(String hostId) {
-        this.hostId = hostId;
-    }
-
-    public String getHostName() {
-        return hostName;
-    }
-
-    public void setHostName(String hostName) {
-        this.hostName = hostName;
-    }
-
-    public String getHostIp() {
-        return hostIp;
-    }
-
-    public void setHostIp(String hostIp) {
-        this.hostIp = hostIp;
-    }
-
-    public String getAutoscalingGroup() {
-        return this.autoscalingGroup;
-    }
-
-    public void setAutoscalingGroup(String autoscalingGroup) {
-        this.autoscalingGroup = autoscalingGroup;
-    }
-
-    public String getAvailabilityZone() {
-        return availabilityZone;
-    }
-
-    public void setAvailabilityZone(String availabilityZone) {
-        this.availabilityZone = availabilityZone;
-    }
-
-    public String getEc2Tags() {
-        return ec2Tags;
-    }
-
-    public void setEc2Tags(String ec2Tags) {
-        this.ec2Tags = ec2Tags;
-    }
-
-    public String getAgentVersion() {
-        return agentVersion;
-    }
-
-    public void setAgentVersion(String agentVersion) {
-        this.agentVersion = agentVersion;
-    }
-
-    public EnvType getStageType() {
-        return stageType;
-    }
-
-    public void setStageType(EnvType stageType) {
-        this.stageType = stageType;
-    }
-
-    public Set<String> getGroups() {
-        return groups;
-    }
-
-    public void setGroups(Set<String> groups) {
-        this.groups = groups;
-    }
-
-    public List<PingReportBean> getReports() {
-        return reports;
-    }
-
-    public String getAccountId() {
-        return accountId;
-    }
-
-    public void setAccountId(String accountId) {
-        this.accountId = accountId;
-    }
-
-    public String getNormandieStatus() { return normandieStatus; }
-
-    public void setNormandieStatus(String normandieStatus) { this.normandieStatus = normandieStatus; }
-
-    public String getKnoxStatus() { return knoxStatus; }
-
-    public void setKnoxStatus(String knoxStatus) { this.knoxStatus = knoxStatus; }
-
-    public void setReports(List<PingReportBean> reports) {
-        this.reports = reports;
-    }
-
-    @Override
-    public String toString() {
-        return ReflectionToStringBuilder.toString(this);
-    }
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
@@ -209,7 +209,8 @@ public class PingHandler {
     }
 
     void updateHostStatus(
-            String hostId, String hostName, String hostIp, String agentVersion, String asg)
+            String hostId, String hostName, String hostIp, String agentVersion, String asg,
+            String normandieStatus, String knoxStatus)
             throws Exception {
         HostAgentBean hostAgentBean = hostAgentDAO.getHostById(hostId);
         long currentTime = System.currentTimeMillis();
@@ -223,8 +224,10 @@ public class PingHandler {
         hostAgentBean.setHost_name(hostName);
         hostAgentBean.setIp(hostIp);
         hostAgentBean.setLast_update(currentTime);
-        hostAgentBean.setAgent_Version(agentVersion);
+        hostAgentBean.setAgent_version(agentVersion);
         hostAgentBean.setAuto_scaling_group(asg);
+        hostAgentBean.setNormandie_status(normandieStatus);
+        hostAgentBean.setKnox_status(knoxStatus);
 
         if (!isExisting) {
             // First ping
@@ -830,7 +833,10 @@ public class PingHandler {
         String agentVersion =
                 pingRequest.getAgentVersion() != null ? pingRequest.getAgentVersion() : "UNKNOWN";
 
-        this.updateHostStatus(hostId, hostName, hostIp, agentVersion, asg);
+        String normandieStatus = pingRequest.getNormandieStatus() != null ? pingRequest.getNormandieStatus() : "UNKNOWN";
+        String knoxStatus = pingRequest.getKnoxStatus() != null ? pingRequest.getKnoxStatus() : "UNKNOWN";
+
+        this.updateHostStatus(hostId, hostName, hostIp, agentVersion, asg, normandieStatus, knoxStatus);
 
         // update the host <-> groups mapping
         this.updateHosts(hostName, hostIp, hostId, groups, accountId);

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
@@ -38,6 +38,8 @@ import com.pinterest.deployservice.bean.HostAgentBean;
 import com.pinterest.deployservice.bean.HostBean;
 import com.pinterest.deployservice.bean.HostState;
 import com.pinterest.deployservice.bean.HostTagBean;
+import com.pinterest.deployservice.bean.KnoxStatus;
+import com.pinterest.deployservice.bean.NormandieStatus;
 import com.pinterest.deployservice.bean.OpCode;
 import com.pinterest.deployservice.bean.PingReportBean;
 import com.pinterest.deployservice.bean.PingRequestBean;
@@ -209,8 +211,8 @@ public class PingHandler {
     }
 
     void updateHostStatus(
-            String hostId, String hostName, String hostIp, String agentVersion, String asg,
-            String normandieStatus, String knoxStatus)
+        String hostId, String hostName, String hostIp, String agentVersion, String asg,
+        NormandieStatus normandieStatus, KnoxStatus knoxStatus)
             throws Exception {
         HostAgentBean hostAgentBean = hostAgentDAO.getHostById(hostId);
         long currentTime = System.currentTimeMillis();
@@ -833,8 +835,8 @@ public class PingHandler {
         String agentVersion =
                 pingRequest.getAgentVersion() != null ? pingRequest.getAgentVersion() : "UNKNOWN";
 
-        String normandieStatus = pingRequest.getNormandieStatus() != null ? pingRequest.getNormandieStatus() : "UNKNOWN";
-        String knoxStatus = pingRequest.getKnoxStatus() != null ? pingRequest.getKnoxStatus() : "UNKNOWN";
+        NormandieStatus normandieStatus = pingRequest.getNormandieStatus() != null ? pingRequest.getNormandieStatus() : NormandieStatus.UNKNOWN;
+        KnoxStatus knoxStatus = pingRequest.getKnoxStatus() != null ? pingRequest.getKnoxStatus() : KnoxStatus.UNKNOWN;
 
         this.updateHostStatus(hostId, hostName, hostIp, agentVersion, asg, normandieStatus, knoxStatus);
 

--- a/deploy-service/common/src/main/resources/sql/schema-update-20.sql
+++ b/deploy-service/common/src/main/resources/sql/schema-update-20.sql
@@ -1,0 +1,1 @@
+../../../../../../tools/mysql/schema-update-20.sql

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/db/DBAgentDAOImplTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/db/DBAgentDAOImplTest.java
@@ -1,6 +1,8 @@
 package com.pinterest.deployservice.db;
 
 import com.pinterest.deployservice.bean.HostAgentBean;
+import com.pinterest.deployservice.bean.KnoxStatus;
+import com.pinterest.deployservice.bean.NormandieStatus;
 import com.pinterest.deployservice.dao.HostAgentDAO;
 import org.apache.commons.dbcp.BasicDataSource;
 import org.junit.jupiter.api.AfterEach;
@@ -86,8 +88,8 @@ public class DBAgentDAOImplTest {
             .last_update(System.currentTimeMillis())
             .agent_version("1.0")
             .auto_scaling_group("auto-scaling-group")
-            .normandie_status("normandie status normal")
-            .knox_status("knox status")
+            .normandie_status(NormandieStatus.OK)
+            .knox_status(KnoxStatus.OK)
             .build();
     }
 

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/db/DBAgentDAOImplTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/db/DBAgentDAOImplTest.java
@@ -1,0 +1,94 @@
+package com.pinterest.deployservice.db;
+
+import com.pinterest.deployservice.bean.HostAgentBean;
+import com.pinterest.deployservice.dao.HostAgentDAO;
+import org.apache.commons.dbcp.BasicDataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DBAgentDAOImplTest {
+
+    private static BasicDataSource dataSource;
+    private static HostAgentDAO hostAgentDAO;
+
+    @BeforeAll
+    public static void setUpClass() throws Exception {
+        dataSource = DBUtils.createTestDataSource();
+
+        hostAgentDAO = new DBHostAgentDAOImpl(dataSource);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        DBUtils.truncateAllTables(dataSource);
+    }
+
+
+    @Test
+    public void testHostAgentDAO() throws Exception {
+        final String hostId = "host-1";
+
+        // Test Insert and getById
+        HostAgentBean hostAgentBean = genDefaultHostAgentBean(hostId);
+        hostAgentDAO.insert(hostAgentBean);
+        HostAgentBean getByIdBean = hostAgentDAO.getHostById(hostId);
+        assertEquals(hostAgentBean, getByIdBean);
+
+        // Test Update and getById
+        hostAgentBean.setIp("192.168.0.1");
+        hostAgentDAO.update(hostId, hostAgentBean);
+        HostAgentBean getByIdBean2 = hostAgentDAO.getHostById(hostId);
+        assertEquals(hostAgentBean, getByIdBean2);
+
+        // Test getHostByName
+        HostAgentBean getByNameBean = hostAgentDAO.getHostByName(hostAgentBean.getHost_name());
+        assertEquals(hostAgentBean, getByNameBean);
+
+        // Test getDistinctHostsCount
+        long hostCount = hostAgentDAO.getDistinctHostsCount();
+        assertEquals(1, hostCount);
+
+        // Test getStaleHosts
+        List<HostAgentBean> staleHosts = hostAgentDAO.getStaleHosts(System.currentTimeMillis() - 100_000);
+        assertTrue(staleHosts.isEmpty());
+
+        List<HostAgentBean> staleHosts2 = hostAgentDAO.getStaleHosts(System.currentTimeMillis() + 100_000);
+        assertEquals(1, staleHosts2.size());
+        assertEquals(hostAgentBean, staleHosts2.get(0));
+
+        List<HostAgentBean> staleHosts3 = hostAgentDAO.getStaleHosts(
+            System.currentTimeMillis() - 100_000, System.currentTimeMillis() + 100_000);
+        assertEquals(1, staleHosts3.size());
+        assertEquals(hostAgentBean, staleHosts3.get(0));
+
+        // Test Delete
+        hostAgentDAO.delete(hostId);
+        HostAgentBean getByIdBean3 = hostAgentDAO.getHostById(hostId);
+        assertNull(getByIdBean3);
+        long hostCount2 = hostAgentDAO.getDistinctHostsCount();
+        assertEquals(0, hostCount2);
+    }
+
+    private HostAgentBean genDefaultHostAgentBean(String hostId) {
+        return HostAgentBean.builder()
+            .ip("127.0.0.1")
+            .host_id(hostId)
+            .host_name(UUID.randomUUID().toString())
+            .create_date(System.currentTimeMillis())
+            .last_update(System.currentTimeMillis())
+            .agent_version("1.0")
+            .auto_scaling_group("auto-scaling-group")
+            .normandie_status("normandie status normal")
+            .knox_status("knox status")
+            .build();
+    }
+
+}

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/db/DBDAOTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/db/DBDAOTest.java
@@ -21,7 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.pinterest.deployservice.bean.AcceptanceStatus;
 import com.pinterest.deployservice.bean.AgentBean;
 import com.pinterest.deployservice.bean.AgentErrorBean;
@@ -38,7 +37,6 @@ import com.pinterest.deployservice.bean.DeployState;
 import com.pinterest.deployservice.bean.DeployType;
 import com.pinterest.deployservice.bean.EnvironBean;
 import com.pinterest.deployservice.bean.GroupRolesBean;
-import com.pinterest.deployservice.bean.HostAgentBean;
 import com.pinterest.deployservice.bean.HostBean;
 import com.pinterest.deployservice.bean.HostState;
 import com.pinterest.deployservice.bean.HostTagBean;
@@ -64,7 +62,6 @@ import com.pinterest.deployservice.dao.DeployDAO;
 import com.pinterest.deployservice.dao.EnvironDAO;
 import com.pinterest.deployservice.dao.GroupDAO;
 import com.pinterest.deployservice.dao.GroupRolesDAO;
-import com.pinterest.deployservice.dao.HostAgentDAO;
 import com.pinterest.deployservice.dao.HostDAO;
 import com.pinterest.deployservice.dao.HostTagDAO;
 import com.pinterest.deployservice.dao.PromoteDAO;
@@ -84,7 +81,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 
 import org.apache.commons.dbcp.BasicDataSource;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -113,7 +109,6 @@ public class DBDAOTest {
     private static TagDAO tagDAO;
     private static ScheduleDAO scheduleDAO;
     private static UtilDAO utilDAO;
-    private static HostAgentDAO hostAgentDAO;
     private static BasicDataSource dataSource;
 
     @BeforeAll
@@ -138,7 +133,6 @@ public class DBDAOTest {
         tagDAO = new DBTagDAOImpl(dataSource);
         scheduleDAO = new DBScheduleDAOImpl(dataSource);
         utilDAO = new DBUtilDAOImpl(dataSource);
-        hostAgentDAO = new DBHostAgentDAOImpl(dataSource);
     }
 
     @AfterEach
@@ -1191,66 +1185,6 @@ public class DBDAOTest {
             assertNotNull(conn);
             utilDAO.releaseLock(lockName, conn);
         }
-    }
-
-    @Test
-    public void testHostAgentDAO() throws Exception {
-        final String hostId = "host-1";
-
-        // Test Insert and getById
-        HostAgentBean hostAgentBean = genDefaultHostAgentBean(hostId);
-        hostAgentDAO.insert(hostAgentBean);
-        HostAgentBean getByIdBean = hostAgentDAO.getHostById(hostId);
-        assertEquals(hostAgentBean, getByIdBean);
-
-        // Test Update and getById
-        hostAgentBean.setIp("192.168.0.1");
-        hostAgentDAO.update(hostId, hostAgentBean);
-        HostAgentBean getByIdBean2 = hostAgentDAO.getHostById(hostId);
-        assertEquals(hostAgentBean, getByIdBean2);
-
-        // Test getHostByName
-        HostAgentBean getByNameBean = hostAgentDAO.getHostByName(hostAgentBean.getHost_name());
-        assertEquals(hostAgentBean, getByNameBean);
-
-        // Test getDistinctHostsCount
-        long hostCount = hostAgentDAO.getDistinctHostsCount();
-        assertEquals(1, hostCount);
-
-        // Test getStaleHosts
-        List<HostAgentBean> staleHosts = hostAgentDAO.getStaleHosts(System.currentTimeMillis() - 100_000);
-        assertTrue(staleHosts.isEmpty());
-
-        List<HostAgentBean> staleHosts2 = hostAgentDAO.getStaleHosts(System.currentTimeMillis() + 100_000);
-        assertEquals(1, staleHosts2.size());
-        assertEquals(hostAgentBean, staleHosts2.get(0));
-
-        List<HostAgentBean> staleHosts3 = hostAgentDAO.getStaleHosts(
-            System.currentTimeMillis() - 100_000, System.currentTimeMillis() + 100_000);
-        assertEquals(1, staleHosts3.size());
-        assertEquals(hostAgentBean, staleHosts3.get(0));
-
-        // Test Delete
-        hostAgentDAO.delete(hostId);
-        HostAgentBean getByIdBean3 = hostAgentDAO.getHostById(hostId);
-        assertNull(getByIdBean3);
-        long hostCount2 = hostAgentDAO.getDistinctHostsCount();
-        assertEquals(0, hostCount2);
-
-    }
-
-    private HostAgentBean genDefaultHostAgentBean(String hostId) {
-        return HostAgentBean.builder()
-            .ip("127.0.0.1")
-            .host_id(hostId)
-            .host_name(UUID.randomUUID().toString())
-            .create_date(System.currentTimeMillis())
-            .last_update(System.currentTimeMillis())
-            .agent_version("1.0")
-            .auto_scaling_group("auto-scaling-group")
-            .normandie_status("normandie status normal")
-            .knox_status("knox status")
-            .build();
     }
 
     private EnvironBean genDefaultEnvBean(

--- a/deploy-service/pom.xml
+++ b/deploy-service/pom.xml
@@ -21,6 +21,7 @@
         <googleJavaFormat.version>1.7</googleJavaFormat.version>
         <spotless.version>2.30.0</spotless.version>
         <okhttp.version>4.12.0</okhttp.version>
+        <lombok.version>1.18.28</lombok.version>
         <source_dir>${maven.repo.local}/com/pinterest/teletraan/${project.artifactId}/${project.version}</source_dir>
     </properties>
 

--- a/deploy-service/universal/pom.xml
+++ b/deploy-service/universal/pom.xml
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.28</version>
+      <version>${lombok.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/tools/mysql/schema-update-20.sql
+++ b/tools/mysql/schema-update-20.sql
@@ -1,0 +1,12 @@
+-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+-- ALWAYS BACKUP YOUR DATA BEFORE EXECUTING THIS SCRIPT
+-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+-- This script upgrade DB schema from version 19 to version 20
+
+ALTER TABLE hosts_and_agents ADD COLUMN normandie_status VARCHAR(64) DEFAULT NULL;
+ALTER TABLE hosts_and_agents ADD COLUMN knox_status VARCHAR(64) DEFAULT NULL;
+
+
+-- make sure to update the schema version to 13
+UPDATE schema_versions SET version=20;

--- a/tools/mysql/schema-update-20.sql
+++ b/tools/mysql/schema-update-20.sql
@@ -8,5 +8,5 @@ ALTER TABLE hosts_and_agents ADD COLUMN normandie_status VARCHAR(64) DEFAULT NUL
 ALTER TABLE hosts_and_agents ADD COLUMN knox_status VARCHAR(64) DEFAULT NULL;
 
 
--- make sure to update the schema version to 13
+-- make sure to update the schema version to 20
 UPDATE schema_versions SET version=20;


### PR DESCRIPTION
# Description
Add normandie status and knox status to ping requests 
[CDP-8328](https://jira.pinadmin.com/browse/CDP-8328)

# Development status
* Normandie status is defined by the presence of a valid normandie's certificate.
* Knox status is defined by knox deamon running successfully 
* Both fields are emitted in ping requests and stored in `hosts_and_agents` SQL table

## Associated PRs
* deploy-agent changes: https://github.com/pinterest/teletraan/pull/1759
* deploy-service: output normandie and knox status in getHosts https://github.com/pinterest/teletraan/pull/1763

## Missing before pushing:
* Database changes in Prod

## Previous version of this PR
https://github.com/pinterest/teletraan/pull/1745
