### PR TITLE
Reduce EntitlementEnforcementProvider cache refresh to 1 minute

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/common/EntitlementEnforcementProvider.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/common/EntitlementEnforcementProvider.java
@@ -61,7 +61,7 @@ public class EntitlementEnforcementProvider {
     private static final Logger LOG = LoggerFactory.getLogger(EntitlementEnforcementProvider.class);
 
     static final int ENFORCE_VALUE = 100;
-    static final int CACHE_REFRESH_THRESHOLD_MINUTES = 5;
+    static final int CACHE_REFRESH_THRESHOLD_MINUTES = 1;
 
     // Decider "entitlement_enforcement_teletraan" (Layer 1 kill switch), delivered by the
     // managed-data framework to /var/config/config.manageddata.admin.decider as a JSON map of


### PR DESCRIPTION
## Summary

Lower the `EntitlementEnforcementProvider` cache refresh window from 5 minutes to 1 minute so decider kill-switch flips and onboarding-list changes take effect faster (at the cost of slightly more frequent file reads).

## Test plan

- [x] `mvn spotless:check` passes (JDK 8, as CI)
- [x] `mvn -pl common -am test -Dtest=EntitlementEnforcementProviderTest` — existing cache tests still pass

Made with [Cursor](https://cursor.com)