### PR TITLE
Redact script-token bearer secret from read paths (BUG-285640)

### DIFF
--- a/deploy-board/deploy_board/templates/users/script_token_deprecation.html
+++ b/deploy-board/deploy_board/templates/users/script_token_deprecation.html
@@ -1,6 +1,8 @@
 <div class="alert alert-warning" role="alert">
     <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
     Script tokens are deprecated and will expire after 180 days. You will need to generate a new one after expiration.
+    Newly created tokens are displayed <strong>only once</strong>, immediately after Save; copy the value
+    then because it cannot be retrieved later. Lost tokens must be revoked and re-issued.
     <a class="btn btn-info"
        href="https://pinch.pinadmin.com/ttst-deprecation"
        target="_blank">Get help</a>

--- a/deploy-board/deploy_board/templates/users/users_config.tmpl
+++ b/deploy-board/deploy_board/templates/users/users_config.tmpl
@@ -39,9 +39,9 @@
                 title="Revoke this permission"> Revoke
         </button>
         {% if user_types == 'token_roles' %}
-            <button type="button" class="showTokenBtn deployToolTip btn btn-default"
-                    title="Show the token in clear text">Show Token</button>
-            <div class="control-label col-md-2" >
+            <div class="control-label col-md-3">
+                <span class="glyphicon glyphicon-lock" aria-hidden="true"
+                      title="The token value is only displayed once, at creation time, and cannot be retrieved afterwards."></span>
                 Expires on {{ user.expireDate|convertTimestamp }}
             </div>
         {% endif %}
@@ -128,26 +128,26 @@
 </div>
 
 <div class="modal fade" id="tokenModalId" tabindex="-1" role="dialog"
-     aria-labelledby="tokenModalLabel" aria-hidden="true">
+     aria-labelledby="tokenModalLabel" aria-hidden="true"
+     data-backdrop="static" data-keyboard="false">
     <div class="modal-dialog modal-lg">
         <div class="modal-content">
-            <form id="tokenFormId" class="form-horizontal" method="post" role="form">
-                <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal"><span
-                            aria-hidden="true">&times;</span><span class="sr-only">Close</span>
-                    </button>
-                    <h4 class="modal-title">Show Token</h4>
+            <div class="modal-header">
+                <h4 class="modal-title" id="tokenModalLabel">New script token(s) - save them now</h4>
+            </div>
+            <div class="modal-body">
+                <div class="alert alert-danger" role="alert">
+                    <strong>This is the only time these token values will be displayed.</strong>
+                    Copy each one and store it in your secrets manager before dismissing this dialog.
+                    Lost tokens cannot be recovered - you will need to revoke and create new ones.
                 </div>
-                <div class="modal-body">
-                    <div class="alert alert-warning" role="alert">
-                        Remember to keep this token secret; treat it just like passwords!
-                    </div>
-                    <pre><div id="tokenDivId"></div></pre>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-primary" data-dismiss="modal">Got It!</button>
-                </div>
-            </form>
+                <div id="newTokensListId"></div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-primary" id="tokenModalDismissBtnId">
+                    I have saved the token(s)
+                </button>
+            </div>
         </div>
     </div>
 </div>
@@ -199,6 +199,67 @@
         });
 
 
