### PR TITLE
Add links to Golden AMI UI

### DIFF
--- a/deploy-board/deploy_board/settings.py
+++ b/deploy-board/deploy_board/settings.py
@@ -433,6 +433,8 @@ if IS_PINTEREST:
     NIMBUS_USE_EGRESS = os.getenv("NIMBUS_USE_EGRESS", "False").lower() == "true"
     NIMBUS_SERVICE_VERSION = os.getenv("NIMBUS_SERVICE_VERSION", None)
 
+    IMAGE_PROVIDER_NAME_URL = os.getenv("IMAGE_PROVIDER_NAME_URL", None)
+
     DEFAULT_CLUSTER_TYPE = "PRODUCTION"
 
     # Auto AMI Update

--- a/deploy-board/deploy_board/templates/clusters/base_image_history.html
+++ b/deploy-board/deploy_board/templates/clusters/base_image_history.html
@@ -55,8 +55,16 @@
                 </tr>
                 <tr>
                     <td>Base Image ID</td>
-                    <td>{{ current_image.id }}</td>
-                    <td>{{ golden_image.id }}</td>
+                    <td>
+                        <a href="/clouds/baseimages/events/{{ current_image.id }}">
+                            {{ current_image.id }}
+                        </a>
+                    </td>
+                    <td>
+                        <a href="/clouds/baseimages/events/{{ golden_image.id }}">
+                            {{ golden_image.id }}
+                        </a>
+                    </td>
                 </tr>
                 <tr>
                     <td>Publish Date</td>
@@ -70,8 +78,16 @@
                 </tr>
                 <tr>
                     <td>Abstract Name</td>
-                    <td>{{ current_image.abstract_name }}</td>
-                    <td>{{ golden_image.abstract_name }}</td>
+                    <td>
+                        <a href="/clouds/baseimages/{{ current_image.abstract_name }}">
+                            {{ current_image.abstract_name }}
+                        </a>
+                    </td>
+                    <td>
+                        <a href="/clouds/baseimages/{{ golden_image.abstract_name }}">
+                            {{ golden_image.abstract_name }}
+                        </a>
+                    </td>
                 </tr>
                 <tr>
                     <td>Arch Name</td>
@@ -98,10 +114,14 @@
                         Provider Name
                     </td>
                     <td>
-                        {{ current_image.provider_name }}
+                        <a href="{{ imageProviderNameUrl }}{{ current_image.provider_name }}?json=False">
+                           {{ current_image.provider_name }}
+                        </a>
                     </td>
                     <td>
-                        {{ golden_image.provider_name }}
+                        <a href="{{ imageProviderNameUrl }}{{ golden_image.provider_name }}?json=False">
+                            {{ golden_image.provider_name }}
+                        </a>
                     </td>
                 </tr>
             </table>

--- a/deploy-board/deploy_board/templates/clusters/base_image_info.tmpl
+++ b/deploy-board/deploy_board/templates/clusters/base_image_info.tmpl
@@ -10,7 +10,12 @@
         <tr>
             <td>Provider Name</td>
             <td>
-                {{ current_image.provider_name }}
+              <a class="deployToolTip" data-toggle="tooltip"
+                  title="Click to see provider name details"
+                  href="{{ imageProviderNameUrl }}{{ current_image.provider_name }}?json=False"
+              >
+                    {{ current_image.provider_name }}
+              </a>
             </td>
         </tr>
         <tr>
@@ -19,7 +24,14 @@
         </tr>
         <tr>
             <td>Abstract Name</td>
-            <td>{{ current_image.abstract_name }}</td>
+            <td>
+              <a class="deployToolTip" data-toggle="tooltip"
+                  title="Click to see abstract name details"
+                  href="/clouds/baseimages/{{ base_image.abstract_name }}"
+              >
+                  {{ current_image.abstract_name }}
+              </a>
+            </td>
         </tr>
         <tr>
             <td>Arch</td>

--- a/deploy-board/deploy_board/templates/clusters/base_images.tmpl
+++ b/deploy-board/deploy_board/templates/clusters/base_images.tmpl
@@ -40,7 +40,12 @@
                     <span class="label label-warning">GOLDEN</span>
                 {% endif %}
             </td>
