### PR TITLE
Fix issue where script configs are wrongly deleted

### DIFF
--- a/deploy-agent/deployd/agent.py
+++ b/deploy-agent/deployd/agent.py
@@ -504,17 +504,33 @@ class DeployAgent(object):
         self._envs[env_name].update_by_response(response)
 
         # update script variables
+        env_dir = self._config.get_agent_directory()
+        script_config_path = os.path.join(env_dir, "{}_SCRIPT_CONFIG".format(env_name))
         if deploy_goal.scriptVariables:
             log.info(
                 "Start to generate script variables for deploy: {}".format(
                     deploy_goal.deployId
                 )
             )
-            env_dir = self._config.get_agent_directory()
-            working_dir = os.path.join(env_dir, "{}_SCRIPT_CONFIG".format(env_name))
-            with open(working_dir, "w+") as f:
+            with open(script_config_path, "w+") as f:
                 for key, value in deploy_goal.scriptVariables.items():
                     f.write("{}={}\n".format(key, value))
+        elif deploy_goal != self.deploy_goal_previous:
+            # Only remove on a new deploy where scriptVariables is explicitly empty
+            if os.path.exists(script_config_path):
+                try:
+                    os.remove(script_config_path)
+                    log.info(
+                        "Removed script config file: {} because scriptVariables is empty or None.".format(
+                            script_config_path
+                        )
+                    )
+                except Exception as e:
+                    log.warning(
+                        "Failed to remove script config file {}: {}".format(
+                            script_config_path, e
+                        )
+                    )
 
         # timing stats - deploy stage start
         if deploy_goal != self.deploy_goal_previous:

--- a/deploy-agent/deployd/agent.py
+++ b/deploy-agent/deployd/agent.py
@@ -515,13 +515,16 @@ class DeployAgent(object):
             with open(script_config_path, "w+") as f:
                 for key, value in deploy_goal.scriptVariables.items():
                     f.write("{}={}\n".format(key, value))
