### PR TITLE
Derive env useEntitlements from entitlement kill switch + rollout config

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/EntitlementEnforcementProvider.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/EntitlementEnforcementProvider.java
@@ -1,0 +1,179 @@
+/**
+ * Copyright (c) 2016-2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.deployservice.common;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pinterest.deployservice.bean.EnvironBean;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Two-layer gate deciding whether a Teletraan cluster ({@code "<env>-<stage>"}) has its capacity
+ * governed by entitlements. It is the source of truth for the {@code useEntitlements} state
+ * surfaced to the UI (capacity fields greyed out, "View Entitlement" shown), so the deploy service
+ * stays in agreement with whatever system produces and consumes the entitlement decisions.
+ *
+ * <ul>
+ *   <li><b>Layer 1 — kill switch.</b> A feature-flag map read from {@link #DEFAULT_FLAG_FILE} (a
+ *       JSON object of string keys to integer values) must have {@link #ENFORCE_FLAG_KEY} at {@link
+ *       #ENFORCE_VALUE}. Any lower value (including a missing/unreadable file) disables it, so the
+ *       UI re-enables manual capacity edits.
+ *   <li><b>Layer 2 — onboarding allowlist.</b> The cluster id must appear in the allowlist read from
+ *       {@link #DEFAULT_ONBOARDED_FILE} (a JSON array of cluster ids). Only listed clusters are
+ *       enforced, so a rollout can be staged cluster-by-cluster by editing the list.
+ * </ul>
+ *
+ * <p>Both files are expected to be delivered to the host by the deployment's configuration-delivery
+ * system; their paths and the flag key are overridable via the environment (the {@code
+ * TELETRAAN_ENTITLEMENT_*} variables) or the constructor, so the public defaults stay generic.
+ * Fail-safe: any missing/undelivered/corrupt input resolves to "not enforced" and never throws into
+ * the request path. The files are re-read on each call so a flag flip or list change is picked up
+ * without a redeploy.
+ */
+public class EntitlementEnforcementProvider {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(EntitlementEnforcementProvider.class);
+
+    static final int ENFORCE_VALUE = 100;
+
+    // Deployment-specific identifiers default to generic values and can be overridden via the
+    // environment, so a deployment points these at its own config-delivery paths and flag key
+    // without baking them into source.
+    static final String ENFORCE_FLAG_KEY =
+            envOrDefault("TELETRAAN_ENTITLEMENT_FLAG_KEY", "entitlement_enforcement");
+    static final String DEFAULT_FLAG_FILE =
+            envOrDefault("TELETRAAN_ENTITLEMENT_FLAG_FILE", "/var/config/entitlement_flags.json");
+    static final String DEFAULT_ONBOARDED_FILE =
+            envOrDefault(
+                    "TELETRAAN_ENTITLEMENT_ONBOARDED_FILE",
+                    "/var/config/entitlement_onboarded.json");
+
+    private final String flagFilePath;
+    private final String onboardedFilePath;
+    private final ObjectMapper objectMapper;
+
+    public EntitlementEnforcementProvider() {
+        this(DEFAULT_FLAG_FILE, DEFAULT_ONBOARDED_FILE);
+    }
+
+    public EntitlementEnforcementProvider(String flagFilePath, String onboardedFilePath) {
+        this.flagFilePath = flagFilePath;
+        this.onboardedFilePath = onboardedFilePath;
+        this.objectMapper = new ObjectMapper();
+    }
+
+    private static String envOrDefault(String name, String fallback) {
+        String value = System.getenv(name);
+        return (value == null || value.isEmpty()) ? fallback : value;
+    }
+
+    /**
+     * The effective {@code useEntitlements} state for {@code clusterId} ({@code "<env>-<stage>"}).
+     * Requires both layers: the kill-switch flag active and the cluster onboarded.
+     */
+    public boolean isEnforced(String clusterId) {
+        if (!isEnforcementFlagActive()) {
+            return false;
+        }
+        return onboardedClusters().contains(clusterId);
+    }
+
+    /**
+     * Override {@code env.useEntitlements} with the live gate value so the UI reflects the current
+     * kill switch + rollout config rather than the static DB column. No-op for {@code null}.
+     */
+    public void applyUseEntitlements(EnvironBean env) {
+        if (env == null) {
+            return;
+        }
+        env.setUse_entitlements(isEnforced(clusterId(env)));
+    }
+
+    /**
+     * Batch variant of {@link #applyUseEntitlements(EnvironBean)} that reads the flag map and
+     * onboarding list once for the whole collection.
+     */
+    public void applyUseEntitlements(Collection<EnvironBean> envs) {
+        if (envs == null || envs.isEmpty()) {
+            return;
+        }
+        Set<String> onboarded =
+                isEnforcementFlagActive() ? onboardedClusters() : Collections.emptySet();
+        for (EnvironBean env : envs) {
+            if (env != null) {
+                env.setUse_entitlements(onboarded.contains(clusterId(env)));
+            }
+        }
+    }
+
+    /** Entitlement scope key for a Teletraan env/stage: {@code "<env>-<stage>"}. */
+    private static String clusterId(EnvironBean env) {
+        return env.getEnv_name() + "-" + env.getStage_name();
+    }
+
+    /**
+     * Layer 1. True only when the kill-switch flag is at {@link #ENFORCE_VALUE}. A
+     * missing/unreadable value resolves to false.
+     */
+    boolean isEnforcementFlagActive() {
+        Integer value = flagMap().getOrDefault(ENFORCE_FLAG_KEY, 0);
+        return value != null && value >= ENFORCE_VALUE;
+    }
+
+    private Map<String, Integer> flagMap() {
+        File file = new File(flagFilePath);
+        if (!file.exists()) {
+            LOG.info("Entitlement flag file does not exist: {}", flagFilePath);
+            return Collections.emptyMap();
+        }
+        try (FileInputStream in = new FileInputStream(file)) {
+            return objectMapper.readValue(in, new TypeReference<Map<String, Integer>>() {});
+        } catch (IOException e) {
+            LOG.error("Failed to read entitlement flag map from file: {}", flagFilePath, e);
+            return Collections.emptyMap();
+        }
+    }
+
+    /** Layer 2. The set of onboarded Teletraan clusterIds. Missing/unreadable -> empty set. */
+    Set<String> onboardedClusters() {
+        File file = new File(onboardedFilePath);
+        if (!file.exists()) {
+            LOG.info("Entitlement onboarding list does not exist: {}", onboardedFilePath);
+            return Collections.emptySet();
+        }
+        try (FileInputStream in = new FileInputStream(file)) {
+            List<String> clusters = objectMapper.readValue(in, new TypeReference<List<String>>() {});
+            return new HashSet<>(clusters);
+        } catch (IOException e) {
+            LOG.error(
+                    "Failed to read entitlement onboarding list from file: {}",
+                    onboardedFilePath,
+                    e);
+            return Collections.emptySet();
+        }
+    }
+}

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/common/EntitlementEnforcementProviderTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/common/EntitlementEnforcementProviderTest.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright (c) 2016-2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.deployservice.common;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.pinterest.deployservice.bean.EnvironBean;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class EntitlementEnforcementProviderTest {
+    private static final String ENV = "example-service";
+    private static final String STAGE_ONBOARDED = "prod";
+    private static final String STAGE_OTHER = "canary";
+    private static final String CLUSTER = ENV + "-" + STAGE_ONBOARDED;
+
+    @TempDir File tempDir;
+
+    /** Flag JSON keyed by the configured flag key, so the test tracks whatever key is in use. */
+    private static String flagJson(int value) {
+        return "{\"" + EntitlementEnforcementProvider.ENFORCE_FLAG_KEY + "\": " + value + "}";
+    }
+
+    private EntitlementEnforcementProvider providerWith(String flagJson, String onboardedJson)
+            throws Exception {
+        File flags = new File(tempDir, "flags");
+        File onboarded = new File(tempDir, "onboarded");
+        if (flagJson != null) {
+            Files.write(flags.toPath(), flagJson.getBytes(StandardCharsets.UTF_8));
+        }
+        if (onboardedJson != null) {
+            Files.write(onboarded.toPath(), onboardedJson.getBytes(StandardCharsets.UTF_8));
+        }
+        return new EntitlementEnforcementProvider(
+                flags.getAbsolutePath(), onboarded.getAbsolutePath());
+    }
+
+    @Test
+    void enforcedWhenFlagActiveAndOnboarded() throws Exception {
+        EntitlementEnforcementProvider provider =
+                providerWith(flagJson(100), "[\"" + CLUSTER + "\"]");
+        assertTrue(provider.isEnforced(CLUSTER));
+    }
+
+    @Test
+    void notEnforcedWhenKillSwitchOff() throws Exception {
+        EntitlementEnforcementProvider provider =
+                providerWith(flagJson(0), "[\"" + CLUSTER + "\"]");
+        assertFalse(provider.isEnforced(CLUSTER));
+    }
+
+    @Test
+    void notEnforcedDuringPartialRollout() throws Exception {
+        EntitlementEnforcementProvider provider =
+                providerWith(flagJson(50), "[\"" + CLUSTER + "\"]");
+        assertFalse(provider.isEnforced(CLUSTER));
+    }
+
+    @Test
+    void notEnforcedWhenNotOnboarded() throws Exception {
+        EntitlementEnforcementProvider provider =
+                providerWith(flagJson(100), "[\"other-cluster\"]");
+        assertFalse(provider.isEnforced(CLUSTER));
+    }
+
+    @Test
+    void notEnforcedWhenFlagKeyMissing() throws Exception {
+        EntitlementEnforcementProvider provider =
+                providerWith("{\"some_other_flag\": 100}", "[\"" + CLUSTER + "\"]");
+        assertFalse(provider.isEnforced(CLUSTER));
+    }
+
+    @Test
+    void failsSafeWhenFilesMissing() {
+        EntitlementEnforcementProvider provider =
+                new EntitlementEnforcementProvider(
+                        new File(tempDir, "nope-flags").getAbsolutePath(),
+                        new File(tempDir, "nope-onboarded").getAbsolutePath());
+        assertFalse(provider.isEnforced(CLUSTER));
+    }
+
+    @Test
+    void failsSafeWhenFilesCorrupt() throws Exception {
+        EntitlementEnforcementProvider provider = providerWith("not json", "also not json");
+        assertFalse(provider.isEnforced(CLUSTER));
+    }
+
+    @Test
+    void applyUseEntitlementsSingleOverridesBean() throws Exception {
+        EntitlementEnforcementProvider provider =
+                providerWith(flagJson(100), "[\"" + CLUSTER + "\"]");
+
+        EnvironBean enforced = new EnvironBean();
+        enforced.setEnv_name(ENV);
+        enforced.setStage_name(STAGE_ONBOARDED);
+        enforced.setUse_entitlements(false);
+        provider.applyUseEntitlements(enforced);
+        assertTrue(enforced.getUse_entitlements());
+
+        EnvironBean notOnboarded = new EnvironBean();
+        notOnboarded.setEnv_name(ENV);
+        notOnboarded.setStage_name(STAGE_OTHER);
+        notOnboarded.setUse_entitlements(true);
+        provider.applyUseEntitlements(notOnboarded);
+        assertFalse(notOnboarded.getUse_entitlements());
+    }
+
+    @Test
+    void applyUseEntitlementsBatchOverridesEachBean() throws Exception {
+        EntitlementEnforcementProvider provider =
+                providerWith(flagJson(100), "[\"" + CLUSTER + "\"]");
+
+        EnvironBean onboarded = new EnvironBean();
+        onboarded.setEnv_name(ENV);
+        onboarded.setStage_name(STAGE_ONBOARDED);
+        onboarded.setUse_entitlements(false);
+
+        EnvironBean other = new EnvironBean();
+        other.setEnv_name(ENV);
+        other.setStage_name(STAGE_OTHER);
+        other.setUse_entitlements(true);
+
+        provider.applyUseEntitlements(Arrays.asList(onboarded, other));
+        assertTrue(onboarded.getUse_entitlements());
+        assertFalse(other.getUse_entitlements());
+    }
+
+    @Test
+    void applyUseEntitlementsBatchClearsAllWhenKillSwitchOff() throws Exception {
+        EntitlementEnforcementProvider provider =
+                providerWith(flagJson(0), "[\"" + CLUSTER + "\"]");
+
+        EnvironBean bean = new EnvironBean();
+        bean.setEnv_name(ENV);
+        bean.setStage_name(STAGE_ONBOARDED);
+        bean.setUse_entitlements(true);
+
+        provider.applyUseEntitlements(Collections.singletonList(bean));
+        assertFalse(bean.getUse_entitlements());
+    }
+}

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
@@ -21,6 +21,7 @@ import com.pinterest.deployservice.bean.TagTargetType;
 import com.pinterest.deployservice.bean.TagValue;
 import com.pinterest.deployservice.bean.TeletraanPrincipalRole;
 import com.pinterest.deployservice.common.Constants;
