### PR TITLE
Update link in groups page

### DIFF
--- a/deploy-board/deploy_board/templates/groups/group_envs.tmpl
+++ b/deploy-board/deploy_board/templates/groups/group_envs.tmpl
@@ -3,7 +3,7 @@
 <div class="row">
 <ul class="list-group">
     {% for env in envs %}
-        <a href="/env/{{ env.envName }}/" class="list-group-item">{{ env.envName}}</a>
+        <a href="/env/{{ env.envName }}/{{ env.stageName }}" class="list-group-item">{{ env.envName }}/{{ env.stageName }}</a>
     {% endfor%}
 </ul>
 </div>


### PR DESCRIPTION
## Summary

Previously, the link would point to the particular environment.

This can be misleading because the group can belong to a particular stage. Update the link to point to the stage

## Screenshots

**Before**

![before](https://github.com/user-attachments/assets/b4b517e9-b383-4571-b19a-1be6b6714286)

**After**

![after](https://github.com/user-attachments/assets/de4d0a5a-9110-4b8b-bca7-3bd8cd84c798)

