### PR TITLE
CDP-8328: Add normandie status and knox statuses to Hosts.get() EnvHosts.getHostByHostName()

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/HostBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/HostBean.java
@@ -15,14 +15,16 @@
  */
 package com.pinterest.deployservice.bean;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
-@Builder
+@SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
@@ -60,6 +62,7 @@ public class HostBean implements Updatable {
     // TO_BE_REPLACED(1) = marked by cluster replace event to be replaced
     // HEALTH_CHECK(2) = host only launch for health check purpose and not to be replaced/retired
 
+    @JsonIgnore
     public Boolean isPendingTerminate() {
         return this.state == HostState.PENDING_TERMINATE
                 || this.state == HostState.PENDING_TERMINATE_NO_REPLACE;

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/HostBeanWithStatuses.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/HostBeanWithStatuses.java
@@ -20,50 +20,17 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
-@Builder
+@SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
-public class HostBeanWithStatuses {
-    @JsonProperty("hostName")
-    private String host_name;
-
-    @JsonProperty("groupName")
-    private String group_name;
-
-    @JsonProperty("ip")
-    private String ip;
-
-    @JsonProperty("hostId")
-    private String host_id;
-
-    @JsonProperty("accountId")
-    private String account_id;
-
-    @JsonProperty("createDate")
-    private Long create_date;
-
-    @JsonProperty("lastUpdateDate")
-    private Long last_update;
-
-    @JsonProperty("state")
-    private HostState state;
-
-    @JsonProperty("canRetire")
-    private Integer can_retire;
-    // canRetire used to be a Boolean field
-    // canRetire now represent the state `HostCanRetireType'
-    // which can be:
-    // NEW(0) = the default value upon a host is launched, means cannot retire
-    // TO_BE_REPLACED(1) = marked by cluster replace event to be replaced
-    // HEALTH_CHECK(2) = host only launch for health check purpose and not to be replaced/retired
-
+public class HostBeanWithStatuses extends HostBean {
     // Normandie and Knox Statuses are NOT in the hosts table, but instead on the hosts_and_agents table
     @JsonProperty("normandieStatus")
     private NormandieStatus normandie_status;
 
     @JsonProperty("knoxStatus")
     private KnoxStatus knox_status;
-
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/HostBeanWithStatuses.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/HostBeanWithStatuses.java
@@ -20,13 +20,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
-public class HostBean implements Updatable {
+public class HostBeanWithStatuses {
     @JsonProperty("hostName")
     private String host_name;
 
@@ -60,38 +59,11 @@ public class HostBean implements Updatable {
     // TO_BE_REPLACED(1) = marked by cluster replace event to be replaced
     // HEALTH_CHECK(2) = host only launch for health check purpose and not to be replaced/retired
 
-    public Boolean isPendingTerminate() {
-        return this.state == HostState.PENDING_TERMINATE
-                || this.state == HostState.PENDING_TERMINATE_NO_REPLACE;
-    }
+    // Normandie and Knox Statuses are NOT in the hosts table, but instead on the hosts_and_agents table
+    @JsonProperty("normandieStatus")
+    private NormandieStatus normandie_status;
 
-    @Override
-    public SetClause genSetClause() {
-        SetClause clause = new SetClause();
-        clause.addColumn("host_name", host_name);
-        clause.addColumn("group_name", group_name);
-        clause.addColumn("ip", ip);
-        clause.addColumn("host_id", host_id);
-        clause.addColumn("create_date", create_date);
-        clause.addColumn("last_update", last_update);
-        clause.addColumn("state", state);
-        clause.addColumn("can_retire", can_retire);
-        clause.addColumn("account_id", account_id);
-        return clause;
-    }
+    @JsonProperty("knoxStatus")
+    private KnoxStatus knox_status;
 
-    public static final String UPDATE_CLAUSE =
-            "host_name=VALUES(host_name),"
-                    + "group_name=VALUES(group_name),"
-                    + "ip=VALUES(ip),"
-                    + "host_id=VALUES(host_id),"
-                    + "create_date=VALUES(create_date),"
-                    + "last_update=VALUES(last_update),"
-                    + "state=VALUES(state),"
-                    + "can_retire=VALUES(can_retire)";
-
-    @Override
-    public String toString() {
-        return ReflectionToStringBuilder.toString(this);
-    }
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostDAO.java
@@ -72,7 +72,7 @@ public interface HostDAO {
 
     HostBean getByEnvIdAndHostId(String envId, String hostId) throws Exception;
 
-    Collection<HostBean> getByEnvIdAndHostName(String envId, String hostName) throws Exception;
+    Collection<HostBeanWithStatuses> getByEnvIdAndHostName(String envId, String hostName) throws Exception;
 
     Collection<String> getToBeRetiredHostIdsByGroup(String groupName) throws Exception;
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostDAO.java
@@ -16,6 +16,8 @@
 package com.pinterest.deployservice.dao;
 
 import com.pinterest.deployservice.bean.HostBean;
+import com.pinterest.deployservice.bean.HostBeanWithStatuses;
+
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.List;
@@ -52,7 +54,7 @@ public interface HostDAO {
 
     Long getGroupSize(String groupName) throws Exception;
 
-    List<HostBean> getHosts(String hostName) throws Exception;
+    List<HostBeanWithStatuses> getHosts(String hostName) throws Exception;
 
     List<HostBean> getAllActiveHostsByGroup(String groupName) throws Exception;
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostDAOImpl.java
@@ -82,9 +82,9 @@ public class DBHostDAOImpl implements HostDAO {
     private static final String GET_HOST_BY_ENVID_AND_HOSTID =
             "SELECT DISTINCT e.* FROM hosts e INNER JOIN groups_and_envs ge ON ge.group_name = e.group_name WHERE ge.env_id=? AND e.host_id=?";
     private static final String GET_HOST_BY_ENVID_AND_HOSTNAME1 =
-            "SELECT hs.* FROM hosts hs INNER JOIN groups_and_envs ge ON ge.group_name = hs.group_name WHERE ge.env_id=? AND hs.host_name=?";
+            "SELECT hs.*, ha.normandie_status, ha.knox_status FROM hosts hs INNER JOIN groups_and_envs ge ON ge.group_name = hs.group_name LEFT JOIN hosts_and_agents ha ON ha.host_id = hs.host_id WHERE ge.env_id=? AND hs.host_name=?";
     private static final String GET_HOST_BY_ENVID_AND_HOSTNAME2 =
-            "SELECT hs.* FROM hosts hs INNER JOIN hosts_and_envs he ON he.host_name = hs.host_name WHERE he.env_id=? AND he.host_name=?";
+            "SELECT hs.*, ha.normandie_status, ha.knox_status FROM hosts hs INNER JOIN hosts_and_envs he ON he.host_name = hs.host_name LEFT JOIN hosts_and_agents ha ON ha.host_id = hs.host_id WHERE he.env_id=? AND he.host_name=?";
     private static final String GET_RETIRED_HOSTIDS_BY_GROUP =
             "SELECT DISTINCT host_id FROM hosts WHERE (can_retire=1 OR can_retire=3) AND group_name=? AND state not in (?,?,?) ORDER BY can_retire";
     private static final String GET_RETIRED_AND_FAILED_HOSTIDS_BY_GROUP =
@@ -322,10 +322,10 @@ public class DBHostDAOImpl implements HostDAO {
     }
 
     @Override
-    public Collection<HostBean> getByEnvIdAndHostName(String envId, String hostName)
+    public Collection<HostBeanWithStatuses> getByEnvIdAndHostName(String envId, String hostName)
             throws Exception {
-        ResultSetHandler<List<HostBean>> h = new BeanListHandler<>(HostBean.class);
-        Collection<HostBean> hostBeans =
+        ResultSetHandler<List<HostBeanWithStatuses>> h = new BeanListHandler<>(HostBeanWithStatuses.class);
+        Collection<HostBeanWithStatuses> hostBeans =
                 new QueryRunner(dataSource)
                         .query(GET_HOST_BY_ENVID_AND_HOSTNAME1, h, envId, hostName);
         if (hostBeans.isEmpty()) {

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostDAOImpl.java
@@ -19,6 +19,7 @@ import com.pinterest.deployservice.bean.AgentState;
 import com.pinterest.deployservice.bean.AgentStatus;
 import com.pinterest.deployservice.bean.DeployStage;
 import com.pinterest.deployservice.bean.HostBean;
+import com.pinterest.deployservice.bean.HostBeanWithStatuses;
 import com.pinterest.deployservice.bean.HostState;
 import com.pinterest.deployservice.bean.SetClause;
 import com.pinterest.deployservice.dao.HostDAO;
@@ -60,7 +61,8 @@ public class DBHostDAOImpl implements HostDAO {
     private static final String GET_ACTIVE_HOST_IDS_BY_HOST_IDS =
             "SELECT DISTINCT(host_id) FROM hosts WHERE host_id IN (%s) AND state = 'ACTIVE'";
 
-    private static final String GET_HOST_BY_NAME = "SELECT * FROM hosts WHERE host_name=?";
+    private static final String GET_HOST_BY_NAME =
+            "SELECT hosts.*, hosts_and_agents.normandie_status, hosts_and_agents.knox_status FROM hosts LEFT JOIN hosts_and_agents ON hosts.host_id = hosts_and_agents.host_id WHERE hosts.host_name=?";
     private static final String GET_HOST_BY_HOSTID =
             "SELECT * FROM hosts WHERE host_id=? ORDER BY create_date";
     private static final String GET_HOSTS_BY_STATES =
@@ -241,8 +243,8 @@ public class DBHostDAOImpl implements HostDAO {
     }
 
     @Override
-    public List<HostBean> getHosts(String hostName) throws Exception {
-        ResultSetHandler<List<HostBean>> h = new BeanListHandler<>(HostBean.class);
+    public List<HostBeanWithStatuses> getHosts(String hostName) throws Exception {
+        ResultSetHandler<List<HostBeanWithStatuses>> h = new BeanListHandler<>(HostBeanWithStatuses.class);
         return new QueryRunner(dataSource).query(GET_HOST_BY_NAME, h, hostName);
     }
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/EnvironHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/EnvironHandler.java
@@ -495,7 +495,7 @@ public class EnvironHandler {
 
         List<HostBean> newHosts = new ArrayList<>();
         for (String hostName : capacityHosts) {
-            Collection<HostBean> hostBeans =
+            Collection<HostBeanWithStatuses> hostBeans =
                     hostDAO.getByEnvIdAndHostName(envBean.getEnv_id(), hostName);
             if (!hostBeans.isEmpty()) {
                 newHosts.add(hostBeans.iterator().next());

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/db/DBDAOTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/db/DBDAOTest.java
@@ -755,7 +755,7 @@ public class DBDAOTest {
                 "host-3", "3.3.3.3", "id-3", HostState.TERMINATING.toString(), groups2, "test");
         assertEquals(environDAO.getMissingHosts("e-3").size(), 0);
 
-        Collection<HostBean> hostBean3 = hostDAO.getByEnvIdAndHostName("e-3", "host-3");
+        Collection<HostBeanWithStatuses> hostBean3 = hostDAO.getByEnvIdAndHostName("e-3", "host-3");
         assertEquals(hostBean3.iterator().next().getHost_name(), "host-3");
 
         groupDAO.addGroupCapacity("e-3", "new_group");
@@ -884,6 +884,16 @@ public class DBDAOTest {
         assertEquals("id-normandie", hostBeansNormandie.get(0).getHost_id());
         assertEquals(NormandieStatus.OK, hostBeansNormandie.get(0).getNormandie_status());
         assertEquals(KnoxStatus.ERROR, hostBeansNormandie.get(0).getKnox_status());
+
+        // Test support for normandie and knox statuses in hostDAO.getByEnvIdAndHostName
+        groupDAO.addHostCapacity("e-3", "host-normandie");
+        Collection<HostBeanWithStatuses> hostBeansNormandie2 =
+            hostDAO.getByEnvIdAndHostName("e-3", "host-normandie");
+        assertEquals(1, hostBeansNormandie2.size());
+        HostBeanWithStatuses hostBeanNormandie2 = hostBeansNormandie2.iterator().next();
+        assertEquals(hostBeanNormandie2.getHost_name(), "host-normandie");
+        assertEquals(NormandieStatus.OK, hostBeanNormandie2.getNormandie_status());
+        assertEquals(KnoxStatus.ERROR, hostBeanNormandie2.getKnox_status());
     }
 
     @Test

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvHosts.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvHosts.java
@@ -17,6 +17,7 @@ package com.pinterest.teletraan.resource;
 
 import com.pinterest.deployservice.bean.EnvironBean;
 import com.pinterest.deployservice.bean.HostBean;
+import com.pinterest.deployservice.bean.HostBeanWithStatuses;
 import com.pinterest.deployservice.bean.TeletraanPrincipalRole;
 import com.pinterest.deployservice.common.Constants;
 import com.pinterest.deployservice.dao.EnvironDAO;
@@ -88,7 +89,7 @@ public class EnvHosts {
             notes = "Returns a host given an environment, stage and host name",
             response = HostBean.class,
             responseContainer = "List")
-    public Collection<HostBean> getHostByHostName(
+    public Collection<HostBeanWithStatuses> getHostByHostName(
             @ApiParam(value = "Environment name", required = true) @PathParam("envName")
                     String envName,
             @ApiParam(value = "Stage name", required = true) @PathParam("stageName")

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Hosts.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Hosts.java
@@ -17,6 +17,7 @@ package com.pinterest.teletraan.resource;
 
 import com.google.common.base.Optional;
 import com.pinterest.deployservice.bean.HostBean;
+import com.pinterest.deployservice.bean.HostBeanWithStatuses;
 import com.pinterest.deployservice.bean.HostState;
 import com.pinterest.deployservice.bean.TeletraanPrincipalRole;
 import com.pinterest.deployservice.dao.HostDAO;
@@ -117,7 +118,7 @@ public class Hosts {
             notes = "Returns a list of host info objects given a host name",
             response = HostBean.class,
             responseContainer = "List")
-    public List<HostBean> get(
+    public List<HostBeanWithStatuses> get(
             @ApiParam(value = "Host name", required = true) @PathParam("hostName") String hostName)
             throws Exception {
         return hostDAO.getHosts(hostName);

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Systems.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Systems.java
@@ -18,6 +18,7 @@ package com.pinterest.teletraan.resource;
 import com.google.common.base.Optional;
 import com.pinterest.deployservice.bean.ChatMessageBean;
 import com.pinterest.deployservice.bean.HostBean;
+import com.pinterest.deployservice.bean.HostBeanWithStatuses;
 import com.pinterest.deployservice.bean.TeletraanPrincipalRole;
 import com.pinterest.deployservice.chat.ChatManager;
 import com.pinterest.deployservice.dao.HostDAO;
@@ -92,7 +93,7 @@ public class Systems {
             notes = "Returns a list of host info objects given a host name",
             response = HostBean.class,
             responseContainer = "List")
-    public List<HostBean> getHosts(
+    public List<HostBeanWithStatuses> getHosts(
             @ApiParam(value = "Host name", required = true) @PathParam("hostName") String hostName)
             throws Exception {
         return hostDAO.getHosts(hostName);

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/resource/HostsTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/resource/HostsTest.java
@@ -1,0 +1,173 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.resource;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.pinterest.deployservice.bean.HostBean;
+import com.pinterest.deployservice.bean.HostBeanWithStatuses;
+import com.pinterest.deployservice.bean.HostState;
+import com.pinterest.deployservice.bean.KnoxStatus;
+import com.pinterest.deployservice.bean.NormandieStatus;
+import com.pinterest.deployservice.dao.HostDAO;
+import com.pinterest.teletraan.TeletraanServiceContext;
+import com.pinterest.teletraan.universal.security.AnonymousAuthFilter;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import io.dropwizard.testing.junit5.ResourceExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
+import java.security.Principal;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.refEq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(DropwizardExtensionsSupport.class)
+public class HostsTest {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private static final ResourceExtension resourceExtension;
+
+    private static final HostDAO hostDAOMock;
+
+    static {
+        TeletraanServiceContext context = new TeletraanServiceContext();
+
+        hostDAOMock = mock(HostDAO.class);
+        context.setHostDAO(hostDAOMock);
+
+        resourceExtension = ResourceExtension.builder()
+            .addResource(new Hosts(context))
+            .addProvider(new AnonymousAuthFilter())
+            .build();
+    }
+
+    @BeforeEach
+    public void setup() {
+        // the mock is static due to resourceExtension requirements, so we need to reset it before each test
+        reset(hostDAOMock);
+    }
+
+    @ParameterizedTest
+    @MethodSource("validHostBeansSource")
+    public void postValidHostBeans() throws Exception {
+        HostBean hostBean = HostBean.builder()
+            .host_id("hostId")
+            .host_name("hostName")
+            .state(HostState.ACTIVE)
+            .account_id("accountId")
+            .group_name("groupName")
+            .build();
+
+        final Response put =
+            resourceExtension.target(Target.V1_HOSTS).request().post(Entity.json(hostBean));
+
+        assertNotEquals(422, put.getStatus());
+
+        verify(hostDAOMock).insert(
+            refEq(hostBean, "create_date", "last_update"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("validHostBeansSource")
+    public void putValidHostBeans() throws Exception {
+        HostBean hostBean = HostBean.builder()
+            .host_id("hostId")
+            .host_name("hostName")
+            .state(HostState.ACTIVE)
+            .account_id("accountId")
+            .group_name("groupName")
+            .build();
+
+        final Response put =
+            resourceExtension.target(Target.V1_HOSTS + "/" + "hostId").request().put(Entity.json(hostBean));
+
+        assertNotEquals(422, put.getStatus());
+
+        verify(hostDAOMock).updateHostById(
+            eq(hostBean.getHost_id()),
+            refEq(hostBean, "last_update"));
+    }
+
+    @Test
+    public void getByHostName() throws Exception {
+        HostBeanWithStatuses hostBean = HostBeanWithStatuses.builder()
+            .host_id("hostId")
+            .host_name("hostName")
+            .state(HostState.ACTIVE)
+            .account_id("accountId")
+            .group_name("groupName")
+            .normandie_status(NormandieStatus.OK)
+            .knox_status(KnoxStatus.ERROR)
+            .build();
+
+        when(hostDAOMock.getHosts("hostName")).thenReturn(ImmutableList.of(hostBean));
+
+        final Response get =
+            resourceExtension.target(Target.V1_HOSTS + "/" + hostBean.getHost_name()).request().get();
+
+        assertNotEquals(422, get.getStatus());
+
+        // GET returns a list of maps, so we need to convert it to a HostBeanWithStatuses
+        List<Map> list = get.readEntity(List.class);
+        HostBeanWithStatuses resultBean = mapper.convertValue(list.get(0), HostBeanWithStatuses.class);
+        assertEquals(hostBean, resultBean);
+    }
+
+    private static Stream<Arguments> validHostBeansSource() {
+        HostBean hostBean = validHostBean();
+
+        // All fields are null - host is still valid
+        HostBean hostBean2 = HostBean.builder().build();
+
+        return Stream.of(
+                Arguments.of(hostBean),
+                Arguments.of(hostBean2));
+    }
+
+    private static HostBean validHostBean() {
+        return HostBean.builder()
+            .host_id("hostId")
+            .host_name("hostName")
+            .state(HostState.ACTIVE)
+            .account_id("accountId")
+            .group_name("groupName")
+            .build();
+    }
+
+    private static class Target {
+        private static final String V1_HOSTS = "/v1/hosts";
+    }
+}


### PR DESCRIPTION
# Description
In deploy-board, Normandie and Knox statuses are to be added to `hosts/host_details.html`.
`hosts/host_details.html` is rendered in two places, using a list of hosts coming from two different methods

`hosts = hosts_helper.get_hosts_by_name(request, hostname)` :https://github.com/pinterest/teletraan/blob/b0f6c6aab3084b4d7b7f4448f2fac210df10f96f/deploy-board/deploy_board/webapp/host_views.py#L150

`hosts = environ_hosts_helper.get_host_by_env_and_hostname(request, name, stage, hostname)` https://github.com/pinterest/teletraan/blob/b0f6c6aab3084b4d7b7f4448f2fac210df10f96f/deploy-board/deploy_board/webapp/host_views.py#L203

This means that both `get_hosts_by_name` and `get_host_by_env_and_hostname` needs to return normandie and knox statuses.

This is done by:
* creating a new POJO class, HostBeanWithStatuses, which inherits HostBean and include the two new fields
* update the relevant DAO methods to return HostBeanWithStatuses
* update the associated SQL queries to retrieve the two fields from `hosts_and_agents` table

## Associated PRs
* deploy-service write changes: https://github.com/pinterest/teletraan/pull/1760
