### PR TITLE
Fix host_side_panel Terminate button URL generation (CDP-11399)

### DIFF
--- a/deploy-board/deploy_board/templates/host_side_panel.html
+++ b/deploy-board/deploy_board/templates/host_side_panel.html
@@ -62,7 +62,7 @@
                 try {
                     result = await $.ajax({
                         type: 'GET',
-                        url: `/groups/{{ group_name }}/hosts`,
+                        url: `/groups/{{ asg_group }}/hosts`,
                         dataType: "json",
                         beforeSend: function(xhr, settings) {
                             var csrftoken = getCookie('csrftoken');


### PR DESCRIPTION
Replace undefined group_name with asg_group in AJAX URL to prevent /groups//hosts 500 errors when clicking Terminate on env-scoped host detail pages. HostDetailView sets asg_group but not group_name in template context.

This fix eliminates ~4 user-visible 5xx errors per hour on deploy_board.docker-prod and restores the Terminate button to working state on env-scoped host detail pages.