### PR TITLE
Add caching to EntitlementEnforcementProvider

### DIFF
--- a/deploy-service/common/pom.xml
+++ b/deploy-service/common/pom.xml
@@ -96,6 +96,11 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>2.9.3</version>
+        </dependency>
+        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>eventbridge</artifactId>
             <version>2.20.149</version>

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/EntitlementEnforcementProvider.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/EntitlementEnforcementProvider.java
@@ -17,6 +17,8 @@ package com.pinterest.deployservice.common;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.pinterest.deployservice.bean.EnvironBean;
 import java.io.File;
 import java.io.FileInputStream;
@@ -27,6 +29,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,6 +59,7 @@ public class EntitlementEnforcementProvider {
     private static final Logger LOG = LoggerFactory.getLogger(EntitlementEnforcementProvider.class);
 
     static final int ENFORCE_VALUE = 100;
+    static final int CACHE_REFRESH_THRESHOLD_MINUTES = 5;
 
     // Decider "entitlement_enforcement_teletraan" (Layer 1 kill switch), delivered by the
     // managed-data framework to /var/config/config.manageddata.admin.decider as a JSON map of
@@ -71,6 +75,8 @@ public class EntitlementEnforcementProvider {
     private final String deciderFilePath;
     private final String onboardedFilePath;
     private final ObjectMapper objectMapper;
+    private final LoadingCache<String, Boolean> deciderCache;
+    private final LoadingCache<String, Set<String>> onboardedCache;
 
     public EntitlementEnforcementProvider() {
         this(DEFAULT_DECIDER_FILE, DEFAULT_ONBOARDED_FILE);
@@ -80,6 +86,16 @@ public class EntitlementEnforcementProvider {
         this.deciderFilePath = deciderFilePath;
         this.onboardedFilePath = onboardedFilePath;
         this.objectMapper = new ObjectMapper();
+        this.deciderCache =
+                Caffeine.newBuilder()
+                        .refreshAfterWrite(CACHE_REFRESH_THRESHOLD_MINUTES, TimeUnit.MINUTES)
+                        .maximumSize(1)
+                        .build(this::isEnforcementDeciderActive);
+        this.onboardedCache =
+                Caffeine.newBuilder()
+                        .refreshAfterWrite(CACHE_REFRESH_THRESHOLD_MINUTES, TimeUnit.MINUTES)
+                        .maximumSize(1)
+                        .build(this::onboardedClusters);
     }
 
     /**
@@ -87,10 +103,10 @@ public class EntitlementEnforcementProvider {
      * Requires both layers: the kill-switch flag active and the cluster onboarded.
      */
     public boolean isEnforced(String clusterId) {
-        if (!isEnforcementDeciderActive()) {
+        if (!deciderCache.get(ENFORCE_DECIDER_KEY)) {
             return false;
         }
-        return onboardedClusters().contains(clusterId);
+        return onboardedCache.get(onboardedFilePath).contains(clusterId);
     }
 
     /**
@@ -113,7 +129,9 @@ public class EntitlementEnforcementProvider {
             return;
         }
         Set<String> onboarded =
-                isEnforcementDeciderActive() ? onboardedClusters() : Collections.emptySet();
+                deciderCache.get(ENFORCE_DECIDER_KEY)
+                        ? onboardedCache.get(onboardedFilePath)
+                        : Collections.emptySet();
         for (EnvironBean env : envs) {
             if (env != null) {
                 env.setUse_entitlements(onboarded.contains(clusterId(env)));
@@ -130,8 +148,8 @@ public class EntitlementEnforcementProvider {
      * Layer 1. True only when the kill-switch decider is at {@link #ENFORCE_VALUE}. A
      * missing/unreadable value resolves to false.
      */
-    boolean isEnforcementDeciderActive() {
-        Integer value = deciderMap().getOrDefault(ENFORCE_DECIDER_KEY, 0);
+    boolean isEnforcementDeciderActive(String deciderKey) {
+        Integer value = deciderMap().getOrDefault(deciderKey, 0);
         return value != null && value >= ENFORCE_VALUE;
     }
 
@@ -150,7 +168,7 @@ public class EntitlementEnforcementProvider {
     }
 
     /** Layer 2. The set of onboarded Teletraan clusterIds. Missing/unreadable -> empty set. */
-    Set<String> onboardedClusters() {
+    Set<String> onboardedClusters(String onboardedFilePath) {
         File file = new File(onboardedFilePath);
         if (!file.exists()) {
             LOG.info("Entitlement onboarding list does not exist: {}", onboardedFilePath);

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/EntitlementEnforcementProvider.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/EntitlementEnforcementProvider.java
@@ -49,8 +49,10 @@ import org.slf4j.LoggerFactory;
  *       are enforced, so a rollout can be staged cluster-by-cluster by editing the list.
  * </ul>
  *
- * <p>Both files are delivered to the host by the managed-data framework and are re-read on each
- * call so a decider flip or list change is picked up without a redeploy. Fail-safe: any
+ * <p>Both files are delivered to the host by the managed-data framework. Their parsed results are
+ * cached and refreshed at most every {@link #CACHE_REFRESH_THRESHOLD_MINUTES} minutes (see {@link
+ * #deciderCache} / {@link #onboardedCache}) to avoid re-reading them on every call, so a decider
+ * flip or list change is picked up within that window without a redeploy. Fail-safe: any
  * missing/undelivered/corrupt input resolves to "not enforced" and never throws into the request
  * path.
  */

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/common/EntitlementEnforcementProviderTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/common/EntitlementEnforcementProviderTest.java
@@ -159,4 +159,36 @@ class EntitlementEnforcementProviderTest {
         provider.applyUseEntitlements(Collections.singletonList(bean));
         assertFalse(bean.getUse_entitlements());
     }
+
+    /**
+     * Overwrites the onboarded file to empty after it has been cached; within the refresh window
+     * the provider must keep serving the cached (onboarded) result rather than re-reading the file.
+     */
+    @Test
+    void onboardedListIsCachedWithinRefreshWindow() throws Exception {
+        EntitlementEnforcementProvider provider =
+                providerWith(deciderJson(100), "[\"" + CLUSTER + "\"]");
+        assertTrue(provider.isEnforced(CLUSTER));
+
+        write("onboarded", "[]");
+        assertTrue(provider.isEnforced(CLUSTER));
+    }
+
+    /**
+     * Overwrites the decider file to off after it has been cached; within the refresh window the
+     * provider must keep serving the cached (enforced) result rather than re-reading the file.
+     */
+    @Test
+    void deciderIsCachedWithinRefreshWindow() throws Exception {
+        EntitlementEnforcementProvider provider =
+                providerWith(deciderJson(100), "[\"" + CLUSTER + "\"]");
+        assertTrue(provider.isEnforced(CLUSTER));
+
+        write("decider", deciderJson(0));
+        assertTrue(provider.isEnforced(CLUSTER));
+    }
+
+    private void write(String name, String content) throws Exception {
+        Files.write(new File(tempDir, name).toPath(), content.getBytes(StandardCharsets.UTF_8));
+    }
 }

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/EnvStages.java
@@ -74,8 +74,12 @@ public class EnvStages {
     private ConfigHistoryHandler configHistoryHandler;
     private TagHandler tagHandler;
     private EnvironmentHandler environmentHandler;
-    private EntitlementEnforcementProvider entitlementEnforcementProvider =
+    // Shared so the provider's file-read caches survive across the per-request resource instances
+    // Jersey creates; a per-instance provider would rebuild an empty cache on every request.
+    private static final EntitlementEnforcementProvider DEFAULT_ENTITLEMENT_ENFORCEMENT_PROVIDER =
             new EntitlementEnforcementProvider();
+    private EntitlementEnforcementProvider entitlementEnforcementProvider =
+            DEFAULT_ENTITLEMENT_ENFORCEMENT_PROVIDER;
 
     public EnvStages(@Context TeletraanServiceContext context) {
         environDAO = context.getEnvironDAO();

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Environs.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Environs.java
@@ -73,8 +73,12 @@ public class Environs {
     private TagHandler tagHandler;
     private UserRolesDAO userRolesDAO;
     private com.pinterest.teletraan.handler.EnvironmentHandler environmentHandler;
-    private EntitlementEnforcementProvider entitlementEnforcementProvider =
+    // Shared so the provider's file-read caches survive across the per-request resource instances
+    // Jersey creates; a per-instance provider would rebuild an empty cache on every request.
+    private static final EntitlementEnforcementProvider DEFAULT_ENTITLEMENT_ENFORCEMENT_PROVIDER =
             new EntitlementEnforcementProvider();
+    private EntitlementEnforcementProvider entitlementEnforcementProvider =
+            DEFAULT_ENTITLEMENT_ENFORCEMENT_PROVIDER;
 
     public Environs(@Context TeletraanServiceContext context) throws Exception {
         environDAO = context.getEnvironDAO();


### PR DESCRIPTION
## Summary

Supersedes #1961. The original caching commit by @osoriano is preserved; this PR adds the fixes needed to make it build and actually take effect.

- Reduce file reads in `EntitlementEnforcementProvider` by caching the decider kill-switch and the onboarded allowlist (Caffeine, refreshed every 5 min).
- **Add the `caffeine` dependency to the `common` module.** The caching code did not compile there — caffeine was only available transitively in `teletraanservice` (via `dropwizard-auth`), not in `common`.
- **Share a single provider per resource** (`EnvStages`/`Environs`). Jersey creates those resources per-request, so a per-instance provider rebuilt an empty cache on every request, defeating the cache; it is now a shared static default (the test seam still overrides per-instance).
- Update the class Javadoc that still claimed the files are re-read on every call.
- Add unit tests covering the caching behavior for both the decider and the onboarded list.

## Test plan

- [x] `mvn -pl common -am test -Dtest=EntitlementEnforcementProviderTest` — 12/12 pass
- [x] `mvn -pl teletraanservice -am test -Dtest=EnvStagesTest` — 5/5 pass
- [x] `mvn spotless:check` passes (JDK 8, as CI)
- [ ] Validate in a real environment that file-read volume drops and that decider/list changes propagate within the ~5 min refresh window. Note: the kill switch is no longer instantaneous (cached up to 5 min); if that matters, use a shorter TTL for the decider.

Made with [Cursor](https://cursor.com)