### PR TITLE
Fix cluster replacement error when using Terminate and Launch option

### DIFF
--- a/deploy-board/deploy_board/webapp/cluster_view.py
+++ b/deploy-board/deploy_board/webapp/cluster_view.py
@@ -1722,7 +1722,6 @@ def gen_replacement_config(request):
         else:
             rollingUpdateConfig["maxHealthyPercentage"] = params["maxHealthyPercentage"]
     elif params["availabilitySettingRadio"] == "terminateAndLaunch":
-        rollingUpdateConfig["maxHealthyPercentage"] = None
         if (
             params["minHealthyPercentage"] is None
             or len(params["minHealthyPercentage"]) == 0


### PR DESCRIPTION
Remove explicit null assignment for maxHealthyPercentage when terminateAndLaunch availability setting is selected. The backend Rodimus service validation rejects null values and expects the field to either be a valid integer or omitted entirely.

This fixes the error: {replaceCluster.arg1=must not be null}