### PR TITLE
Add CERTIFYING_BUILD tag to tagging system

### DIFF
--- a/deploy-board/deploy_board/webapp/build_views.py
+++ b/deploy-board/deploy_board/webapp/build_views.py
@@ -208,6 +208,8 @@ def tag_build(request, id):
             tag["value"] = tags_helper.TagValue.BAD_BUILD
         elif value.lower()=="certified":
             tag["value"] = tags_helper.TagValue.CERTIFIED_BUILD
+        elif value.lower()=="certifying":
+            tag["value"] = tags_helper.TagValue.CERTIFYING_BUILD
         else:
             return HttpResponse(status=400)
         builds_helper.set_build_tag(request, tag)

--- a/deploy-board/deploy_board/webapp/helpers/tags_helper.py
+++ b/deploy-board/deploy_board/webapp/helpers/tags_helper.py
@@ -23,6 +23,7 @@ class TagValue(object):
     BAD_BUILD="BAD_BUILD"
     GOOD_BUILD="GOOD_BUILD"
     CERTIFIED_BUILD="CERTIFIED_BUILD"
+    CERTIFYING_BUILD="CERTIFYING_BUILD"
 
 def get_latest_by_target_id(request, target_id):
     return deploy_client.get("/tags/targets/%s/latest" % target_id, request.teletraan_user_id.token)

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/TagValue.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/TagValue.java
@@ -19,6 +19,7 @@ public enum TagValue {
     BAD_BUILD, // This tag means the build is known bad
     GOOD_BUILD, // This tag means the build is known good
     CERTIFIED_BUILD, // This tag means the build is certified
+    CERTIFYING_BUILD, // This tag means the build is being certified
     ENABLE_ENV,
     DISABLE_ENV
 }

--- a/docs/api/definitions.md
+++ b/docs/api/definitions.md
@@ -429,16 +429,16 @@
 
 ### TagBean
 
-| Name                           | Schema                                                                 |
-| ------------------------------ | ---------------------------------------------------------------------- |
-| **comments** <br>_optional_    | string                                                                 |
-| **createdDate** <br>_optional_ | integer (int64)                                                        |
-| **id** <br>_optional_          | string                                                                 |
-| **metaInfo** <br>_optional_    | string                                                                 |
-| **operator** <br>_optional_    | string                                                                 |
-| **targetId** <br>_optional_    | string                                                                 |
-| **targetType** <br>_optional_  | enum (BUILD, ENVIRONMENT, TELETRAAN)                                   |
-| **value** <br>_optional_       | enum (BAD_BUILD, GOOD_BUILD, CERTIFIED_BUILD, ENABLE_ENV, DISABLE_ENV) |
+| Name                           | Schema                                                                                   |
+| ------------------------------ | ---------------------------------------------------------------------------------------- |
+| **comments** <br>_optional_    | string                                                                                   |
+| **createdDate** <br>_optional_ | integer (int64)                                                                          |
+| **id** <br>_optional_          | string                                                                                   |
+| **metaInfo** <br>_optional_    | string                                                                                   |
+| **operator** <br>_optional_    | string                                                                                   |
+| **targetId** <br>_optional_    | string                                                                                   |
+| **targetType** <br>_optional_  | enum (BUILD, ENVIRONMENT, TELETRAAN)                                                     |
+| **value** <br>_optional_       | enum (BAD_BUILD, GOOD_BUILD, CERTIFIED_BUILD, CERTIFYING_BUILD, ENABLE_ENV, DISABLE_ENV) |
 
 <a name="tokenrolesbean"></a>
 
@@ -512,8 +512,6 @@ You may obtain a copy of the License at
 
       http://www.apache.org/licenses/LICENSE-2.0
 
-
-
 Unless required by applicable law or agreed to in writing, software
 
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -560,8 +558,6 @@ You may obtain a copy of the License at
 
       http://www.apache.org/licenses/LICENSE-2.0
 
-
-
 Unless required by applicable law or agreed to in writing, software
 
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -583,8 +579,6 @@ you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
       http://www.apache.org/licenses/LICENSE-2.0
-
-
 
 Unless required by applicable law or agreed to in writing, software
 
@@ -608,8 +602,6 @@ You may obtain a copy of the License at
 
       http://www.apache.org/licenses/LICENSE-2.0
 
-
-
 Unless required by applicable law or agreed to in writing, software
 
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -631,8 +623,6 @@ you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
       http://www.apache.org/licenses/LICENSE-2.0
-
-
 
 Unless required by applicable law or agreed to in writing, software
 
@@ -680,8 +670,6 @@ You may obtain a copy of the License at
 
       http://www.apache.org/licenses/LICENSE-2.0
 
-
-
 Unless required by applicable law or agreed to in writing, software
 
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -703,8 +691,6 @@ you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
       http://www.apache.org/licenses/LICENSE-2.0
-
-
 
 Unless required by applicable law or agreed to in writing, software
 
@@ -770,8 +756,6 @@ You may obtain a copy of the License at
 
       http://www.apache.org/licenses/LICENSE-2.0
 
-
-
 Unless required by applicable law or agreed to in writing, software
 
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -793,8 +777,6 @@ you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
       http://www.apache.org/licenses/LICENSE-2.0
-
-
 
 Unless required by applicable law or agreed to in writing, software
 
@@ -818,8 +800,6 @@ You may obtain a copy of the License at
 
       http://www.apache.org/licenses/LICENSE-2.0
 
-
-
 Unless required by applicable law or agreed to in writing, software
 
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -841,8 +821,6 @@ you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
       http://www.apache.org/licenses/LICENSE-2.0
-
-
 
 Unless required by applicable law or agreed to in writing, software
 
@@ -866,8 +844,6 @@ You may obtain a copy of the License at
 
       http://www.apache.org/licenses/LICENSE-2.0
 
-
-
 Unless required by applicable law or agreed to in writing, software
 
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -889,8 +865,6 @@ you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
       http://www.apache.org/licenses/LICENSE-2.0
-
-
 
 Unless required by applicable law or agreed to in writing, software
 
@@ -936,8 +910,6 @@ You may obtain a copy of the License at
 
       http://www.apache.org/licenses/LICENSE-2.0
 
-
-
 Unless required by applicable law or agreed to in writing, software
 
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -959,8 +931,6 @@ you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
       http://www.apache.org/licenses/LICENSE-2.0
-
-
 
 Unless required by applicable law or agreed to in writing, software
 
@@ -999,8 +969,6 @@ you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
       http://www.apache.org/licenses/LICENSE-2.0
-
-
 
 Unless required by applicable law or agreed to in writing, software
 


### PR DESCRIPTION
## Summary

Introduce a new build tag, "CERTIFYING_BUILD," to explicitly mark builds that are being tested for certification. This tag acts as an exclusion flag, preventing these builds from being considered for canary deployments.