### PR TITLE
Add budgeting entity to contextual link for Entitlements

### DIFF
--- a/deploy-board/deploy_board/templates/clusters/cluster_capacity.tmpl
+++ b/deploy-board/deploy_board/templates/clusters/cluster_capacity.tmpl
@@ -38,7 +38,7 @@
     <div class="panel-footer clearfix">
         <div class="pull-right">
             {% if useEntitlements %}
-            <a href="{{ entitlements_ui_link }}?service={{envName}}-{{stageName}}" target="_blank" type="button" id="saveClusterConfigBtnId" class="btn btn-default"
+            <a href="{{ entitlements_ui_link }}?service={{envName}}-{{stageName}}&budgetingEntity=all" target="_blank" type="button" id="saveClusterConfigBtnId" class="btn btn-default"
                     title="View in Entitlements UI">
                 <span class="glyphicon glyphicon-new-window"></span>
                 View Entitlement


### PR DESCRIPTION
Add `budgetingEntity=all` to contextual lint to Entitlements so it redirects to the correct Entitlement page