### PR TITLE
Add deploy info metrics

### DIFF
--- a/deploy-agent/deployd/agent.py
+++ b/deploy-agent/deployd/agent.py
@@ -589,12 +589,17 @@ class DeployAgent(object):
                     f"Skip deploy info metric for {env_name} due to missing commit"
                 )
                 continue
+            if not build_info.build_name:
+                log.info(
+                    f"Skip deploy info metric for {env_name} due to missing build_name"
+                )
+                continue
 
             put_stmts.append(
                 f"put {DEPLOY_INFO_METRIC_NAME} "
                 f"{epoch_in_seconds} {DEPLOY_INFO_METRIC_VALUE} "
                 f"source=teletraan "
-                f"artifact={env_name} "
+                f"artifact={build_info.build_name} "
                 f"commit_sha={build_info.build_commit}"
             )
 

--- a/deploy-agent/deployd/common/config.py
+++ b/deploy-agent/deployd/common/config.py
@@ -310,3 +310,13 @@ class Config(object):
 
     def get_s3_download_allow_list(self) -> List:
         return self._get_download_allow_list("s3_download_allow_list")
+
+    # OpenTSDB server to send deploy info (non-aggregated) metric data
+    def get_tsd_host(self) -> str:
+        return self.get_var("tsd_host", "localhost")
+
+    def get_tsd_port(self) -> int:
+        return self.get_intvar("tsd_port", 18126)
+
+    def get_tsd_timeout_seconds(self) -> int:
+        return self.get_intvar("tsd_timeout_seconds", 5)

--- a/deploy-agent/tests/unit/deploy/server/test_agent.py
+++ b/deploy-agent/tests/unit/deploy/server/test_agent.py
@@ -20,6 +20,7 @@ from tests import TestCase
 from deployd.agent import DeployAgent
 from deployd.common.utils import ensure_dirs
 from deployd.common.types import (
+    BuildInfo,
     DeployReport,
     DeployStatus,
     OpCode,
@@ -46,6 +47,9 @@ class TestDeployAgent(TestCase):
         cls.config.get_agent_directory = mock.Mock(return_value="/tmp/deployd/")
         cls.config.get_builds_directory = mock.Mock(return_value="/tmp/deployd/builds/")
         cls.config.get_log_directory = mock.Mock(return_value="/tmp/logs/")
+        cls.config.get_tsd_host = mock.Mock(return_value="localhost")
+        cls.config.get_tsd_port = mock.Mock(return_value=18126)
+        cls.config.get_tsd_timeout_seconds = mock.Mock(return_value=5)
         ensure_dirs(cls.config)
         cls.executor = mock.Mock()
         cls.executor.execute_command = mock.Mock(
@@ -472,7 +476,13 @@ class TestDeployAgent(TestCase):
         d.serve_build()
         client.send_reports.assert_called_once_with({})
 
-    def test_report_health(self):
+    @mock.patch("socket.socket")
+    @mock.patch("time.time")
+    def test_report_health(self, mock_time, mock_socket):
+        mock_time.return_value = 100.1
+        mock_sock = mock.Mock()
+        mock_socket.return_value = mock_sock
+
         status = DeployStatus()
         ping_report = {}
         ping_report["deployId"] = "123"
@@ -482,6 +492,9 @@ class TestDeployAgent(TestCase):
         ping_report["deployStage"] = DeployStage.SERVING_BUILD
         ping_report["status"] = AgentStatus.SUCCEEDED
         status.report = PingReport(jsonValue=ping_report)
+        status.build_info = BuildInfo(
+            "test_commit_sha", "test_build_url", "test_build_id"
+        )
 
         envs = {"234": status}
         client = mock.Mock()
@@ -504,6 +517,12 @@ class TestDeployAgent(TestCase):
             agent._curr_report.report.deployStage, DeployStage.SERVING_BUILD
         )
         self.assertEqual(agent._curr_report.report.status, AgentStatus.SUCCEEDED)
+
+        mock_socket.assert_called_once()
+        mock_sock.settimeout.assert_called_once_with(5)
+        mock_sock.connect.assert_called_once_with(("localhost", 18126))
+        expected_put = "put deploy.info 100 1 source=teletraan artifact=234 commit_sha=test_commit_sha\n"
+        mock_sock.sendall.assert_called_once_with(expected_put.encode("utf-8"))
 
     def test_report_with_deploy_goal(self):
         if os.path.exists("/tmp/env_status"):

--- a/deploy-agent/tests/unit/deploy/server/test_agent.py
+++ b/deploy-agent/tests/unit/deploy/server/test_agent.py
@@ -493,7 +493,10 @@ class TestDeployAgent(TestCase):
         ping_report["status"] = AgentStatus.SUCCEEDED
         status.report = PingReport(jsonValue=ping_report)
         status.build_info = BuildInfo(
-            "test_commit_sha", "test_build_url", "test_build_id"
+            "test_commit_sha",
+            "test_build_url",
+            "test_build_id",
+            build_name="test_build_name",
         )
 
         envs = {"234": status}
@@ -521,7 +524,7 @@ class TestDeployAgent(TestCase):
         mock_socket.assert_called_once()
         mock_sock.settimeout.assert_called_once_with(5)
         mock_sock.connect.assert_called_once_with(("localhost", 18126))
-        expected_put = "put deploy.info 100 1 source=teletraan artifact=234 commit_sha=test_commit_sha\n"
+        expected_put = "put deploy.info 100 1 source=teletraan artifact=test_build_name commit_sha=test_commit_sha\n"
         mock_sock.sendall.assert_called_once_with(expected_put.encode("utf-8"))
 
     def test_report_with_deploy_goal(self):


### PR DESCRIPTION
## Summary

Add deployment info metric data that could be used for ACA. These are sent at the end of the deploy-agent run

## Testing

* Added unit tests
* Ran on a local setup and verified metrics were visible
* Ran on a dev cluster, verified metrics were visible and able to be used to segment canary/non-canary metrics
* Ran a performance test on a large cluster (3k+ nodes). Ensured metrics could still be sent through the socket quickly (<1s)

## Rollout Plan

Although, there shouldn't be any performance issues due to the large amounts of requests the metrics system can handle, it will still be rolled out gradually since this affects many hosts