### PR TITLE
Return 404 on missing environment for promotes endpoint

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/EnvironHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/EnvironHandler.java
@@ -320,6 +320,10 @@ public class EnvironHandler {
 
     public PromoteBean getEnvPromote(String envName, String stageName) throws Exception {
         EnvironBean envBean = environDAO.getByStage(envName, stageName);
+        if (envBean == null) {
+            throw new NotFoundException(
+                    String.format("Environment %s/%s does not exist.", envName, stageName));
+        }
         PromoteBean promoteBean = promoteDAO.getById(envBean.getEnv_id());
         if (promoteBean == null) {
             return genDefaultEnvPromote(envBean.getEnv_id());

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/handler/EnvironHandlerTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/handler/EnvironHandlerTest.java
@@ -30,8 +30,6 @@ import com.google.common.collect.ImmutableList;
 import com.pinterest.deployservice.ServiceContext;
 import com.pinterest.deployservice.bean.EnvType;
 import com.pinterest.deployservice.bean.EnvironBean;
-import com.pinterest.deployservice.bean.PromoteBean;
-import com.pinterest.deployservice.common.Constants;
 import com.pinterest.deployservice.bean.HostBean;
 import com.pinterest.deployservice.bean.HostState;
 import com.pinterest.deployservice.dao.AgentDAO;
@@ -220,7 +218,6 @@ class EnvironHandlerTest {
     void getEnvPromote_nonExistentEnv_throwsNotFoundException() throws Exception {
         when(environDAO.getByStage("noEnv", "noStage")).thenReturn(null);
         assertThrows(
-                NotFoundException.class,
-                () -> environHandler.getEnvPromote("noEnv", "noStage"));
+                NotFoundException.class, () -> environHandler.getEnvPromote("noEnv", "noStage"));
     }
 }

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/handler/EnvironHandlerTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/handler/EnvironHandlerTest.java
@@ -30,6 +30,8 @@ import com.google.common.collect.ImmutableList;
 import com.pinterest.deployservice.ServiceContext;
 import com.pinterest.deployservice.bean.EnvType;
 import com.pinterest.deployservice.bean.EnvironBean;
+import com.pinterest.deployservice.bean.PromoteBean;
+import com.pinterest.deployservice.common.Constants;
 import com.pinterest.deployservice.bean.HostBean;
 import com.pinterest.deployservice.bean.HostState;
 import com.pinterest.deployservice.dao.AgentDAO;
@@ -212,5 +214,13 @@ class EnvironHandlerTest {
         verify(promoteDAO, times(1)).delete(eq(TEST_ENV_ID));
         verify(udmDataUpdateService, times(1))
                 .notifyStageDeleted(eq(TEST_ENV_NAME), eq(TEST_STAGE_NAME));
+    }
+
+    @Test
+    void getEnvPromote_nonExistentEnv_throwsNotFoundException() throws Exception {
+        when(environDAO.getByStage("noEnv", "noStage")).thenReturn(null);
+        assertThrows(
+                NotFoundException.class,
+                () -> environHandler.getEnvPromote("noEnv", "noStage"));
     }
 }


### PR DESCRIPTION
When the environment is missing, a 500 is thrown. Switch this to a 404 to indicate it as user error.