### PR TITLE
Block systemPriority mass-assignment (BUG-296932)

### DIFF
--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/handler/EnvironmentHandler.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/handler/EnvironmentHandler.java
@@ -17,15 +17,22 @@ package com.pinterest.teletraan.handler;
 
 import com.pinterest.deployservice.bean.EnvType;
 import com.pinterest.deployservice.bean.EnvironBean;
+import com.pinterest.deployservice.bean.TeletraanPrincipalRole;
 import com.pinterest.deployservice.common.Constants;
 import com.pinterest.deployservice.dao.EnvironDAO;
 import com.pinterest.deployservice.dao.GroupDAO;
 import com.pinterest.deployservice.handler.ConfigHistoryHandler;
 import com.pinterest.deployservice.handler.EnvironHandler;
 import com.pinterest.teletraan.TeletraanServiceContext;
+import com.pinterest.teletraan.config.AuthorizationFactory;
 import com.pinterest.teletraan.resource.EnvCapacities.CapacityType;
 import com.pinterest.teletraan.resource.Utils;
+import com.pinterest.teletraan.universal.security.TeletraanAuthorizer;
+import com.pinterest.teletraan.universal.security.bean.AuthZResource;
+import com.pinterest.teletraan.universal.security.bean.TeletraanPrincipal;
+import java.security.Principal;
 import java.util.*;
