### PR TITLE
Map errors to exceptions

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
@@ -161,9 +161,7 @@ public class DeployHandler implements DeployHandlerInterface {
                                 newDeployBean.getOperator(),
                                 autoPromote,
                                 envBean.getExternal_id());
-                Map<String, String> headers = new HashMap<>();
-                headers.put("Content-Type", "application/json");
-                httpClient.post(changeFeedUrl, feedPayload, headers);
+                httpClient.post(changeFeedUrl, feedPayload, null);
                 LOG.info("Send change feed {} to {} successfully", feedPayload, changeFeedUrl);
             } catch (Exception e) {
                 LOG.error(

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Deploys.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Deploys.java
@@ -40,7 +40,6 @@ import io.swagger.annotations.Tag;
 import java.util.List;
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/http/HttpClient.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/http/HttpClient.java
@@ -53,6 +53,12 @@ public class HttpClient {
     private static final OkHttpClient sharedOkHttpClient = new OkHttpClient();
     private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(20);
 
+    static {
+        observationRegistry
+                .observationConfig()
+                .observationHandler(new DefaultMeterObservationHandler(Metrics.globalRegistry));
+    }
+
     @Getter private final OkHttpClient okHttpClient;
 
     @Builder(buildMethodName = "buildInternal")
@@ -64,10 +70,6 @@ public class HttpClient {
             int httpProxyPort,
             Duration callTimeout,
             Supplier<String> authorizationSupplier) {
-        observationRegistry
-                .observationConfig()
-                .observationHandler(new DefaultMeterObservationHandler(Metrics.globalRegistry));
-
         callTimeout = callTimeout == null ? DEFAULT_TIMEOUT : callTimeout;
 
         OkHttpClient.Builder clientBuilder =

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/http/HttpClient.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/http/HttpClient.java
@@ -209,9 +209,9 @@ public class HttpClient {
             case 400:
                 throw new BadRequestException(responseBody);
             case 401:
-                throw new ForbiddenException(responseBody);
-            case 403:
                 throw new NotAuthorizedException(responseBody);
+            case 403:
+                throw new ForbiddenException(responseBody);
             case 404:
                 throw new NotFoundException(responseBody);
             default:

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/http/HttpClientTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/http/HttpClientTest.java
@@ -264,8 +264,8 @@ class HttpClientTest {
     void testMapResponseToException() {
         String response = "error";
         assertThrows(BadRequestException.class, () -> sut.mapResponseToException(400, response));
-        assertThrows(ForbiddenException.class, () -> sut.mapResponseToException(401, response));
-        assertThrows(NotAuthorizedException.class, () -> sut.mapResponseToException(403, response));
+        assertThrows(NotAuthorizedException.class, () -> sut.mapResponseToException(401, response));
+        assertThrows(ForbiddenException.class, () -> sut.mapResponseToException(403, response));
         assertThrows(NotFoundException.class, () -> sut.mapResponseToException(404, response));
         assertThrows(ClientErrorException.class, () -> sut.mapResponseToException(429, response));
         assertThrows(ServerErrorException.class, () -> sut.mapResponseToException(500, response));

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/http/HttpClientTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/http/HttpClientTest.java
@@ -25,8 +25,12 @@ import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.util.Map;
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.ClientErrorException;
+import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.HttpMethod;
+import javax.ws.rs.NotAuthorizedException;
+import javax.ws.rs.NotFoundException;
 import javax.ws.rs.ServerErrorException;
 import javax.ws.rs.WebApplicationException;
 import okhttp3.mockwebserver.Dispatcher;
@@ -254,6 +258,19 @@ class HttpClientTest {
                         ServerErrorException.class,
                         () -> requestWithBody(method, "", TEST_HEADERS));
         assertEquals(500, exception.getResponse().getStatus());
+    }
+
+    @Test
+    void testMapResponseToException() {
+        String response = "error";
+        assertThrows(BadRequestException.class, () -> sut.mapResponseToException(400, response));
+        assertThrows(ForbiddenException.class, () -> sut.mapResponseToException(401, response));
+        assertThrows(NotAuthorizedException.class, () -> sut.mapResponseToException(403, response));
+        assertThrows(NotFoundException.class, () -> sut.mapResponseToException(404, response));
+        assertThrows(ClientErrorException.class, () -> sut.mapResponseToException(429, response));
+        assertThrows(ServerErrorException.class, () -> sut.mapResponseToException(500, response));
+        assertThrows(
+                WebApplicationException.class, () -> sut.mapResponseToException(600, response));
     }
 
     String requestWithBody(String method, String body, Map<String, String> headers)


### PR DESCRIPTION
Map WebApplicationException to more detailed subclasses, this is helpful for Rodimus adoption of this HttpClient implementation. Additionally, making `callTimeout` configurable and replacing existing `readTimeout` and `connectTimeout`. It's needed by Rodimus and it's easier to control 1 then 2. 

> The call timeout spans the entire call: resolving DNS, connecting, writing the request body, server processing, and reading the response body. If the call requires redirects or retries all must complete within one timeout period.

Lastly, there is a leak in the constructor. It's now moved to the static init block. 

