### PR TITLE
Update base image links

### DIFF
--- a/deploy-board/deploy_board/templates/clusters/base_image_info.tmpl
+++ b/deploy-board/deploy_board/templates/clusters/base_image_info.tmpl
@@ -27,7 +27,7 @@
             <td>
               <a class="deployToolTip" data-toggle="tooltip"
                   title="Click to see abstract name details"
-                  href="/clouds/baseimages/{{ base_image.abstract_name }}"
+                  href="/clouds/baseimages/{{ current_image.abstract_name }}"
               >
                   {{ current_image.abstract_name }}
               </a>

--- a/deploy-board/deploy_board/webapp/cluster_view.py
+++ b/deploy-board/deploy_board/webapp/cluster_view.py
@@ -627,6 +627,7 @@ def get_base_images_by_abstract_name(request, abstract_name):
             "pageSize": len(base_images),
             "disablePrevious": True,
             "disableNext": True,
+            "imageProviderNameUrl": IMAGE_PROVIDER_NAME_URL,
         },
     )
 


### PR DESCRIPTION
## Summary

Update the links in two places:

* Link to the base image name page. Due to a typo, it was linking to the base image home page
* Link to the ami provider. The `imageProviderNameUrl` was not being propagated

## Testing Done

* Deployed to development cluster
* Verified the two links were now correct

## Screenshots

![Screenshot 2025-04-30 at 5 56 46 PM](https://github.com/user-attachments/assets/1dfcc3e0-ca43-46ba-a6c1-a89b5d27902a)

![Screenshot 2025-04-30 at 5 59 39 PM](https://github.com/user-attachments/assets/142fbb18-dcbe-4ab1-aa55-4ee960ed69db)


