### PR TITLE
Update deploy schedule last session

### DIFF
--- a/deploy-board/deploy_board/templates/configs/schedule_config.tmpl
+++ b/deploy-board/deploy_board/templates/configs/schedule_config.tmpl
@@ -27,7 +27,7 @@
                 Use Infinite Cooldown Periods
             </label>
             <h4>Sessions</h4>
-            <div>Note: All sessions will be able to be overidden during the deploy process</div>
+            <div>Note: All sessions will be able to be overidden during the deploy process. After the last session, all hosts can proceed</div>
             <br />
             <table id="sessionTable" class="table">
             <tr>
@@ -35,25 +35,6 @@
                 <th id="hostNumberTitle" class="col-md-3">Number of Hosts</th>
                 <th class="col-md-3">Cooldown Period</th>
                 <th class="col-md-4"></th>
-            </tr>
-            <tr>
-                <td><strong>Final</strong></td>
-                <td class="hostNumber">
-                     <div class="input-group">
-                        <input disabled type="text" class="form-control">
-                        <span id="finalHostNumberUnits" class="input-group-addon">hosts</span>
-                    </div>
-                        <div class="input-group">
-                    </div>
-                </td>
-                <td class="cooldownTime">
-                    <div class="input-group">
-                        <input disabled type="text" class="form-control">
-                        <span class="input-group-addon">minutes</span>
-                    </div>
-                </td>
-                <td class="text-right">
-                </td>
             </tr>
             </table>
             {% csrf_token %}
@@ -101,7 +82,7 @@
                 const cooldownTime = useInfiniteCooldownPeriods ? "Infinite" : timesArray[i - 1];
                 const cooldownInputDisabled = useInfiniteCooldownPeriods ? "disabled" : "";
                 const sessionHtml = buildSessionHtml(i, hostNumber, hostUnits, cooldownInputDisabled, cooldownTime);
-                $("#sessionTable tr:last").before(sessionHtml);
+                $("#sessionTable").append(sessionHtml);
                 totalAgentCount = totalAgentCount - numbersArray[i-1];
             }
 
@@ -140,7 +121,6 @@
             var n = parseInt($(this).val());
             if (!isNaN(n) && n % 1 === 0) { // if is number and is integer
                 totalAgentCount = totalAgentCount - parseInt($(this).val());
-                $("#sessionTable tr:last").find('.hostNumber input').val(totalAgentCount);
             }
         }
     });
@@ -151,7 +131,7 @@
         const cooldownInputDisabled = $("#useInfiniteCooldownPeriods")[0].checked ? 'disabled' : "";
         const cooldownTime = $("#useInfiniteCooldownPeriods")[0].checked ? "Infinite" : "";
         const sessionHtml = buildSessionHtml(totalSessions, "", hostUnits, cooldownInputDisabled, cooldownTime);
