### PR TITLE
Support same image name different arch

### DIFF
--- a/deploy-board/deploy_board/static/js/base-image-utils.js
+++ b/deploy-board/deploy_board/static/js/base-image-utils.js
@@ -9,13 +9,12 @@ function baseImageSorter(item1, item2) {
 }
 
 function getDefaultBaseImageId(baseImagesSorted) {
-    let baseImagesAcceptedSorted = baseImagesSorted.filter(e => e.acceptance == 'ACCEPTED');
-    return baseImagesAcceptedSorted.length > 0 ? baseImagesAcceptedSorted[0].id : baseImagesSorted[0].id;
+    return baseImagesSorted[0].id;
 };
 
 function mapBaseImagesToOptions(baseImagesSorted) {
     return baseImagesSorted.map(o => {
-        const status = o.golden ? ' [CURRENT_GOLDEN]' : (o.acceptance && o.acceptance !== 'UNKNOWN' ? ` [${o.acceptance}]` : ''); 
+        const status = o.golden ? ' [CURRENT_GOLDEN]' : '';
         const date = new Date(o.publish_date);
 
         return {
@@ -42,13 +41,13 @@ function ensureCurrentImageIsIncluded(baseImages, currentBaseImage) {
 }
 
 function isPinImageEnabled(goldenImage) {
-    // If there is golden - enable Pin Image checkbox 
-    // If there is no golden - disable Pin Image checkbox 
+    // If there is golden - enable Pin Image checkbox
+    // If there is no golden - disable Pin Image checkbox
     return !!goldenImage;
 }
 
 function getPinImageValue(goldenImage, clusterAutoUpdateBaseImage) {
     // If there is golden: getPinImageValue = !clusterAutoUpdateBaseImage
     // if there is no golden: getPinImageValue = true. Always pin
-    return !!goldenImage ? !clusterAutoUpdateBaseImage : true; 
+    return !!goldenImage ? !clusterAutoUpdateBaseImage : true;
 }

--- a/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
+++ b/deploy-board/deploy_board/static/js/components/clusterconfigcomponents.js
@@ -158,9 +158,8 @@ Vue.component('base-image-help', {
             { name: 'Name', headerClass: 'col-sm-1' },
             { name: 'Image', headerClass: 'col-sm-1' },
             { name: 'Qualified', headerClass: 'col-sm-1' },
-            { name: 'Description', headerClass: 'col-sm-4' },
-            { name: 'Acceptance', headerClass: 'col-sm-4' }],
-            keys: ['publish_date', 'abstract_name', 'provider_name', 'qualified', 'description', 'acceptance']
+            { name: 'Description', headerClass: 'col-sm-4' }],
+            keys: ['publish_date', 'abstract_name', 'provider_name', 'qualified', 'description']
         }
     },
 }

--- a/deploy-board/deploy_board/templates/clusters/base_images.tmpl
+++ b/deploy-board/deploy_board/templates/clusters/base_images.tmpl
@@ -13,7 +13,6 @@
             <th class="col-lg-1">Cloud Provider</th>
             <th class="col-lg-2">Publish Date</th>
             <th class="col-lg-2">Description</th>
-            <th class="col-lg-2">Acceptance</th>
         </tr>
         {% for base_image in base_images %}
         <tr>
@@ -57,11 +56,6 @@
             <td> {{ base_image.provider }} </td>
             <td> {{ base_image.publish_date | convertTimestamp }} </td>
             <td> {{ base_image.description }} </td>
-            {% if base_image.acceptance %}
-            <td> {{ base_image.acceptance }} </td>
-            {% else %}
-            <td> </td>
-            {% endif %}
         </tr>
         {% endfor %}
     </table>

--- a/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
+++ b/deploy-board/deploy_board/templates/clusters/cluster_configuration.html
@@ -867,11 +867,12 @@
                 },
                 imageNameChange: function(value) {
                     var cell = capacitySetting.currentCell;
+                    var arch = capacitySetting.currentArch;
                     capacitySetting.imageNameValue = value;
                     //Grab all images for this image name
                     $.ajax({
                         type: 'GET',
-                        url: location.protocol + '//' + location.host + '/clouds/get_base_images/' + value + '?cell=' + cell,
+                        url: location.protocol + '//' + location.host + '/clouds/get_base_images/' + value + '?cell=' + cell + '&arch=' + arch,
                         dataType: "json",
                         beforeSend: function(xhr, settings) {
                             var csrftoken = getCookie('csrftoken')

--- a/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
+++ b/deploy-board/deploy_board/templates/configs/new_capacity_adv.html
@@ -454,6 +454,7 @@ var capacitySetting = new Vue({
         },
         imageNameChange: function (value) {
             var cell = capacitySetting.currentCell;
+            var arch = capacitySetting.currentArch;
             capacitySetting.imageNameValue = value;
             if (!value) {
                 capacitySetting.baseImages = [];
@@ -465,7 +466,7 @@ var capacitySetting = new Vue({
             //Grab all images for this image name
             $.ajax({
                 type: 'GET',
-                url: location.protocol + '//' + location.host + '/clouds/get_base_images/' + value + '?cell=' + cell,
+                url: location.protocol + '//' + location.host + '/clouds/get_base_images/' + value + '?cell=' + cell + '&arch=' + arch,
                 dataType: "json",
                 beforeSend: function (xhr, settings) {
                     var csrftoken = getCookie('csrftoken')


### PR DESCRIPTION
## Summary:

Add support for sharing an image name across different arches, similar to how the same image name can be used across different cells.

At a high level, here are the two changes.

* Pass the `arch` to the various Golden AMI calls that were needed
* Remove the unused "Image Validation" or "Image Acceptance" feature

## Testing Done:
<!-- What steps you've taken to check your work? Paste the commands with output. --> 
<!-- Please avoid vague plans like "Jenkins passed" or "Tested on devapp" -->

* Deployed the schema updates
* Verified promotion and demotion still works as expected
* Deployed to code changes
* Verified promotion and demotion still works as expected
* Registered two cmp_base golden AMIs. One with arm64, one with amd64
* Created two clusters, one with `arm64`, one with `amd64`
* Verified the promotion and demotion of these clusters worked independently

## Screenshots

See screenshots in related PRs