### PR TITLE
Default tags for deploy-agent

### DIFF
--- a/deploy-agent/deployd/agent.py
+++ b/deploy-agent/deployd/agent.py
@@ -28,7 +28,12 @@ from deployd.common.exceptions import AgentException
 from deployd.common.helper import Helper
 from deployd.common.env_status import EnvStatus
 from deployd.common.single_instance import SingleInstance
-from deployd.common.stats import TimeElapsed, create_sc_timing, create_sc_increment
+from deployd.common.stats import (
+    TimeElapsed,
+    create_sc_timing,
+    create_sc_increment,
+    add_default_tag,
+)
 from deployd.common.utils import (
     get_telefig_version,
     get_container_health_info,
@@ -77,14 +82,12 @@ class DeployAgent(object):
         self.stat_time_elapsed_total = TimeElapsed()
         self.stat_stage_time_elapsed = None
         self.deploy_goal_previous = None
-        self._first_run = False
         self._helper = helper or Helper(self._config)
         self._STATUS_FILE = self._config.get_env_status_fn()
         self._client = client
         self._env_status = estatus or EnvStatus(self._STATUS_FILE)
         # load environment deploy status file from local disk
         self.load_status_file()
-        self._telefig_version = get_telefig_version()
 
     def load_status_file(self) -> None:
         self._envs = self._env_status.load_envs()
@@ -96,22 +99,11 @@ class DeployAgent(object):
         self._curr_report = list(self._envs.values())[0]
         self._config.update_variables(self._curr_report)
 
-    @property
-    def first_run(self) -> bool:
-        """check if this the very first run of agent on this instance.
-        first_run will evaluate to True, even if self._envs is set, until the process has exited.
-        self._envs is not populated when running for the first time on a new instance
-        return: bool self._first_run
-        """
-        if self._first_run or not self._envs:
-            self._first_run = True
-        return self._first_run
-
     def _send_deploy_status_stats(self, deploy_report) -> None:
         if not self._response.deployGoal or not deploy_report:
             return
 
-        tags = {"first_run": self.first_run}
+        tags = {}
         if self._response.deployGoal.deployStage:
             tags["deploy_stage"] = self._response.deployGoal.deployStage
         if self._response.deployGoal.envName:
@@ -120,8 +112,6 @@ class DeployAgent(object):
             tags["stage_name"] = self._response.deployGoal.stageName
         if deploy_report.status_code:
             tags["status_code"] = deploy_report.status_code
-        if self._telefig_version:
-            tags["telefig_version"] = self._telefig_version
         create_sc_increment("deployd.stats.deploy.status.sum", tags=tags)
 
     def serve_build(self) -> None:
@@ -465,7 +455,7 @@ class DeployAgent(object):
             and self.deploy_goal_previous.deployStage
             and self.stat_stage_time_elapsed
         ):
-            tags = {"first_run": self.first_run}
+            tags = {}
             if self.deploy_goal_previous.deployStage:
                 tags["deploy_stage"] = self.deploy_goal_previous.deployStage
             if self.deploy_goal_previous.envName:
@@ -511,7 +501,7 @@ class DeployAgent(object):
         # timing stats - deploy stage start
         if deploy_goal != self.deploy_goal_previous:
             # a deploy goal has changed
-            tags = {"first_run": self.first_run}
+            tags = {}
 
             # deploy stage has changed, close old previous timer
             self._timing_stats_deploy_stage_time_elapsed()
@@ -648,6 +638,8 @@ def main():
 
         pinlogger.initialize_logger(logger_filename="deploy-agent.log")
         pinlogger.LOG_TO_STDERR = True