-        $('#sessionTable tr:last').before(sessionHtml);
+        $('#sessionTable').append(sessionHtml);
     });
 
     $("#sessionTable").on("click", "#removeBtn", function () {
@@ -160,7 +140,6 @@
             if (!isNaN(n) && n % 1 === 0) {
                 totalAgentCount = totalAgentCount+n;
             }
-            $('#sessionTable tr:last').find('.hostNumber input').val(totalAgentCount)
         }
         $(this).closest('tr').remove();
         totalSessions = totalSessions-1;
@@ -190,7 +169,7 @@
         const useHostPercentages = $("#useHostPercentages")[0].checked;
         if (!useHostPercentages) {
             // check if number of hosts entered doesn't exceed max
-            if (parseInt($("#sessionTable tr:last").find(".hostNumber input").val()) < 0) {
+            if (totalAgentCount < 0) {
                 $('#errorBannerId').text("Total number of hosts exceeds number of available hosts. Please reenter host numbers.");
                 $('#errorBannerId').show();
                 error = true;
@@ -199,7 +178,7 @@
         }
 
         // check for valid cooldown time input values
-        $("#sessionTable .cooldownTime input").not(":last").each(function() {
+        $("#sessionTable .cooldownTime input").each(function() {
             const inputVal = $(this).val();
             if (inputVal !== "Infinite" && isNaN(parseInt(inputVal))) {
                 $(this).closest('.input-group').addClass('has-error');
@@ -213,7 +192,7 @@
 
         // check for valid host number input values
         const hostNumbersArray = [];
-        $("#sessionTable .hostNumber input").not(":last").each(function() {
+        $("#sessionTable .hostNumber input").each(function() {
             const number = parseInt($(this).val());
             if (isNaN(number)) {
                 $(this).closest('.input-group').addClass('has-error');
@@ -250,7 +229,7 @@
         var hostNumbers= "";
 
         const useInfiniteCooldownPeriods = $("#useInfiniteCooldownPeriods")[0].checked;
-        $("#sessionTable tr").not(':first').not(':last').each(function() {
+        $("#sessionTable tr").not(':first').each(function() {
             var hostNumber = $(this).find(".hostNumber input").val();
             if (useHostPercentages) {
                 hostNumber += "%";
@@ -298,12 +277,8 @@
     function updateHostUnits(useHostPercentages) {
         if (useHostPercentages) {
           $("#hostNumberTitle").text("Percentage of Hosts");
-          $("#finalHostNumberUnits").text("% hosts");
-          $("#sessionTable tr:last").find('.hostNumber input').val(100);
         } else {
           $("#hostNumberTitle").text("Number of Hosts");
-          $("#finalHostNumberUnits").text("hosts");
-          $("#sessionTable tr:last").find('.hostNumber input').val(totalAgentCount);
         }
     }
     // Build the html of a single session configuration row
@@ -331,7 +306,7 @@
     }
 
     function resetSchedule() {
-        $("#sessionTable tr").not(':first').not(':last').remove();
+        $("#sessionTable tr").not(':first').remove();
         totalSessions = 0;
         totalAgentCount = {{ agent_count }};
     }

--- a/deploy-board/deploy_board/templates/deploys/schedule.tmpl
+++ b/deploy-board/deploy_board/templates/deploys/schedule.tmpl
@@ -9,15 +9,10 @@
                 <th class="col-md-2">State</th>
                 <th class="col-md-2"></th>
             </tr>
-                <td class="sessionNumber"><strong>FINAL</strong></td>
-                <td class="hostNumber">
-                    <div>N/A</div>
-                </td>
-                <td class="cooldownTime">
-                    <div>N/A</div>
-                </td>
-                <td class="state"></td>
-                <td class="text-right">
+            <tr id="sessionsComplete" class="info" style="display:none;border-radius:25px">
+                <td colspan="4" style="padding:14px 8px">
+                    <i class="fa fa-check-circle color-green" style="margin-right:5px"></i>
+                    Deploy schedule is complete. All hosts can proceed
                 </td>
             </tr>
             </table>
@@ -28,7 +23,6 @@
 </div>
 
 <script type="text/javascript">
-    var finalHostNumber = {{ agent_number }};
      {% if schedule %}
         var cooldownTimes = "{{ schedule.cooldownTimes }}";
         var timesArray = cooldownTimes.split(",");
@@ -51,13 +45,10 @@
                 button = '<td class="text-right"><button id="overrideBtn" type="button" class="btn btn-danger">Override</button></td>';
             }
             $('#sessionTable tr:last').before('<tr id=session' + i +'><td class="sessionNumber" id=sessionNumber'+i+'><strong>'+i+'</strong></td><td class="hostNumber"><div>'+numbersArray[i-1]+' hosts</div></td><td class="cooldownTime"><div>'+getCooldownTimeDisplay(timesArray[i-1])+'</div></td><td class="state">'+state+'</td>'+button+'</tr>');
-            finalHostNumber = finalHostNumber - numbersArray[i-1];
         }
 
         if (scheduleState == "FINAL") {
-            $('#sessionTable tr:last').addClass("info");
-            $('#sessionTable tr:last').css('borderRadius', '25px');
-            $('#sessionTable tr:last .state').text("RUNNING");
+            $("#sessionsComplete")[0].style.display = "table-row";
         } else {
             if (scheduleState == "COOLING_DOWN" && timesArray[currentSession - 1] !== "-1") {
                 // calculates time left until next session
@@ -71,15 +62,8 @@
             }
             $("#session" + currentSession).addClass("info");
             $("#session" + currentSession).css('borderRadius', '3em');
-            $('#sessionTable tr:last .state').text("NOT STARTED");
         }
     {% endif %}
-
-    if (numbersArray.every(n => n.endsWith("%"))) {
-        $('#sessionTable tr:last').find('.hostNumber div').html("100% hosts");
-    } else {
-        $('#sessionTable tr:last').find('.hostNumber div').html(finalHostNumber + " hosts");
-    }
 
     $(document).on('click', '#overrideBtn', function () {
       var sessionNum = parseInt($(this).closest('tr').find('.sessionNumber strong').text());

--- a/deploy-board/deploy_board/webapp/env_views.py
+++ b/deploy-board/deploy_board/webapp/env_views.py
@@ -2266,7 +2266,6 @@ def get_deploy_schedule(request, name, stage):
         schedule = schedules_helper.get_schedule(request, name, stage, schedule_id)
     else:
         schedule = None
-    agent_number = agents_helper.get_agents_total_by_env(request, env["id"])
     return render(
         request,
         "deploys/deploy_schedule.html",
@@ -2274,7 +2273,6 @@ def get_deploy_schedule(request, name, stage):
             "envs": envs,
             "env": env,
             "schedule": schedule,
-            "agent_number": agent_number,
         },
     )
 


### PR DESCRIPTION
## Summary

The UI currently attempts to show a "final" session. This "final" session does not actually exist in the backend. Instead, in the backend, all hosts are allowed to deploy after the last session.

To remove this confusion, remove this "final" session. Instead, the UI will explain the behavior that occurs after the last session.

## Testing Done

Tested on a local setup (see screenshots)

## Screenshots

**Before: Schedule Config**

<img width="730" height="703" alt="config-before2" src="https://github.com/user-attachments/assets/f2a1ba67-2b46-4597-8c2a-dc068fbba758" />

**After: Schedule Config**

<img width="723" height="672" alt="config-after" src="https://github.com/user-attachments/assets/5aba6650-7f77-4929-bde2-5bda8e1c21db" />

**Before: Schedule View Start**

<img width="703" height="435" alt="schedule-before2" src="https://github.com/user-attachments/assets/402d7f1e-270d-4dca-b3c2-6e3209a12f02" />

**After: Schedule View Start**

<img width="664" height="422" alt="schedule-after1" src="https://github.com/user-attachments/assets/258a2d71-b86f-4459-ad37-f72b1797dff3" />


**Before: Schedule View End**

<img width="731" height="419" alt="schedule-before1" src="https://github.com/user-attachments/assets/e68ec4fd-3594-4143-bdd8-15e8eda2fd8d" />

**After: Schedule View End**

<img width="669" height="430" alt="schedule-after2" src="https://github.com/user-attachments/assets/9c2ac7f3-9651-41e4-bbdf-140c9b11f5ee" />