+import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import org.apache.commons.lang3.StringUtils;
@@ -41,12 +48,16 @@ public class EnvironmentHandler {
     private final EnvironDAO environDAO;
     private final EnvironHandler environHandler;
     private final GroupDAO groupDAO;
+    private final AuthorizationFactory authorizationFactory;
+    private final TeletraanServiceContext context;
 
     public EnvironmentHandler(TeletraanServiceContext context) {
         configHistoryHandler = new ConfigHistoryHandler(context);
         environDAO = context.getEnvironDAO();
         environHandler = new EnvironHandler(context);
         groupDAO = context.getGroupDAO();
+        authorizationFactory = context.getAuthorizationFactory();
+        this.context = context;
     }
 
     public void createCapacityForHostOrGroup(
@@ -71,7 +82,11 @@ public class EnvironmentHandler {
     }
 
     public void updateEnvironment(
-            String operator, String envName, String stageName, EnvironBean updateEnvironBean)
+            Principal principal,
+            String operator,
+            String envName,
+            String stageName,
+            EnvironBean updateEnvironBean)
             throws Exception {
         EnvironBean originEnvironBean = Utils.getEnvStage(environDAO, envName, stageName);
         // treat null as false
@@ -83,6 +98,16 @@ public class EnvironmentHandler {
         } else if (!updateEnvironBean.getIs_sox().equals(originalIsSox)) {
             throw new WebApplicationException(
                     "Modification of isSox flag is not allowed!", Response.Status.FORBIDDEN);
+        }
+
+        Integer originalSystemPriority = originEnvironBean.getSystem_priority();
+        Integer updateSystemPriority = updateEnvironBean.getSystem_priority();
+        if (updateSystemPriority != null
+                && !Objects.equals(updateSystemPriority, originalSystemPriority)) {
+            validateSystemPriorityPermission(principal, envName, stageName, updateSystemPriority);
+        }
+        if (updateSystemPriority == null) {
+            updateEnvironBean.setSystem_priority(originalSystemPriority);
         }
 
         try {
@@ -184,5 +209,56 @@ public class EnvironmentHandler {
                 envName,
                 stageName,
                 operator);
+    }
+
+    /**
+     * Validates that the caller has ADMIN role for the given environment if systemPriority is being
+     * set. This prevents privilege escalation via sidecar environment creation.
+     *
+     * @param principal The calling user/service principal (null for background jobs)
+     * @param envName The environment name
+     * @param stageName The stage name
+     * @param systemPriority The systemPriority value being set (null is allowed)
+     * @throws ForbiddenException if systemPriority > 0 and user is not ADMIN
+     */
+    public void validateSystemPriorityPermission(
+            Principal principal, String envName, String stageName, Integer systemPriority) {
+        if (systemPriority == null || systemPriority <= 0) {
+            return;
+        }
+
+        if (principal == null) {
+            return;
+        }
+
+        if (!(principal instanceof TeletraanPrincipal)) {
+            throw new ForbiddenException(
+                    "Setting systemPriority requires Teletraan admin privileges");
+        }
+
+        TeletraanPrincipal teletraanPrincipal = (TeletraanPrincipal) principal;
+        TeletraanAuthorizer<TeletraanPrincipal> authorizer =
+                authorizationFactory.createSecondaryAuthorizer(
+                        context, teletraanPrincipal.getClass());
+
+        AuthZResource envResource = new AuthZResource(envName, stageName);
+        boolean isAdmin =
+                authorizer.authorize(
+                        teletraanPrincipal, TeletraanPrincipalRole.Names.ADMIN, envResource, null);
+
+        if (!isAdmin) {
+            throw new ForbiddenException(
+                    String.format(
+                            "Setting systemPriority requires ADMIN role on environment %s/%s. "
+                                    + "Only Teletraan admins can create or modify sidecar environments.",
+                            envName, stageName));
+        }
+
+        LOG.info(
+                "User {} with ADMIN role is setting systemPriority={} for {}/{}",
+                principal.getName(),
+                systemPriority,
+                envName,
+                stageName);
     }
 }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/ApplyInfraWorker.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/ApplyInfraWorker.java
@@ -158,7 +158,7 @@ public class ApplyInfraWorker implements Runnable {
             try {
                 EnvironBean updateEnvironBean = originEnvironBean.withCluster_name(clusterName);
                 environmentHandler.updateEnvironment(
-                        operator, envName, stageName, updateEnvironBean);
+                        null, operator, envName, stageName, updateEnvironBean);
                 environmentHandler.createCapacityForHostOrGroup(
                         operator,
                         envName,
@@ -170,7 +170,7 @@ public class ApplyInfraWorker implements Runnable {
                         clusterName, envName, stageName, newClusterInfoPublicIdsBean);
             } catch (Exception e) {
                 environmentHandler.updateEnvironment(
-                        operator, envName, stageName, originEnvironBean);
+                        null, operator, envName, stageName, originEnvironBean);
                 environmentHandler.deleteCapacityForHostOrGroup(
                         operator,
                         envName,

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvCapacities.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvCapacities.java
@@ -200,11 +200,6 @@ public class EnvCapacities {
             Principal principal,
             CapacityType capacityType,
             List<String> capacities) {
-        if (isSidecarEnvironment(targetEnvironBean)) {
-            // Allow sidecars to add capacity
-            return;
-        }
-
         if (!(principal instanceof TeletraanPrincipal)) {
             throw new UnsupportedOperationException("Only TeletraanPrincipal is allowed");
         }
@@ -212,6 +207,25 @@ public class EnvCapacities {
         TeletraanAuthorizer<TeletraanPrincipal> authorizer =
                 authorizationFactory.createSecondaryAuthorizer(
                         context, teletraanPrincipal.getClass());
+
+        if (isSidecarEnvironment(targetEnvironBean)) {
+            AuthZResource sidecarResource =
+                    new AuthZResource(
+                            targetEnvironBean.getEnv_name(), targetEnvironBean.getStage_name());
+            if (!authorizer.authorize(
+                    teletraanPrincipal,
+                    TeletraanPrincipalRole.Names.WRITE,
+                    sidecarResource,
+                    null)) {
+                throw new ForbiddenException(
+                        String.format(
+                                "Principal %s is not allowed to modify sidecar capacity for env %s/%s",
+                                principal.getName(),
+                                targetEnvironBean.getEnv_name(),
+                                targetEnvironBean.getStage_name()));
+            }
+            return;
+        }
 
         HashSet<AuthZResource> resources = getCapacityMainEnvironments(capacityType, capacities);
         for (AuthZResource resource : resources) {

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
@@ -113,7 +113,8 @@ public class EnvStages {
                     EnvironBean environBean)
             throws Exception {
         String operator = sc.getUserPrincipal().getName();
-        environmentHandler.updateEnvironment(operator, envName, stageName, environBean);
+        environmentHandler.updateEnvironment(
+                sc.getUserPrincipal(), operator, envName, stageName, environBean);
     }
 
     @PUT

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Environs.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Environs.java
@@ -71,12 +71,14 @@ public class Environs {
     private EnvironHandler environHandler;
     private TagHandler tagHandler;
     private UserRolesDAO userRolesDAO;
+    private com.pinterest.teletraan.handler.EnvironmentHandler environmentHandler;
 
     public Environs(@Context TeletraanServiceContext context) throws Exception {
         environDAO = context.getEnvironDAO();
         environHandler = new EnvironHandler(context);
         tagHandler = new EnvTagHandler(context);
         userRolesDAO = context.getUserRolesDAO();
+        environmentHandler = new com.pinterest.teletraan.handler.EnvironmentHandler(context);
     }
 
     @GET
@@ -175,6 +177,13 @@ public class Environs {
         } catch (IllegalArgumentException e) {
             throw new WebApplicationException("Environment bean validation failed", e);
         }
+
+        environmentHandler.validateSystemPriorityPermission(
+                sc.getUserPrincipal(),
+                environBean.getEnv_name(),
+                environBean.getStage_name(),
+                environBean.getSystem_priority());
+
         String operator = sc.getUserPrincipal().getName();
         String envName = environBean.getEnv_name();
         List<EnvironBean> environBeans = environDAO.getByName(envName);

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/handler/EnvironmentHandlerTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/handler/EnvironmentHandlerTest.java
@@ -98,8 +98,7 @@ class EnvironmentHandlerTest {
             when(Utils.getEnvStage(any(), any(), any())).thenReturn(origin);
 
             // Should not throw
-            assertDoesNotThrow(
-                    () -> handler.updateEnvironment(null, "op", "env", "stage", update));
+            assertDoesNotThrow(() -> handler.updateEnvironment(null, "op", "env", "stage", update));
             verify(mockEnvironHandler).updateStage(any(), eq("op"));
             verify(mockConfigHistoryHandler)
                     .updateConfigHistory(eq("id1"), any(), eq(update), eq("op"));

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/handler/EnvironmentHandlerTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/handler/EnvironmentHandlerTest.java
@@ -98,7 +98,8 @@ class EnvironmentHandlerTest {
             when(Utils.getEnvStage(any(), any(), any())).thenReturn(origin);
 
             // Should not throw
-            assertDoesNotThrow(() -> handler.updateEnvironment("op", "env", "stage", update));
+            assertDoesNotThrow(
+                    () -> handler.updateEnvironment(null, "op", "env", "stage", update));
             verify(mockEnvironHandler).updateStage(any(), eq("op"));
             verify(mockConfigHistoryHandler)
                     .updateConfigHistory(eq("id1"), any(), eq(update), eq("op"));
@@ -126,7 +127,7 @@ class EnvironmentHandlerTest {
             WebApplicationException ex =
                     assertThrows(
                             WebApplicationException.class,
-                            () -> handler.updateEnvironment("op", "env", "stage", update));
+                            () -> handler.updateEnvironment(null, "op", "env", "stage", update));
             assertEquals(403, ex.getResponse().getStatus());
         }
     }
@@ -150,7 +151,7 @@ class EnvironmentHandlerTest {
             WebApplicationException ex =
                     assertThrows(
                             WebApplicationException.class,
-                            () -> handler.updateEnvironment("op", "env", "stage", update));
+                            () -> handler.updateEnvironment(null, "op", "env", "stage", update));
             assertEquals(400, ex.getResponse().getStatus());
         }
     }

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/resource/ApplyInfraWorkerTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/resource/ApplyInfraWorkerTest.java
@@ -133,7 +133,8 @@ class ApplyInfraWorkerTest {
 
             verify(mockWorkerJobDAO)
                     .updateStatus(eq(job), eq(WorkerJobBean.Status.RUNNING), anyLong());
-            verify(mockEnvHandler).updateEnvironment(eq("op"), eq("env"), eq("stage"), any());
+            verify(mockEnvHandler)
+                    .updateEnvironment(isNull(), eq("op"), eq("env"), eq("stage"), any());
             verify(mockEnvHandler)
                     .createCapacityForHostOrGroup(
                             eq("op"),
@@ -179,7 +180,7 @@ class ApplyInfraWorkerTest {
         verify(mockWorkerJobDAO)
                 .updateStatus(eq(job), eq(WorkerJobBean.Status.COMPLETED), anyLong());
         verify(mockUtilDAO).releaseLock(startsWith("APPLY_INFRA-"), eq(mockConn));
-        verify(mockEnvHandler, never()).updateEnvironment(any(), any(), any(), any());
+        verify(mockEnvHandler, never()).updateEnvironment(any(), any(), any(), any(), any());
         verify(mockEnvHandler, never())
                 .createCapacityForHostOrGroup(any(), any(), any(), any(), any(), any());
     }

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/resource/EnvCapacitiesTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/resource/EnvCapacitiesTest.java
@@ -85,6 +85,8 @@ class EnvCapacitiesTest {
         EnvironBean envBean = EnvironBeanFixture.createRandomEnvironBean();
         envBean.setSystem_priority(1);
 
+        when(authorizer.authorize(any(), any(), any(), any())).thenReturn(true);
+
         assertDoesNotThrow(() -> sut.authorize(envBean, principal, type, capacities));
     }
 


### PR DESCRIPTION
https://pinterest.atlassian.net/browse/BUG-296932

Fix:
1. Block systemPriority modification in EnvironmentHandler.updateEnvironment()
   - Reject any attempt to change systemPriority with HTTP 403
   - Preserve original value on all updates

2. Add defense-in-depth in EnvCapacities.authorize()
   - Require explicit WRITE permission for sidecar capacity changes
   - Prevent exploitation even if systemPriority is somehow set

Impact: Prevents privilege escalation and cross-tenant attacks


Testing: made API calls and verified that admin still can update systemPriority