### PR TITLE
teletraan deploy-agent: structured logs for 5 oncall-patrol findings (CDP-11366)

### DIFF
--- a/deploy-agent/deployd/common/env_status.py
+++ b/deploy-agent/deployd/common/env_status.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import errno
 import json
 import logging
 import lockfile
 import os
+import shutil
 import traceback
 
 from deployd import IS_PINTEREST
@@ -23,6 +25,22 @@ from deployd.common.types import DeployStatus
 from deployd.common.utils import touch
 
 log = logging.getLogger(__name__)
+
+# Errnos that indicate the host is out of disk space or quota. When we hit one
+# of these while writing the status file, surface disk stats at ERROR so the
+# oncall does not chase the downstream misleading ImageNotFound / retry
+# failure modes (see T002: 'Failed to dump status to the disk' is the strongest
+# on-host signal that disk is full).
+_DISK_FULL_ERRNOS = frozenset(
+    filter(
+        None,
+        (
+            getattr(errno, "ENOSPC", None),
+            getattr(errno, "EDQUOT", None),
+            getattr(errno, "EFBIG", None),
+        ),
+    )
+)
 
 
 class EnvStatus(object):
@@ -95,8 +113,50 @@ class EnvStatus(object):
                 self._touch_or_rm_host_type_file(envs, "canary")
             return True
         except IOError as e:
-            log.warning("Could not write to {}. Reason: {}".format(self._status_fn, e))
+            self._log_dump_failure(e)
             return False
         except Exception:
             log.error(traceback.format_exc())
             return False
+
+    def _log_dump_failure(self, exc) -> None:
+        """Emit a diagnostic log line for a failed status dump.
+
+        When the failure is disk-full (ENOSPC / EDQUOT), escalate to ERROR and
+        attach free/used/total bytes for the mount containing the status file.
+        This is the canonical on-host signal for host disk exhaustion, which
+        otherwise surfaces downstream as a misleading Docker 'ImageNotFound'.
+        """
+        errno_value = getattr(exc, "errno", None)
+        try:
+            probe_path = os.path.dirname(self._status_fn) or self._status_fn
+            usage = shutil.disk_usage(probe_path)
+            disk_info = (
+                " probe_path=%s disk_total_bytes=%d disk_used_bytes=%d "
+                "disk_free_bytes=%d"
+            ) % (probe_path, usage.total, usage.used, usage.free)
+        except Exception as probe_exc:  # disk_usage best-effort
+            disk_info = " probe_path=%s disk_probe_failed=%s" % (
+                self._status_fn,
+                probe_exc,
+            )
+
+        if errno_value in _DISK_FULL_ERRNOS:
+            log.error(
+                "Failed to dump status to the disk (disk-full): status_fn=%s "
+                "errno=%s reason=%s%s. Subsequent deploys on this host will "
+                "likely surface as misleading Docker ImageNotFound errors until "
+                "disk is reclaimed.",
+                self._status_fn,
+                errno_value,
+                exc,
+                disk_info,
+            )
+        else:
+            log.warning(
+                "Could not write to %s. Reason: %s errno=%s%s",
+                self._status_fn,
+                exc,
+                errno_value,
+                disk_info,
+            )

--- a/deploy-agent/deployd/common/executor.py
+++ b/deploy-agent/deployd/common/executor.py
@@ -241,6 +241,13 @@ class Executor(object):
     def execute_command(self, script) -> DeployReport:
         try:
             deploy_step = os.getenv("DEPLOY_STEP")
