### PR TITLE
Add deploy and replaced build ID to changefeed event

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
@@ -86,6 +86,8 @@ public class DeployHandler implements DeployHandlerInterface {
                     + "\"author\":\"%s\","
                     + "\"automation\":\"%s\","
                     + "\"source\":\"Teletraan\","
+                    + "\"deploy_build_id\":\"%s\","
+                    + "\"replaced_build_id\":\"%s\","
                     + "\"nimbus_uuid\":\"%s\"}";
     private static final String COMPARE_DEPLOY_URL =
             "https://deploy.pinadmin.com/env/%s/%s/compare_deploys_2/?chkbox_1=%s&chkbox_2=%s";
@@ -159,6 +161,8 @@ public class DeployHandler implements DeployHandlerInterface {
                                 newDeployBean.getDeploy_type(),
                                 newDeployBean.getOperator(),
                                 autoPromote,
+                                newDeployBean.getBuild_id(),
+                                oldDeployBean != null ? oldDeployBean.getBuild_id() : "",
                                 envBean.getExternal_id());
                 httpClient.post(changeFeedUrl, feedPayload, null);
                 LOG.info("Send change feed {} to {} successfully", feedPayload, changeFeedUrl);


### PR DESCRIPTION
Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
  ## Summary

  ### Problem (Why)
  The changefeed payload only included deployment metadata but not the build IDs involved in the
  deploy. For rollback events, downstream consumers (like ACA or observability systems) need both the  
  build being deployed and the build being replaced to correlate with previous deployments and analyze
  rollback patterns.                                                                                   
              
  ### Solution (What + How)
  Added two new fields to the changefeed JSON payload in `DeployHandler.java`:

  - `deploy_build_id`: The build ID being deployed (from `newDeployBean.getBuild_id()`)
  - `replaced_build_id`: The build ID being replaced (from `oldDeployBean.getBuild_id()`, or empty
  string for first deploys)                                                                            
   
  For rollback events:                                                                                 
  - `deploy_build_id` = the good build being rolled back TO
  - `replaced_build_id` = the bad build being rolled back FROM

  The change is backward compatible — adding fields to JSON payloads won't break existing consumers.

  ## Test Plan
  - Verified format string placeholders match argument count (9 placeholders, 9 arguments)
  - Confirmed `build_id` is `NOT NULL` in the database schema, so no additional null checks needed on
  the field itself                                                                                     
  - `oldDeployBean` is properly null-checked with ternary operator for first deploys
  - No unit tests exist for `updateChangeFeed()` method — manual testing recommended by deploying to a 
  test environment and verifying changefeed payload structure

  https://pinterest.atlassian.net/browse/OBS-8774