### PR TITLE
attempt to fix bug that fail hotfix state too fast

### DIFF
--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/HotfixStateTransitioner.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/HotfixStateTransitioner.java
@@ -78,13 +78,13 @@ public class HotfixStateTransitioner implements Runnable {
             jenkins = serviceContext.getJenkins();
         } else {
             try {
-                jenkins = (Jenkins) ciPlatformManagerProxy.getCIPlatform("jenkins");
+                jenkins = (Jenkins) ciPlatformManagerProxy.getCIPlatform("Jenkins");
             } catch (Exception e) {
                 LOG.error("Failed to initialize Jenkins CI platform", e);
                 throw new RuntimeException("Failed to initialize Jenkins CI platform", e);
             }
             try {
-                buildkite = (Buildkite) ciPlatformManagerProxy.getCIPlatform("buildkite");
+                buildkite = (Buildkite) ciPlatformManagerProxy.getCIPlatform("Buildkite");
             } catch (Exception e) {
                 LOG.error("Failed to initialize Buildkite CI platform", e);
                 throw new RuntimeException("Failed to initialize Buildkite CI platform", e);
@@ -208,8 +208,8 @@ public class HotfixStateTransitioner implements Runnable {
                             }
                         }
                         // Right now only transition state when Jenkins job is created
-                        if (buildResultMap.containsKey("jenkins")
-                                && !StringUtils.isEmpty(buildResultMap.get("jenkins"))) {
+                        if (buildResultMap.containsKey("Jenkins")
+                                && !StringUtils.isEmpty(buildResultMap.get("Jenkins"))) {
                             LOG.info("Jenkins job started successfully for hotfix id {}", hotfixId);
                             transition(hotBean);
                         } else {
@@ -229,10 +229,16 @@ public class HotfixStateTransitioner implements Runnable {
 
                 } else if (state == HotfixState.PUSHING) {
                     if (!StringUtils.isEmpty(jobNum)) {
-                        Jenkins.Build build =
-                                (Jenkins.Build)
-                                        ciPlatformManagerProxy.getBuild(
-                                                "jenkins", hotBean.getJob_name(), jobNum);
+                        Jenkins.Build build = null;
+                        if (useCIProxy) {
+                            build =
+                                    (Jenkins.Build)
+                                            ciPlatformManagerProxy.getBuild(
+                                                    "Jenkins", hotBean.getJob_name(), jobNum);
+                        } else {
+                            build = jenkins.getBuild(hotBean.getJob_name(), jobNum);
+                        }
+
                         String status = build.getStatus().replace("\"", "");
                         int newProgress = build.getProgress();
 
@@ -287,7 +293,15 @@ public class HotfixStateTransitioner implements Runnable {
                     }
                 } else if (state == HotfixState.BUILDING) {
                     if (!StringUtils.isEmpty(jobNum)) {
-                        Jenkins.Build build = jenkins.getBuild(hotBean.getJob_name(), jobNum);
+                        Jenkins.Build build = null;
+                        if (useCIProxy) {
+                            build =
+                                    (Jenkins.Build)
+                                            ciPlatformManagerProxy.getBuild(
+                                                    "Jenkins", hotBean.getJob_name(), jobNum);
+                        } else {
+                            build = jenkins.getBuild(hotBean.getJob_name(), jobNum);
+                        }
                         String status = build.getStatus().replace("\"", "");
                         int newProgress = build.getProgress();
 


### PR DESCRIPTION
[Previous change](https://github.com/pinterest/teletraan/pull/1795/files#) include some bug that cause hotfix state to show as `failed` unexpectedly, this is because the `ciType` is constructed with the key being `Jenkins` instead of `jenkins` and `Buildkite` instead of `buildkite`. I was able to add some [debugging lines in configHelper](https://github.com/pinterest/teletraan/blob/master/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/ConfigHelper.java#L170-L174) to figure it out.

Beside this above bug fix, this change will also include some more backward compatibility updates.