### PR TITLE
Format all java code

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/alerts/AlertAction.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/alerts/AlertAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Pinterest, Inc.
+ * Copyright (c) 2017-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/alerts/AlertAction.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/alerts/AlertAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-2024 Pinterest, Inc.
+ * Copyright (c) 2017-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/alerts/AlertContext.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/alerts/AlertContext.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Pinterest, Inc.
+ * Copyright (c) 2017-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/alerts/AlertContext.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/alerts/AlertContext.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-2024 Pinterest, Inc.
+ * Copyright (c) 2017-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/alerts/AlertContextBuilder.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/alerts/AlertContextBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Pinterest, Inc.
+ * Copyright (c) 2017-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/alerts/AlertContextBuilder.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/alerts/AlertContextBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-2024 Pinterest, Inc.
+ * Copyright (c) 2017-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/alerts/DefaultAlertContextBuilder.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/alerts/DefaultAlertContextBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Pinterest, Inc.
+ * Copyright (c) 2017-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/alerts/DefaultAlertContextBuilder.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/alerts/DefaultAlertContextBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-2024 Pinterest, Inc.
+ * Copyright (c) 2017-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/alerts/ExternalAlertFactory.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/alerts/ExternalAlertFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Pinterest, Inc.
+ * Copyright (c) 2017-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/alerts/ExternalAlertFactory.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/alerts/ExternalAlertFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-2024 Pinterest, Inc.
+ * Copyright (c) 2017-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/alerts/MarkBadBuildAction.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/alerts/MarkBadBuildAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Pinterest, Inc.
+ * Copyright (c) 2017-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/alerts/MarkBadBuildAction.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/alerts/MarkBadBuildAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-2024 Pinterest, Inc.
+ * Copyright (c) 2017-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/allowlists/Allowlist.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/allowlists/Allowlist.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019-2024 Pinterest, Inc.
+ * Copyright (c) 2019-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/allowlists/Allowlist.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/allowlists/Allowlist.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019-2021 Pinterest, Inc.
+ * Copyright (c) 2019-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/allowlists/BuildAllowlistImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/allowlists/BuildAllowlistImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019-2024 Pinterest, Inc.
+ * Copyright (c) 2019-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/allowlists/BuildAllowlistImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/allowlists/BuildAllowlistImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019-2021 Pinterest, Inc.
+ * Copyright (c) 2019-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/AcceptanceStatus.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/AcceptanceStatus.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/AcceptanceStatus.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/AcceptanceStatus.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/AcceptanceType.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/AcceptanceType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/AcceptanceType.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/AcceptanceType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/AgentState.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/AgentState.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2023 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/AgentState.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/AgentState.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/AgentStatus.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/AgentStatus.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/AgentStatus.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/AgentStatus.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/BuildTagBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/BuildTagBean.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/BuildTagBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/BuildTagBean.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/DeployCandidatesResponse.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/DeployCandidatesResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Pinterest, Inc.
+ * Copyright (c) 2017-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/DeployCandidatesResponse.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/DeployCandidatesResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-2024 Pinterest, Inc.
+ * Copyright (c) 2017-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/DeployConstraintType.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/DeployConstraintType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 Pinterest, Inc.
+ * Copyright (c) 2018-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/DeployConstraintType.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/DeployConstraintType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2024 Pinterest, Inc.
+ * Copyright (c) 2018-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/DeployPriority.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/DeployPriority.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/DeployPriority.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/DeployPriority.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/DeployStage.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/DeployStage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/DeployStage.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/DeployStage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/DeployState.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/DeployState.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/DeployState.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/DeployState.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/DeployType.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/DeployType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/DeployType.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/DeployType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvState.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvState.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvState.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvState.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvType.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2023 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvType.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironState.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironState.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironState.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/EnvironState.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/ExternalAlert.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/ExternalAlert.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Pinterest, Inc.
+ * Copyright (c) 2017-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/ExternalAlert.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/ExternalAlert.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-2024 Pinterest, Inc.
+ * Copyright (c) 2017-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/GroupHostBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/GroupHostBean.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/GroupHostBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/GroupHostBean.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/HostState.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/HostState.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2022 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/HostState.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/HostState.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/HotfixState.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/HotfixState.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/HotfixState.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/HotfixState.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/OpCode.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/OpCode.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/OpCode.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/OpCode.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/OverridePolicy.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/OverridePolicy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/OverridePolicy.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/OverridePolicy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/PingResult.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/PingResult.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Pinterest, Inc.
+ * Copyright (c) 2017-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/PingResult.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/PingResult.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-2024 Pinterest, Inc.
+ * Copyright (c) 2017-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/PromoteDisablePolicy.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/PromoteDisablePolicy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/PromoteDisablePolicy.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/PromoteDisablePolicy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/PromoteFailPolicy.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/PromoteFailPolicy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/PromoteFailPolicy.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/PromoteFailPolicy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/PromoteType.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/PromoteType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/PromoteType.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/PromoteType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/ScheduleState.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/ScheduleState.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/ScheduleState.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/ScheduleState.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/SetClause.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/SetClause.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/SetClause.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/SetClause.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/TagSyncState.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/TagSyncState.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Pinterest, Inc.
+ * Copyright (c) 2017-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/TagSyncState.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/TagSyncState.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-2024 Pinterest, Inc.
+ * Copyright (c) 2017-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/TagTargetType.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/TagTargetType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/TagTargetType.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/TagTargetType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/TagValue.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/TagValue.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/TagValue.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/TagValue.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/Updatable.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/Updatable.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/Updatable.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/Updatable.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/UpdateStatement.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/UpdateStatement.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/UpdateStatement.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/UpdateStatement.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/buildtags/BuildTagsManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/buildtags/BuildTagsManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/buildtags/BuildTagsManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/buildtags/BuildTagsManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/chat/ChatManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/chat/ChatManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/chat/ChatManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/chat/ChatManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/chat/DefaultChatManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/chat/DefaultChatManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/chat/DefaultChatManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/chat/DefaultChatManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/chat/HipChatManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/chat/HipChatManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/chat/HipChatManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/chat/HipChatManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/chat/SlackChatManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/chat/SlackChatManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2023 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/chat/SlackChatManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/chat/SlackChatManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/CommonUtils.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/CommonUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/CommonUtils.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/CommonUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/Constants.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/Constants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2020 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/Constants.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/Constants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/DeployInternalException.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/DeployInternalException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/DeployInternalException.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/DeployInternalException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/EncryptionUtils.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/EncryptionUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022 Pinterest, Inc.
+ * Copyright (c) 2022-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/EncryptionUtils.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/EncryptionUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022-2024 Pinterest, Inc.
+ * Copyright (c) 2022-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/EventMessage.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/EventMessage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/EventMessage.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/EventMessage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/KeyReader.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/KeyReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/KeyReader.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/KeyReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2021 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/KeyReaderFactory.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/KeyReaderFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/KeyReaderFactory.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/KeyReaderFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2021 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/KnoxDBKeyReader.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/KnoxDBKeyReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2024 Pinterest, Inc.
+ * Copyright (c) 2018-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/KnoxDBKeyReader.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/KnoxDBKeyReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2021 Pinterest, Inc.
+ * Copyright (c) 2018-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/KnoxKeyManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/KnoxKeyManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2024 Pinterest, Inc.
+ * Copyright (c) 2021-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/KnoxKeyManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/KnoxKeyManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 Pinterest, Inc.
+ * Copyright (c) 2021-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/PersistableJSONFactory.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/PersistableJSONFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/PersistableJSONFactory.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/PersistableJSONFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/StateMachines.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/StateMachines.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/StateMachines.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/StateMachines.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/AgentCountDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/AgentCountDAO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2020 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/AgentCountDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/AgentCountDAO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/AgentDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/AgentDAO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2018 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/AgentDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/AgentDAO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/AgentErrorDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/AgentErrorDAO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/AgentErrorDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/AgentErrorDAO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/BuildDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/BuildDAO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2019 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/BuildDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/BuildDAO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/ConfigHistoryDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/ConfigHistoryDAO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/ConfigHistoryDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/ConfigHistoryDAO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/DataDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/DataDAO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/DataDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/DataDAO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/DeployConstraintDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/DeployConstraintDAO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Pinterest, Inc.
+ * Copyright (c) 2017-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/DeployConstraintDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/DeployConstraintDAO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-2024 Pinterest, Inc.
+ * Copyright (c) 2017-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/GroupDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/GroupDAO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/GroupDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/GroupDAO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostAgentDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostAgentDAO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2023 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostAgentDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostAgentDAO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostTagDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostTagDAO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2018 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostTagDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostTagDAO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HotfixDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HotfixDAO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HotfixDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HotfixDAO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/PromoteDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/PromoteDAO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/PromoteDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/PromoteDAO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/RatingDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/RatingDAO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/RatingDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/RatingDAO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/ScheduleDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/ScheduleDAO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/ScheduleDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/ScheduleDAO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/TagDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/TagDAO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2017 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/TagDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/TagDAO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/UtilDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/UtilDAO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/UtilDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/UtilDAO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBAgentCountDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBAgentCountDAOImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2024 Pinterest, Inc.
+ * Copyright (c) 2020-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBAgentCountDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBAgentCountDAOImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 Pinterest, Inc.
+ * Copyright (c) 2020-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBAgentErrorDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBAgentErrorDAOImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBAgentErrorDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBAgentErrorDAOImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBConfigHistoryDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBConfigHistoryDAOImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBConfigHistoryDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBConfigHistoryDAOImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBDataDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBDataDAOImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBDataDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBDataDAOImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBDeployConstraintDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBDeployConstraintDAOImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Pinterest, Inc.
+ * Copyright (c) 2017-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBDeployConstraintDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBDeployConstraintDAOImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-2024 Pinterest, Inc.
+ * Copyright (c) 2017-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBGroupDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBGroupDAOImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBGroupDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBGroupDAOImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostAgentDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostAgentDAOImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2023 Pinterest, Inc.
+ * Copyright (c) 2020-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostAgentDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostAgentDAOImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2024 Pinterest, Inc.
+ * Copyright (c) 2020-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHotfixDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHotfixDAOImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHotfixDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHotfixDAOImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBPromoteDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBPromoteDAOImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBPromoteDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBPromoteDAOImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBRatingsDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBRatingsDAOImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBRatingsDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBRatingsDAOImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBTagDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBTagDAOImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2017 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBTagDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBTagDAOImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBUtilDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBUtilDAOImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2022 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBUtilDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBUtilDAOImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/HostTagBeanRowProcessor.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/HostTagBeanRowProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Pinterest, Inc.
+ * Copyright (c) 2017-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/HostTagBeanRowProcessor.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/HostTagBeanRowProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-2024 Pinterest, Inc.
+ * Copyright (c) 2017-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/SingleResultSetHandlerFactory.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/SingleResultSetHandlerFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/SingleResultSetHandlerFactory.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/SingleResultSetHandlerFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/email/DefaultMailManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/email/DefaultMailManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/email/DefaultMailManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/email/DefaultMailManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/email/MailManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/email/MailManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/email/MailManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/email/MailManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/events/BuildEventPublisher.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/events/BuildEventPublisher.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023 Pinterest, Inc.
+ * Copyright (c) 2023-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/events/BuildEventPublisher.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/events/BuildEventPublisher.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023-2024 Pinterest, Inc.
+ * Copyright (c) 2023-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/events/DeployEvent.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/events/DeployEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023 Pinterest, Inc.
+ * Copyright (c) 2023-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/events/DeployEvent.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/events/DeployEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023-2024 Pinterest, Inc.
+ * Copyright (c) 2023-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/BuildTagHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/BuildTagHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/BuildTagHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/BuildTagHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/ConfigHistoryHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/ConfigHistoryHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2023 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/ConfigHistoryHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/ConfigHistoryHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandlerInterface.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandlerInterface.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Pinterest, Inc.
+ * Copyright (c) 2017-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandlerInterface.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandlerInterface.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-2024 Pinterest, Inc.
+ * Copyright (c) 2017-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/EnvTagHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/EnvTagHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/EnvTagHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/EnvTagHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/HostHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/HostHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2024 Pinterest, Inc.
+ * Copyright (c) 2021-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/HostHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/HostHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2023 Pinterest, Inc.
+ * Copyright (c) 2021-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/RatingsHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/RatingsHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/RatingsHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/RatingsHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/TagHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/TagHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/TagHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/TagHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/knox/CommandLineKnox.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/knox/CommandLineKnox.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 Pinterest, Inc.
+ * Copyright (c) 2018-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/knox/CommandLineKnox.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/knox/CommandLineKnox.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2024 Pinterest, Inc.
+ * Copyright (c) 2018-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/knox/FileSystemKnox.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/knox/FileSystemKnox.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 Pinterest, Inc.
+ * Copyright (c) 2018-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/knox/FileSystemKnox.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/knox/FileSystemKnox.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2024 Pinterest, Inc.
+ * Copyright (c) 2018-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/knox/Knox.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/knox/Knox.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 Pinterest, Inc.
+ * Copyright (c) 2018-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/knox/Knox.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/knox/Knox.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2024 Pinterest, Inc.
+ * Copyright (c) 2018-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/knox/KnoxJsonDecoder.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/knox/KnoxJsonDecoder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 Pinterest, Inc.
+ * Copyright (c) 2018-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/knox/KnoxJsonDecoder.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/knox/KnoxJsonDecoder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2024 Pinterest, Inc.
+ * Copyright (c) 2018-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/DefaultRodimusManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/DefaultRodimusManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2022 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/DefaultRodimusManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/DefaultRodimusManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/RodimusManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/RodimusManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2022 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/RodimusManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/RodimusManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/RodimusManagerImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/RodimusManagerImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2023 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/RodimusManagerImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/rodimus/RodimusManagerImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/scm/BaseManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/scm/BaseManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2022 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/scm/BaseManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/scm/BaseManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/scm/DefaultSourceControlManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/scm/DefaultSourceControlManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2022 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/scm/DefaultSourceControlManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/scm/DefaultSourceControlManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/scm/SourceControlManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/scm/SourceControlManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2022 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/scm/SourceControlManager.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/scm/SourceControlManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/alerts/PinterestExternalAlertFactoryTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/alerts/PinterestExternalAlertFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Pinterest, Inc.
+ * Copyright (c) 2017-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/alerts/PinterestExternalAlertFactoryTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/alerts/PinterestExternalAlertFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-2024 Pinterest, Inc.
+ * Copyright (c) 2017-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/buildtags/BuildTagsManagerImplTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/buildtags/BuildTagsManagerImplTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2017 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/buildtags/BuildTagsManagerImplTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/buildtags/BuildTagsManagerImplTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/common/CommonUtilsTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/common/CommonUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2017 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/common/CommonUtilsTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/common/CommonUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/events/EventBridgePublisherTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/events/EventBridgePublisherTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023 Pinterest, Inc.
+ * Copyright (c) 2023-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/events/EventBridgePublisherTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/events/EventBridgePublisherTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023-2024 Pinterest, Inc.
+ * Copyright (c) 2023-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/handler/ConfigHistoryHandlerTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/handler/ConfigHistoryHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022-2023 Pinterest, Inc.
+ * Copyright (c) 2022-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/handler/ConfigHistoryHandlerTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/handler/ConfigHistoryHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022-2024 Pinterest, Inc.
+ * Copyright (c) 2022-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/handler/PingHandlerTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/handler/PingHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/handler/PingHandlerTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/handler/PingHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2021 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/rodimus/RodimusManagerImplTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/rodimus/RodimusManagerImplTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023 Pinterest, Inc.
+ * Copyright (c) 2023-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/rodimus/RodimusManagerImplTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/rodimus/RodimusManagerImplTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023-2024 Pinterest, Inc.
+ * Copyright (c) 2023-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/scm/GithubManagerTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/scm/GithubManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022 Pinterest, Inc.
+ * Copyright (c) 2022-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/scm/GithubManagerTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/scm/GithubManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022-2024 Pinterest, Inc.
+ * Copyright (c) 2022-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/AppEventFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/AppEventFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2023 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/AppEventFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/AppEventFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/AuthenticationFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/AuthenticationFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/AuthenticationFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/AuthenticationFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/AutoScalingFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/AutoScalingFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/AutoScalingFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/AutoScalingFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/BuildAllowlistFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/BuildAllowlistFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/BuildAllowlistFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/BuildAllowlistFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2021 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/ChatFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/ChatFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/ChatFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/ChatFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/DataSourceFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/DataSourceFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/DataSourceFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/DataSourceFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/DefaultChatFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/DefaultChatFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/DefaultChatFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/DefaultChatFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/DefaultEmailFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/DefaultEmailFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/DefaultEmailFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/DefaultEmailFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/DefaultSourceControlFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/DefaultSourceControlFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/DefaultSourceControlFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/DefaultSourceControlFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/EmailFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/EmailFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/EmailFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/EmailFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/ExternalAlertsConfigFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/ExternalAlertsConfigFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Pinterest, Inc.
+ * Copyright (c) 2017-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/ExternalAlertsConfigFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/ExternalAlertsConfigFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-2024 Pinterest, Inc.
+ * Copyright (c) 2017-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/GithubFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/GithubFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2022 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/GithubFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/GithubFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/JenkinsFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/JenkinsFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Pinterest, Inc.
+ * Copyright (c) 2017-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/JenkinsFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/JenkinsFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-2024 Pinterest, Inc.
+ * Copyright (c) 2017-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/MicrometerMetricsFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/MicrometerMetricsFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023 Pinterest, Inc.
+ * Copyright (c) 2023-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/MicrometerMetricsFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/MicrometerMetricsFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023-2024 Pinterest, Inc.
+ * Copyright (c) 2023-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/MysqlDataSourceFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/MysqlDataSourceFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2017 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/MysqlDataSourceFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/MysqlDataSourceFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/PhabricatorFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/PhabricatorFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2022 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/PhabricatorFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/PhabricatorFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/RodimusFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/RodimusFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2023 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/RodimusFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/RodimusFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/SMTPFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/SMTPFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/SMTPFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/SMTPFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/SourceControlFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/SourceControlFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/SourceControlFactory.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/config/SourceControlFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/health/GenericHealthCheck.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/health/GenericHealthCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2023 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/health/GenericHealthCheck.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/health/GenericHealthCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/health/WorkerHealthCheck.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/health/WorkerHealthCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/health/WorkerHealthCheck.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/health/WorkerHealthCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/BuildBodyExtractor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/BuildBodyExtractor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/BuildBodyExtractor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/BuildBodyExtractor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/BuildPathExtractor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/BuildPathExtractor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/BuildPathExtractor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/BuildPathExtractor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/DeployPathExtractor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/DeployPathExtractor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/DeployPathExtractor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/DeployPathExtractor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/EnvPathExtractor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/EnvPathExtractor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/EnvPathExtractor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/EnvPathExtractor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/EnvStagePathExtractor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/EnvStagePathExtractor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/EnvStagePathExtractor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/EnvStagePathExtractor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/HostPathExtractor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/HostPathExtractor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/HostPathExtractor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/HostPathExtractor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/HotfixBodyExtractor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/HotfixBodyExtractor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/HotfixBodyExtractor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/HotfixBodyExtractor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/HotfixPathExtractor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/HotfixPathExtractor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/HotfixPathExtractor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/security/HotfixPathExtractor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/PromoteResult.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/PromoteResult.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Pinterest, Inc.
+ * Copyright (c) 2017-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/PromoteResult.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/PromoteResult.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-2024 Pinterest, Inc.
+ * Copyright (c) 2017-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/SimpleAgentJanitor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/SimpleAgentJanitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2023 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/SimpleAgentJanitor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/SimpleAgentJanitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/BasePathExtractorTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/BasePathExtractorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/BasePathExtractorTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/BasePathExtractorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/ScriptTokenRoleAuthorizerTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/ScriptTokenRoleAuthorizerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/ScriptTokenRoleAuthorizerTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/ScriptTokenRoleAuthorizerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Pinterest, Inc.
+ * Copyright (c) 2024-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/UserRoleAuthorizerTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/UserRoleAuthorizerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/UserRoleAuthorizerTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/security/UserRoleAuthorizerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Pinterest, Inc.
+ * Copyright (c) 2024-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/events/AppEvent.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/events/AppEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023 Pinterest, Inc.
+ * Copyright (c) 2023-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/events/AppEvent.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/events/AppEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023-2024 Pinterest, Inc.
+ * Copyright (c) 2023-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/events/AppEventListener.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/events/AppEventListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023 Pinterest, Inc.
+ * Copyright (c) 2023-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/events/AppEventListener.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/events/AppEventListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023-2024 Pinterest, Inc.
+ * Copyright (c) 2023-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/events/AppEventPublisher.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/events/AppEventPublisher.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023 Pinterest, Inc.
+ * Copyright (c) 2023-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/events/AppEventPublisher.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/events/AppEventPublisher.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023-2024 Pinterest, Inc.
+ * Copyright (c) 2023-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/events/GenericEventPublisher.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/events/GenericEventPublisher.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023 Pinterest, Inc.
+ * Copyright (c) 2023-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/events/GenericEventPublisher.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/events/GenericEventPublisher.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023-2024 Pinterest, Inc.
+ * Copyright (c) 2023-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/events/MetricsAsEventsListener.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/events/MetricsAsEventsListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023 Pinterest, Inc.
+ * Copyright (c) 2023-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/events/MetricsAsEventsListener.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/events/MetricsAsEventsListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023-2024 Pinterest, Inc.
+ * Copyright (c) 2023-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/events/ReactiveEventPublisher.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/events/ReactiveEventPublisher.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023 Pinterest, Inc.
+ * Copyright (c) 2023-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/events/ReactiveEventPublisher.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/events/ReactiveEventPublisher.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023-2024 Pinterest, Inc.
+ * Copyright (c) 2023-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/events/ResourceChangedEvent.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/events/ResourceChangedEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023 Pinterest, Inc.
+ * Copyright (c) 2023-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/events/ResourceChangedEvent.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/events/ResourceChangedEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023-2024 Pinterest, Inc.
+ * Copyright (c) 2023-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/metrics/Constants.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/metrics/Constants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023 Pinterest, Inc.
+ * Copyright (c) 2023-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/metrics/Constants.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/metrics/Constants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023-2024 Pinterest, Inc.
+ * Copyright (c) 2023-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/metrics/Utils.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/metrics/Utils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023 Pinterest, Inc.
+ * Copyright (c) 2023-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/metrics/Utils.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/metrics/Utils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023-2024 Pinterest, Inc.
+ * Copyright (c) 2023-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/metrics/micrometer/PinStatsConfig.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/metrics/micrometer/PinStatsConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023 Pinterest, Inc.
+ * Copyright (c) 2023-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/metrics/micrometer/PinStatsConfig.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/metrics/micrometer/PinStatsConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023-2024 Pinterest, Inc.
+ * Copyright (c) 2023-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/metrics/micrometer/PinStatsNamingConvention.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/metrics/micrometer/PinStatsNamingConvention.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023 Pinterest, Inc.
+ * Copyright (c) 2023-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/metrics/micrometer/PinStatsNamingConvention.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/metrics/micrometer/PinStatsNamingConvention.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023-2024 Pinterest, Inc.
+ * Copyright (c) 2023-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/metrics/micrometer/PinStatsPublisher.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/metrics/micrometer/PinStatsPublisher.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023 Pinterest, Inc.
+ * Copyright (c) 2023-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/metrics/micrometer/PinStatsPublisher.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/metrics/micrometer/PinStatsPublisher.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023-2024 Pinterest, Inc.
+ * Copyright (c) 2023-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/AnonymousAuthFilter.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/AnonymousAuthFilter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/AnonymousAuthFilter.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/AnonymousAuthFilter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/Constants.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/Constants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/Constants.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/Constants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/OpenAuthorizer.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/OpenAuthorizer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/OpenAuthorizer.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/OpenAuthorizer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/PinDeployPipelinePrincipalReplacer.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/PinDeployPipelinePrincipalReplacer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/PinDeployPipelinePrincipalReplacer.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/PinDeployPipelinePrincipalReplacer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/PrincipalReplacer.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/PrincipalReplacer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/PrincipalReplacer.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/PrincipalReplacer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/ResourceAuthZInfo.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/ResourceAuthZInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/ResourceAuthZInfo.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/ResourceAuthZInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/ResourceAuthZInfoFeature.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/ResourceAuthZInfoFeature.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/ResourceAuthZInfoFeature.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/ResourceAuthZInfoFeature.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/ResourceAuthZInfoFilter.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/ResourceAuthZInfoFilter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/ResourceAuthZInfoFilter.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/ResourceAuthZInfoFilter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/ScriptTokenProvider.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/ScriptTokenProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/ScriptTokenProvider.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/ScriptTokenProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/TeletraanAuthorizer.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/TeletraanAuthorizer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/TeletraanAuthorizer.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/TeletraanAuthorizer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/AnonymousUser.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/AnonymousUser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/AnonymousUser.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/AnonymousUser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/EnvoyCredentials.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/EnvoyCredentials.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/EnvoyCredentials.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/EnvoyCredentials.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/MaskBasedRole.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/MaskBasedRole.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/MaskBasedRole.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/MaskBasedRole.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/RoleEnum.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/RoleEnum.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/RoleEnum.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/RoleEnum.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/ScriptTokenPrincipal.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/ScriptTokenPrincipal.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/ScriptTokenPrincipal.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/ScriptTokenPrincipal.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/ServicePrincipal.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/ServicePrincipal.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/ServicePrincipal.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/ServicePrincipal.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/TeletraanPrincipal.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/TeletraanPrincipal.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/TeletraanPrincipal.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/TeletraanPrincipal.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/UserPrincipal.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/UserPrincipal.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/UserPrincipal.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/UserPrincipal.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/ValueBasedRole.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/ValueBasedRole.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/ValueBasedRole.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/ValueBasedRole.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/metrics/micrometer/PinStatsMeterRegistryCompatibilityTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/metrics/micrometer/PinStatsMeterRegistryCompatibilityTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023 Pinterest, Inc.
+ * Copyright (c) 2023-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/metrics/micrometer/PinStatsMeterRegistryCompatibilityTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/metrics/micrometer/PinStatsMeterRegistryCompatibilityTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023-2024 Pinterest, Inc.
+ * Copyright (c) 2023-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/bean/ValueBasedRoleTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/bean/ValueBasedRoleTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Pinterest, Inc.
+ * Copyright (c) 2016-2024 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/bean/ValueBasedRoleTest.java
+++ b/deploy-service/universal/src/test/java/com/pinterest/teletraan/universal/security/bean/ValueBasedRoleTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 Pinterest, Inc.
+ * Copyright (c) 2016-2025 Pinterest, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Formatted all the java code twice, since after the first format command, the history is updated and it needs another format.
Verified that running the formatter again does not produce an additional changes.

Ran:
```
mvn spotless:apply -DspotlessSetLicenseHeaderYearsFromGitHistory=true
git commit -am "Format all java code"
mvn spotless:apply -DspotlessSetLicenseHeaderYearsFromGitHistory=true
git commit -am "Format all java code, again"
```