### PR TITLE
Update Teletraan UI to support non-jenkins builds

### DIFF
--- a/deploy-board/deploy_board/templates/builds/build_details.tmpl
+++ b/deploy-board/deploy_board/templates/builds/build_details.tmpl
@@ -87,4 +87,3 @@
 {% endif %}
 {% endif %}
 </table>
-

--- a/deploy-board/deploy_board/templates/builds/build_details.tmpl
+++ b/deploy-board/deploy_board/templates/builds/build_details.tmpl
@@ -47,7 +47,7 @@
         <td>
            {% if build.publishInfo != "UNKNOWN" %}
            <a class="deployToolTip" data-toggle="tooltip"
-           title="Click to see the details of jenkins build job"
+           title="Click to see the details of the build job"
            href='{{ build.publishInfo }}'>
            <i class="fa fa-wrench"></i>
             Publisher Information
@@ -81,7 +81,7 @@
         <td>Tag Created Date</td>
         <td>{{ tag.createdDate|convertTimestamp }}</td>
     </tr>
-    {%if tag.value == "BAD_BUILD" %} 
+    {%if tag.value == "BAD_BUILD" %}
         <div id="buildErrorMsg" style="display: none;">The build is marked as {{tag.value}} by {{tag.operator}} on {{ tag.createdDate|convertTimestamp }}</div>
     {% endif %}
 {% endif %}

--- a/deploy-board/deploy_board/templates/builds/pick_a_build.tmpl
+++ b/deploy-board/deploy_board/templates/builds/pick_a_build.tmpl
@@ -2,11 +2,12 @@
 {% load static %}
 <table id="buildPickTableId" class="table table-condensed table-striped table-hover">
     <tr>
-        <th class="col-lg-3">Publish Date</th>
-        <th class="col-lg-3">Commit</th>
+        <th class="col-lg-2">Publish Date</th>
+        <th class="col-lg-2">Commit</th>
         <th class="col-lg-2">Branch</th>
         <th class="col-lg-2">Repo</th>
         <th class="col-lg-2">Build Name</th>
+        <th class="col-lg-1">Build Job URL</th>
         <th class="col-lg-1">Details</th>
     </tr>
     {% for buildInfo in builds %}
@@ -59,6 +60,7 @@
         <td>{{ buildInfo.build.branch }}</td>
         <td>{{ buildInfo.build.repo }}</td>
         <td>{{ buildInfo.build.name }}</td>
+        <td><a href="{{ buildInfo.build.publishInfo }}">view</a></td>
         <td><a href="/builds/{{ buildInfo.build.id }}">view</a></td>
     </tr>
     {% if builds|length > 1 %}

--- a/deploy-board/deploy_board/templates/clusters/base_image_info.tmpl
+++ b/deploy-board/deploy_board/templates/clusters/base_image_info.tmpl
@@ -38,7 +38,7 @@
             <td>
                 {% if current_image.publish_info  %}
                     <a class="deployToolTip" data-toggle="tooltip"
-                        title="Click to see the details of jenkins build job"
+                        title="Click to see the details of the build job"
                         href='{{ current_image.publish_info }}'
                     >
                         <i class="fa fa-wrench"></i>

--- a/deploy-board/deploy_board/templates/groups/host_infos.html
+++ b/deploy-board/deploy_board/templates/groups/host_infos.html
@@ -22,7 +22,7 @@
 	<div class="row">
         <a type="button" href="/groups/{{ group_name }}/config/"
                 class="deployToolTip btn btn-default btn-block"
-            data-toggle="tooltip" title="Start an Jenkins build job">
+            data-toggle="tooltip" title="Config current group">
             <span class="glyphicon glyphicon-cog"></span> Configuration
         </a>
     </div>

--- a/deploy-board/deploy_board/templates/groups/scaling_activities.html
+++ b/deploy-board/deploy_board/templates/groups/scaling_activities.html
@@ -22,7 +22,7 @@
 	<div class="row">
         <a type="button" href="/groups/{{ group_name }}/config/"
                 class="deployToolTip btn btn-default btn-block"
-            data-toggle="tooltip" title="Start an Jenkins build job">
+            data-toggle="tooltip" title="Config current group">
             <span class="glyphicon glyphicon-cog"></span> Configuration
         </a>
     </div>


### PR DESCRIPTION
# Summary
Teletraan builds are published from multiple sources including jenkins and buildkite. Given the growing usage of buildkite, UI components that reference jenkins instead of generic CI jobs need to be updated for clarity. This is to address: [ER-9180](https://jira.pinadmin.com/browse/ER-9180)

# Tests

  <details><summary>Build Details</summary>
  <p>
    <img width="705" alt="image" src="https://github.com/user-attachments/assets/a8027c52-5667-4a65-978d-051c3877ee56" />
  </p>
  </details> 
  <details><summary>Pick a Build</summary>
  <p>
    <img width="1435" alt="image" src="https://github.com/user-attachments/assets/1c811fd3-347a-4e4e-a314-34f4bc9026a3" />
  </p>
  </details> 
  <details><summary>Base Image</summary>
  <p>
    <img width="1094" alt="image" src="https://github.com/user-attachments/assets/4d4c44e2-1e37-4efa-9a8c-84874bb4cc95" />
  </p>
  </details> 
  <details><summary>Scaling Activities </summary>
  <p>
    <img width="489" alt="image" src="https://github.com/user-attachments/assets/2a63ccc4-8c0b-4394-b70f-29ec99b02a6f" />
  </p>
  </details> 


