### PR TITLE
Teletraan Health Check should show failure when timed out

### DIFF
--- a/deploy-board/deploy_board/templates/groups/health_check_activities.tmpl
+++ b/deploy-board/deploy_board/templates/groups/health_check_activities.tmpl
@@ -39,7 +39,7 @@
                     <td> N/A </td>
                 {% endif %}
                 <td>
-                    <span class="deployToolTip pointer-cursor {{ health_check.status | healthCheckStatusIcon }}"></span>
+                    <span class="deployToolTip pointer-cursor {{ health_check.status | healthCheckStatusIcon(health_check.deploy_complete_time) }}"></span>
                     {% if health_check.status == "SUCCEEDED" %}
                         STATE SUCCEEDED
                     {% elif health_check.status == "QUALIFIED" %}
@@ -50,6 +50,10 @@
                         FAILED (terminating)
                     {% elif health_check.error_message %}
                         FAILED (pending termination)
+                    {% elif not health_check.deploy_complete_time and health_check.status == "TELETRAAN_STOP_REQUESTED" and health_check.host_terminated == 1 %}
+                        TIMEOUT (terminated)
+                    {% elif not health_check.deploy_complete_time and health_check.status == "TELETRAAN_STOP_REQUESTED" %}
+                        TIMEOUT (terminating)
                     {% elif health_check.status == "TELETRAAN_STOP_REQUESTED" and health_check.host_terminated == 1 %}
                         QUALIFIED (terminated)
                     {% elif health_check.status == "TELETRAAN_STOP_REQUESTED" %}

--- a/deploy-board/deploy_board/templates/groups/health_check_activities.tmpl
+++ b/deploy-board/deploy_board/templates/groups/health_check_activities.tmpl
@@ -39,7 +39,7 @@
                     <td> N/A </td>
                 {% endif %}
                 <td>
-                    <span class="deployToolTip pointer-cursor {{ health_check.status | healthCheckStatusIcon(health_check.deploy_complete_time) }}"></span>
+                    <span class="deployToolTip pointer-cursor {{ health_check.status | healthCheckStatusIcon:health_check.deploy_complete_time }}"></span>
                     {% if health_check.status == "SUCCEEDED" %}
                         STATE SUCCEEDED
                     {% elif health_check.status == "QUALIFIED" %}

--- a/deploy-board/deploy_board/templates/groups/health_check_details.html
+++ b/deploy-board/deploy_board/templates/groups/health_check_details.html
@@ -104,7 +104,7 @@
             <tr>
                 <td class="col-lg-2">Health Check Status</td>
                 <td>
-                    <span class="deployToolTip pointer-cursor {{ health_check.status | healthCheckStatusIcon(health_check.deploy_complete_time) }}"></span>
+                    <span class="deployToolTip pointer-cursor {{ health_check.status | healthCheckStatusIcon:health_check.deploy_complete_time }}"></span>
                     {% if health_check.status == "SUCCEEDED" %}
                         STATE SUCCEEDED
                     {% elif health_check.status == "QUALIFIED" %}

--- a/deploy-board/deploy_board/templates/groups/health_check_details.html
+++ b/deploy-board/deploy_board/templates/groups/health_check_details.html
@@ -104,7 +104,7 @@
             <tr>
                 <td class="col-lg-2">Health Check Status</td>
                 <td>
-                    <span class="deployToolTip pointer-cursor {{ health_check.status | healthCheckStatusIcon }}"></span>
+                    <span class="deployToolTip pointer-cursor {{ health_check.status | healthCheckStatusIcon(health_check.deploy_complete_time) }}"></span>
                     {% if health_check.status == "SUCCEEDED" %}
                         STATE SUCCEEDED
                     {% elif health_check.status == "QUALIFIED" %}
@@ -115,6 +115,10 @@
                         FAILED (terminating)
                     {% elif health_check.error_message %}
                         FAILED (pending termination)
+                    {% elif not health_check.deploy_complete_time and health_check.status == "TELETRAAN_STOP_REQUESTED" and health_check.host_terminated == 1 %}
+                        TIMEOUT (terminated)
+                    {% elif not health_check.deploy_complete_time and health_check.status == "TELETRAAN_STOP_REQUESTED" %}
+                        TIMEOUT (terminating)
                     {% elif health_check.status == "TELETRAAN_STOP_REQUESTED" and health_check.host_terminated == 1 %}
                         QUALIFIED (terminated)
                     {% elif health_check.status == "TELETRAAN_STOP_REQUESTED" %}

--- a/deploy-board/deploy_board/webapp/templatetags/utils.py
+++ b/deploy-board/deploy_board/webapp/templatetags/utils.py
@@ -1126,7 +1126,10 @@ def healthCheckStatusClass(error_message):
 
 
 @register.filter("healthCheckStatusIcon")
-def healthStatusIcon(status):
+def healthStatusIcon(status, completed):
+    if not completed and status == "TELETRAAN_STOP_REQUESTED":
+        return "fa fa-minus-circle"
+        
     return _HEALTH_STATUS_TO_ICONS[status]
 
 

--- a/deploy-board/deploy_board/webapp/templatetags/utils.py
+++ b/deploy-board/deploy_board/webapp/templatetags/utils.py
@@ -1129,7 +1129,6 @@ def healthCheckStatusClass(error_message):
 def healthStatusIcon(status, completed):
     if not completed and status == "TELETRAAN_STOP_REQUESTED":
         return "fa fa-minus-circle"
-        
     return _HEALTH_STATUS_TO_ICONS[status]
 
 


### PR DESCRIPTION
Before:
https://deploy-integ.pinadmin.com/groups/helloworlddummyservice-server-test-osoriano-integ/health_check_activities/
<img width="1670" alt="Screenshot 2025-05-30 at 2 05 12 PM" src="https://github.com/user-attachments/assets/d013a562-0e58-4676-8b84-08561c3155e6" />

After:
<img width="1631" alt="Screenshot 2025-05-30 at 2 14 43 PM" src="https://github.com/user-attachments/assets/bd072b46-8bfa-4d60-be86-1abadc2d1e16" />