+            # FIRST_DEPLOY is exported to the environment by
+            # Config.update_variables() when deploy_goal.firstDeploy is truthy.
+            # Detecting it here lets us attach a first-deploy hint to the
+            # 'teletraan directory cannot be found' message, which is the top
+            # source of confusion for POST_DOWNLOAD failures (T014).
+            first_deploy_env = os.getenv("FIRST_DEPLOY", "")
+            is_first_deploy = first_deploy_env.lower() in ("1", "true", "yes")
             if not os.path.exists(self._config.get_script_directory()):
                 """if the teletraan directory does not exist in the pre stage steps. It
                 means it's a newly added host (never deployed before). Show a warning message
@@ -250,6 +257,37 @@ class Executor(object):
                     "teletraan directory cannot be found "
                     "in the tar ball in step {}!".format(deploy_step)
                 )
+                # T014: POST_DOWNLOAD in particular never runs on a first
+                # deploy because there is no prior on-host state to post-
+                # process yet. Surface this explicitly so users don't chase a
+                # packaging bug on a fresh host.
+                if deploy_step == "POST_DOWNLOAD" and is_first_deploy:
+                    error_msg = (
+                        error_msg
+                        + " Note: this host has no prior deploys "
+                        "(FIRST_DEPLOY=true). POST_DOWNLOAD does NOT run on "
+                        "the first deploy to a fresh host — if critical "
+                        "logic lives there, move it to RESTARTING or "
+                        "PRE_RESTART."
+                    )
+                elif deploy_step == "POST_DOWNLOAD":
+                    error_msg = (
+                        error_msg
+                        + " Note: this is a POST_DOWNLOAD failure. "
+                        "POST_DOWNLOAD does NOT run on the first deploy to a "
+                        "fresh host; confirm this host has prior deploys. "
+                        "Also verify the 'teletraan/' directory is packaged "
+                        "in the build tarball (this is NOT an S3/IAM issue)."
+                    )
+                else:
+                    # T004-adjacent: make it explicit that a missing teletraan
+                    # directory is a packaging problem, not an S3/IAM one.
+                    error_msg = (
+                        error_msg
+                        + " This is a PACKAGING issue (teletraan/ missing "
+                        "from the build tarball), NOT an S3/IAM permission "
+                        "issue."
+                    )
                 if deploy_step in PRE_STAGE_STEPS:
                     log.warning(error_msg)
                     return DeployReport(status_code=AgentStatus.SUCCEEDED)

--- a/deploy-agent/deployd/common/utils.py
+++ b/deploy-agent/deployd/common/utils.py
@@ -300,12 +300,102 @@ def redeploy_check_without_container_status(commit, service, redeploy):
         )
 
 
+_DOCKER_DAEMON_ERROR_MARKERS = (
+    "Cannot connect to the Docker daemon",
+    "ConnectionRefusedError",
+    "connection refused",
+    "UnixHTTPConnectionPool",
+    "Read timed out",
+    "read timeout",
+    "dial unix /var/run/docker.sock",
+)
+
+
+def _log_docker_daemon_hint(context: str, detail: Optional[str] = None) -> None:
+    """Emit an operator-actionable hint when docker commands fail to talk to the daemon.
+
+    T030: `docker` subprocess calls that fail with ConnectionRefusedError /
+    UnixHTTPConnectionPool read-timeout symptoms are almost always a
+    dockerd crash or a systemd rate-limit on docker.service restart.
+    Probe `systemctl status docker` best-effort and surface the suggested
+    remediation directly, so the oncall doesn't have to SSH and rediscover it.
+    """
+    systemd_status = "probe_skipped"
+    systemd_detail = ""
+    try:
+        probe = subprocess.run(
+            ["systemctl", "is-active", "docker"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=5,
+        )
+        systemd_status = (probe.stdout or b"").decode(errors="replace").strip() or (
+            "rc=%d" % probe.returncode
+        )
+    except Exception as probe_exc:
+        systemd_status = "probe_failed=%s" % probe_exc
+
+    try:
+        journal = subprocess.run(
+            [
+                "systemctl",
+                "status",
+                "--no-pager",
+                "-n",
+                "20",
+                "docker",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=5,
+        )
+        systemd_detail = (journal.stdout or b"").decode(errors="replace").strip()
+    except Exception:
+        systemd_detail = ""
+
+    log.error(
+        "Docker daemon appears unreachable during %s%s. systemctl_is_active=%s. "
+        "Remediation: 'sudo systemctl reset-failed docker && sudo systemctl "
+        "restart docker'. If systemd reports 'Start request repeated too "
+        "quickly', the docker.service unit is rate-limited and reset-failed is "
+        "required before restart.",
+        context,
+        " (detail=%s)" % detail if detail else "",
+        systemd_status,
+    )
+    if systemd_detail:
+        # Keep the journal excerpt at DEBUG to avoid log bloat on every failure;
+        # the ERROR above already contains the actionable remediation.
+        log.debug("systemctl status docker excerpt:\n%s", systemd_detail)
+
+
+def _looks_like_docker_daemon_failure(text: str) -> bool:
+    if not text:
+        return False
+    return any(marker in text for marker in _DOCKER_DAEMON_ERROR_MARKERS)
+
+
 def get_container_health_info(commit, service, redeploy) -> Optional[str]:
     try:
         log.info(f"Get health info for service {service} with commit {commit}")
         result = []
         cmd = ["docker", "ps", "--format", "{{.Image}};{{.Names}};{{.Labels}}"]
-        output = subprocess.run(cmd, check=True, stdout=subprocess.PIPE).stdout
+        try:
+            proc = subprocess.run(
+                cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            )
+            output = proc.stdout
+        except subprocess.CalledProcessError as docker_err:
+            # T030: when 'docker ps' itself fails with daemon-unreachable
+            # signatures, surface the remediation hint before the generic
+            # failure log below.
+            stderr = (docker_err.stderr or b"").decode(errors="replace")
+            if _looks_like_docker_daemon_failure(stderr):
+                _log_docker_daemon_hint(
+                    "get_container_health_info (docker ps)",
+                    detail=stderr.strip(),
+                )
+            raise
         if output:
             lines = output.decode().strip().splitlines()
             for line in lines:
@@ -371,11 +461,30 @@ def get_telefig_version() -> Optional[str]:
         return None
     try:
         cmd = ["configure-serviceset", "-v"]
-        output = subprocess.run(cmd, check=True, stdout=subprocess.PIPE).stdout
+        proc = subprocess.run(
+            cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        output = proc.stdout
         if output:
             return output.decode().strip()
         else:
             return None
+    except subprocess.CalledProcessError as sub_err:
+        # T030: configure-serviceset shells out to docker. When the docker
+        # daemon is down or rate-limited, the stderr will contain one of the
+        # daemon-unreachable markers — surface the same remediation hint.
+        stderr = (sub_err.stderr or b"").decode(errors="replace")
+        if _looks_like_docker_daemon_failure(stderr):
+            _log_docker_daemon_hint(
+                "get_telefig_version (configure-serviceset -v)",
+                detail=stderr.strip(),
+            )
+        log.error(
+            "Error when fetching teletraan configure manager version: rc=%d stderr=%s",
+            sub_err.returncode,
+            stderr.strip(),
+        )
+        return None
     except Exception:
         log.error("Error when fetching teletraan configure manager version")
         return None

--- a/deploy-agent/deployd/download/http_download_helper.py
+++ b/deploy-agent/deployd/download/http_download_helper.py
@@ -55,7 +55,22 @@ class HTTPDownloadHelper(DownloadHelper):
 
         status_code = self._download_files(local_full_fn)
         if status_code != Status.SUCCEEDED:
-            log.error("Failed to download the tar ball for {}".format(local_full_fn))
+            # Note: the local_full_fn path below is a HOST-LOCAL path (e.g.
+            # /mnt/builds/...). Users and oncalls frequently misread this as an
+            # S3 / IAM permission issue — it is NOT. This is a tarball download
+            # failure over HTTPS. If the file is missing from the build
+            # tarball (e.g. ServicesetConfNotFound: '.../serviceset.<stage>.conf
+            # is not in the build'), this is a PACKAGING / RESTARTING-wildcard
+            # problem, not S3/IAM. See T004.
+            log.error(
+                "Failed to download the tar ball for %s (source_url=%s). "
+                "This is a tarball download failure, NOT an S3/IAM permission "
+                "issue. If a subsequent step reports a missing serviceset conf, "
+                "verify that the expected config file is packaged in the build "
+                "tarball (check RESTARTING / POST_DOWNLOAD script wildcards).",
+                local_full_fn,
+                self._url,
+            )
             build_name = Helper.get_build_name(local_full_fn.rsplit("/", 1)[-1])
             tags = {"type": "http", "build_name": build_name}
             create_sc_increment("deployd.stats.download.failed", tags=tags)

--- a/deploy-agent/deployd/download/local_download_helper.py
+++ b/deploy-agent/deployd/download/local_download_helper.py
@@ -45,8 +45,19 @@ class LocalDownloadHelper(DownloadHelper):
 
         error = self._download_files(local_full_fn)
         if error != Status.SUCCEEDED:
+            # The local_full_fn below is a HOST-LOCAL path (often under
+            # /mnt/builds/...). A failure here is a local fetch issue — it is
+            # NOT an S3 / IAM permission problem. If a subsequent deploy step
+            # surfaces 'ServicesetConfNotFound', that is a packaging/wildcard
+            # gap (missing config file inside the build tarball), not S3/IAM.
+            # See T004.
             log.error(
-                "Failed to download the local tar ball for {}".format(local_full_fn)
+                "Failed to download the local tar ball for %s (source_url=%s). "
+                "This is a LOCAL fetch failure, NOT an S3/IAM permission "
+                "issue. If a missing serviceset conf is reported later, verify "
+                "the expected config file is included in the build tarball.",
+                local_full_fn,
+                self._url,
             )
         return error
 

--- a/deploy-agent/deployd/staging/stager.py
+++ b/deploy-agent/deployd/staging/stager.py
@@ -15,6 +15,7 @@
 import argparse
 import os
 from pwd import getpwnam
+import re
 import sys
 import shutil
 import traceback
@@ -29,6 +30,43 @@ from deployd.common.stats import create_sc_increment
 from .transformer import Transformer
 
 log = logging.getLogger(__name__)
+
+# T036: TELETRAAN_* variable substitution only runs on files that live under
+# the `teletraan_template/` directory. Tokens in other locations are silently
+# left unsubstituted and show up much later as cryptic runtime failures.
+# _TELETRAAN_TOKEN_RE matches both ${TELETRAAN_NAME}, {$TELETRAAN_NAME}, and
+# bare $TELETRAAN_NAME usages so we can warn at deploy time.
+_TELETRAAN_TOKEN_RE = re.compile(r"\$\{?TELETRAAN_[A-Za-z0-9_\-]+")
+# Extensions we are willing to scan for tokens. Large binary files in the
+# build directory are not worth reading; keep the list to config/script-ish
+# files to stay cheap and avoid false positives in compiled assets.
+_TELETRAAN_SCAN_EXTENSIONS = (
+    "",
+    ".sh",
+    ".bash",
+    ".zsh",
+    ".py",
+    ".rb",
+    ".pl",
+    ".conf",
+    ".cfg",
+    ".ini",
+    ".properties",
+    ".yaml",
+    ".yml",
+    ".json",
+    ".env",
+    ".txt",
+    ".service",
+    ".xml",
+    ".tmpl",
+    ".template",
+)
+# Cap per-deploy to avoid walking extremely large build trees; the warning is
+# best-effort and only needs to catch the top offenders.
+_TELETRAAN_SCAN_MAX_FILES = 2000
+_TELETRAAN_SCAN_MAX_WARNINGS = 50
+_TELETRAAN_SCAN_MAX_FILE_BYTES = 1 * 1024 * 1024  # 1 MiB per file
 
 
 class Stager(object):
@@ -130,6 +168,86 @@ class Stager(object):
             template_dirname=self._template_dirname,
             script_dirname=self._script_dirname,
         )
+
+        # T036: warn (best-effort) when $TELETRAAN_* tokens appear in files
+        # that live outside the teletraan_template/ directory — those tokens
+        # are NOT substituted by the Transformer and will reach the runtime
+        # as literal strings.
+        try:
+            self._warn_on_unsubstituted_teletraan_tokens(template_dir)
+        except Exception:
+            log.debug(
+                "TELETRAAN_ token scan failed; continuing: %s",
+                traceback.format_exc(),
+            )
+
+    def _warn_on_unsubstituted_teletraan_tokens(self, template_dir: str) -> None:
+        """Walk the build target and warn if $TELETRAAN_* tokens appear
+        outside ``teletraan_template/``.
+
+        Only those tokens get substituted by the Transformer, so any
+        occurrence elsewhere is a silent no-op that users typically discover
+        at runtime via a cryptic symptom. Logging at deploy time gives a
+        much clearer breadcrumb (T036).
+        """
+        if not self._target or not os.path.isdir(self._target):
+            return
+
+        template_dir_abs = os.path.abspath(template_dir)
+        files_scanned = 0
+        warnings_emitted = 0
+        for root, dirs, files in os.walk(self._target, followlinks=False):
+            # Skip the template directory itself — tokens there are expected
+            # and will be substituted.
+            root_abs = os.path.abspath(root)
+            if (
+                root_abs == template_dir_abs
+                or root_abs.startswith(template_dir_abs + os.sep)
+            ):
+                dirs[:] = []
+                continue
+
+            for filename in files:
+                if files_scanned >= _TELETRAAN_SCAN_MAX_FILES:
+                    return
+                if warnings_emitted >= _TELETRAAN_SCAN_MAX_WARNINGS:
+                    log.warning(
+                        "TELETRAAN_ token scan: suppressing further warnings "
+                        "after %d hits (emit cap). Inspect files outside "
+                        "teletraan_template/ for remaining $TELETRAAN_* tokens.",
+                        warnings_emitted,
+                    )
+                    return
+                ext = os.path.splitext(filename)[1].lower()
+                if ext not in _TELETRAAN_SCAN_EXTENSIONS:
+                    continue
+                fpath = os.path.join(root, filename)
+                try:
+                    size = os.path.getsize(fpath)
+                except OSError:
+                    continue
+                if size == 0 or size > _TELETRAAN_SCAN_MAX_FILE_BYTES:
+                    continue
+                files_scanned += 1
+                try:
+                    with open(fpath, "r", errors="replace") as fh:
+                        content = fh.read()
+                except (OSError, UnicodeDecodeError):
+                    continue
+                matches = _TELETRAAN_TOKEN_RE.findall(content)
+                if not matches:
+                    continue
+                unique_tokens = sorted(set(matches))
+                log.warning(
+                    "Found unsubstituted TELETRAAN_ token(s) %s in %s — this "
+                    "file is OUTSIDE teletraan_template/ so variables were "
+                    "NOT substituted and will reach runtime as literals. "
+                    "Move the file under teletraan_template/ or export the "
+                    "value from a RESTARTING script. (T036)",
+                    unique_tokens[:5],
+                    fpath,
+                )
+                warnings_emitted += 1
 
 
 def main() -> int:

--- a/deploy-agent/tests/unit/deploy/utils/test_status.py
+++ b/deploy-agent/tests/unit/deploy/utils/test_status.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import errno
+import logging
 import os
 import tempfile
 import unittest
+from unittest import mock
 import tests
 
 from deployd.common.types import DeployStatus, BuildInfo, DeployStage, AgentStatus
@@ -88,6 +91,50 @@ class TestStatusFunction(tests.TestCase):
         env_status = EnvStatus(fn)
         envs = env_status.load_envs()
         self.assertEqual(envs, {})
+        os.remove(fn)
+
+    def test_dump_envs_disk_full_logs_error_with_disk_stats(self):
+        """T002: ENOSPC while dumping status must surface an ERROR log
+        carrying disk stats so oncalls don't chase a misleading
+        ImageNotFound downstream. Behavior (return False) is preserved.
+        """
+        fn = tempfile.mkstemp()[1]
+        env_status = EnvStatus(fn)
+
+        disk_full = IOError(errno.ENOSPC, "No space left on device")
+        with mock.patch(
+            "deployd.common.env_status.open",
+            side_effect=disk_full,
+            create=True,
+        ), self.assertLogs("deployd.common.env_status", level="ERROR") as cm:
+            result = env_status.dump_envs({})
+
+        self.assertFalse(result)
+        joined = "\n".join(cm.output)
+        self.assertIn("disk-full", joined)
+        self.assertIn("disk_free_bytes=", joined)
+        self.assertIn("errno=28", joined)
+        os.remove(fn)
+
+    def test_dump_envs_non_disk_full_stays_warning(self):
+        """A non-disk-full IOError must stay at WARN (behavior-preserving)."""
+        fn = tempfile.mkstemp()[1]
+        env_status = EnvStatus(fn)
+
+        permission_denied = IOError(errno.EACCES, "Permission denied")
+        with mock.patch(
+            "deployd.common.env_status.open",
+            side_effect=permission_denied,
+            create=True,
+        ), self.assertLogs("deployd.common.env_status", level="WARNING") as cm:
+            result = env_status.dump_envs({})
+
+        self.assertFalse(result)
+        # Must NOT have been escalated to ERROR
+        self.assertFalse(
+            any(record.levelno >= logging.ERROR for record in cm.records),
+            "non-disk-full IOError should stay at WARN",
+        )
         os.remove(fn)
 
 


### PR DESCRIPTION
## Summary

Part of the CDP log-improvement campaign (epic **CDP-11360** / task **CDP-11366** Teletraan deploy-agent). Applies 5 deploy-agent findings distilled from 333 CDP oncall patrol journals (2026-03-12 → 2026-04-17).

Behavior-preserving — each finding adds structured WARN/ERROR alongside existing throw/return paths. Split out of the original combined PR #1934 (which also covered deploy-service); deploy-service now has its own PR.

## Findings shipped — commit `98ec730c`

| ID | File | Change |
| --- | --- | --- |
| **T002** | `deployd/common/env_status.py` | `Failed to dump status to disk` escalates to ERROR on `ENOSPC / EDQUOT / EFBIG` with `disk_free_bytes`, `disk_used_bytes`, `disk_total_bytes` via `shutil.disk_usage()`. Non-disk-full `IOError`s stay at WARN. Hints that downstream deploys will surface as misleading Docker `ImageNotFound` until disk is reclaimed. (teletraan-5033, -4992) |
| **T004** | `deployd/download/http_download_helper.py`, `.../local_download_helper.py`, `deployd/common/executor.py` | Tarball download failures on `/mnt/...` paths now log explicitly that this is **not** an S3 / IAM permission issue (patrol ticket was mis-triaged as "S3 permission"). (teletraan-4965, -5017) |
| **T014** | `deployd/common/executor.py` | `POST_DOWNLOAD` failure detects first-deploy via `FIRST_DEPLOY` env var and attaches a note that `POST_DOWNLOAD` doesn't run on first deploy to a fresh host — if critical logic lives there, move it to `RESTARTING` or `PRE_RESTART`. (teletraan-5017) |
| **T030** | `deployd/common/utils.py` | When `docker ps` / `configure-serviceset -v` stderr matches daemon-unreachable markers (`ConnectionRefusedError`, `UnixHTTPConnectionPool`, `Read timed out`, `Cannot connect to the Docker daemon`, `dial unix /var/run/docker.sock`), emit an ERROR naming `sudo systemctl reset-failed docker && sudo systemctl restart docker` and include `systemctl is-active docker` output (status excerpt at DEBUG to avoid log bloat). (teletraan-4939) |
| **T036** | `deployd/staging/stager.py` | After `transform_scripts()`, walk the deploy target (excluding `teletraan_template/`) for residual `$TELETRAAN_*` tokens in common config/script extensions. WARN per hit with file path + first 5 unique tokens, capped at 50 warnings / 2000 files. (teletraan-5020) |

## Deferred

- **T001** — docker `_pull` call site lives in the internal `teletraan_config_manager` (configure-serviceset) repo, not in `pinterest/teletraan`. The adjacent deploy-agent docker-subprocess failures are covered by T030; the disk-full signal lands via T002.
- **T015** — telefig log ingestion into OpenSearch. L-effort; largest single-service win. Deferred.

## Test plan
- [ ] `deployd` Python tests pass (2 new disk-full branch tests on `EnvStatus.dump_envs`)

Tracking: CDP-11366.

🤖 Generated with [Claude Code](https://claude.com/claude-code)