### PR TITLE
Handle duplicate hosts ids in deploy constraint

### DIFF
--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/DeployTagWorker.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/DeployTagWorker.java
@@ -26,8 +26,8 @@ import java.net.ConnectException;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.*;
+import java.util.stream.Collectors;
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.collections4.TransformerUtils;
 import org.apache.commons.dbcp.BasicDataSource;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
@@ -73,12 +73,11 @@ public class DeployTagWorker implements Runnable {
         Collection<HostBean> hostBeans = hostDAO.getHostsByEnvId(envId);
         Collection<HostTagBean> hostTagBeans = hostTagDAO.getAllByEnvIdAndTagName(envId, tagName);
 
-        Collection<String> envHostIds =
-                CollectionUtils.collect(
-                        hostBeans, TransformerUtils.invokerTransformer("getHost_id"));
-        Collection<String> envHostIdsWithHostTag =
-                CollectionUtils.collect(
-                        hostTagBeans, TransformerUtils.invokerTransformer("getHost_id"));
+        Set<String> envHostIds =
+                hostBeans.stream().map(HostBean::getHost_id).collect(Collectors.toSet());
+
+        Set<String> envHostIdsWithHostTag =
+                hostTagBeans.stream().map(HostTagBean::getHost_id).collect(Collectors.toSet());
 
         List<String> missings =
                 new ArrayList(CollectionUtils.subtract(envHostIds, envHostIdsWithHostTag));


### PR DESCRIPTION
## Summary

The `DeployTagWorker` syncs hosts tags to the database, which are then used by deploy constraints.

Currently, the logic fails for host capacity. This is because a host can be in multiple groups (e.g. application, sidecar, shards, etc.), so the call to `getHostsByEnvId` can contain rows with duplicate Host IDs.

These duplicates were not being handled well. Switch to a `Set` to handle this an properly check if the host id tags are synced in the database

## Testing Done

* Added a test to handle the case of `HostBean` rows with duplicate host ids