### PR TITLE
Check debug logging flag as an optimization

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
@@ -828,7 +828,7 @@ public class PingHandler {
         // go through ec2Tags
         String ec2Tags = pingRequest.getEc2Tags();
         LOG.debug("go through ec2 tags: {}", ec2Tags);
-        if (ec2Tags != null) {
+        if (ec2Tags != null && LOG.isDebugEnabled()) {
             ObjectMapper mapper = new ObjectMapper();
             Map<String, String> tags = mapper.readValue(ec2Tags, Map.class);
             for (Map.Entry<String, String> entry : tags.entrySet()) {


### PR DESCRIPTION
For a minor optimization, check if debug logging is enabled before processing and logging a `Map`