### PR TITLE
Remove duplicate deploy agent version

### DIFF
--- a/deploy-agent/deployd/client/client.py
+++ b/deploy-agent/deployd/client/client.py
@@ -20,6 +20,7 @@ import socket
 import traceback
 import json
 
+from deployd import __version__
 from deployd.client.base_client import BaseClient
 from deployd.client.restfulclient import RestfulClient
 from deployd.common.decorators import retry
@@ -43,7 +44,6 @@ class Client(BaseClient):
         self._config = config
         self._use_facter = use_facter
         self._use_host_info = use_host_info
-        self._agent_version = self._config.get_deploy_agent_version()
         self._autoscaling_group = None
         self._availability_zone = None
         self._stage_type = None
@@ -199,7 +199,7 @@ class Client(BaseClient):
         log.info("Host information is loaded. "
                  "Host name: {}, IP: {}, host id: {}, agent_version={}, autoscaling_group: {}, "
                  "availability_zone: {}, ec2_tags: {}, stage_type: {}, group: {}, account id: {}".format(self._hostname, self._ip, self._id,
-                 self._agent_version, self._autoscaling_group, self._availability_zone, self._ec2_tags, self._stage_type, self._hostgroup, self._account_id))
+                 __version__, self._autoscaling_group, self._availability_zone, self._ec2_tags, self._stage_type, self._hostgroup, self._account_id))
 
         if not self._availability_zone:
             log.error("Fail to read host info: availablity zone")
@@ -224,7 +224,7 @@ class Client(BaseClient):
                         report.errorMessage = report.errorMessage.encode('ascii', 'ignore').decode()
                 ping_request = PingRequest(hostId=self._id, hostName=self._hostname, hostIp=self._ip,
                                         groups=self._hostgroup, reports=reports,
-                                        agentVersion=self._agent_version,
+                                        agentVersion=__version__,
                                         autoscalingGroup=self._autoscaling_group,
                                         availabilityZone=self._availability_zone,
                                         ec2Tags=self._ec2_tags,

--- a/deploy-agent/deployd/common/config.py
+++ b/deploy-agent/deployd/common/config.py
@@ -19,8 +19,6 @@ import json
 
 from typing import Any, List, Optional
 
-from deployd import __version__
-
 from deployd.common.exceptions import DeployConfigException
 from deployd.common.types import DeployType
 from deployd.common.utils import exit_abruptly
@@ -274,9 +272,6 @@ class Config(object):
 
     def get_verify_https_certificate(self) -> Optional[str]:
         return self.get_var('verify_https_certificate', 'False')
-
-    def get_deploy_agent_version(self) -> str:
-        return self.get_var('deploy_agent_version', __version__)
 
     def get_facter_az_key(self) -> Optional[str]:
         return self.get_var('availability_zone_key', None)

--- a/deploy-agent/tests/unit/deploy/client/test_client.py
+++ b/deploy-agent/tests/unit/deploy/client/test_client.py
@@ -10,10 +10,6 @@ class TestClient(TestCase):
     def test_extends_base_client(self):
         self.assertTrue(issubclass(Client, BaseClient))
 
-    def test_no_config_provided(self):
-        with self.assertRaises(AttributeError):
-            Client()
-
     def test_read_host_info(self):
         client = Client(config=Config())
         client._ec2_tags = {}


### PR DESCRIPTION
## Summary

There were two ways of determining the deploy agent version:

1. From the `__version__` variable
2. From the config file

Keep the `__version__` variable and remove the config file version

Also, clean up the test which was not testing a real scenario since the
config is always passed in to the client

## Testing Done

Ran the updated code and ensured the agent version was still logged and sent in the ping request