### PR TITLE
teletraan deploy-service: structured logs for 12 oncall-patrol findings (CDP-11364)

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/ci/Buildkite.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/ci/Buildkite.java
@@ -31,6 +31,7 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import javax.ws.rs.NotAuthorizedException;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -330,6 +331,9 @@ public class Buildkite extends BaseCIPlatformManager {
         KeyReader knoxKeyReader = new KnoxKeyReader();
         knoxKeyReader.init(knoxKeyString);
         String apiToken = knoxKeyReader.getKey();
+        // T024: record token source at call time so a subsequent 401 can correlate directly
+        // to which Knox key the service was reading.
+        boolean tokenPresent = StringUtils.isNotBlank(apiToken);
         String metadata = "";
         int count = 0;
         Set<String> keys = buildMetadata.keySet();
@@ -374,8 +378,23 @@ public class Buildkite extends BaseCIPlatformManager {
             String[] delimitStrings = url.getAsString().split("/");
             String jobNum = delimitStrings[delimitStrings.length - 1];
             return jobNum;
+        } catch (NotAuthorizedException t) {
+            // T021 / T024: 401 from Buildkite — surface token source + pipeline identity so
+            // oncalls don't have to re-derive which Knox key is misrotated.
+            LOG.error(
+                    "Buildkite trigger failed status=401 pipeline={} bk_org=pinterest token_source=knox token_name={} token_present={} remediation=check_knox_key_rotation",
+                    pipeline,
+                    knoxKeyString,
+                    tokenPresent,
+                    t);
+            return "";
         } catch (Exception t) {
-            LOG.error("Error in triggering build for pipeline " + pipeline, t);
+            LOG.error(
+                    "Error in triggering build for pipeline {} token_source=knox token_name={} token_present={}",
+                    pipeline,
+                    knoxKeyString,
+                    tokenPresent,
+                    t);
             return "";
         }
     }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/CommonHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/CommonHandler.java
@@ -380,17 +380,33 @@ public class CommonHandler {
             }
             newDeployBean.setState(DeployState.SUCCEEDING);
             if (!DeployState.SUCCEEDING.equals(oldState)) {
+                // T013: include from/to/reason + agent counts on every state transition so
+                // oncalls can tell a legitimate recovery from a polling race.
                 LOG.info(
-                        "Set deploy {} as SUCCEEDING since {} agents are succeeded.",
+                        "Deploy state transition deploy_id={} env_id={} from={} to=SUCCEEDING reason=ACCEPT_THRESHOLD_MET agents_total={} agents_succeeded={} agents_stuck={} success_th={}",
                         deployId,
-                        succeeded);
+                        envId,
+                        oldState,
+                        total,
+                        succeeded,
+                        stucked,
+                        sucThreshold);
             }
             return;
         }
 
         if (stucked * 10000 > (10000 - sucThreshold) * total) {
             newDeployBean.setState(DeployState.FAILING);
-            LOG.info("Set deploy {} as FAILING since {} agents are stuck.", deployId, stucked);
+            // T013: structured transition log — explicit reason enum + agent counts
+            LOG.info(
+                    "Deploy state transition deploy_id={} env_id={} from={} to=FAILING reason=STUCK_AGENT_THRESHOLD agents_total={} agents_succeeded={} agents_stuck={} success_th={}",
+                    deployId,
+                    envId,
+                    oldState,
+                    total,
+                    succeeded,
+                    stucked,
+                    sucThreshold);
             return;
         }
 
@@ -403,9 +419,15 @@ public class CommonHandler {
             if (oldState == DeployState.SUCCEEDING) {
                 // This is the case when deploy has been in SUCCEEDING for a while without updates
                 // And a new machine being provisioned, in this case, we set status back to RUNNING
+                // T013: structured transition log — SUCCEEDING→RUNNING due to new hosts joining
                 LOG.info(
-                        "Set deploy {} back to RUNNING most likely there are new hosts joining in.",
-                        deployId);
+                        "Deploy state transition deploy_id={} env_id={} from=SUCCEEDING to=RUNNING reason=NEW_HOSTS_JOINING agents_total={} agents_succeeded={} agents_stuck={} duration_s={}",
+                        deployId,
+                        envId,
+                        total,
+                        succeeded,
+                        stucked,
+                        duration);
                 newDeployBean.setState(DeployState.RUNNING);
                 return;
             } else {
@@ -416,10 +438,17 @@ public class CommonHandler {
                     }
                 }
                 newDeployBean.setState(DeployState.FAILING);