+        add_default_tag("telefig_version", get_telefig_version())
+        add_default_tag("first_run", config.first_run)
     else:
         log_filename = os.path.join(config.get_log_directory(), "deploy-agent.log")
         logging.basicConfig(
@@ -675,9 +667,7 @@ def main():
 
     uptime = utils_uptime()
     agent = DeployAgent(client=client, conf=config)
-    create_sc_timing(
-        "deployd.stats.ec2_uptime_sec", uptime, tags={"first_run": agent.first_run}
-    )
+    create_sc_timing("deployd.stats.ec2_uptime_sec", uptime)
     utils_listen()
     if args.daemon:
         logger = logging.getLogger()
@@ -693,13 +683,11 @@ def main():
     create_sc_timing(
         "deployd.stats.internal.time_elapsed_proc_sec",
         agent.stat_time_elapsed_internal.get(),
-        tags={"first_run": agent.first_run},
     )
     # timing stats - agent total run time
     create_sc_timing(
         "deployd.stats.internal.time_elapsed_proc_total_sec",
         agent.stat_time_elapsed_total.get(),
-        tags={"first_run": agent.first_run},
     )
     # timing stats - agent exit time
     create_sc_timing("deployd.stats.internal.time_end_sec", int(time.time()))

--- a/deploy-agent/deployd/common/config.py
+++ b/deploy-agent/deployd/common/config.py
@@ -37,6 +37,7 @@ class Config(object):
         self._configs = {}
         self._filenames = None
         self._environ = {}
+        self._first_run = False
         if config_reader:
             self._config_reader = config_reader
             return
@@ -310,3 +311,14 @@ class Config(object):
 
     def get_s3_download_allow_list(self) -> List:
         return self._get_download_allow_list("s3_download_allow_list")
+
+    @property
+    def first_run(self) -> bool:
+        """check if this the very first run on this instance.
+        first_run will evaluate to True, even if the env_status file is present, until the process has exited.
+        The env_status file is not present when running for the first time on a new instance
+        return: bool self._first_run
+        """
+        if self._first_run or not os.path.exists(self.get_env_status_fn()):
+            self._first_run = True
+        return self._first_run

--- a/deploy-agent/deployd/common/stats.py
+++ b/deploy-agent/deployd/common/stats.py
@@ -49,6 +49,13 @@ else:
 
 
 log = logging.getLogger(__name__)
+default_tags = {
+    "deploy_agent_version": __version__,
+}
+
+
+def add_default_tag(key, val):
+    default_tags[key] = val
 
 
 class DefaultStatsdTimer(object):
@@ -114,6 +121,7 @@ def create_sc_gauge(name, value, sample_rate=1.0, tags=None) -> None:
 
 def send_statsboard_metric(name, value, tags=None) -> None:
     tags["host"] = socket.gethostname()
+    tags.update(default_tags)
     tags_params = [f"{tag}={tags[tag]}" for tag in tags]
     tags_str = ",".join(tags_params)
     url = f"{STATSBOARD_URL}put/{name}?value={value}&tags={tags_str}"
@@ -278,12 +286,9 @@ class MetricClient:
         :param: tags as dict
         return: dict
         """
-        if not __version__:
-            # defensive case, should not be hit
-            return tags
-        if __version__ and not tags:
+        if tags is None:
             tags = dict()
-        tags["deploy_agent_version"] = __version__
+        tags.update(default_tags)
         return tags
 
     @staticmethod

--- a/deploy-agent/deployd/common/utils.py
+++ b/deploy-agent/deployd/common/utils.py
@@ -119,11 +119,6 @@ def ensure_dirs(config) -> None:
     mkdir_p(config.get_log_directory())
 
 
-def is_first_run(config) -> bool:
-    env_status_file = config.get_env_status_fn()
-    return not os.path.exists(env_status_file)
-
-
 def check_prereqs(config) -> bool:
     """
     Check prerequisites before deploy agent can run
@@ -188,7 +183,7 @@ def check_first_puppet_run_success(config) -> bool:
 
     :return: returns True if success else False
     """
-    if not is_first_run(config):
+    if not config.first_run:
         return True
 
     puppet_exit_code = get_puppet_exit_code(config)

--- a/deploy-agent/tests/unit/deploy/common/test_config.py
+++ b/deploy-agent/tests/unit/deploy/common/test_config.py
@@ -113,6 +113,20 @@ class TestConfigFunctions(tests.TestCase):
             config._get_deploy_type_from_opcode(opCode="STOP"), DeployType.STOP
         )
 
+    def test_config_first_run(self):
+        config = Config()
+        with mock.patch("os.path.exists") as os_path_exists:
+            # first run
+            os_path_exists.return_value = False
+            self.assertTrue(config.first_run)
+
+            # first run stickiness
+            os_path_exists.return_value = True
+            self.assertTrue(config.first_run)
+
+            # subsequent run
+            self.assertFalse(Config().first_run)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/deploy-agent/tests/unit/deploy/common/test_utils.py
+++ b/deploy-agent/tests/unit/deploy/common/test_utils.py
@@ -27,18 +27,19 @@ from deployd.common.utils import (
     "deployd.common.utils.send_statsboard_metric", new=mock.Mock(return_value=None)
 )
 class TestCommonUtils(TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.estatus = mock.Mock()
-        cls.estatus.load_envs = mock.Mock(return_value=None)
-        cls.config = mock.Mock()
-        cls.config.load_env_and_configs = mock.Mock()
-        cls.config.get_agent_directory = mock.Mock(return_value="/tmp/deployd/")
-        cls.config.get_builds_directory = mock.Mock(return_value="/tmp/deployd/builds/")
-        cls.config.get_log_directory = mock.Mock(return_value="/tmp/logs/")
-        cls.config.respect_puppet = mock.Mock(return_value=True)
-        cls.config.get_puppet_state_file_path = mock.Mock(return_value="/tmp/deployd")
-        ensure_dirs(cls.config)
+    def setUp(self):
+        self.estatus = mock.Mock()
+        self.estatus.load_envs = mock.Mock(return_value=None)
+        self.config = mock.Mock()
+        self.config.load_env_and_configs = mock.Mock()
+        self.config.get_agent_directory = mock.Mock(return_value="/tmp/deployd/")
+        self.config.get_builds_directory = mock.Mock(
+            return_value="/tmp/deployd/builds/"
+        )
+        self.config.get_log_directory = mock.Mock(return_value="/tmp/logs/")
+        self.config.respect_puppet = mock.Mock(return_value=True)
+        self.config.get_puppet_state_file_path = mock.Mock(return_value="/tmp/deployd")
+        ensure_dirs(self.config)
 
     @mock.patch("deployd.common.utils.IS_PINTEREST", False)
     def test_check_prereqs_not_pins(self):
@@ -46,7 +47,6 @@ class TestCommonUtils(TestCase):
         self.assertTrue(result)
 
     @mock.patch("deployd.common.utils.IS_PINTEREST", True)
-    @mock.patch("deployd.common.utils.is_first_run", new=mock.Mock(return_value=True))
     @mock.patch(
         "deployd.common.utils.load_puppet_summary",
         new=mock.Mock(return_value={"events": {"failure": 0}}),
@@ -61,7 +61,6 @@ class TestCommonUtils(TestCase):
         self.assertTrue(result)
 
     @mock.patch("deployd.common.utils.IS_PINTEREST", True)
-    @mock.patch("deployd.common.utils.is_first_run", new=mock.Mock(return_value=True))
     @mock.patch(
         "deployd.common.utils.load_puppet_summary",
         new=mock.Mock(return_value={"events": {"failure": 0}}),
@@ -74,7 +73,6 @@ class TestCommonUtils(TestCase):
         self.assertTrue(result)
 
     @mock.patch("deployd.common.utils.IS_PINTEREST", True)
-    @mock.patch("deployd.common.utils.is_first_run", new=mock.Mock(return_value=True))
     @mock.patch(
         "deployd.common.utils.load_puppet_summary",
         new=mock.Mock(return_value={"events": {"failure": 3}}),
@@ -89,7 +87,6 @@ class TestCommonUtils(TestCase):
         self.assertFalse(result)
 
     @mock.patch("deployd.common.utils.IS_PINTEREST", True)
-    @mock.patch("deployd.common.utils.is_first_run", new=mock.Mock(return_value=False))
     @mock.patch(
         "deployd.common.utils.load_puppet_summary",
         new=mock.Mock(return_value={"events": {"failure": 2}}),
@@ -98,13 +95,14 @@ class TestCommonUtils(TestCase):
         "deployd.common.utils.get_puppet_exit_code", new=mock.Mock(return_value=999)
     )
     def test_check_prereqs_no_state_file(self):
+        self.config.first_run = False
         self.config.get_puppet_state_file_path = mock.Mock(return_value=None)
         result = check_prereqs(self.config)
         self.assertTrue(result)
 
     @mock.patch("deployd.common.utils.IS_PINTEREST", True)
-    @mock.patch("deployd.common.utils.is_first_run", new=mock.Mock(return_value=False))
     def test_check_prereqs_not_first_run(self):
+        self.config.first_run = False
         result = check_prereqs(self.config)
         self.assertTrue(result)
 

--- a/deploy-agent/tests/unit/deploy/server/test_agent.py
+++ b/deploy-agent/tests/unit/deploy/server/test_agent.py
@@ -122,38 +122,6 @@ class TestDeployAgent(TestCase):
         cls.ping_response6 = {"deployGoal": cls.deploy_goal6, "opCode": OpCode.DELETE}
         cls.ping_noop_response = {"deployGoal": None, "opCode": OpCode.NOOP}
 
-    def test_agent_first_run(self):
-        # first run
-        ping_response_list = [
-            PingResponse(jsonValue=self.ping_response1),
-            None,
-            PingResponse(jsonValue=self.ping_response1),
-        ]
-        client = mock.Mock()
-        client.send_reports = mock.Mock(side_effect=ping_response_list)
-        d = DeployAgent(
-            client=client,
-            estatus=self.estatus,
-            conf=self.config,
-            executor=self.executor,
-            helper=self.helper,
-        )
-        self.assertTrue(d.first_run)
-        # first run stickiness
-        d._envs = {"data": "data"}
-        self.assertTrue(d.first_run)
-        # subsequent run
-        client.send_reports = mock.Mock(side_effect=ping_response_list)
-        d = DeployAgent(
-            client=client,
-            estatus=self.estatus,
-            conf=self.config,
-            executor=self.executor,
-            helper=self.helper,
-        )
-        d._envs = {"data": "data"}
-        self.assertFalse(d.first_run)
-
     def test_agent_status_on_ping_failure(self):
         ping_response_list = [
             PingResponse(jsonValue=self.ping_response1),
@@ -674,7 +642,6 @@ class TestDeployAgent(TestCase):
         mock_create_sc.assert_called_once_with(
             "deployd.stats.deploy.status.sum",
             tags={
-                "first_run": False,
                 "deploy_stage": "PRE_DOWNLOAD",
                 "env_name": "abc",
                 "stage_name": "beta",


### PR DESCRIPTION
## Summary

Add default metric tags for deploy-agent including: `deploy-agent version`, `telefig version`, `first_run`
These are low cardinality metrics which should avoid impact on the metric system performance.

Also:
* Refactor the deploy goal tags
* Refactor `first_run` logic to the `Config` class, since it is used by both the main function and `utils.check_first_puppet_run_success`

## Testing Done

* Ran the changes on a local setup
* WIP