### PR TITLE
Bound agentless host janitor query with a configurable lookback window

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/HostDAO.java
@@ -63,7 +63,17 @@ public interface HostDAO {
 
     List<HostBean> getTerminatingHosts() throws Exception;
 
-    List<String> getStaleAgentlessHostIds(long lastUpdateBefore, int limit) throws SQLException;
+    /**
+     * Return ids of hosts whose {@code last_update} falls within the half-open window {@code
+     * (lastUpdateAfter, lastUpdateBefore)} and that have no row in {@code hosts_and_agents}.
+     *
+     * <p>The lower bound exists to prevent the underlying index range scan from walking the entire
+     * historical {@code hosts} table; agentless hosts older than the lower bound are persistently
+     * broken and re-finding them on every cycle adds DB load without changing behavior. Pass {@code
+     * 0} for {@code lastUpdateAfter} to disable the lower bound.
+     */
+    List<String> getStaleAgentlessHostIds(long lastUpdateBefore, long lastUpdateAfter, int limit)
+            throws SQLException;
 
     List<HostBean> getAgentlessHosts(long lastUpdateAfter, int limit) throws SQLException;
 

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBHostDAOImpl.java
@@ -70,7 +70,7 @@ public class DBHostDAOImpl implements HostDAO {
     private static final String GET_GROUP_NAMES_BY_HOST =
             "SELECT group_name FROM hosts WHERE host_name=?";
     private static final String GET_STALE_AGENTLESS_HOST_IDS =
-            "SELECT DISTINCT hosts.host_id FROM hosts LEFT JOIN hosts_and_agents ON hosts.host_id = hosts_and_agents.host_id WHERE hosts.last_update < ? AND hosts_and_agents.host_id IS NULL ORDER BY hosts.last_update DESC LIMIT ?";
+            "SELECT DISTINCT hosts.host_id FROM hosts LEFT JOIN hosts_and_agents ON hosts.host_id = hosts_and_agents.host_id WHERE hosts.last_update < ? AND hosts.last_update > ? AND hosts_and_agents.host_id IS NULL ORDER BY hosts.last_update DESC LIMIT ?";
     private static final String GET_AGENTLESS_HOSTS =
             "SELECT hosts.* FROM hosts LEFT JOIN hosts_and_agents ON hosts.host_id = hosts_and_agents.host_id WHERE hosts.last_update > ? AND hosts_and_agents.host_id IS NULL ORDER BY hosts.last_update DESC LIMIT ?";
     private static final String GET_HOST_NAMES_BY_GROUP =
@@ -280,13 +280,14 @@ public class DBHostDAOImpl implements HostDAO {
     }
 
     @Override
-    public List<String> getStaleAgentlessHostIds(long lastUpdateBefore, int limit)
-            throws SQLException {
+    public List<String> getStaleAgentlessHostIds(
+            long lastUpdateBefore, long lastUpdateAfter, int limit) throws SQLException {
         return new QueryRunner(dataSource)
                 .query(
                         GET_STALE_AGENTLESS_HOST_IDS,
                         SingleResultSetHandlerFactory.<String>newListObjectHandler(),
                         lastUpdateBefore,
+                        lastUpdateAfter,
                         limit);
     }
 

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/ConfigHelper.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/ConfigHelper.java
@@ -106,6 +106,7 @@ public class ConfigHelper {
     private static final int DEFAULT_MAX_STALE_HOST_THRESHOLD_SECONDS = 600; // 10 min
     private static final int DEFAULT_MIN_STALE_HOST_THRESHOLD_SECONDS = 150; // 2.5 min
     private static final int DEFAULT_LAUNCH_LATENCY_THRESHOLD_SECONDS = 600;
+    private static final int DEFAULT_AGENTLESS_HOST_LOOKBACK_THRESHOLD_SECONDS = 86400; // 1 day
     private static final String DEFAULT_DEPLOY_JANITOR_SCHEDULE = "0 30 3 * * ?";
     private static final String DEFAULT_BUILD_JANITOR_SCHEDULE = "0 40 3 * * ?";
     private static final int DEFAULT_MAX_DAYS_TO_KEEP = 180;
@@ -358,12 +359,18 @@ public class ConfigHelper {
                                 properties,
                                 "maxLaunchLatencyThreshold",
                                 DEFAULT_LAUNCH_LATENCY_THRESHOLD_SECONDS);
+                int agentlessHostLookbackThreshold =
+                        MapUtils.getIntValue(
+                                properties,
+                                "agentlessHostLookbackThreshold",
+                                DEFAULT_AGENTLESS_HOST_LOOKBACK_THRESHOLD_SECONDS);
                 Runnable worker =
                         new AgentJanitor(
                                 serviceContext,
                                 minStaleHostThreshold,
                                 maxStaleHostThreshold,
-                                maxLaunchLatencyThreshold);
+                                maxLaunchLatencyThreshold,
+                                agentlessHostLookbackThreshold);
                 scheduler.scheduleAtFixedRate(worker, initDelay, period, TimeUnit.SECONDS);
                 LOG.info("Scheduled AgentJanitor.");
             }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AgentJanitor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AgentJanitor.java
@@ -56,6 +56,7 @@ public class AgentJanitor implements Runnable {
             WorkerTimerFactory.createWorkerTimer(AgentJanitor.class);
     private final RodimusManager rodimusManager;
     private final long maxLaunchLatencyThreshold;
+    private final long agentlessHostLookbackThreshold;
     private final long absoluteThreshold = TimeUnit.DAYS.toMillis(7);
     private final int agentlessHostBatchSize = 300;
     private final AtomicInteger unreachableHostsCount;
@@ -74,7 +75,8 @@ public class AgentJanitor implements Runnable {
             ServiceContext serviceContext,
             int minStaleHostThresholdSeconds,
             int maxStaleHostThresholdSeconds,
-            int maxLaunchLatencyThresholdSeconds) {
+            int maxLaunchLatencyThresholdSeconds,
+            int agentlessHostLookbackThresholdSeconds) {
         agentDAO = serviceContext.getAgentDAO();
         hostDAO = serviceContext.getHostDAO();
         hostAgentDAO = serviceContext.getHostAgentDAO();
@@ -83,6 +85,8 @@ public class AgentJanitor implements Runnable {
         this.maxStaleHostThreshold = maxStaleHostThresholdSeconds * 1000;
         this.minStaleHostThreshold = minStaleHostThresholdSeconds * 1000;
         maxLaunchLatencyThreshold = TimeUnit.SECONDS.toMillis(maxLaunchLatencyThresholdSeconds);
+        agentlessHostLookbackThreshold =
+                TimeUnit.SECONDS.toMillis(agentlessHostLookbackThresholdSeconds);
         unreachableHostsCount = Metrics.gauge("unreachable_hosts", new AtomicInteger(0));
         staleHostsCount = Metrics.gauge("stale_hosts", new AtomicInteger(0));
 
@@ -277,13 +281,24 @@ public class AgentJanitor implements Runnable {
      * <p>If a host is directly added to Teletraan, there will be no agent associated with it
      * immediately. Hosts may stuck in this state so we should clean up here. We wait 10x
      * maxLaunchLatencyThreshold before doing cleanup.
+     *
+     * <p>The query is bounded below by {@code agentlessHostLookbackThreshold} so the underlying
+     * range scan does not walk the entire historical {@code hosts} table. Hosts older than the
+     * lookback are persistently broken — Rodimus reports them as still running on every cycle and
+     * the janitor takes no action — so excluding them does not change observable behavior. A
+     * value of 0 disables the lower bound.
      */
     private void cleanUpAgentlessHosts() {
         long noUpdateSince = janitorStartTime - 10 * maxLaunchLatencyThreshold;
+        long lookbackFloor =
+                agentlessHostLookbackThreshold > 0
+                        ? janitorStartTime - agentlessHostLookbackThreshold
+                        : 0;
         List<String> agentlessHosts;
         try {
             agentlessHosts =
-                    hostDAO.getStaleAgentlessHostIds(noUpdateSince, agentlessHostBatchSize);
+                    hostDAO.getStaleAgentlessHostIds(
+                            noUpdateSince, lookbackFloor, agentlessHostBatchSize);
         } catch (SQLException ex) {
             LOG.error("failed to get agentless hosts", ex);
             errorBudgetFailure.increment();

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AgentJanitor.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/worker/AgentJanitor.java
@@ -285,8 +285,8 @@ public class AgentJanitor implements Runnable {
      * <p>The query is bounded below by {@code agentlessHostLookbackThreshold} so the underlying
      * range scan does not walk the entire historical {@code hosts} table. Hosts older than the
      * lookback are persistently broken — Rodimus reports them as still running on every cycle and
-     * the janitor takes no action — so excluding them does not change observable behavior. A
-     * value of 0 disables the lower bound.
+     * the janitor takes no action — so excluding them does not change observable behavior. A value
+     * of 0 disables the lower bound.
      */
     private void cleanUpAgentlessHosts() {
         long noUpdateSince = janitorStartTime - 10 * maxLaunchLatencyThreshold;

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/worker/AgentJanitorTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/worker/AgentJanitorTest.java
@@ -16,6 +16,7 @@
 package com.pinterest.teletraan.worker;
 
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.longThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.eq;
@@ -36,6 +37,7 @@ import com.pinterest.deployservice.dao.HostTagDAO;
 import com.pinterest.deployservice.rodimus.RodimusManager;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -54,6 +56,7 @@ public class AgentJanitorTest {
     private final int maxStaleHostThresholdSeconds = 150;
     private final int minStaleHostThresholdSeconds = 600;
     private final int maxLaunchLatencyThresholdSeconds = 600;
+    private final int agentlessHostLookbackThresholdSeconds = 86400;
 
     @BeforeAll
     public static void setUpClass() {
@@ -80,7 +83,8 @@ public class AgentJanitorTest {
                         serviceContext,
                         minStaleHostThresholdSeconds,
                         maxStaleHostThresholdSeconds,
-                        maxLaunchLatencyThresholdSeconds);
+                        maxLaunchLatencyThresholdSeconds,
+                        agentlessHostLookbackThresholdSeconds);
     }
 
     @AfterEach
@@ -177,7 +181,7 @@ public class AgentJanitorTest {
         // Set up mock data
         HostAgentBean hostAgentBean = createHostAgentBean();
         String hostId = hostAgentBean.getHost_id();
-        when(hostDAO.getStaleAgentlessHostIds(anyLong(), eq(300)))
+        when(hostDAO.getStaleAgentlessHostIds(anyLong(), anyLong(), eq(300)))
                 .thenReturn(ImmutableList.of(hostId));
         when(rodimusManager.getTerminatedHosts(eq(ImmutableList.of(hostId))))
                 .thenReturn(ImmutableSet.of(hostId));
@@ -191,6 +195,42 @@ public class AgentJanitorTest {
         verify(hostAgentDAO, times(1)).delete(eq(hostId));
         verify(hostDAO, times(1)).deleteAllById(eq(hostId));
         verify(agentDAO, times(0)).updateAgentById(any(), any());
+    }
+
+    @Test
+    public void testCleanUpAgentlessHosts_lookbackBoundsApplied() throws Exception {
+        // Verify the configured lookback is applied as a non-zero lower bound and the upper bound
+        // is strictly greater than the lower bound.
+        long beforeRun = System.currentTimeMillis();
+        long lookbackMs = TimeUnit.SECONDS.toMillis(agentlessHostLookbackThresholdSeconds);
+        when(hostDAO.getStaleAgentlessHostIds(anyLong(), anyLong(), eq(300)))
+                .thenReturn(ImmutableList.of());
+
+        agentJanitor.run();
+
+        verify(hostDAO, times(1))
+                .getStaleAgentlessHostIds(
+                        longThat(upper -> upper > 0 && upper <= System.currentTimeMillis()),
+                        longThat(lower -> lower >= beforeRun - lookbackMs - 1000 && lower > 0),
+                        eq(300));
+    }
+
+    @Test
+    public void testCleanUpAgentlessHosts_lookbackDisabled() throws Exception {
+        // When configured to 0 the lower bound should be 0 (disabled).
+        AgentJanitor janitorNoLookback =
+                new AgentJanitor(
+                        serviceContext,
+                        minStaleHostThresholdSeconds,
+                        maxStaleHostThresholdSeconds,
+                        maxLaunchLatencyThresholdSeconds,
+                        0);
+        when(hostDAO.getStaleAgentlessHostIds(anyLong(), anyLong(), eq(300)))
+                .thenReturn(ImmutableList.of());
+
+        janitorNoLookback.run();
+
+        verify(hostDAO, times(1)).getStaleAgentlessHostIds(anyLong(), eq(0L), eq(300));
     }
 
     private HostAgentBean createHostAgentBean() {


### PR DESCRIPTION
  ## Summary

  `AgentJanitor.cleanUpAgentlessHosts()` issues a query against `hosts` LEFT JOIN `hosts_and_agents` filtered only by `last_update < (now − 10 × maxLaunchLatency)`. Because per-ping writes touch `hosts_and_agents.last_update` (not
  `hosts.last_update`), that predicate matches the bulk of the `hosts` table — `EXPLAIN ANALYZE` on prod showed **2.58s + 1.49M PK probes against `hosts_and_agents` to return ~3 rows**, every cycle, on every worker.

  The PR adds a configurable lower bound (`agentlessHostLookbackThreshold`, default **1 day**) so the underlying index range scan walks a narrow window instead of the entire historical table.

  ```sql
  SELECT DISTINCT hosts.host_id
  FROM hosts LEFT JOIN hosts_and_agents ON hosts.host_id = hosts_and_agents.host_id
  WHERE hosts.last_update < ?    -- existing upper bound
    AND hosts.last_update > ?    -- NEW: configurable lower bound
    AND hosts_and_agents.host_id IS NULL
  ORDER BY hosts.last_update DESC
  LIMIT ?
```

  Why this is safe

  cleanUpAgentlessHosts was introduced in #1217 (CDP-6636) specifically to clean up hosts that never had an agent — by definition a recent failure. Hosts older than the lookback fall into one of two categories, both already mishandled today:

  1. Rodimus reports them as still running → existing code logs "Agentless host {} is stale but might be running" and leaves the row forever; the next cycle re-finds the same row.
  2. Host was actually terminated → hostHandler.removeHost(id) already cleaned the hosts row.

  Excluding them therefore does not change observable behavior. Set the threshold to 0 to disable the lower bound and restore the old query.

  Configuration

  Default is 1 day. Override per environment in the worker yaml:
```
  - name: AgentJanitor
    properties:
      initialDelay: 30
      period: 300
      minStaleHostThreshold: 150
      maxStaleHostThreshold: 600
      agentlessHostLookbackThreshold: 86400  # optional; default 1 day
```

  Test plan

  - [ ] mvn -pl deploy-service/teletraanservice test -Dtest=AgentJanitorTest (3 new/updated cases: existing host-removed flow, lower-bound-applied, lower-bound-disabled)
  - [ ] mvn -pl deploy-service/common test (DAO signature change compiles, existing tests pass)
  - [ ] Deploy to staging; confirm worker logs "Start agent janitor process..." and that prod-equivalent queries on staging show range scan over the windowed predicate
  - [ ] Verify on dev1/staging that the worker_timer micrometer Timer (added in #1870) decreases for AgentJanitor
  - [ ] Production: monitor teletraandb DB CPU and AgentJanitor worker timing post-deploy

  CDP-11575