### PR TITLE
support migration strategy with pinci pipeline tag & fix branch assignment bug

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/ci/Buildkite.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/ci/Buildkite.java
@@ -356,7 +356,7 @@ public class Buildkite extends BaseCIPlatformManager {
             String res =
                     httpClient.post(
                             constructPortalEndpoint("trigger", pipeline), bodyString, headers);
-            LOG.error(
+            LOG.info(
                     "[Buildkite][startBuild] portal url "
                             + constructPortalEndpoint("trigger", pipeline)
                             + " bodyString "
@@ -470,13 +470,11 @@ public class Buildkite extends BaseCIPlatformManager {
     }
 
     private boolean tagExists(JsonObject fullJson) {
-        LOG.error(String.format("fullJson is %s", fullJson.toString()));
         if (fullJson.has("tags") && !fullJson.get("tags").isJsonNull()) {
             JsonArray tags = fullJson.getAsJsonArray("tags");
-            LOG.error(String.format("Json tags is %s", tags.toString()));
+            LOG.debug(String.format("Json tags is %s", tags.toString()));
             if (tags.size() > 0) {
                 for (JsonElement tag : tags) {
-                    LOG.error(String.format("current tag is %s", tag.toString()));
                     if (tag.getAsString().equals("teletraan-ready")) {
                         return true;
                     }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/ci/CIPlatformManagerProxy.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/ci/CIPlatformManagerProxy.java
@@ -91,7 +91,7 @@ public class CIPlatformManagerProxy {
             throw new Exception("Unsupported CI type: " + ciType);
         }
         boolean jobExist = manager.jobExist(jobName);
-        LOG.error("Job existence for {}: {} - {}", ciType, jobName, jobExist);
+        LOG.info("Job existence for {}: {} - {}", ciType, jobName, jobExist);
         // return manager.jobExist(jobName);
         return jobExist;
     }


### PR DESCRIPTION
## Summary

Previously we landed https://github.com/pinterest/teletraan/pull/1827 which prioritizes PinCI 
(over Jenkins) as the hotfix CI execution platform.

Later we discovered a bug in the PinCI triggering logic where the branch name was not passed as value to the `branch` variable but only passed in as metadata. As a result, the `pinboard-private-build` was building the default branch (`master`) rather than the hotfix branch. This PR should fix that behavior.

Additionally, we added extra logics in PinCI `jobExist()` function to validate if the queried PinCI pipeline contains tag `teletraan-ready`. If the tag presents, then the pipeline will be triggered on PinCI (rather than Jenkins), otherwise the pipeline will be consider "not ready", and the CI execution of that pipeline will fall back to Jenkins.

## Test plan

- Deployed this change to deploy-integ environment
- Created several hotfixs in https://deploy-integ.pinadmin.com/env/pinboardjasmine/pindboard-test/
  - Remove the tag "teletraan-ready" on PinCI pipelines, made sure the Jenkins pipeline was triggered ([hotfix](https://deploy-integ.pinadmin.com/env/pinboardjasmine/pindboard-test/hotfix/q86SdtMqSW-6XXjTVQ-Ljw), [jenkins pinboard-hotfix-job](https://jenkinsmaster-001.pinadmin.com/job/pinboard-hotfix-job/2872/), [jenkins pinboard-private-build](https://jenkins.pinadmin.com/job//pinboard-private-build/2566))
  - Add back tag "teletraan-ready" to PinCI pipelines, made sure the Buildkite pipelines were triggered ([hotfix](https://deploy-integ.pinadmin.com/env/pinboardjasmine/pindboard-test/hotfix/4derWYR_SIK6ZWV0xAUmsw), [buildkite pinboard-hotfix-job](https://buildkite.com/pinterest/pinboard-hotfix-job/builds/68#01976a61-9e5c-4146-93c2-5f4f7bd2fed6), [buildkite pinboard-private-build](https://buildkite.com/pinterest/pinboard-private-build/builds/13))
- Made sure the branch is passed down properly
  - <img width="1772" alt="Screenshot 2025-06-13 at 11 55 00 AM" src="https://github.com/user-attachments/assets/070eba61-7f39-461e-bf7e-cf808bae14f8" />