-            <td> {{ base_image.provider_name }} </td>
+            <td>
+              <a id="listGroupsBtnId" href="{{ imageProviderNameUrl }}{{ base_image.provider_name }}?json=False"
+                    title="Click to see provider name details">
+                    {{ base_image.provider_name }}
+              </a>
+            </td>
             <td>
                 <a id="listGroupsBtnId" href="/clouds/baseimages/{{ base_image.abstract_name }}"
                     title="Click to see image update events">

--- a/deploy-board/deploy_board/templates/clusters/base_images_events.tmpl
+++ b/deploy-board/deploy_board/templates/clusters/base_images_events.tmpl
@@ -20,7 +20,7 @@
         <tr>
             <td>
                 {% if base_images_event.status == "SUCCEEDED" %}
-                    <input type="radio" id="select_{{forloop.counter}}" 
+                    <input type="radio" id="select_{{forloop.counter}}"
                     {% if base_images_event.old_image_id == current_image.id %}
                         checked
                     {% endif %}
@@ -35,8 +35,18 @@
                     {{ base_images_event.cluster_name }}
                 </a>
             </td>
-            <td> {{ base_images_event.old_image_id }} </td>
-            <td> {{ base_images_event.new_image_id }} </td>
+            <td>
+              <a id="listGroupsBtnId" href="/clouds/baseimages/events/{{ base_images_event.old_image_id }}"
+                  title="Click to see image update events">
+                  {{ base_images_event.old_image_id }}
+              </a>
+            </td>
+            <td>
+              <a id="listGroupsBtnId" href="/clouds/baseimages/events/{{ base_images_event.new_image_id }}"
+                  title="Click to see image update events">
+                  {{ base_images_event.new_image_id }}
+              </a>
+            </td>
             <td> {{ base_images_event.status }} </td>
             <td> {{ base_images_event.create_time|convertTimestamp }} </td>
             <td> {{ base_images_event.start_time|convertTimestamp }} </td>

--- a/deploy-board/deploy_board/webapp/cluster_view.py
+++ b/deploy-board/deploy_board/webapp/cluster_view.py
@@ -48,6 +48,7 @@ if IS_PINTEREST:
         PUPPET_CONFIG_REPOSITORY,
         PUPPET_HIERA_PATHS,
         CONFLICTING_DEPLOY_SERVICE_WIKI_URL,
+        IMAGE_PROVIDER_NAME_URL,
     )
 
 import json
@@ -565,6 +566,7 @@ def get_base_images(request):
             "pageSize": DEFAULT_PAGE_SIZE,
             "disablePrevious": index <= 1,
             "disableNext": len(base_images) < DEFAULT_PAGE_SIZE,
+            "imageProviderNameUrl": IMAGE_PROVIDER_NAME_URL,
         },
     )
 
@@ -652,6 +654,7 @@ def get_base_image_events(request, image_id):
             "golden_prod": golden_prod,
             "cancellable": cancel,
             "progress": progress_info,
+            "imageProviderNameUrl": IMAGE_PROVIDER_NAME_URL,
         },
     )
 
@@ -1886,6 +1889,7 @@ class ClusterBaseImageHistoryView(View):
             "golden_image": golden_image,
             "base_images_events": base_images_update_events,
             "current_cluster": json.dumps(current_cluster),
+            "imageProviderNameUrl": IMAGE_PROVIDER_NAME_URL,
         }
 
         return render(request, "clusters/base_image_history.html", data)


### PR DESCRIPTION
## Summary

For convenience, add more links to the Golden AMI including:

- Linking base image ids
- Linking base image names
- Linking to provider name UI

## Screenshots

**Before**

![base-image-history-before](https://github.com/user-attachments/assets/ed266f44-be87-43c0-8f4b-01e33553f18e)


**After**

![base-image-history-after](https://github.com/user-attachments/assets/f34c6aa5-d7ee-4153-88b9-baf85348e86f)