-        elif deploy_goal != self.deploy_goal_previous:
-            # Only remove on a new deploy where scriptVariables is explicitly empty
+        elif deploy_goal.scriptVariables is not None:
+            # scriptVariables is an empty dict {} — the server explicitly told us
+            # there are no script variables (user cleared them via the UI).
+            # This is distinct from None, which means the server did not include
+            # scriptVariables in this response (e.g. not the first deploy stage).
             if os.path.exists(script_config_path):
                 try:
                     os.remove(script_config_path)
                     log.info(
-                        "Removed script config file: {} because scriptVariables is empty or None.".format(
+                        "Removed script config file: {} because scriptVariables is explicitly empty.".format(
                             script_config_path
                         )
                     )

--- a/deploy-agent/tests/unit/deploy/common/test_empty_vars.py
+++ b/deploy-agent/tests/unit/deploy/common/test_empty_vars.py
@@ -40,7 +40,7 @@ class TestScriptVariablesConfig(unittest.TestCase):
         shutil.rmtree(self.temp_dir)
 
     def test_script_variables_file_created(self):
-        # Simulate a deploy_goal with scriptVariables
+        """File is created when scriptVariables is a non-empty dict."""
         deploy_goal = MagicMock()
         deploy_goal.envName = self.env_name
         deploy_goal.scriptVariables = {"FOO": "bar", "BAZ": "qux"}
@@ -56,20 +56,19 @@ class TestScriptVariablesConfig(unittest.TestCase):
         self.assertIn("FOO=bar", content)
         self.assertIn("BAZ=qux", content)
 
-    def test_script_variables_file_removed_on_new_deploy(self):
-        """File should be removed when a NEW deploy goal has no scriptVariables."""
+    def test_script_variables_file_removed_when_empty_dict(self):
+        """File should be removed when scriptVariables is an explicit empty dict {}.
+
+        The server sends {} on the first deploy stage (PRE_DOWNLOAD) when the
+        user has cleared all script variables.  This is distinct from None which
+        means 'not included in this response'.
+        """
         with open(self.script_config_path, "w") as f:
             f.write("SHOULD_BE_REMOVED=1\n")
 
-        # Set a previous deploy goal so the new one is detected as different
-        previous_goal = MagicMock()
-        previous_goal.envName = self.env_name
-        self.agent.deploy_goal_previous = previous_goal
-
-        # Simulate a NEW deploy_goal with no scriptVariables
         deploy_goal = MagicMock()
         deploy_goal.envName = self.env_name
-        deploy_goal.scriptVariables = None
+        deploy_goal.scriptVariables = {}  # explicit empty dict from server
         deploy_goal.deployId = "deploy-2"
 
         response = MagicMock()
@@ -79,18 +78,42 @@ class TestScriptVariablesConfig(unittest.TestCase):
 
         self.assertFalse(os.path.exists(self.script_config_path))
 
-    def test_script_variables_file_preserved_on_same_deploy(self):
-        """File should NOT be removed on a routine ping with the same deploy goal.
+    def test_script_variables_file_preserved_when_none(self):
+        """File should NOT be removed when scriptVariables is None.
 
-        This is the key scenario that caused the incident: on every ping cycle the
-        server returns scriptVariables=None for an unchanged deploy.  The config
-        file must be left intact so that containers keep using the previously
-        written variables.
+        None means the server did not include scriptVariables in this response
+        (e.g. it is not the first deploy stage).  The previously written config
+        file must be left intact so that containers keep using the variables.
+        This is the key scenario that caused the incident.
         """
         with open(self.script_config_path, "w") as f:
             f.write("EXISTING_VAR=1\n")
 
-        # Simulate a deploy_goal with no scriptVariables
+        deploy_goal = MagicMock()
+        deploy_goal.envName = self.env_name
+        deploy_goal.scriptVariables = None
+        deploy_goal.deployId = "deploy-1"
+
+        response = MagicMock()
+        response.deployGoal = deploy_goal
+
+        self.agent._update_internal_deploy_goal(response)
+
+        # File must still exist
+        self.assertTrue(os.path.exists(self.script_config_path))
+        with open(self.script_config_path) as f:
+            content = f.read()
+        self.assertIn("EXISTING_VAR=1", content)
+
+    def test_script_variables_file_preserved_on_same_deploy_none(self):
+        """File preserved when same deploy goal pings again with scriptVariables=None.
+
+        On routine ping cycles the server returns scriptVariables=None for an
+        unchanged deploy.  The config file must be left intact.
+        """
+        with open(self.script_config_path, "w") as f:
+            f.write("EXISTING_VAR=1\n")
+
         deploy_goal = MagicMock()
         deploy_goal.envName = self.env_name
         deploy_goal.scriptVariables = None
@@ -104,20 +127,28 @@ class TestScriptVariablesConfig(unittest.TestCase):
 
         self.agent._update_internal_deploy_goal(response)
 
-        # File must still exist — this is what the buggy code broke
         self.assertTrue(os.path.exists(self.script_config_path))
         with open(self.script_config_path) as f:
             content = f.read()
         self.assertIn("EXISTING_VAR=1", content)
 
-    def test_script_variables_file_removed_when_no_previous_goal(self):
-        """File should be removed when there is no previous deploy goal (first deploy)."""
+    def test_script_variables_file_preserved_on_next_stage(self):
+        """File preserved when deploy advances to next stage with scriptVariables=None.
+
+        The server only sends scriptVariables during PRE_DOWNLOAD.  On DOWNLOADING
+        and later stages, scriptVariables is None.  Even though the deploy goal
+        changed (different stage), the config file must NOT be deleted.
+        """
         with open(self.script_config_path, "w") as f:
-            f.write("STALE_VAR=1\n")
+            f.write("V=1\n")
 
-        # No previous deploy goal (agent just started)
-        self.agent.deploy_goal_previous = None
+        # Simulate a previous goal from PRE_DOWNLOAD stage
+        previous_goal = MagicMock()
+        previous_goal.envName = self.env_name
+        previous_goal.scriptVariables = {"V": "1"}
+        self.agent.deploy_goal_previous = previous_goal
 
+        # Now the agent gets the DOWNLOADING stage — scriptVariables is None
         deploy_goal = MagicMock()
         deploy_goal.envName = self.env_name
         deploy_goal.scriptVariables = None
@@ -128,26 +159,43 @@ class TestScriptVariablesConfig(unittest.TestCase):
 
         self.agent._update_internal_deploy_goal(response)
 
-        self.assertFalse(os.path.exists(self.script_config_path))
+        # File must still exist — this is critical
+        self.assertTrue(os.path.exists(self.script_config_path))
+        with open(self.script_config_path) as f:
+            content = f.read()
+        self.assertIn("V=1", content)
 
-    def test_script_variables_file_not_present_no_error(self):
-        """No error when file doesn't exist and scriptVariables is empty on new deploy."""
-        # Ensure no file exists
+    def test_empty_dict_no_file_no_error(self):
+        """No error when file doesn't exist and scriptVariables is empty dict."""
         if os.path.exists(self.script_config_path):
             os.remove(self.script_config_path)
 
-        previous_goal = MagicMock()
-        self.agent.deploy_goal_previous = previous_goal
-
         deploy_goal = MagicMock()
         deploy_goal.envName = self.env_name
-        deploy_goal.scriptVariables = None
+        deploy_goal.scriptVariables = {}
         deploy_goal.deployId = "deploy-2"
 
         response = MagicMock()
         response.deployGoal = deploy_goal
 
         # Should not raise
+        self.agent._update_internal_deploy_goal(response)
+        self.assertFalse(os.path.exists(self.script_config_path))
+
+    def test_none_no_file_no_error(self):
+        """No error when file doesn't exist and scriptVariables is None."""
+        if os.path.exists(self.script_config_path):
+            os.remove(self.script_config_path)
+
+        deploy_goal = MagicMock()
+        deploy_goal.envName = self.env_name
+        deploy_goal.scriptVariables = None
+        deploy_goal.deployId = "deploy-1"
+
+        response = MagicMock()
+        response.deployGoal = deploy_goal
+
+        # Should not raise, file should still not exist
         self.agent._update_internal_deploy_goal(response)
         self.assertFalse(os.path.exists(self.script_config_path))
 

--- a/deploy-agent/tests/unit/deploy/common/test_empty_vars.py
+++ b/deploy-agent/tests/unit/deploy/common/test_empty_vars.py
@@ -1,0 +1,156 @@
+import os
+import tempfile
+import shutil
+import unittest
+
+from unittest.mock import MagicMock, patch
+
+# Patch LOCKFILE_DIR before importing DeployAgent to avoid /var/lock permission error
+patch("deployd.common.single_instance.LOCKFILE_DIR", new="/tmp/lock").start()
+from deployd.agent import DeployAgent  # noqa: E402
+
+
+class TestScriptVariablesConfig(unittest.TestCase):
+    def setUp(self):
+        # Create a temp directory to act as the agent directory
+        self.temp_dir = tempfile.mkdtemp()
+        self.env_name = "testenv"
+        self.script_config_path = os.path.join(
+            self.temp_dir, f"{self.env_name}_SCRIPT_CONFIG"
+        )
+
+        # Mock config to return our temp dir
+        self.mock_config = MagicMock()
+        self.mock_config.get_agent_directory.return_value = self.temp_dir
+
+        # Provide a mock executor with update_configs method
+        self.mock_executor = MagicMock()
+
+        # Create a minimal DeployAgent with the mocked config and executor
+        self.agent = DeployAgent(
+            client=MagicMock(), conf=self.mock_config, executor=self.mock_executor
+        )
+
+        # Patch log to avoid clutter
+        patcher = patch("deployd.agent.log")
+        self.addCleanup(patcher.stop)
+        self.mock_log = patcher.start()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    def test_script_variables_file_created(self):
+        # Simulate a deploy_goal with scriptVariables
+        deploy_goal = MagicMock()
+        deploy_goal.envName = self.env_name
+        deploy_goal.scriptVariables = {"FOO": "bar", "BAZ": "qux"}
+        deploy_goal.deployId = "dummy"
+
+        response = MagicMock()
+        response.deployGoal = deploy_goal
+
+        self.agent._update_internal_deploy_goal(response)
+
+        with open(self.script_config_path) as f:
+            content = f.read()
+        self.assertIn("FOO=bar", content)
+        self.assertIn("BAZ=qux", content)
+
+    def test_script_variables_file_removed_on_new_deploy(self):
+        """File should be removed when a NEW deploy goal has no scriptVariables."""
+        with open(self.script_config_path, "w") as f:
+            f.write("SHOULD_BE_REMOVED=1\n")
+
+        # Set a previous deploy goal so the new one is detected as different
+        previous_goal = MagicMock()
+        previous_goal.envName = self.env_name
+        self.agent.deploy_goal_previous = previous_goal
+
+        # Simulate a NEW deploy_goal with no scriptVariables
+        deploy_goal = MagicMock()
+        deploy_goal.envName = self.env_name
+        deploy_goal.scriptVariables = None
+        deploy_goal.deployId = "deploy-2"
+
+        response = MagicMock()
+        response.deployGoal = deploy_goal
+
+        self.agent._update_internal_deploy_goal(response)
+
+        self.assertFalse(os.path.exists(self.script_config_path))
+
+    def test_script_variables_file_preserved_on_same_deploy(self):
+        """File should NOT be removed on a routine ping with the same deploy goal.
+
+        This is the key scenario that caused the incident: on every ping cycle the
+        server returns scriptVariables=None for an unchanged deploy.  The config
+        file must be left intact so that containers keep using the previously
+        written variables.
+        """
+        with open(self.script_config_path, "w") as f:
+            f.write("EXISTING_VAR=1\n")
+
+        # Simulate a deploy_goal with no scriptVariables
+        deploy_goal = MagicMock()
+        deploy_goal.envName = self.env_name
+        deploy_goal.scriptVariables = None
+        deploy_goal.deployId = "deploy-1"
+
+        # Set previous goal to the SAME object (routine ping, no change)
+        self.agent.deploy_goal_previous = deploy_goal
+
+        response = MagicMock()
+        response.deployGoal = deploy_goal
+
+        self.agent._update_internal_deploy_goal(response)
+
+        # File must still exist — this is what the buggy code broke
+        self.assertTrue(os.path.exists(self.script_config_path))
+        with open(self.script_config_path) as f:
+            content = f.read()
+        self.assertIn("EXISTING_VAR=1", content)
+
+    def test_script_variables_file_removed_when_no_previous_goal(self):
+        """File should be removed when there is no previous deploy goal (first deploy)."""
+        with open(self.script_config_path, "w") as f:
+            f.write("STALE_VAR=1\n")
+
+        # No previous deploy goal (agent just started)
+        self.agent.deploy_goal_previous = None
+
+        deploy_goal = MagicMock()
+        deploy_goal.envName = self.env_name
+        deploy_goal.scriptVariables = None
+        deploy_goal.deployId = "deploy-1"
+
+        response = MagicMock()
+        response.deployGoal = deploy_goal
+
+        self.agent._update_internal_deploy_goal(response)
+
+        self.assertFalse(os.path.exists(self.script_config_path))
+
+    def test_script_variables_file_not_present_no_error(self):
+        """No error when file doesn't exist and scriptVariables is empty on new deploy."""
+        # Ensure no file exists
+        if os.path.exists(self.script_config_path):
+            os.remove(self.script_config_path)
+
+        previous_goal = MagicMock()
+        self.agent.deploy_goal_previous = previous_goal
+
+        deploy_goal = MagicMock()
+        deploy_goal.envName = self.env_name
+        deploy_goal.scriptVariables = None
+        deploy_goal.deployId = "deploy-2"
+
+        response = MagicMock()
+        response.deployGoal = deploy_goal
+
+        # Should not raise
+        self.agent._update_internal_deploy_goal(response)
+        self.assertFalse(os.path.exists(self.script_config_path))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
@@ -1061,11 +1061,15 @@ public class PingHandler {
             String scriptConfigId = envBean.getSc_config_id();
             if (scriptConfigId != null) {
                 Map<String, String> variables = dataHandler.getMapById(scriptConfigId);
-                goal.setScriptVariables(variables);
+                goal.setScriptVariables(variables != null ? variables : Collections.emptyMap());
                 LOG.debug(
                         "Add script varibles {} to goal at {} stage",
                         variables,
                         updateBean.getDeploy_stage());
+            } else {
+                // Explicitly send empty map so the agent knows there are no script
+                // variables, rather than leaving it null (which means "not sent").
+                goal.setScriptVariables(Collections.emptyMap());
             }
         }
 


### PR DESCRIPTION
This previous [change](https://github.com/pinterest/teletraan/pull/1878) was intended to fix the bug described below, but it wrongly deletes config file.

> When there is no script env variables, deploy_goal.scriptVariables is null/empty. No update to {}_SCRIPT_CONFIG is done. This means existing {}_SCRIPT_CONFIG file will be used when launching containers.
> 
> There is env V=1
> Deploy. A file is created with V=1. This file is read when launching container.
> All envs are removed/deleted from the environment via Teletraan UI (control plan).
> Deploy. Since scriptVariables is empty, the file created at step 2 is intact.
> V=1 is still used for launching container. THIS IS NOT EXPECTED.

However, there is a problem with above change. The change is correct in intent but too aggressive in scope. It runs on every ping/response cycle, not just when a deploy actively changes script variables.

The `deploy_goal.scriptVariables` field from the server response is None/empty in two different situations:

- User explicitly removed all script variables (intended case) — the file should be deleted.
- No script variable change was made — the server simply doesn't populate `scriptVariables` in the response because there's nothing to update. The file should be left alone.

The else branch didn't distinguish between these two cases. Every time the agent pings the server and gets a response where `scriptVariables` is not set (null) (which is the normal, steady-state case for most deploys), it deletes the existing config file.

We need to differentiate the cases above and only delete config file if user explicitly removed all script variables.

| JSON value | Meaning | Agent action |
|---|---|---|
| `{"V":"1"}` | Variables exist | Write file |
| `{}` | Explicitly empty | Delete file |
| absent/`null` | Not sent (not first stage) | No-op |

`scriptVariables` now has a new value `{}` to indicate that there is no script configs.

Note that `scriptVariables` is set only when `isFirstStage` is true - which is the first stage (PRE_DOWNLOAD) where agent downloads build/artifact. In subsequent, steady pings, `scriptVariables` is not set (null), deploy agent will do nothing regarding script config file.
If configs are removed (users delete configs from UI for example), the script config file will not be deleted (since it's not first stage) until is new build is triggered (first stage starts).

## Test

1. Add some script configs to an existing environment, save.
2. Go to host, check log `tail -n 300 /var/log/deployd/deploy-agent.log | grep "scriptVariables"`.  Confirm `scriptVariables=None` in Ping response.
3. Confirm script config file on host is intact and still present after few ping cycles: `cat /mnt/deployd/helloworlddummyservice-server_SCRIPT_CONFIG`. Wait for 30 minutes to confirm.
4. Add new script config in Teletraan UI. Save.
5. Restart deployment in Teletraan UI.
6. Confirm `helloworlddummyservice-server_SCRIPT_CONFIG` file is updated with new config values.
7. Subsequently, this file stays intact.
8. Remove all script configs in Teletraan UI. Save. Restart deployment.
Confirm this log. And the file is deleted. This logs show `scriptVariables` has a new value `{}` indicating that no script configs are added for this environment.
<img width="1178" height="83" alt="Screenshot 2026-04-23 at 1 18 18 PM" src="https://github.com/user-attachments/assets/04176961-2797-406c-974f-3e408c9a8030" />

```
PingResponse(opCode=RESTART, deployGoal=DeployGoal(deployId=uqu-o-inS7uQRaFlRo6GLg, envId=zaYVCJgrQ66Qm-TW4QTV7A, envName=helloworlddummyservice-server, stageName=rfleur, stageType=STAGING, deployStage=**PRE_DOWNLOAD**, build=None, deployAlias=None, agentConfig=None,**scriptVariables={},** firstDeploy=False, isDocker=False))
I0423 17:09:38.112.0 MainThread /root/.cache/deploy-agent-1.2.74-py3.12-1.pex/installed_wheels/a954c0a86acfc4b472391340db1c5939a026b2840d7159ba8257fc042c36625a/deploy_agent-1.2.74-py3-none-any.whl/deployd/agent.py:526] **Removed script config file: /mnt/deployd/helloworlddummyservice-server_SCRIPT_CONFIG because scriptVariables is explicitly empty.**
```
10. Repeat step 1 and confirm.

---------
```
- POST /v1/system/ping o11y_hostname:teletraan-agent-integ-docker-0a01a6c6 level:DEBUG logger:com.pinterest.deployservice.handler.PingHandler message:Add script varibles {STAGE_NAME=prod, REDIRECT_CREATE_ENV_PAGE_URL=https://nimbus.pinadmin.com/projects/overview/generic/platform-teletraan/create, AMITYPE=docker, CODE_FREEZE=false, TRANSFER_OWNERSHIP_URL=https://console.pinadmin.com/identifiers/transfer, IS_DOCKER=TRUE, JIRA_SOURCE_URL=https://jira.pinadmin.com/projects/CHMGMT, CODE_FREEZE_URL=https://w.pinadmin.com/spaces/OPS/pages/401014933/Production+Change+Freeze, STAGE=manage_prod, SERVICE_USE_BEARER=true, DISABLE_BACKUP_INSTANCE_TYPES=false} to goal at PRE_DOWNLOAD stage
```