+        // BUG-285640: A freshly minted bearer token is included in the POST response exactly
+        // once. Render the list of new tokens (if any) into a modal so the operator can copy
+        // each value before the page refreshes the user list.
+        function renderNewTokensModal(newTokens) {
+            var $list = $('#newTokensListId').empty();
+            for (var i = 0; i < newTokens.length; i++) {
+                var t = newTokens[i];
+                var name = String(t.name || '');
+                var role = String(t.role || '');
+                var token = String(t.token || '');
+                var inputId = 'newTokenValue_' + i;
+                var rowId = 'newTokenRow_' + i;
+                var row = $('<div class="form-group row" id="' + rowId + '"></div>');
+                row.append(
+                    $('<label class="control-label col-md-2"></label>').text(name)
+                );
+                row.append(
+                    $('<div class="control-label col-md-2"></div>').text(role)
+                );
+                var inputCol = $('<div class="col-md-6"></div>');
+                inputCol.append(
+                    $('<input type="text" class="form-control" readonly="readonly" />')
+                        .attr('id', inputId)
+                        .val(token)
+                );
+                row.append(inputCol);
+                var btnCol = $('<div class="col-md-2"></div>');
+                btnCol.append(
+                    $('<button type="button" class="btn btn-default copyTokenBtn">' +
+                      '<span class="glyphicon glyphicon-copy"></span> Copy</button>')
+                        .attr('data-target', '#' + inputId)
+                );
+                row.append(btnCol);
+                $list.append(row);
+            }
+            $('#tokenModalId').modal('show');
+        }
+
+        $('#tokenModalId').on('click', '.copyTokenBtn', function () {
+            var $btn = $(this);
+            var $input = $($btn.data('target'));
+            $input.select();
+            try {
+                document.execCommand('copy');
+                $btn.html('<span class="glyphicon glyphicon-ok"></span> Copied');
+                setTimeout(function () {
+                    $btn.html('<span class="glyphicon glyphicon-copy"></span> Copy');
+                }, 1500);
+            } catch (e) {
+                // Fallback: leave the value selected so the user can copy manually.
+            }
+        });
+
+        $('#tokenModalDismissBtnId').click(function () {
+            // Scrub token values from the DOM before closing - they exist in this page only
+            // until the user explicitly acknowledges them.
+            $('#newTokensListId input').val('');
+            $('#tokenModalId').modal('hide');
+            $('#newTokensListId').empty();
+        });
+
         $('#saveConfigMapBtnId').click(function () {
             var btn = $(this);
             $.ajax({
@@ -216,6 +277,9 @@
                     } else {
                         $('#usersConfigId').html(data.html);
                         $('#errorBannerId').empty().hide();
+                        if (data && data.new_tokens && data.new_tokens.length > 0) {
+                            renderNewTokensModal(data.new_tokens);
+                        }
                     }
                     btn.button('reset');
                 },
@@ -245,13 +309,6 @@
             $(this).parent().remove();
             $('#saveConfigMapBtnId').removeAttr('disabled');
             $('#resetConfigMapBtnId').removeAttr('disabled');
-        });
-
-        $('#usersFormId').on('click', '.showTokenBtn', function () {
-            var user_name = $(this).parent().find("label").text();
-            $('#tokenDivId').load('/env/{{ env_name }}/get_user_token/' +
-                user_name + '/?user_types={{ user_types }}');
-            $('#tokenModalId').modal();
         });
 
     });

--- a/deploy-board/deploy_board/webapp/urls.py
+++ b/deploy-board/deploy_board/webapp/urls.py
@@ -66,10 +66,6 @@ urlpatterns = [
     ),
     re_path(r"^env/(?P<name>[a-zA-Z0-9\-_]+)/get_users/$", user_views.get_users),
     re_path(
-        r"^env/(?P<name>[a-zA-Z0-9\-_]+)/get_user_token/(?P<user_name>[a-zA-Z0-9\-_]+)/$",
-        user_views.get_user_token,
-    ),
-    re_path(
         r"^env/(?P<name>[a-zA-Z0-9\-_]+)/(?P<stage>[a-zA-Z0-9\-_]+)/deploy/$",
         env_views.EnvLandingView.as_view(),
     ),

--- a/deploy-board/deploy_board/webapp/user_views.py
+++ b/deploy-board/deploy_board/webapp/user_views.py
@@ -65,14 +65,9 @@ def get_users(request, name):
     return HttpResponse(json.dumps({"html": html}), content_type="application/json")
 
 
-def get_user_token(request, name, user_name):
-    user_types = request.GET.get("user_types")
-    user = users_helper.get_env_user(request, name, user_name, user_types)
-    return HttpResponse(user["token"], content_type="application/text")
-
-
 def update_users_config(request, name):
     user_types = request.GET.get("user_types")
+    is_token_roles = user_types == "token_roles"
     # First, retrive all the original users
     origin_user_dict = {}
     for key, value in request.POST.items():
@@ -108,8 +103,22 @@ def update_users_config(request, name):
         users_helper.delete_env_user(request, name, key, user_types)
     for key, value in updated_user_dict.items():
         users_helper.update_env_user(request, name, key, value, user_types)
+
+    # BUG-285640: For token_roles, the POST response is the *only* time the raw bearer secret is
+    # disclosed. Capture it here so the UI can surface it to the operator once; afterwards it is
+    # not retrievable through any GET endpoint.
+    new_tokens = []
     for key, value in new_user_dict.items():
