### PR TITLE
CDP-8328: Add normandie status and knox statuses to Host Details page

### DIFF
--- a/deploy-board/deploy_board/templates/hosts/host_details.html
+++ b/deploy-board/deploy_board/templates/hosts/host_details.html
@@ -100,6 +100,8 @@
         <th class="col-lg-1">State</th>
         <th class="col-lg-2">Create Date</th>
         <th class="col-lg-2">Last Update</th>
+        <th class="col-lg-2">Normandie</th>
+        <th class="col-lg-2">Knox</th>
     </tr>
     {% for host in hosts %}
     <tr class="{{ host.state|hostStateClass}}">
@@ -113,6 +115,8 @@
         <td><span class="deployToolTip pointer-cursor" data-toggle="tooltip" title="{{ host|hostTip }}">{{ host.state }}</span></td>
         <td>{{ host.createDate|convertTimestamp }}</td>
         <td>{{ host.lastUpdateDate|convertTimestamp }}</td>
+        <td>{{ host.normandieStatus }}</td>
+        <td>{{ host.knoxStatus }}</td>
     </tr>
     {% endfor %}
 </table>


### PR DESCRIPTION
# Description
Add normandie status and knox statuses to HostBean and hostDAO.getHosts


## Associated PRs
* deploy-service changes: 
    * https://github.com/pinterest/teletraan/pull/1760
    * https://github.com/pinterest/teletraan/pull/1763