### PR TITLE
Return schedule config on upsert

### DIFF
--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Schedules.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Schedules.java
@@ -72,7 +72,7 @@ public class Schedules {
     @ResourceAuthZInfo(
             type = AuthZResource.Type.ENV_STAGE,
             idLocation = ResourceAuthZInfo.Location.PATH)
-    public void updateSchedule(
+    public ScheduleBean updateSchedule(
             @Context SecurityContext sc,
             @PathParam("envName") String envName,
             @PathParam("stageName") String stageName,
@@ -113,7 +113,9 @@ public class Schedules {
                         operator,
                         scheduleBean);
             }
-        } else if (scheduleId != null) { // there are no sessions, so delete the schedule
+            return scheduleBean;
+        }
+        if (scheduleId != null) { // there are no sessions, so delete the schedule
             scheduleDAO.delete(scheduleId);
             environDAO.deleteSchedule(envName, stageName);
             LOG.info(
@@ -122,6 +124,7 @@ public class Schedules {
                     stageName,
                     operator);
         }
+        return null;
     }
 
     @PUT


### PR DESCRIPTION
## Summary

In case the schedule config is created or updated, include the schedule in the API response.

This will allow the caller to view the schedule id and any other fields in the response

## Testing Done

* Ran the changes locally
* Called the API to delete/create/update the config. Ensured valid response
* (wip) Deployed to staging