### PR TITLE
Fix Slack channel name for project ownership

### DIFF
--- a/deploy-board/deploy_board/templates/environs/env_landing.html
+++ b/deploy-board/deploy_board/templates/environs/env_landing.html
@@ -368,7 +368,7 @@ $('#privateBldUploadBtnId button').click(function () {
                 {% else %}
                 <div class="btn-project-info-warning">
                     <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
-                    <p>Missing project ownership information, please contact slack #infra-console to add it.</p>
+                    <p>Missing project ownership information, please contact slack #infra-nimbus to add it.</p>
                 </div>
                 {% endif %}
             {% endif %}


### PR DESCRIPTION
The #infra-console Slack channel does not exist, so update this message with the correct one.