### PR TITLE
Bump deploy agent version to 1.2.76

### DIFF
--- a/deploy-agent/deployd/__init__.py
+++ b/deploy-agent/deployd/__init__.py
@@ -31,4 +31,4 @@ REDEPLOY_MAX_RETRY = 3
 # 2: puppet applied successfully with changes
 PUPPET_SUCCESS_EXIT_CODES = [0, 2]
 
-__version__ = "1.2.75"
+__version__ = "1.2.76"


### PR DESCRIPTION
Bump deploy agent version to 1.2.76 to release this [change](https://github.com/pinterest/teletraan/pull/1920). Please review the tests done in the PR.