+import com.pinterest.deployservice.common.EntitlementEnforcementProvider;
 import com.pinterest.deployservice.dao.EnvironDAO;
 import com.pinterest.deployservice.handler.ConfigHistoryHandler;
 import com.pinterest.deployservice.handler.EnvTagHandler;
@@ -73,6 +74,8 @@ public class EnvStages {
     private ConfigHistoryHandler configHistoryHandler;
     private TagHandler tagHandler;
     private EnvironmentHandler environmentHandler;
+    private EntitlementEnforcementProvider entitlementEnforcementProvider =
+            new EntitlementEnforcementProvider();
 
     public EnvStages(@Context TeletraanServiceContext context) {
         environDAO = context.getEnvironDAO();
@@ -80,6 +83,11 @@ public class EnvStages {
         configHistoryHandler = new ConfigHistoryHandler(context);
         tagHandler = new EnvTagHandler(context);
         environmentHandler = new EnvironmentHandler(context);
+    }
+
+    /** Visible for testing: override the entitlement enforcement gate (kill switch + onboarding). */
+    void setEntitlementEnforcementProvider(EntitlementEnforcementProvider provider) {
+        this.entitlementEnforcementProvider = provider;
     }
 
     @GET
@@ -93,7 +101,11 @@ public class EnvStages {
             @ApiParam(value = "Stage name", required = true) @PathParam("stageName")
                     String stageName)
             throws Exception {
-        return Utils.getEnvStage(environDAO, envName, stageName);
+        EnvironBean bean = Utils.getEnvStage(environDAO, envName, stageName);
+        // useEntitlements is derived from the live kill switch + rollout config, not the static
+        // DB column, so the capacity UI greys out (or re-enables) as the flag/list change.
+        entitlementEnforcementProvider.applyUseEntitlements(bean);
+        return bean;
     }
 
     @PUT

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Environs.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Environs.java
@@ -22,6 +22,7 @@ import com.pinterest.deployservice.bean.TagTargetType;
 import com.pinterest.deployservice.bean.TagValue;
 import com.pinterest.deployservice.bean.TeletraanPrincipalRole;
 import com.pinterest.deployservice.bean.UserRolesBean;
+import com.pinterest.deployservice.common.EntitlementEnforcementProvider;
 import com.pinterest.deployservice.dao.EnvironDAO;
 import com.pinterest.deployservice.dao.UserRolesDAO;
 import com.pinterest.deployservice.handler.EnvTagHandler;
@@ -71,12 +72,19 @@ public class Environs {
     private EnvironHandler environHandler;
     private TagHandler tagHandler;
     private UserRolesDAO userRolesDAO;
+    private EntitlementEnforcementProvider entitlementEnforcementProvider =
+            new EntitlementEnforcementProvider();
 
     public Environs(@Context TeletraanServiceContext context) throws Exception {
         environDAO = context.getEnvironDAO();
         environHandler = new EnvironHandler(context);
         tagHandler = new EnvTagHandler(context);
         userRolesDAO = context.getUserRolesDAO();
+    }
+
+    /** Visible for testing: override the entitlement enforcement gate (kill switch + onboarding). */
+    void setEntitlementEnforcementProvider(EntitlementEnforcementProvider provider) {
+        this.entitlementEnforcementProvider = provider;
     }
 
     @GET
@@ -93,6 +101,7 @@ public class Environs {
             throw new WebApplicationException(
                     String.format("Environment %s does not exist.", id), Response.Status.NOT_FOUND);
         }
+        entitlementEnforcementProvider.applyUseEntitlements(environBean);
         return environBean;
     }
 
@@ -136,25 +145,27 @@ public class Environs {
             @QueryParam("groupName") String groupName,
             @QueryParam("stageType") String stageType)
             throws Exception {
+        final List<EnvironBean> result;
         if (!StringUtils.isBlank(envName)) {
             final List<EnvironBean> envs = environDAO.getByName(envName);
             if (!StringUtils.isBlank(stageType)) {
-                return envs.stream()
-                        .filter(
-                                e ->
-                                        StringUtils.equalsIgnoreCase(
-                                                e.getStage_type().toString(), stageType))
-                        .collect(Collectors.toList());
+                result =
+                        envs.stream()
+                                .filter(
+                                        e ->
+                                                StringUtils.equalsIgnoreCase(
+                                                        e.getStage_type().toString(), stageType))
+                                .collect(Collectors.toList());
+            } else {
+                result = envs;
             }
-
-            return envs;
+        } else if (!StringUtils.isEmpty(groupName)) {
+            result = environDAO.getEnvsByGroups(Arrays.asList(groupName));
+        } else {
+            result = environDAO.getAllEnvs();
         }
-
-        if (!StringUtils.isEmpty(groupName)) {
-            return environDAO.getEnvsByGroups(Arrays.asList(groupName));
-        }
-
-        return environDAO.getAllEnvs();
+        entitlementEnforcementProvider.applyUseEntitlements(result);
+        return result;
     }
 
     @POST

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/resource/EnvStagesTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/resource/EnvStagesTest.java
@@ -16,22 +16,29 @@
 package com.pinterest.teletraan.resource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.pinterest.deployservice.bean.EnvironBean;
+import com.pinterest.deployservice.common.EntitlementEnforcementProvider;
 import com.pinterest.deployservice.dao.EnvironDAO;
 import com.pinterest.deployservice.fixture.EnvironBeanFixture;
 import com.pinterest.teletraan.TeletraanServiceContext;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.dropwizard.testing.junit5.ResourceExtension;
+import java.io.File;
 import java.lang.annotation.Annotation;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.security.Principal;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
 class EnvStagesTest {
@@ -78,6 +85,57 @@ class EnvStagesTest {
         public Class<? extends Annotation> annotationType() {
             return null;
         }
+    }
+
+    @TempDir File tempDir;
+
+    private EnvStages resourceWithGate(String flagJson, String onboardedJson) throws Exception {
+        File flags = new File(tempDir, "flags");
+        File onboarded = new File(tempDir, "onboarded");
+        Files.write(flags.toPath(), flagJson.getBytes(StandardCharsets.UTF_8));
+        Files.write(onboarded.toPath(), onboardedJson.getBytes(StandardCharsets.UTF_8));
+
+        TeletraanServiceContext context = new TeletraanServiceContext();
+        context.setEnvironDAO(environDAO);
+        EnvStages resource = new EnvStages(context);
+        resource.setEntitlementEnforcementProvider(
+                new EntitlementEnforcementProvider(
+                        flags.getAbsolutePath(), onboarded.getAbsolutePath()));
+        return resource;
+    }
+
+    @Test
+    void testGet_overridesUseEntitlementsFromGate() throws Exception {
+        EnvironBean bean = EnvironBeanFixture.createRandomEnvironBean();
+        bean.setEnv_name(ENV1);
+        bean.setStage_name(STAGE1);
+        // The static DB column says false, but the live gate should flip it on.
+        bean.setUse_entitlements(false);
+        when(environDAO.getByStage(ENV1, STAGE1)).thenReturn(bean);
+
+        EnvStages resource =
+                resourceWithGate(
+                        "{\"entitlement_enforcement\": 100}",
+                        "[\"" + ENV1 + "-" + STAGE1 + "\"]");
+
+        assertTrue(resource.get(ENV1, STAGE1).getUse_entitlements());
+    }
+
+    @Test
+    void testGet_killSwitchOffReenablesEditing() throws Exception {
+        EnvironBean bean = EnvironBeanFixture.createRandomEnvironBean();
+        bean.setEnv_name(ENV1);
+        bean.setStage_name(STAGE1);
+        // Column stale-true, but kill switch is off -> UI must re-enable editing.
+        bean.setUse_entitlements(true);
+        when(environDAO.getByStage(ENV1, STAGE1)).thenReturn(bean);
+
+        EnvStages resource =
+                resourceWithGate(
+                        "{\"entitlement_enforcement\": 0}",
+                        "[\"" + ENV1 + "-" + STAGE1 + "\"]");
+
+        assertFalse(resource.get(ENV1, STAGE1).getUse_entitlements());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Makes the capacity UI's "entitlement enforced" state (capacity fields greyed out + "View Entitlement" button, driven by `EnvironBean.use_entitlements`) reflect a live two-layer control instead of a static DB column, so the entitlement rollout and its incident kill switch take effect without a redeploy or DB write.

A new `EntitlementEnforcementProvider` (deploy-service `common`) computes the effective state for a cluster (`<env>-<stage>`) from two on-box managed-data inputs, read on each request (fail-safe: any missing/corrupt input → "not enforced", never throws):

- **Layer 1 — kill switch:** the `entitlement_enforcement_teletraan` decider (`/var/config/config.manageddata.admin.decider`) must be at 100.
- **Layer 2 — onboarding/rollout list:** the cluster id must be in the `entitlements/onboarded_teletraan` managed-data list (`/var/config/config.manageddata.entitlements.onboarded_teletraan`), delivered next to the decider.

`EnvStages`/`Environs` call `applyUseEntitlements(...)` on read so the value the deploy-board renders always reflects the current decider + rollout list. Flipping the decider to 0 (or removing a cluster from the list) instantly re-enables manual capacity editing.

The onboarding source uses the classic managed-data list framework (same framework/delivery as the decider), not PinConf, so it reuses Teletraan's existing managed-data integration.

## Test plan

- [ ] Unit: `EntitlementEnforcementProviderTest` — enforced only when decider==100 AND cluster onboarded; fail-safe on missing/corrupt decider/list.
- [ ] Unit: `EnvStagesTest` — `use_entitlements` overridden from the live gate; kill switch off re-enables editing.
- [ ] Manual (staging): onboarded cluster shows greyed capacity + "View Entitlement" with decider at 100; becomes editable when decider flipped to 0.

Jira: (add ticket)

Made with [Cursor](https://cursor.com)