-        users_helper.create_env_user(request, name, key, value, user_types)
+        created = users_helper.create_env_user(request, name, key, value, user_types)
+        if is_token_roles and isinstance(created, dict) and created.get("token"):
+            new_tokens.append(
+                {
+                    "name": created.get("name", key),
+                    "role": created.get("role", value),
+                    "token": created["token"],
+                    "expireDate": created.get("expireDate"),
+                }
+            )
 
     users = users_helper.get_env_users(request, name, user_types)
     html = render_to_string(
@@ -123,4 +132,7 @@ def update_users_config(request, name):
         },
     )
 
-    return HttpResponse(json.dumps({"html": html}), content_type="application/json")
+    return HttpResponse(
+        json.dumps({"html": html, "new_tokens": new_tokens}),
+        content_type="application/json",
+    )

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/CreatedTokenRolesResponse.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/CreatedTokenRolesResponse.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2016-2026 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.deployservice.bean;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.pinterest.teletraan.universal.security.bean.AuthZResource;
+
+/**
+ * Response payload for the script-token creation endpoint.
+ *
+ * <p>This DTO is the <em>only</em> HTTP response shape that includes the raw bearer {@code token}
+ * value. The on-disk {@link TokenRolesBean} marks {@code token} as write-only so that GET endpoints
+ * never expose it (see BUG-285640). The newly minted token is disclosed exactly once, in the 201
+ * Created response from {@code POST /v1/envs/{env}/token_roles}, to the WRITE-role caller that
+ * created it. Callers must persist the token at that moment; it cannot be retrieved afterwards.
+ */
+public class CreatedTokenRolesResponse {
+
+    @JsonProperty("name")
+    private final String scriptName;
+
+    @JsonProperty("resource")
+    private final String resourceId;
+
+    @JsonProperty("type")
+    private final AuthZResource.Type resourceType;
+
+    @JsonProperty("token")
+    private final String token;
+
+    @JsonProperty("role")
+    private final TeletraanPrincipalRole role;
+
+    @JsonProperty("expireDate")
+    private final Long expireDate;
+
+    public CreatedTokenRolesResponse(TokenRolesBean bean, String rawToken) {
+        this.scriptName = bean.getScript_name();
+        this.resourceId = bean.getResource_id();
+        this.resourceType = bean.getResource_type();
+        this.token = rawToken;
+        this.role = bean.getRole();
+        this.expireDate = bean.getExpire_date();
+    }
+
+    public String getScriptName() {
+        return scriptName;
+    }
+
+    public String getResourceId() {
+        return resourceId;
+    }
+
+    public AuthZResource.Type getResourceType() {
+        return resourceType;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public TeletraanPrincipalRole getRole() {
+        return role;
+    }
+
+    public Long getExpireDate() {
+        return expireDate;
+    }
+}

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/TeletraanPrincipalRole.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/TeletraanPrincipalRole.java
@@ -30,6 +30,14 @@ public enum TeletraanPrincipalRole implements RoleEnum<ValueBasedRole> {
     WRITE(9),
     DELETE(9),
     /**
+     * Role required to read or mutate Teletraan script-token metadata (env- and system-scoped
+     * /token_roles APIs). Hardened away from READ/WRITE/DELETE in BUG-285640 because the metadata
+     * (script name, role, expiry) is sensitive. In the Pastis policy it is granted only to the
+     * `admin` and `envOwner` roles; other roles such as `legacyOperator`, `envMember`, `deployer`,
+     * and `reader` do NOT receive it.
+     */
+    MANAGE_SCRIPT_TOKEN(15),
+    /**
      * Role where user can modify a specific environment's config and perform deploy related
      * actions.
      */
@@ -54,6 +62,8 @@ public enum TeletraanPrincipalRole implements RoleEnum<ValueBasedRole> {
         public static final String WRITE = "WRITE";
         public static final String EXECUTE = "EXECUTE";
         public static final String DELETE = "DELETE";
+
+        public static final String MANAGE_SCRIPT_TOKEN = "MANAGE_SCRIPT_TOKEN";
 
         public static final String UPDATE_EXTERNAL_ID = "UPDATE_EXTERNAL_ID";
     }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/TokenRolesBean.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/bean/TokenRolesBean.java
@@ -34,7 +34,16 @@ public class TokenRolesBean implements Updatable {
     @JsonProperty("type")
     private AuthZResource.Type resource_type;
 
-    @JsonProperty("token")
+    /**
+     * The bearer secret used to authenticate {@code Authorization: token <value>} requests.
+     *
+     * <p>This field is intentionally write-only as far as Jackson is concerned: it may be
+     * deserialized from inbound JSON (used internally by {@code TokenRoles.create()} and updates),
+     * but is never serialized into HTTP responses. The raw token is disclosed exactly once, by
+     * {@link com.pinterest.deployservice.bean.CreatedTokenRolesResponse}, in the 201 Created
+     * response from the token-creation endpoint. GET endpoints redact it. See BUG-285640.
+     */
+    @JsonProperty(value = "token", access = JsonProperty.Access.WRITE_ONLY)
     private String token;
 
     @NotNull
@@ -106,6 +115,6 @@ public class TokenRolesBean implements Updatable {
 
     @Override
     public String toString() {
-        return ReflectionToStringBuilder.toString(this);
+        return ReflectionToStringBuilder.toStringExclude(this, "token");
     }
 }

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBTokenRolesDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBTokenRolesDAOImpl.java
@@ -37,13 +37,27 @@ public class DBTokenRolesDAOImpl implements TokenRolesDAO {
     private static final String UPDATE_TEMPLATE =
             "UPDATE tokens_and_roles SET %s WHERE script_name=? AND resource_id=? AND resource_type=?";
 
+    /**
+     * Defense in depth (BUG-285640): the read paths that feed HTTP responses must never load the
+     * {@code token} column, so a future regression cannot leak the bearer secret even if a Jackson
+     * annotation is dropped or a new endpoint forgets to redact.
+     */
+    private static final String SAFE_COLUMNS =
+            "script_name, resource_id, resource_type, role, expire_date";
+
+    // GET_BY_TOKEN is the authentication lookup path used by TeletraanScriptTokenProvider; it must
+    // select the token column to match the presented bearer credential against the stored value.
     private static final String GET_BY_TOKEN = "SELECT * FROM tokens_and_roles WHERE token=?";
 
     private static final String GET_BY_RESOURCE =
-            "SELECT * FROM tokens_and_roles WHERE resource_id=? AND resource_type=? ORDER BY script_name";
+            "SELECT "
+                    + SAFE_COLUMNS
+                    + " FROM tokens_and_roles WHERE resource_id=? AND resource_type=? ORDER BY script_name";
 
     private static final String GET_BY_NAME_AND_RESOURCE =
-            "SELECT * FROM tokens_and_roles WHERE script_name =? AND resource_id=? AND resource_type=?";
+            "SELECT "
+                    + SAFE_COLUMNS
+                    + " FROM tokens_and_roles WHERE script_name=? AND resource_id=? AND resource_type=?";
 
     private BasicDataSource dataSource;
 

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/bean/TokenRolesBeanTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/bean/TokenRolesBeanTest.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2016-2026 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.deployservice.bean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pinterest.teletraan.universal.security.bean.AuthZResource;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression coverage for BUG-285640.
+ *
+ * <p>The {@code token} field on {@link TokenRolesBean} carries a bearer secret that the auth filter
+ * compares verbatim. It must never appear in any HTTP response (only the one-shot {@link
+ * CreatedTokenRolesResponse} returned by the creation endpoint may include it) and must never leak
+ * into log output via {@code toString()}.
+ */
+public class TokenRolesBeanTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static TokenRolesBean populatedBean() {
+        TokenRolesBean bean = new TokenRolesBean();
+        bean.setScript_name("ci-runner");
+        bean.setResource_id("test-env");
+        bean.setResource_type(AuthZResource.Type.ENV);
+        bean.setRole(TeletraanPrincipalRole.OPERATOR);
+        bean.setExpire_date(1_700_000_000_000L);
+        bean.setToken("super-secret-bearer-value");
+        return bean;
+    }
+
+    @Test
+    void tokenIsNeverSerializedToJson() throws Exception {
+        String json = MAPPER.writeValueAsString(populatedBean());
+        JsonNode root = MAPPER.readTree(json);
+
+        assertFalse(
+                root.has("token"),
+                "TokenRolesBean must not serialize the `token` field; got: " + json);
+        assertFalse(
+                json.contains("super-secret-bearer-value"),
+                "Raw token value leaked into JSON: " + json);
+
+        // The other fields must continue to serialize as before, so we don't break clients.
+        assertEquals("ci-runner", root.path("name").asText());
+        assertEquals("test-env", root.path("resource").asText());
+        assertEquals("ENV", root.path("type").asText());
+        assertEquals("OPERATOR", root.path("role").asText());
+        assertEquals(1_700_000_000_000L, root.path("expireDate").asLong());
+    }
+
+    @Test
+    void tokenCanStillBeDeserializedFromInboundJson() throws Exception {
+        String inbound =
+                "{\"name\":\"ci-runner\",\"resource\":\"test-env\",\"type\":\"ENV\","
+                        + "\"role\":\"OPERATOR\",\"token\":\"inbound-secret\","
+                        + "\"expireDate\":1700000000000}";
+
+        TokenRolesBean bean = MAPPER.readValue(inbound, TokenRolesBean.class);
+
+        // Deserialization remains symmetric so existing service-internal code paths
+        // (e.g. PUT update flows) keep working; only the serialization side is redacted.
+        assertEquals("ci-runner", bean.getScript_name());
+        assertEquals("inbound-secret", bean.getToken());
+        assertEquals(TeletraanPrincipalRole.OPERATOR, bean.getRole());
+    }
+
+    @Test
+    void toStringDoesNotIncludeTheTokenValue() {
+        String rendered = populatedBean().toString();
+
+        // ReflectionToStringBuilder formats every included field as "<name>=<value>", so the
+        // sentinel "token=" is what we look for. We can't blanket-ban the substring "token"
+        // because the class name itself (TokenRolesBean) contains it.
+        assertFalse(
+                rendered.contains("token="),
+                "toString() must not include the token field; got: " + rendered);
+        assertFalse(
+                rendered.contains("super-secret-bearer-value"),
+                "Raw token value leaked into toString(): " + rendered);
+        // Non-secret fields should still be present so log output remains useful.
+        assertTrue(rendered.contains("ci-runner"));
+        assertTrue(rendered.contains("test-env"));
+        assertTrue(rendered.contains("OPERATOR"));
+    }
+
+    @Test
+    void createdTokenRolesResponseDoesExposeTokenExactlyOnce() throws Exception {
+        String json =
+                MAPPER.writeValueAsString(
+                        new CreatedTokenRolesResponse(populatedBean(), "fresh-bearer"));
+        JsonNode root = MAPPER.readTree(json);
+
+        assertEquals("fresh-bearer", root.path("token").asText());
+        assertEquals("ci-runner", root.path("name").asText());
+        assertEquals("ENV", root.path("type").asText());
+        assertEquals("OPERATOR", root.path("role").asText());
+    }
+}

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/db/DBDAOTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/db/DBDAOTest.java
@@ -1111,6 +1111,21 @@ public class DBDAOTest {
         TokenRolesBean bean2 =
                 tokenRolesDAO.getByNameAndResource("test", "envTest", AuthZResource.Type.ENV);
         assertEquals(bean2.getRole(), TeletraanPrincipalRole.ADMIN);
+
+        // BUG-285640: read paths that feed HTTP responses must not load the token column.
+        assertNull(bean2.getToken());
+        List<TokenRolesBean> byResource =
+                tokenRolesDAO.getByResource("envTest", AuthZResource.Type.ENV);
+        assertEquals(1, byResource.size());
+        assertNull(byResource.get(0).getToken());
+        assertEquals("test", byResource.get(0).getScript_name());
+
+        // The authentication lookup path (used by TeletraanScriptTokenProvider) must still return
+        // the token so that bearer-credential comparison continues to work.
+        TokenRolesBean byToken = tokenRolesDAO.getByToken("token");
+        assertNotNull(byToken);
+        assertEquals("token", byToken.getToken());
+        assertEquals(TeletraanPrincipalRole.ADMIN, byToken.getRole());
     }
 
     @Test

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvTokenRoles.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvTokenRoles.java
@@ -29,7 +29,7 @@ import javax.validation.Valid;
 import javax.ws.rs.*;
 import javax.ws.rs.core.*;
 
-@RolesAllowed(TeletraanPrincipalRole.Names.READ)
+@RolesAllowed(TeletraanPrincipalRole.Names.MANAGE_SCRIPT_TOKEN)
 @Path("/v1/envs/{envName : [a-zA-Z0-9\\-_]+}/token_roles")
 @Api(value = "Script Tokens")
 @Produces(MediaType.APPLICATION_JSON)
@@ -41,13 +41,19 @@ public class EnvTokenRoles extends TokenRoles {
         super(context);
     }
 
+    // BUG-285640: All endpoints (read AND mutate) require MANAGE_SCRIPT_TOKEN. Script-token
+    // metadata
+    // (script name, role, expiry) is sensitive, and the bearer secret itself can be re-issued via
+    // create/update/delete; both surfaces must be restricted to admin/envOwner principals only.
+    // MANAGE_SCRIPT_TOKEN is granted by exactly two Pastis roles (admin, envOwner); legacyOperator,
+    // envMember, deployer, and reader do not receive it.
     @GET
     @ApiOperation(
             value = "Get environment TokenRoles objects",
             notes = "Returns all the TokenRoles objects for a given environment.",
             response = TokenRolesBean.class,
             responseContainer = "List")
-    @RolesAllowed(TeletraanPrincipalRole.Names.READ)
+    @RolesAllowed(TeletraanPrincipalRole.Names.MANAGE_SCRIPT_TOKEN)
     @ResourceAuthZInfo(type = AuthZResource.Type.ENV, idLocation = ResourceAuthZInfo.Location.PATH)
     public List<TokenRolesBean> getByResource(
             @ApiParam(value = "Environment name.", required = true) @PathParam("envName")
@@ -62,7 +68,7 @@ public class EnvTokenRoles extends TokenRoles {
             value = "Get TokenRoles object by script and environment names",
             notes = "Returns a TokenRoles object given a script and environment name.",
             response = TokenRolesBean.class)
-    @RolesAllowed(TeletraanPrincipalRole.Names.READ)
+    @RolesAllowed(TeletraanPrincipalRole.Names.MANAGE_SCRIPT_TOKEN)
     @ResourceAuthZInfo(type = AuthZResource.Type.ENV, idLocation = ResourceAuthZInfo.Location.PATH)
     public TokenRolesBean getByNameAndResource(
             @ApiParam(value = "Environment name.", required = true) @PathParam("envName")
@@ -79,7 +85,7 @@ public class EnvTokenRoles extends TokenRoles {
             value = "Update an envrionment's script token",
             notes =
                     "Update a specific environment script token given environment and script names.")
-    @RolesAllowed(TeletraanPrincipalRole.Names.WRITE)
+    @RolesAllowed(TeletraanPrincipalRole.Names.MANAGE_SCRIPT_TOKEN)
     @ResourceAuthZInfo(type = AuthZResource.Type.ENV, idLocation = ResourceAuthZInfo.Location.PATH)
     public void update(
             @ApiParam(value = "Environment name.", required = true) @PathParam("envName")
@@ -97,7 +103,7 @@ public class EnvTokenRoles extends TokenRoles {
             notes =
                     "Creates an environment script token with given environment name and TokenRoles object.",
             response = Response.class)
-    @RolesAllowed(TeletraanPrincipalRole.Names.WRITE)
+    @RolesAllowed(TeletraanPrincipalRole.Names.MANAGE_SCRIPT_TOKEN)
     @ResourceAuthZInfo(type = AuthZResource.Type.ENV, idLocation = ResourceAuthZInfo.Location.PATH)
     public Response create(
             @Context UriInfo uriInfo,
@@ -113,7 +119,7 @@ public class EnvTokenRoles extends TokenRoles {
     @ApiOperation(
             value = "Delete an environment script token",
             notes = "Deletes a script token by given environment and script name.")
-    @RolesAllowed(TeletraanPrincipalRole.Names.DELETE)
+    @RolesAllowed(TeletraanPrincipalRole.Names.MANAGE_SCRIPT_TOKEN)
     @ResourceAuthZInfo(type = AuthZResource.Type.ENV, idLocation = ResourceAuthZInfo.Location.PATH)
     public void delete(
             @ApiParam(value = "Environment name.", required = true) @PathParam("envName")

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/SystemTokenRoles.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/SystemTokenRoles.java
@@ -27,7 +27,7 @@ import javax.validation.Valid;
 import javax.ws.rs.*;
 import javax.ws.rs.core.*;
 
-@RolesAllowed(TeletraanPrincipalRole.Names.READ)
+@RolesAllowed(TeletraanPrincipalRole.Names.MANAGE_SCRIPT_TOKEN)
 @Path("/v1/system/token_roles")
 @Api(tags = "Script Tokens")
 @SwaggerDefinition(
@@ -44,13 +44,18 @@ public class SystemTokenRoles extends TokenRoles {
         super(context);
     }
 
+    // BUG-285640: All endpoints (read AND mutate) require MANAGE_SCRIPT_TOKEN. Kept consistent with
+    // EnvTokenRoles even though this resource is not currently registered in TeletraanService and
+    // is therefore unreachable; if/when it is re-enabled the role guard must already be correct.
+    // MANAGE_SCRIPT_TOKEN on a SYSTEM resource is granted only by SYSTEM:* admin (groups: cdp,
+    // sre-sec).
     @GET
     @ApiOperation(
             value = "Get system script tokens",
             notes = "Returns all system TokenRoles objects",
             response = TokenRolesBean.class,
             responseContainer = "List")
-    @RolesAllowed(TeletraanPrincipalRole.Names.READ)
+    @RolesAllowed(TeletraanPrincipalRole.Names.MANAGE_SCRIPT_TOKEN)
     @ResourceAuthZInfo(type = AuthZResource.Type.SYSTEM)
     public List<TokenRolesBean> getByResource() throws Exception {
         return super.getByResource(RESOURCE_ID, RESOURCE_TYPE);
@@ -62,7 +67,7 @@ public class SystemTokenRoles extends TokenRoles {
             value = "Get system TokenRoles object by script name",
             notes = "Returns a TokenRoles object for given script name",
             response = TokenRolesBean.class)
-    @RolesAllowed(TeletraanPrincipalRole.Names.READ)
+    @RolesAllowed(TeletraanPrincipalRole.Names.MANAGE_SCRIPT_TOKEN)
     @ResourceAuthZInfo(type = AuthZResource.Type.SYSTEM)
     public TokenRolesBean getByNameAndResource(
             @ApiParam(value = "Script name.", required = true) @PathParam("scriptName")
@@ -77,7 +82,7 @@ public class SystemTokenRoles extends TokenRoles {
             value = "Update a system script token",
             notes =
                     "Updates a TokenRoles object by given script name and replacement TokenRoles object")
-    @RolesAllowed(TeletraanPrincipalRole.Names.WRITE)
+    @RolesAllowed(TeletraanPrincipalRole.Names.MANAGE_SCRIPT_TOKEN)
     @ResourceAuthZInfo(type = AuthZResource.Type.SYSTEM)
     public void update(
             @ApiParam(value = "Script name.", required = true) @PathParam("scriptName")
@@ -92,7 +97,7 @@ public class SystemTokenRoles extends TokenRoles {
             value = "Create a system script token",
             notes = "Creates a specified system wide TokenRole and returns a Response object",
             response = Response.class)
-    @RolesAllowed(TeletraanPrincipalRole.Names.WRITE)
+    @RolesAllowed(TeletraanPrincipalRole.Names.MANAGE_SCRIPT_TOKEN)
     @ResourceAuthZInfo(type = AuthZResource.Type.SYSTEM)
     public Response create(
             @Context UriInfo uriInfo,
@@ -106,7 +111,7 @@ public class SystemTokenRoles extends TokenRoles {
     @ApiOperation(
             value = "Delete a system wide script token",
             notes = "Deletes a system wide TokenRoles object by specified script name")
-    @RolesAllowed(TeletraanPrincipalRole.Names.DELETE)
+    @RolesAllowed(TeletraanPrincipalRole.Names.MANAGE_SCRIPT_TOKEN)
     @ResourceAuthZInfo(type = AuthZResource.Type.SYSTEM)
     public void delete(
             @ApiParam(value = "Script name.", required = true) @PathParam("scriptName")

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/TokenRoles.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/TokenRoles.java
@@ -15,6 +15,7 @@
  */
 package com.pinterest.teletraan.resource;
 
+import com.pinterest.deployservice.bean.CreatedTokenRolesResponse;
 import com.pinterest.deployservice.bean.TokenRolesBean;
 import com.pinterest.deployservice.common.CommonUtils;
 import com.pinterest.deployservice.dao.TokenRolesDAO;
@@ -74,15 +75,15 @@ public abstract class TokenRoles {
         bean.setResource_type(resourceType);
         bean.setExpire_date(Instant.now().plus(VALIDATE_TIME, ChronoUnit.DAYS).toEpochMilli());
         tokenRolesDAO.insert(bean);
-        bean.setToken("xxxxxxxx");
         LOG.info(
                 "Successfully created new script permission for resource {} with {}",
                 resourceId,
                 bean);
-        TokenRolesBean newBean = tokenRolesDAO.getByToken(token);
         UriBuilder ub = uriInfo.getAbsolutePathBuilder();
-        URI roleUri = ub.path(newBean.getScript_name()).build();
-        return Response.created(roleUri).entity(newBean).build();
+        URI roleUri = ub.path(bean.getScript_name()).build();
+        // BUG-285640: the raw token is disclosed exactly once, here, in the 201 Created response
+        // to the WRITE-role caller. GET endpoints redact the token field on TokenRolesBean.
+        return Response.created(roleUri).entity(new CreatedTokenRolesResponse(bean, token)).build();
     }
 
     public void delete(String scriptName, String resourceId, AuthZResource.Type resourceType)

--- a/docs/auth/teletraan_auth.yaml
+++ b/docs/auth/teletraan_auth.yaml
@@ -43,6 +43,7 @@ definitions:
       - PINGER
       - USE
       - UPDATE_EXTERNAL_ID
+      - MANAGE_SCRIPT_TOKEN
   role:
     type: object
     description: |


### PR DESCRIPTION
Previously, every script-token read path returned the raw bearer secret as part of `TokenRolesBean`. Anyone with the legacy READ role on an environment could enumerate all tokens via
`GET /v1/envs/{env}/token_roles` and impersonate the script principal, which effectively allowed privilege escalation since some tokens carry ADMIN role.

## Defense-in-depth changes:

### Backend (deploy-service)
✅ Rec #1 — Redact token on read operations
- `TokenRolesBean.token` is now `@JsonProperty(access = WRITE_ONLY)` so it is never serialized into HTTP responses. `toString()` excludes the field to keep logs and exception traces clean.

✅ Rec #2 — Elevate @RolesAllowed on GET endpoints
- New role `MANAGE_SCRIPT_TOKEN` (privilege level 15) added between OPERATOR and ADMIN. All `EnvTokenRoles` and `SystemTokenRoles` endpoints (read AND mutate) now require this role instead of READ/WRITE/DELETE. In Pastis, only `admin` and `envOwner` are granted it; `legacyOperator`, `envMember`, `deployer`, and `reader` no longer see token metadata.

✅ Rec #3 — Stop using SELECT * for token queries
- `DBTokenRolesDAOImpl` selects a `SAFE_COLUMNS` list (no `token`) for `getByResource` / `getByNameAndResource`. The authentication lookup `getByToken` still does `SELECT *` because the bearer comparison needs the column.

✅ Rec #4 — Audit the creation response
- `TokenRoles.create()` now returns a new `CreatedTokenRolesResponse` DTO that includes the raw token. This is the *only* response shape that contains the secret, and it is disclosed exactly once on the `201 Created` reply to the caller.

### Test:
- Added tests to cover token redaction at both DAO and bean levels.

### Frontend (deploy-board)
- Removed the now-broken `Show Token` button and its `get_user_token` view/URL; the backend no longer exposes the value.
- `update_users_config` captures the one-time token from each `POST /token_roles` response and returns them to the browser.
- New non-dismissible modal displays freshly minted tokens once with per-row copy-to-clipboard; values are scrubbed from the DOM on acknowledgement. Deprecation banner updated to make the one-shot disclosure model explicit.

<img width="1034" height="534" alt="Screenshot 2026-05-13 at 12 26 47 AM" src="https://github.com/user-attachments/assets/826a860d-b6df-4bcf-91eb-4bbcce6d8817" />
<img width="927" height="331" alt="Screenshot 2026-05-13 at 12 27 34 AM" src="https://github.com/user-attachments/assets/fff8e7e1-6dac-4c9a-b31d-87a27ea2618f" />

Docs
- Added `MANAGE_SCRIPT_TOKEN` to the Teletraan auth action enum so external authorizers (Pastis) accept it.