### PR TITLE
Update commitInfo after loading builds

### DIFF
--- a/deploy-board/deploy_board/templates/builds/pick_a_build.tmpl
+++ b/deploy-board/deploy_board/templates/builds/pick_a_build.tmpl
@@ -4,7 +4,7 @@
     <tr>
         <th class="col-lg-2">Publish Date</th>
         <th class="col-lg-2">Commit</th>
-        <th class="col-lg-2 commitInfo"   style="display: none;">Commit Info</th>
+        <th class="col-lg-2 commitInfo" style="display: none;">Commit Info</th>
         <th class="col-lg-2">Branch</th>
         <th class="col-lg-2">Repo</th>
         <th class="col-lg-2">Build Name</th>
@@ -228,5 +228,12 @@
                     '&page_index={{ pageIndex|add:"-1" }}&page_size={{ pageSize }}' +
                     '&current_build_id={{ current_build.id }}' + '&override_policy={{ env.overridePolicy }}&deploy_id={{ env.deployId }}');
         });
+
+        const showCommitInfo = localStorage.getItem('showCommitInfo') === 'true';
+        if (showCommitInfo) {
+            $('.commitInfo').show();
+        } else {
+            $('.commitInfo').hide();
+        }
     });
 </script>


### PR DESCRIPTION
## Summary

Since the builds load asynchronously, set the commitInfo styles after loading the builds

## Testing Done

* Ran the local setup
* Ensured that if the box is checked in the "new_deploy" page, then after refreshing, the commitInfo is still shown