### PR TITLE
add a new auth type, SOX_PROPERTY, for isSOX api to pass through

### DIFF
--- a/deploy-service/pom.xml
+++ b/deploy-service/pom.xml
@@ -62,7 +62,7 @@
             <dependency>
                 <groupId>com.pinterest.teletraan</groupId>
                 <artifactId>universal</artifactId>
-                <version>2.4-SNAPSHOT</version>
+                <version>2.5-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.pinterest.teletraan</groupId>

--- a/deploy-service/universal/pom.xml
+++ b/deploy-service/universal/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>com.pinterest.teletraan</groupId>
   <artifactId>universal</artifactId>
-  <version>2.4-SNAPSHOT</version>
+  <version>2.5-SNAPSHOT</version>
 
   <name>Teletraan platform universal components</name>
   <url>https://github.com/pinterest/teletraan/</url>

--- a/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/AuthZResource.java
+++ b/deploy-service/universal/src/main/java/com/pinterest/teletraan/universal/security/bean/AuthZResource.java
@@ -121,6 +121,8 @@ public class AuthZResource {
         PROVISION_PREFIX,
         /** For instance type mapping url */
         INSTANCE_TYPE_MAPPING,
+        /** For SOX, Sarbanes-Oxley Act, related resources */
+        SOX_PROPERTY,
         /* For anything else */
         UNSPECIFIED,
     }

--- a/docs/auth/teletraan_auth.yaml
+++ b/docs/auth/teletraan_auth.yaml
@@ -88,6 +88,7 @@ definitions:
           - HOST
           - PROVISION_PREFIX
           - INSTANCE_TYPE_MAPPING
+          - SOX_PROPERTY
           - UNSPECIFIED
       resourceName:
         type: string


### PR DESCRIPTION
In [this ER](https://jira.pinadmin.com/browse/ER-11482), we need to give SOX client the permission to access isSOX API, which is currently only accessible by Teletraan's system admin. 
To avoid grand the SOX team to be Teletraan system admins, our solution is add a new auth type, SOX_PROPERTY, and modify pastis acl.

- jira: https://jira.pinadmin.com/browse/CDP-9352
- ER: https://jira.pinadmin.com/browse/ER-11482