### PR TITLE
Update default CMP image

### DIFF
--- a/deploy-board/deploy_board/settings.py
+++ b/deploy-board/deploy_board/settings.py
@@ -393,8 +393,8 @@ if IS_PINTEREST:
     DEFAULT_PROVIDER = "AWS"
 
     # Pinterest Default AMI image name
-    DEFAULT_CMP_IMAGE = "cmp_base-ebs-18.04"
-    DEFAULT_CMP_ARM_IMAGE = "cmp_base_u20_arm64"
+    DEFAULT_CMP_IMAGE = "cmp_base"
+    DEFAULT_CMP_ARM_IMAGE = "cmp_base"
 
     # Pinterest Default setting whether to use launch template or not
     DEFAULT_USE_LAUNCH_TEMPLATE = True


### PR DESCRIPTION
- Verified the `cmp_base` is the dropdown default on the advanced cluster configuration during cluster creation
- Verified that the image is `cmp_base` after the cluster is  created from basic cluster configuration page