### PR TITLE
Remove duplicate golden image

### DIFF
--- a/deploy-board/deploy_board/webapp/cluster_view.py
+++ b/deploy-board/deploy_board/webapp/cluster_view.py
@@ -776,9 +776,11 @@ def get_base_image_info_by_name(request, name, cell, arch):
         golden_image = baseimages_helper.get_current_golden_image(
             request, name, cell, arch
         )
-        if golden_image:
-            golden_image["golden"] = True
-            base_images.append(golden_image)
+        if golden_image and base_images:
+            for base_image in base_images:
+                if base_image["id"] == golden_image["id"]:
+                    base_image["golden"] = True
+                    break
         return base_images
     return baseimages_helper.get_by_name(request, name, cell, arch)
 


### PR DESCRIPTION
## Summary

In the Teletraan UI, the golden image image was duplicated in the dropdown. Remove the duplication by updating the existing image with the golden tag

## Testing Done

* Deployed to a development cluster
* Verified there were no duplicates anymore

## Screenshots

![Screenshot 2025-04-30 at 6 04 22 PM](https://github.com/user-attachments/assets/c79359ec-76ff-43d0-b626-7ecd687a1b24)
