### PR TITLE
Remove redundant host tag

### DIFF
--- a/deploy-agent/deployd/client/client.py
+++ b/deploy-agent/deployd/client/client.py
@@ -261,7 +261,7 @@ class Client(BaseClient):
             log.error("Fail to read host info: availablity zone")
             create_sc_increment(
                 name="deploy.failed.agent.hostinfocollection",
-                tags={"host": self._hostname, "info": "availability_zone"},
+                tags={"info": "availability_zone"},
             )
             return False
 
@@ -363,24 +363,17 @@ class Client(BaseClient):
                     knoxStatus=self._knox_status,
                 )
 
-                with create_stats_timer(
-                    "deploy.agent.request.latency", tags={"host": self._hostname}
-                ):
+                with create_stats_timer("deploy.agent.request.latency"):
                     ping_response = self.send_reports_internal(ping_request)
 
                 log.debug("%s -> %s" % (ping_request, ping_response))
                 return ping_response
             else:
                 log.error("Fail to read host info")
-                create_sc_increment(
-                    name="deploy.failed.agent.hostinfocollection",
-                    tags={"host": self._hostname},
-                )
+                create_sc_increment(name="deploy.failed.agent.hostinfocollection")
         except Exception:
             log.error(traceback.format_exc())
-            create_sc_increment(
-                name="deploy.failed.agent.requests", tags={"host": self._hostname}
-            )
+            create_sc_increment(name="deploy.failed.agent.requests")
             return None
 
     @retry(ExceptionToCheck=Exception, delay=1, tries=3)

--- a/deploy-agent/deployd/common/stats.py
+++ b/deploy-agent/deployd/common/stats.py
@@ -302,10 +302,6 @@ class MetricClient:
         func = getattr(sc, self.stat.mtype)
         func_v2 = getattr(sc_v2, self.stat.mtype)
 
-        # remove specific tags
-        if isinstance(self.stat.tags, dict):
-            self.stat.tags.pop("host", None)
-
         # name suffix to differentiate sc from sc_v2
         name_sc_v2 = "{}.cluster".format(self.stat.name)
 


### PR DESCRIPTION
Some methods were passing a `host` tag. However, it was being popped off in the metrics class.

Also, the pinstatsd library is already expected to handle the hostname tag