### PR TITLE
Handle missing env for constraint id

### DIFF
--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/DeployTagWorker.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/DeployTagWorker.java
@@ -63,6 +63,10 @@ public class DeployTagWorker implements Runnable {
 
     private void processEachEnvironConstraint(DeployConstraintBean bean) throws Exception {
         EnvironBean environBean = environDAO.getEnvByDeployConstraintId(bean.getConstraint_id());
+        if (environBean == null) {
+            LOG.warn("Environment not found for deploy constraint {}", bean.getConstraint_id());
+            return;
+        }
         String tagName = bean.getConstraint_key();
         String envId = environBean.getEnv_id();
         Collection<HostBean> hostBeans = hostDAO.getHostsByEnvId(envId);


### PR DESCRIPTION
## Summary

While debugging issues with deploy constraints, there were many `NullPointerException`s in the logs.

Looks like there is a cleanup issue with the deploy constraints. Log a warning when hitting this case to help clean up the log and distinguish this case with other deploy constraint exceptions

## Testing Done

* Ran local setup. Will deploy to staging environment

## Stack Trace

```
Error NullPointerException:  stack java.lang.NullPointerException
	at com.pinterest.teletraan.worker.DeployTagWorker.processEachEnvironConstraint(DeployTagWorker.java:67)
	at com.pinterest.teletraan.worker.DeployTagWorker.processBatch(DeployTagWorker.java:178)
	at com.pinterest.teletraan.worker.DeployTagWorker.run(DeployTagWorker.java:217)
	at com.pinterest.teletraan.resource.DeployConstraints.update(DeployConstraints.java:143)
	at sun.reflect.GeneratedMethodAccessor467.invoke(Unknown Source)
```