### PR TITLE
Implement selective update for HostAgentBean and add unit tests

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/HostAgentBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/HostAgentBean.java
@@ -22,7 +22,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
-@Builder
+@Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
@@ -67,6 +67,33 @@ public class HostAgentBean implements Updatable {
         clause.addColumn("normandie_status", normandie_status);
         clause.addColumn("knox_status", knox_status);
         return clause;
+    }
+
+    public SetClause genChangedSetClause(HostAgentBean originalBean) {
+        SetClause clause = new SetClause();
+        // host_id is the primary key, create_date is the creation time, so they should not be
+        // updated
+        addChangedColumn(clause, "host_name", host_name, originalBean.getHost_name());
+        addChangedColumn(clause, "ip", ip, originalBean.getIp());
+        addChangedColumn(clause, "create_date", create_date, originalBean.getCreate_date());
+        addChangedColumn(clause, "last_update", last_update, originalBean.getLast_update());
+        addChangedColumn(clause, "agent_version", agent_version, originalBean.getAgent_version());
+        addChangedColumn(
+                clause,
+                "auto_scaling_group",
+                auto_scaling_group,
+                originalBean.getAuto_scaling_group());
+        addChangedColumn(
+                clause, "normandie_status", normandie_status, originalBean.getNormandie_status());
+        addChangedColumn(clause, "knox_status", knox_status, originalBean.getKnox_status());
+        return clause;
+    }
+
+    private void addChangedColumn(
+            SetClause clause, String columnName, Object newValue, Object originalValue) {
+        if (newValue != null && !newValue.equals(originalValue)) {
+            clause.addColumn(columnName, newValue);
+        }
     }
 
     public static final String UPDATE_CLAUSE =

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostAgentDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostAgentDAO.java
@@ -23,7 +23,16 @@ import java.util.List;
 public interface HostAgentDAO {
     void insert(HostAgentBean hostAgentBean) throws Exception;
 
-    void update(String hostId, HostAgentBean hostAgentBean) throws Exception;
+    /**
+     * Update with the new host agent bean. Only the non-null changed fields are updated.
+     *
+     * @param hostId
+     * @param hostAgentBean the original host agent bean
+     * @param newHostAgentBean the new host agent bean
+     * @throws SQLException
+     */
+    void updateChanged(String hostId, HostAgentBean hostAgentBean, HostAgentBean newHostAgentBean)
+            throws SQLException;
 
     void delete(String hostId) throws Exception;
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostAgentDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostAgentDAOImpl.java
@@ -63,10 +63,12 @@ public class DBHostAgentDAOImpl implements HostAgentDAO {
     }
 
     @Override
-    public void update(String id, HostAgentBean bean) throws Exception {
-        SetClause setClause = bean.genSetClause();
+    public void updateChanged(String hostId, HostAgentBean oldBean, HostAgentBean newBean)
+            throws SQLException {
+        SetClause setClause =
+                oldBean == null ? newBean.genSetClause() : newBean.genChangedSetClause(oldBean);
         String clause = String.format(UPDATE_HOST_BY_ID, setClause.getClause());
-        setClause.addValue(id);
+        setClause.addValue(hostId);
         new QueryRunner(dataSource).update(clause, setClause.getValueArray());
     }
 

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/bean/BeanUtils.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/bean/BeanUtils.java
@@ -29,4 +29,18 @@ public class BeanUtils {
         bean.setState(HostState.PROVISIONED);
         return bean;
     }
+
+    public static HostAgentBean createHostAgentBean() {
+        return HostAgentBean.builder()
+                .host_name("test-host")
+                .ip("1.2.3.4")
+                .host_id("i-" + UUID.randomUUID().toString().substring(0, 8))
+                .create_date(1L)
+                .last_update(2L)
+                .agent_version("1.0")
+                .auto_scaling_group("group")
+                .normandie_status(NormandieStatus.UNKNOWN)
+                .knox_status(KnoxStatus.UNKNOWN)
+                .build();
+    }
 }

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/bean/HostAgentBeanTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/bean/HostAgentBeanTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.deployservice.bean;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class HostAgentBeanTest {
+    @Test
+    void testGenChangedSetClause() {
+        HostAgentBean oldBean = BeanUtils.createHostAgentBean();
+        HostAgentBean newBean =
+                oldBean.toBuilder().agent_version("new agent version").ip("new ip").build();
+
+        SetClause setClause = newBean.genChangedSetClause(oldBean);
+
+        assertTrue(setClause.getClause().contains("ip"));
+        assertTrue(setClause.getClause().contains("agent_version"));
+
+        assertFalse(setClause.getClause().contains("host_id"));
+        assertFalse(setClause.getClause().contains("create_date"));
+        assertFalse(setClause.getClause().contains("auto_scaling_group"));
+    }
+}


### PR DESCRIPTION
This pull request includes several changes to the `deploy-service` module, focusing on updating the `HostAgentBean` class and related components to support partial updates. The most important changes include adding a new method to generate a set clause for changed fields, modifying the `HostAgentDAO` and `DBHostAgentDAOImpl` classes to use this new method, and updating the `PingHandler` class to utilize these changes. Additionally, a new test class for `HostAgentBean` has been added.

### Enhancements to `HostAgentBean`:

* [`deploy-service/common/src/main/java/com/pinterest/deployservice/bean/HostAgentBean.java`](diffhunk://#diff-920ebc5af4e4efb85c5c1386f3a867b2681cf6915f9c5222a3cd3baff637f99aL25-R25): Added `toBuilder = true` to the `@Builder` annotation and introduced the `genChangedSetClause` method to generate a set clause for only the changed fields. Also added the `addChangedColumn` helper method. [[1]](diffhunk://#diff-920ebc5af4e4efb85c5c1386f3a867b2681cf6915f9c5222a3cd3baff637f99aL25-R25) [[2]](diffhunk://#diff-920ebc5af4e4efb85c5c1386f3a867b2681cf6915f9c5222a3cd3baff637f99aR72-R98)

### Updates to DAO classes:

* [`deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostAgentDAO.java`](diffhunk://#diff-5495126b69f4e788dcf4c3e7e364fba9dd4f7e32bc6645e45d2435218414991fL26-R35): Added the `updateChanged` method to update only the non-null changed fields of a `HostAgentBean`.
* [`deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostAgentDAOImpl.java`](diffhunk://#diff-28a722a436f1cbaa42de1804dcdd3906730009a0929999a97a66e13619019c85L66-R71): Modified the `update` method to use the new `genChangedSetClause` method and renamed it to `updateChanged` to reflect the new functionality.

### Changes to `PingHandler`:

* [`deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java`](diffhunk://#diff-067abe2f4de3c1b2b383cf5d982f41aa5d8c8232b22d68b5b617549816b70698L61): Removed unused DAO fields and updated the `updateHostStatus` method to use the new `updateChanged` method in `HostAgentDAO`. [[1]](diffhunk://#diff-067abe2f4de3c1b2b383cf5d982f41aa5d8c8232b22d68b5b617549816b70698L61) [[2]](diffhunk://#diff-067abe2f4de3c1b2b383cf5d982f41aa5d8c8232b22d68b5b617549816b70698L83) [[3]](diffhunk://#diff-067abe2f4de3c1b2b383cf5d982f41aa5d8c8232b22d68b5b617549816b70698L108) [[4]](diffhunk://#diff-067abe2f4de3c1b2b383cf5d982f41aa5d8c8232b22d68b5b617549816b70698L117) [[5]](diffhunk://#diff-067abe2f4de3c1b2b383cf5d982f41aa5d8c8232b22d68b5b617549816b70698L131-L135) [[6]](diffhunk://#diff-067abe2f4de3c1b2b383cf5d982f41aa5d8c8232b22d68b5b617549816b70698L222-R243)

### New test class:

* [`deploy-service/common/src/test/java/com/pinterest/deployservice/bean/HostAgentBeanTest.java`](diffhunk://#diff-df8665bedf6524fc60baba52fc5a69e568d94b877f7b2f856965e891f1f1d507R1-R39): Added a new test class to verify the functionality of the `genChangedSetClause` method.

These changes improve the efficiency of updates to `HostAgentBean` by ensuring that only the modified fields are updated in the database.