### PR TITLE
Add workflow for deploy-agent version check

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,13 @@
+name: Bump Version
+
+on:
+  pull_request:
+    paths:
+      - 'deploy-agent/deployd/**'
+      - '!deploy-agent/deployd/__init__.py'
+jobs:
+  check-for-version-update:
+    runs-on: default
+    steps:
+      - name: Fail job
+        run: exit 1


### PR DESCRIPTION
## Summary

Similar to other host binaries (e.g. TCM), raise a PR check error if the source code changes
without a version bump

## Testing Done

* Create a PR without any deploy agent changes (wip)