### PR TITLE
ci: declare contents:read on Deploy Agent CI workflow

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -18,6 +18,9 @@ defaults:
     shell: bash
     working-directory: ./deploy-agent
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `Deploy Agent CI` workflow currently doesn't declare a `permissions:` block, so the workflow `GITHUB_TOKEN` falls back to whatever the repository default grants. The single `build` job only runs `actions/checkout`, `actions/setup-python`, `pip install tox tox-gh-actions`, and `tox -v`. No GitHub API write, no cache plumbing.

This patch sets `permissions: contents: read` at workflow scope, matching the per-job permission blocks already declared by `codeql-analysis.yml` (`actions: read, contents: read, security-events: write`) and `labeler.yml`.

Third-party action exposure: `actions/checkout`, `actions/setup-python`. Both are first-party from `actions/*`, so the defense-in-depth argument here is less strong than for repos heavy on third-party actions, but the cost of pinning the scope is one line and the benefit (Token-Permissions check passing, scope contract documented in-file) is real.

`maven.yml` is deliberately out of scope because it uses `cache: 'maven'` in `setup-java`, which interacts with the cache-save path; that deserves a separate look.

`pre-commit.yml` is 16 lines and below the noise floor.