### PR TITLE
adding sox permission

### DIFF
--- a/deploy-service/universal/pom.xml
+++ b/deploy-service/universal/pom.xml
@@ -182,6 +182,8 @@
                 <argument>${source_dir}/${project.build.finalName}-sources.jar</argument>
                 <argument>--to_repo</argument>
                 <argument>maven-private-prod-sox-local</argument>
+                <argument>--usage</argument>
+                <argument>buildkite_publish_sox</argument>
               </arguments>
             </configuration>
           </execution>


### PR DESCRIPTION
## Summary
Adding the `--usage buildkite_publish_sox` argument to the artifactory-push invocation in deploy-service/universal/pom.xml.

The `artifactory-push` tool uses the `--usage` flag to identify which Buildkite pipeline is calling it, which in turn maps to a specific permission set. Previously, this call had no `--usage` flag, meaning it would fall back to a default (non-SOX) permission context when publishing the universal artifact to `maven-private-prod-sox-local`.

By explicitly setting `--usage buildkite_publish_sox`, this change ensures the publish step runs under the correct SOX-scoped Buildkite permissions, separating SOX artifact publishing from non-SOX publishing. This is required to comply with access control requirements tracked in CIP-10107.

## Testing
This change only affects the internal Buildkite publish pipeline. No functional logic changes, validated by confirming the mvn deploy phase invokes `artifactory-push` with the correct arguments.

<img width="1457" height="452" alt="Screenshot 2026-06-24 at 3 32 19 PM" src="https://github.com/user-attachments/assets/d7d265fd-40d7-453a-96e8-f9e7c1459f77" />