+                // T013: structured transition log — FAILING due to stuck timeout
                 LOG.info(
-                        "Set deploy {} as FAILING since {} seconds past without complete the deploy.",
+                        "Deploy state transition deploy_id={} env_id={} from={} to=FAILING reason=DEPLOY_STUCK_TIMEOUT agents_total={} agents_succeeded={} agents_stuck={} duration_s={} stuck_th_s={}",
                         deployId,
-                        duration);
+                        envId,
+                        oldState,
+                        total,
+                        succeeded,
+                        stucked,
+                        duration,
+                        stuckTh);
 
                 // TODO, temp hack do NOT set lastUpdate for deploy stuck case, otherwise the
                 // next round transition will convert FAILING to RUNNING since new lastUpdate
@@ -432,7 +461,16 @@ public class CommonHandler {
 
         // At this point, always set to RUNNING
         if (oldState != DeployState.RUNNING) {
-            LOG.info("Set deploy {} from {} to RUNNING.", deployId, oldState);
+            // T013: cover the FAILING→RUNNING (recovery) path explicitly with counts; this is
+            // the state-flip that teletraan-5063 highlighted as having no reason field.
+            LOG.info(
+                    "Deploy state transition deploy_id={} env_id={} from={} to=RUNNING reason=PROGRESS_OBSERVED agents_total={} agents_succeeded={} agents_stuck={}",
+                    deployId,
+                    envId,
+                    oldState,
+                    total,
+                    succeeded,
+                    stucked);
         } else {
             LOG.debug("Deploy {} is still RUNNING...", deployId);
         }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/DeployHandler.java
@@ -471,6 +471,27 @@ public class DeployHandler implements DeployHandlerInterface {
             throw new InvalidBuildException(buildBean.getBuild_name(), envBean.getBuild_name());
         }
 
+        // T037: BAD_BUILD auto-propagation warning. If the effective tag on this build is
+        // BAD_BUILD, the deploy will still proceed (Teletraan doesn't gate on this), but emit a
+        // WARN so oncalls can correlate post-hoc. Spinnaker only blocks explicit BAD_BUILD tags;
+        // auto-propagated ones from upstream envs sneak through silently today.
+        try {
+            TagBean buildTag = buildTagsManager.getEffectiveBuildTag(buildBean);
+            if (buildTag != null && buildTag.getValue() == TagValue.BAD_BUILD) {
+                LOG.warn(
+                        "Deploying a BAD_BUILD-tagged build env={}/{} build_id={} build_name={} scm_branch={} tag=BAD_BUILD tag_operator={} gate=none",
+                        envBean.getEnv_name(),
+                        envBean.getStage_name(),
+                        buildId,
+                        buildBean.getBuild_name(),
+                        buildBean.getScm_branch(),
+                        buildTag.getOperator());
+            }
+        } catch (Exception e) {
+            // Never fail the deploy on a tag-lookup error; just log at DEBUG.
+            LOG.debug("Failed to check BAD_BUILD tag for build {}", buildId, e);
+        }
+
         if (envBean.getStage_type() != EnvType.DEV
                 && buildAllowlist != null
                 && !buildAllowlist.trusted(buildBean.getArtifact_url())
@@ -498,6 +519,14 @@ public class DeployHandler implements DeployHandlerInterface {
         }
         // disallow sox deploy if the build artifact is private
         if (envBean.getIs_sox() && isPrivateBuild(buildBean)) {
+            // T022: log offending build/env so the SOX failure is searchable
+            LOG.warn(
+                    "SOX validation failed reason=private_build env={}/{} build_id={} artifact_url={} scm_branch={}",
+                    envBean.getEnv_name(),
+                    envBean.getStage_name(),
+                    buildBean.getBuild_id(),
+                    buildBean.getArtifact_url(),
+                    buildBean.getScm_branch());
             throw new WebApplicationException(
                     ERROR_STAGE_REQUIRES_SOX_BUILD_COMPLIANT_STAGE, Response.Status.BAD_REQUEST);
         }
@@ -505,8 +534,21 @@ public class DeployHandler implements DeployHandlerInterface {
         if (envBean.getIs_sox()
                 && buildAllowlist != null
                 && !buildAllowlist.sox_compliant(buildBean.getArtifact_url())) {
+            // T022: name the offending repo (artifact_url) and build so the oncall can point to
+            // the allowlist entry to add without spelunking pinconf.
+            LOG.warn(
+                    "SOX validation failed reason=artifact_not_sox_compliant env={}/{} build_id={} build_name={} artifact_url={} remediation=add_repo_to_sox_allowlist",
+                    envBean.getEnv_name(),
+                    envBean.getStage_name(),
+                    buildBean.getBuild_id(),
+                    buildBean.getBuild_name(),
+                    buildBean.getArtifact_url());
             throw new WebApplicationException(
-                    ERROR_STAGE_REQUIRES_SOX_BUILD_COMPLIANT_SOURCE, Response.Status.BAD_REQUEST);
+                    String.format(
+                            "%s Offending artifact_url=%s",
+                            ERROR_STAGE_REQUIRES_SOX_BUILD_COMPLIANT_SOURCE,
+                            buildBean.getArtifact_url()),
+                    Response.Status.BAD_REQUEST);
         }
     }
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/EnvironHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/EnvironHandler.java
@@ -391,18 +391,45 @@ public class EnvironHandler {
         String envId = envBean.getEnv_id();
         List<String> groups = groupDAO.getCapacityGroups(envBean.getEnv_id());
         if (groups != null && !groups.isEmpty()) {
+            // T011: surface the blocking capacity so oncalls/users can act without digging
+            LOG.warn(
+                    "Env-delete blocked env={}/{} env_id={} reason=group_capacity_present groups={} operator={}",
+                    envName,
+                    envStage,
+                    envId,
+                    groups,
+                    operator);
             throw new DeployInternalException(
-                    "Reject the delete of env %s while it still has group capacity", envId);
+                    "Reject the delete of env %s while it still has group capacity: %s",
+                    envId, groups);
         }
 
         List<String> hosts = groupDAO.getCapacityHosts(envBean.getEnv_id());
         if (hosts != null && !hosts.isEmpty()) {
+            // T011: surface the orphan host ids so the operator can terminate via PinConsole
+            LOG.warn(
+                    "Env-delete blocked env={}/{} env_id={} reason=host_capacity_present host_count={} hosts={} operator={}",
+                    envName,
+                    envStage,
+                    envId,
+                    hosts.size(),
+                    hosts,
+                    operator);
             throw new DeployInternalException(
-                    "Reject the delete of env %s while it still has host capacity", envId);
+                    "Reject the delete of env %s while it still has host capacity: %s",
+                    envId, hosts);
         }
 
         long total = agentDAO.countAgentByEnv(envId);
         if (total > 0) {
+            // T011: active-agent count is the third orphan-EC2 failure mode — name it explicitly
+            LOG.warn(
+                    "Env-delete blocked env={}/{} env_id={} reason=active_agents_present active_count={} operator={}",
+                    envName,
+                    envStage,
+                    envId,
+                    total,
+                    operator);
             throw new DeployInternalException(
                     "Reject the delete of env %s while there are still %d hosts active",
                     envId, total);
@@ -549,20 +576,51 @@ public class EnvironHandler {
             try {
                 EnvironBean mainEnv = environDAO.getMainEnvByHostId(hostId);
                 if (mainEnv == null) {
+                    // T003: structured WARN — no owning env found for host; caller will get 404
+                    LOG.warn(
+                            "Host-operation rejected host_id={} requested_env={}/{} reason=no_owning_env",
+                            hostId,
+                            environBean.getEnv_name(),
+                            environBean.getStage_name());
                     throw new NotFoundException(
                             String.format(
                                     "No main environment found for host %s, refuse to proceed",
                                     hostId));
                 }
                 if (!mainEnv.getEnv_id().equals(environBean.getEnv_id())) {
+                    // T003: structured WARN — host belongs to a different env; caller will get 403.
+                    // Include the actual owning env so operators can route to the correct stage.
+                    LOG.warn(
+                            "Host-operation rejected host_id={} requested_env={}/{} actual_env={}/{} reason=wrong_env correct_env_url=/env/{}/{}/host/{}",
+                            hostId,
+                            environBean.getEnv_name(),
+                            environBean.getStage_name(),
+                            mainEnv.getEnv_name(),
+                            mainEnv.getStage_name(),
+                            mainEnv.getEnv_name(),
+                            mainEnv.getStage_name(),
+                            hostId);
                     throw new ForbiddenException(
                             String.format(
-                                    "%s/%s is not the owning environment of host %s",
+                                    "%s/%s is not the owning environment of host %s. "
+                                            + "Host belongs to %s/%s — use /env/%s/%s/host/%s instead.",
                                     environBean.getEnv_name(),
                                     environBean.getStage_name(),
+                                    hostId,
+                                    mainEnv.getEnv_name(),
+                                    mainEnv.getStage_name(),
+                                    mainEnv.getEnv_name(),
+                                    mainEnv.getStage_name(),
                                     hostId));
                 }
             } catch (SQLException e) {
+                // T003: log the DB-level failure (was silently wrapped as 500 before).
+                LOG.error(
+                        "Host-ownership lookup failed host_id={} requested_env={}/{}",
+                        hostId,
+                        environBean.getEnv_name(),
+                        environBean.getStage_name(),
+                        e);
                 throw new WebApplicationException(
                         String.format("Failed to get main environment for host %s", hostId), e);
             }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
@@ -185,6 +185,19 @@ public class PingHandler {
         Set<String> recordedGroups = new HashSet<String>(hostDAO.getGroupNamesByHost(hostName));
         String recordedAccountId = hostDAO.getAccountIdByHost(hostName);
 
+        // T018: when a host was previously recorded under a group that's not in the newly-reported
+        // set AND no incoming group matches any recorded group, this is the signature of
+        // cross-env group collision (see teletraan-5063). Emit WARN so the mismatch is searchable.
+        if (!recordedGroups.isEmpty() && Collections.disjoint(recordedGroups, groups)) {
+            LOG.warn(
+                    "Host registered under unexpected groups host_name={} host_id={} recorded_groups={} reported_groups={} account_id={}",
+                    hostName,
+                    hostId,
+                    recordedGroups,
+                    groups,
+                    accountId);
+        }
+
         Set<String> groupsToAdd = new HashSet<String>();
         // Insert if not recorded
         for (String group : groups) {

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/ApplyInfraWorker.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/ApplyInfraWorker.java
@@ -169,6 +169,20 @@ public class ApplyInfraWorker implements Runnable {
                 rodimusManager.createClusterWithEnvPublicIds(
                         clusterName, envName, stageName, newClusterInfoPublicIdsBean);
             } catch (Exception e) {
+                // T034 / T038: surface the Rodimus/AWS-origin error message rather than let it be
+                // swallowed as a generic worker-job failure. Common causes include
+                // cross-account AMI sharing ("Not authorized for images") and missing AMI
+                // registration in a new region.
+                LOG.error(
+                        "Cluster creation failed cluster={} env={}/{} region={} base_image={} operator={} error_message={}",
+                        clusterName,
+                        envName,
+                        stageName,
+                        newClusterInfoPublicIdsBean.getRegion(),
+                        newClusterInfoPublicIdsBean.getBaseImage(),
+                        operator,
+                        e.getMessage(),
+                        e);
                 environmentHandler.updateEnvironment(
                         operator, envName, stageName, originEnvironBean);
                 environmentHandler.deleteCapacityForHostOrGroup(
@@ -181,12 +195,44 @@ public class ApplyInfraWorker implements Runnable {
             }
         } else {
             LOG.info("Updating cluster: {}", clusterName);
-            rodimusManager.updateClusterWithPublicIds(clusterName, newClusterInfoPublicIdsBean);
+            try {
+                rodimusManager.updateClusterWithPublicIds(
+                        clusterName, newClusterInfoPublicIdsBean);
+            } catch (Exception e) {
+                // T034: surface Rodimus message on update failure (ARM AMI / AWS permission etc.)
+                LOG.error(
+                        "Cluster update failed cluster={} env={}/{} region={} base_image={} error_message={}",
+                        clusterName,
+                        envName,
+                        stageName,
+                        newClusterInfoPublicIdsBean.getRegion(),
+                        newClusterInfoPublicIdsBean.getBaseImage(),
+                        e.getMessage(),
+                        e);
+                throw e;
+            }
         }
 
         LOG.info("Updating cluster capacity for cluster: {}", clusterName);
-        rodimusManager.updateClusterCapacity(
-                clusterName, infraConfigBean.getMinCapacity(), infraConfigBean.getMaxCapacity());
+        try {
+            rodimusManager.updateClusterCapacity(
+                    clusterName,
+                    infraConfigBean.getMinCapacity(),
+                    infraConfigBean.getMaxCapacity());
+        } catch (Exception e) {
+            // T033: subnet IP exhaustion surfaces here as a Rodimus error; surface the message
+            // with a remediation hint so the user knows to visit the placements UI.
+            LOG.error(
+                    "Cluster capacity change failed cluster={} env={}/{} min={} max={} error_message={} remediation=check_subnet_capacity_at_/clouds/placements",
+                    clusterName,
+                    envName,
+                    stageName,
+                    infraConfigBean.getMinCapacity(),
+                    infraConfigBean.getMaxCapacity(),
+                    e.getMessage(),
+                    e);
+            throw e;
+        }
 
         // Manage Cluster AutoScaling Resources
         RodimusAutoScalingPolicies existingRodimusAutoScalingPolicies =

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvAgentConfigs.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvAgentConfigs.java
@@ -93,6 +93,9 @@ public class EnvAgentConfigs {
         EnvironBean envBean = Utils.getEnvStage(environDAO, envName, stageName);
         String userName = sc.getUserPrincipal().getName();
         Utils.trimMapValues(configs);
+        // T006: pre-persist validation — reject invisible/zero-width/bidi unicode
+        Utils.rejectDisallowedUnicode(
+                configs, userName, String.format("agent_configs:%s/%s", envName, stageName));
         environHandler.updateAdvancedConfigs(envBean, configs, userName);
         configHistoryHandler.updateConfigHistory(
                 envBean.getEnv_id(), Constants.TYPE_ENV_ADVANCED, configs, userName);

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvCapacities.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvCapacities.java
@@ -217,10 +217,23 @@ public class EnvCapacities {
         for (AuthZResource resource : resources) {
             if (!authorizer.authorize(
                     teletraanPrincipal, TeletraanPrincipalRole.Names.WRITE, resource, null)) {
+                // T025: log which specific resource denied the capacity-mutation so operators
+                // know exactly which acl.yaml entry is missing without reading the whole bean.
+                LOG.warn(
+                        "Capacity-mutation denied principal={} target_env={}/{} capacity_type={} capacities={} denied_resource_type=ENV_STAGE denied_resource_name={} required_role=WRITE",
+                        principal.getName(),
+                        targetEnvironBean.getEnv_name(),
+                        targetEnvironBean.getStage_name(),
+                        capacityType,
+                        capacities,
+                        resource.getName());
                 throw new ForbiddenException(
                         String.format(
-                                "Principal %s is not allowed to modify capacity owned by env %s",
-                                principal.getName(), resource.getName()));
+                                "Principal %s is not allowed to modify capacity owned by env %s. "
+                                        + "Denied resource=ENV_STAGE:%s; required_role=WRITE.",
+                                principal.getName(),
+                                resource.getName(),
+                                resource.getName()));
             }
         }
     }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvScriptConfigs.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvScriptConfigs.java
@@ -93,6 +93,9 @@ public class EnvScriptConfigs {
             throws Exception {
         EnvironBean envBean = Utils.getEnvStage(environDAO, envName, stageName);
         String operator = sc.getUserPrincipal().getName();
+        // T006: pre-persist validation — reject invisible/zero-width/bidi unicode
+        Utils.rejectDisallowedUnicode(
+                configs, operator, String.format("script_configs:%s/%s", envName, stageName));
         environHandler.updateScriptConfigs(envBean, configs, operator);
         configHistoryHandler.updateConfigHistory(
                 envBean.getEnv_id(), Constants.TYPE_ENV_SCRIPT, configs, operator);

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Utils.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Utils.java
@@ -28,6 +28,54 @@ import org.slf4j.LoggerFactory;
 public class Utils {
     private static final Logger LOG = LoggerFactory.getLogger(Utils.class);
 
+    /**
+     * T006 — Reject invisible / bidi / zero-width unicode characters in config string values.
+     *
+     * <p>These characters (U+200B..U+200F, U+2028, U+2029, U+FEFF) are commonly pasted from
+     * rich-text editors and cause opaque 500s in downstream serialization without any actionable
+     * signal for the user. Validate pre-persist and fail fast with 422 + structured WARN.
+     */
+    public static void rejectDisallowedUnicode(
+            Map<String, String> configs, String principal, String resource) {
+        if (configs == null) {
+            return;
+        }
+        for (Map.Entry<String, String> entry : configs.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+            if (value == null) {
+                continue;
+            }
+            for (int i = 0; i < value.length(); i++) {
+                char c = value.charAt(i);
+                if (isDisallowedInvisible(c)) {
+                    LOG.warn(
+                            "Config rejected — disallowed invisible unicode codepoint field={} codepoint=U+{} offset={} principal={} resource={}",
+                            key,
+                            String.format("%04X", (int) c),
+                            i,
+                            principal,
+                            resource);
+                    String msg =
+                            String.format(
+                                    "Config value for field '%s' contains disallowed invisible "
+                                            + "character U+%04X at offset %d. Remove and retry.",
+                                    key, (int) c, i);
+                    throw new WebApplicationException(
+                            msg, Response.status(422).entity(msg).build());
+                }
+            }
+        }
+    }
+
+    private static boolean isDisallowedInvisible(char c) {
+        // Zero-width + bidi + line/paragraph-separator + BOM
+        return (c >= 0x200B && c <= 0x200F) // zero-width + LRM/RLM
+                || c == 0x2028 // LINE SEPARATOR
+                || c == 0x2029 // PARAGRAPH SEPARATOR
+                || c == 0xFEFF; // BYTE ORDER MARK / zero-width no-break space
+    }
+
     public static EnvironBean getEnvStage(EnvironDAO environDAO, String envName, String stageName)
             throws Exception {
         EnvironBean environBean = environDAO.getByStage(envName, stageName);

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AgentJanitor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AgentJanitor.java
@@ -257,10 +257,19 @@ public class AgentJanitor implements Runnable {
                 HostAgentBean hostAgent = staleHostMap.get(staleId);
                 if (isHostStale(hostAgent)) {
                     markUnreachableHost(staleId);
+                    Long lastUpdate = hostAgent.getLast_update();
+                    long lastPingSecondsAgo =
+                            lastUpdate == null
+                                    ? -1L
+                                    : TimeUnit.MILLISECONDS.toSeconds(
+                                            janitorStartTime - lastUpdate);
                     LOG.warn(
-                            "{}:{} is stale (not Pinging Teletraan), but might be running.",
+                            "AgentJanitor: host stale (not pinging Teletraan), but might be running host_id={} auto_scaling_group={} last_ping_ts={} last_ping_s_ago={} max_stale_threshold_ms={}",
+                            hostAgent.getHost_id(),
                             hostAgent.getAuto_scaling_group(),
-                            hostAgent.getHost_id());
+                            lastUpdate,
+                            lastPingSecondsAgo,
+                            maxStaleHostThreshold);
                     staleHostCount++;
                     errorBudgetSuccess.increment();
                 } else {
@@ -295,7 +304,11 @@ public class AgentJanitor implements Runnable {
             if (terminatedHosts.contains(hostId)) {
                 removeStaleHost(hostId);
             } else {
-                LOG.warn("Agentless host {} is stale but might be running", hostId);
+                LOG.warn(
+                        "AgentJanitor: agentless host stale but might be running host_id={} no_update_since_ts={} no_update_since_s_ago={}",
+                        hostId,
+                        noUpdateSince,
+                        TimeUnit.MILLISECONDS.toSeconds(janitorStartTime - noUpdateSince));
                 errorBudgetSuccess.increment();
             }
         }

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/resource/UtilsTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/resource/UtilsTest.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2026 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.resource;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.ws.rs.WebApplicationException;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link Utils#rejectDisallowedUnicode} (T006). */
+class UtilsTest {
+
+    @Test
+    void rejectDisallowedUnicode_allowsCleanValues() {
+        Map<String, String> configs = new HashMap<>();
+        configs.put("LD_LIBRARY_PATH", "/usr/lib/foo");
+        configs.put("TEAM", "homefeed-serving");
+        assertDoesNotThrow(() -> Utils.rejectDisallowedUnicode(configs, "alice", "agent_configs"));
+    }
+
+    @Test
+    void rejectDisallowedUnicode_allowsNullInput() {
+        assertDoesNotThrow(() -> Utils.rejectDisallowedUnicode(null, "alice", "agent_configs"));
+    }
+
+    @Test
+    void rejectDisallowedUnicode_allowsNullValues() {
+        Map<String, String> configs = new HashMap<>();
+        configs.put("FOO", null);
+        assertDoesNotThrow(() -> Utils.rejectDisallowedUnicode(configs, "alice", "agent_configs"));
+    }
+
+    @Test
+    void rejectDisallowedUnicode_rejectsLeftToRightMark() {
+        // U+200E LEFT-TO-RIGHT MARK — the exact codepoint from teletraan-5054
+        Map<String, String> configs = new HashMap<>();
+        configs.put("TEAM", "homefeed\u200E-serving");
+        WebApplicationException ex =
+                assertThrows(
+                        WebApplicationException.class,
+                        () -> Utils.rejectDisallowedUnicode(configs, "alice", "agent_configs"));
+        assertEquals(422, ex.getResponse().getStatus());
+        assertTrue(ex.getMessage().contains("TEAM"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("U+200E"), ex.getMessage());
+    }
+
+    @Test
+    void rejectDisallowedUnicode_rejectsZeroWidthSpace() {
+        Map<String, String> configs = new HashMap<>();
+        configs.put("KEY", "val\u200Bue");
+        WebApplicationException ex =
+                assertThrows(
+                        WebApplicationException.class,
+                        () -> Utils.rejectDisallowedUnicode(configs, "alice", "script_configs"));
+        assertEquals(422, ex.getResponse().getStatus());
+        assertTrue(ex.getMessage().contains("U+200B"), ex.getMessage());
+    }
+
+    @Test
+    void rejectDisallowedUnicode_rejectsByteOrderMark() {
+        Map<String, String> configs = new HashMap<>();
+        configs.put("KEY", "\uFEFFvalue");
+        assertThrows(
+                WebApplicationException.class,
+                () -> Utils.rejectDisallowedUnicode(configs, "alice", "script_configs"));
+    }
+}


### PR DESCRIPTION
## Summary

Part of the CDP log-improvement campaign (epic **CDP-11360** / task **CDP-11364** Teletraan deploy-service). Applies 12 deploy-service findings distilled from 333 CDP oncall patrol journals (2026-03-12 → 2026-04-17).

Behavior-preserving wherever possible — each finding adds structured WARN/ERROR alongside existing throw/return paths so investigators can grep structured fields instead of re-deriving from bean dumps. One validation path (T006 unicode-reject) adds a 422 at the resource boundary. Split out of the original combined PR #1934; deploy-agent now has its own PR.

## Findings shipped

### deploy-service — commit `2f45d7fa`
| ID | File | Change |
| --- | --- | --- |
| **T003** | `EnvironHandler.java` | Host-ownership lookup before force-terminate. WARN with `requested_env`, `actual_env`, correct-env URL; enriched `ForbiddenException` message preserved. (teletraan-5063, -5027, -4979, F091) |
| **T006** | `Utils.java`, `EnvScriptConfigs.java`, `EnvAgentConfigs.java`, `UtilsTest.java` | New `Utils.rejectDisallowedUnicode` rejects zero-width / bidi / BOM codepoints (`U+200B..U+200F, U+2028, U+2029, U+FEFF`) with 422 + structured WARN. Wired into `EnvScriptConfigs` and `EnvAgentConfigs` mutation paths. (teletraan-5054, F084) |
| **T011** | `EnvironHandler.java` | Env-delete WARN surfaces blocking groups/hosts/active-agent counts so operators can act without a second round-trip. (teletraan-5027, -4937, F073) |
| **T013** | `CommonHandler.java` | Every `FAILING` / `SUCCEEDING` / `RUNNING` deploy-state transition now logs `from` / `to` / `reason` + agent counts (`ACCEPT_THRESHOLD_MET`, `STUCK_AGENT_THRESHOLD`, `DEPLOY_STUCK_TIMEOUT`, `NEW_HOSTS_JOINING`, `PROGRESS_OBSERVED`). (teletraan-5063, -5087, F063) |
| **T018** | `PingHandler.java` | WARN when a host's recorded groups set is disjoint from the newly-reported set (cross-env name-collision signature). (teletraan-5063) |
| **T021 / T024** | `Buildkite.java` | Dedicated `NotAuthorizedException` catch with `pipeline`, `token_source`, `token_name`, `token_present`; generic-exception catch also enriched with token metadata. (teletraan-5024, -4911, F078) |
| **T022** | `DeployHandler.java` | SOX-validation WARN with `env`, `build_id`, `artifact_url`, `scm_branch` on both private-build and non-sox-compliant rejections; `BAD_REQUEST` message names the offending artifact URL. (F099) |
| **T025** | `EnvCapacities.java` | Cluster-capacity 403 WARN names the denied `ENV_STAGE` resource and `required_role`; `ForbiddenException` message includes the denied resource so users don't have to re-derive from the bean dump. (teletraan-5034, -5044, -5067, F070) |
| **T033 / T034 / T038** | `ApplyInfraWorker.java` | Create-cluster / update-cluster / update-capacity wrapped with try/catch that logs the Rodimus error alongside env/region/base_image. Captures subnet-exhaustion (T033), ARM AMI cross-account (T034), missing AMI region registration (T038). (teletraan-5051, -5071, -5078, F082/F083/F093) |
| **T037** | `DeployHandler.java` | `validateBuild` WARN when the effective build tag is `BAD_BUILD`, even though deploy proceeds (Teletraan does not gate on this). Makes auto-propagated `BAD_BUILD`s searchable in OpenSearch. (teletraan-4985, pindeploy-1755, F089) |

### deploy-service — AgentJanitor — commit `5ce323b0`
| ID | File | Change |
| --- | --- | --- |
| **T040** | `AgentJanitor.java` | Reshape the two stale / agentless-host WARNs into SLF4J structured key=value form (`host_id`, `auto_scaling_group`, `last_ping_ts`, `last_ping_s_ago`, `max_stale_threshold_ms`, `no_update_since_ts`, `no_update_since_s_ago`). Level unchanged — volume reduction (T017, T027) is out of scope for this PR. |

## Deferred

- **T009** (Clone Cluster) — feature is UI-only; no Java handler exists in `deploy-service`. File against `teletraan-ui`.
- **T015** — deploy-agent log ingestion. Moved to CDP-11366.
- **T016 / T025-pastis** — cross-service pastis-proxy correlation. Out of single-repo scope.
- **T019, T020, T023, T026, T027, T028, T029, T031, T032, T035, T039, T041, T042** — deferred to follow-up PRs.

## Test plan
- [ ] Maven CI `deploy-service` build passes
- [ ] Maven CI `deploy-service` unit tests pass (new `UtilsTest` for T006 unicode-reject)

Tracking: CDP-11364.

🤖 Generated with [Claude Code](https://claude.com/claude-code)