### PR TITLE
resource: enforce per-environment WRITE authorization on pindeploy pipeline endpoints

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/PindeployDAO.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/dao/PindeployDAO.java
@@ -21,6 +21,8 @@ import com.pinterest.deployservice.bean.PindeployBean;
 public interface PindeployDAO {
     PindeployBean get(String envId) throws Exception;
 
+    PindeployBean getByPipeline(String pipeline) throws Exception;
+
     void delete(String pipeline) throws Exception;
 
     void insertOrUpdate(PindeployBean pindeployBean) throws Exception;

--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBPindeployDAOImpl.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/db/DBPindeployDAOImpl.java
@@ -26,6 +26,8 @@ import org.apache.commons.dbutils.handlers.BeanHandler;
 /* count table cache to store # of actively deploying agents and # of existing agents */
 public class DBPindeployDAOImpl implements PindeployDAO {
     private static final String GET_PINDEPLOY = "SELECT * FROM pindeploy WHERE env_id=?";
+    private static final String GET_PINDEPLOY_BY_PIPELINE =
+            "SELECT * FROM pindeploy WHERE pipeline=?";
     private static final String DELETE_PINDEPLOY = "DELETE FROM pindeploy WHERE pipeline=?";
     private static final String INSERT_OR_UPDATE_PINDEPLOY =
             "INSERT INTO pindeploy SET %s ON DUPLICATE KEY UPDATE pipeline=?, is_pindeploy=?";
@@ -40,6 +42,12 @@ public class DBPindeployDAOImpl implements PindeployDAO {
     public PindeployBean get(String envId) throws Exception {
         ResultSetHandler<PindeployBean> h = new BeanHandler<PindeployBean>(PindeployBean.class);
         return new QueryRunner(dataSource).query(GET_PINDEPLOY, h, envId);
+    }
+
+    @Override
+    public PindeployBean getByPipeline(String pipeline) throws Exception {
+        ResultSetHandler<PindeployBean> h = new BeanHandler<PindeployBean>(PindeployBean.class);
+        return new QueryRunner(dataSource).query(GET_PINDEPLOY_BY_PIPELINE, h, pipeline);
     }
 
     @Override

--- a/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Pindeploy.java
+++ b/deploy-service/teletraanservice/src/main/java/com/pinterest/teletraan/resource/Pindeploy.java
@@ -21,7 +21,12 @@ import com.pinterest.deployservice.bean.TeletraanPrincipalRole;
 import com.pinterest.deployservice.dao.EnvironDAO;
 import com.pinterest.deployservice.dao.PindeployDAO;
 import com.pinterest.teletraan.TeletraanServiceContext;
+import com.pinterest.teletraan.config.AuthorizationFactory;
+import com.pinterest.teletraan.universal.security.TeletraanAuthorizer;
+import com.pinterest.teletraan.universal.security.bean.AuthZResource;
+import com.pinterest.teletraan.universal.security.bean.TeletraanPrincipal;
 import io.swagger.annotations.*;
+import java.security.Principal;
 import javax.annotation.security.RolesAllowed;
 import javax.validation.constraints.NotEmpty;
 import javax.ws.rs.*;
@@ -42,10 +47,42 @@ public class Pindeploy {
     private static final Logger LOG = LoggerFactory.getLogger(Pindeploy.class);
     private PindeployDAO pindeployDAO;
     private EnvironDAO environDAO;
+    private AuthorizationFactory authorizationFactory;
+    private TeletraanServiceContext context;
 
     public Pindeploy(@Context TeletraanServiceContext context) throws Exception {
+        this.context = context;
         pindeployDAO = context.getPindeployDAO();
         environDAO = context.getEnvironDAO();
+        authorizationFactory = context.getAuthorizationFactory();
+    }
+
+    /**
+     * enable/disablePindeployPipeline carry no {@code @ResourceAuthZInfo} because their
+     * envName/stageName/pipeline identifiers arrive as query params, a location the resource
+     * extractor factory does not support (see TeletraanAuthZResourceExtractorFactory) -- adding
+     * the annotation would 500 at request time rather than authorize. This performs the same
+     * per-instance WRITE check the framework would have run, using the on-the-fly authorizer
+     * pattern already used by EnvironmentHandler.validateSystemPriorityPermission.
+     */
+    private void requireWriteOnEnvStage(SecurityContext sc, String envName, String stageName) {
+        Principal principal = sc.getUserPrincipal();
+        if (!(principal instanceof TeletraanPrincipal)) {
+            throw new ForbiddenException("Modifying pindeploy pipeline wiring requires an authenticated Teletraan principal");
+        }
+        TeletraanPrincipal teletraanPrincipal = (TeletraanPrincipal) principal;
+        TeletraanAuthorizer<TeletraanPrincipal> authorizer =
+                authorizationFactory.createSecondaryAuthorizer(context, teletraanPrincipal.getClass());
+        AuthZResource envResource = new AuthZResource(envName, stageName);
+        boolean isAuthorized =
+                authorizer.authorize(
+                        teletraanPrincipal, TeletraanPrincipalRole.Names.WRITE, envResource, null);
+        if (!isAuthorized) {
+            throw new ForbiddenException(
+                    String.format(
+                            "Modifying pindeploy pipeline wiring requires WRITE role on environment %s/%s",
+                            envName, stageName));
+        }
     }
 
     @GET
@@ -63,9 +100,17 @@ public class Pindeploy {
 
     @DELETE
     @Path("/disable")
+    @RolesAllowed(TeletraanPrincipalRole.Names.WRITE)
     public void disablePindeployPipeline(
             @Context SecurityContext sc, @NotEmpty @QueryParam("pipeline") String pipeline)
             throws Exception {
+        PindeployBean existing = pindeployDAO.getByPipeline(pipeline);
+        if (existing != null) {
+            EnvironBean owningEnv = environDAO.getById(existing.getEnv_id());
+            if (owningEnv != null) {
+                requireWriteOnEnvStage(sc, owningEnv.getEnv_name(), owningEnv.getStage_name());
+            }
+        }
         String operator = sc.getUserPrincipal().getName();
         pindeployDAO.delete(pipeline);
         LOG.info(
@@ -75,6 +120,7 @@ public class Pindeploy {
 
     @POST
     @Path("/enable")
+    @RolesAllowed(TeletraanPrincipalRole.Names.WRITE)
     public void enablePindeployPipeline(
             @Context SecurityContext sc,
             @NotEmpty @QueryParam("envName") String envName,
@@ -82,6 +128,7 @@ public class Pindeploy {
             @NotEmpty @QueryParam("pipeline") String pipeline)
             throws Exception {
         EnvironBean envBean = Utils.getEnvStage(environDAO, envName, stageName);
+        requireWriteOnEnvStage(sc, envName, stageName);
         String operator = sc.getUserPrincipal().getName();
         PindeployBean pindeployBean = new PindeployBean();
         pindeployBean.setEnv_id(envBean.getEnv_id());

--- a/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/resource/PindeployAuthorizationGapPocTest.java
+++ b/deploy-service/teletraanservice/src/test/java/com/pinterest/teletraan/resource/PindeployAuthorizationGapPocTest.java
@@ -1,0 +1,159 @@
+/**
+ * Copyright (c) 2016-2026 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.teletraan.resource;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.pinterest.deployservice.bean.EnvironBean;
+import com.pinterest.deployservice.bean.PindeployBean;
+import com.pinterest.deployservice.dao.EnvironDAO;
+import com.pinterest.deployservice.dao.PindeployDAO;
+import com.pinterest.teletraan.TeletraanServiceContext;
+import com.pinterest.teletraan.config.AuthorizationFactory;
+import com.pinterest.teletraan.universal.security.TeletraanAuthorizer;
+import com.pinterest.teletraan.universal.security.bean.TeletraanPrincipal;
+import com.pinterest.teletraan.universal.security.bean.UserPrincipal;
+import java.util.Collections;
+import javax.ws.rs.ForbiddenException;
+import javax.ws.rs.core.SecurityContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test for the authorization gap in {@code Pindeploy.enablePindeployPipeline}/{@code
+ * disablePindeployPipeline}: neither method previously carried any per-instance authorization
+ * check (only the class-level {@code @RolesAllowed(READ)}, the lowest role, granted to every
+ * authenticated Teletraan user). A caller with zero grants on an environment could flip its
+ * pindeploy pipeline wiring. The fix adds an explicit on-the-fly WRITE check
+ * (requireWriteOnEnvStage) mirroring the existing EnvironmentHandler.validateSystemPriorityPermission
+ * pattern, since the framework's @ResourceAuthZInfo annotation does not support query-param-based
+ * resource ids (see TeletraanAuthZResourceExtractorFactory).
+ *
+ * <p>These tests confirm: (1) a caller who is NOT authorized on the target env/stage is now
+ * rejected with ForbiddenException before any DAO write happens, and (2) a caller who IS
+ * authorized still succeeds, so the fix does not break the legitimate path.
+ */
+public class PindeployAuthorizationGapPocTest {
+
+    private PindeployDAO pindeployDAO;
+    private EnvironDAO environDAO;
+    private AuthorizationFactory authorizationFactory;
+    private TeletraanAuthorizer<TeletraanPrincipal> authorizer;
+    private TeletraanServiceContext context;
+    private SecurityContext sc;
+
+    @SuppressWarnings("unchecked")
+    @BeforeEach
+    public void setUp() throws Exception {
+        pindeployDAO = mock(PindeployDAO.class);
+        environDAO = mock(EnvironDAO.class);
+        authorizationFactory = mock(AuthorizationFactory.class);
+        authorizer = mock(TeletraanAuthorizer.class);
+
+        context = new TeletraanServiceContext();
+        context.setPindeployDAO(pindeployDAO);
+        context.setEnvironDAO(environDAO);
+        context.setAuthorizationFactory(authorizationFactory);
+
+        when(authorizationFactory.createSecondaryAuthorizer(any(), any())).thenReturn(authorizer);
+
+        sc = mock(SecurityContext.class);
+        when(sc.getUserPrincipal())
+                .thenReturn(
+                        new UserPrincipal("attacker-with-only-baseline-read", Collections.emptyList()));
+    }
+
+    @Test
+    public void enable_rejectsCallerWithNoWriteGrantOnTargetEnv() throws Exception {
+        String victimEnv = "payments-critical-service";
+        String victimStage = "prod";
+        String victimEnvId = "env-payments-prod-001";
+
+        EnvironBean victimEnvBean = new EnvironBean();
+        victimEnvBean.setEnv_id(victimEnvId);
+        victimEnvBean.setEnv_name(victimEnv);
+        victimEnvBean.setStage_name(victimStage);
+        when(environDAO.getByStage(victimEnv, victimStage)).thenReturn(victimEnvBean);
+
+        // Not authorized on the victim's env/stage.
+        when(authorizer.authorize(any(), anyString(), any(), any())).thenReturn(false);
+
+        Pindeploy pindeploy = new Pindeploy(context);
+
+        assertThrows(
+                ForbiddenException.class,
+                () ->
+                        pindeploy.enablePindeployPipeline(
+                                sc, victimEnv, victimStage, "attacker-controlled-pipeline"));
+
+        verify(pindeployDAO, never()).insertOrUpdate(any());
+    }
+
+    @Test
+    public void enable_allowsCallerWithWriteGrantOnTargetEnv() throws Exception {
+        String ownEnv = "my-own-service";
+        String ownStage = "prod";
+        String ownEnvId = "env-my-own-prod-001";
+
+        EnvironBean ownEnvBean = new EnvironBean();
+        ownEnvBean.setEnv_id(ownEnvId);
+        ownEnvBean.setEnv_name(ownEnv);
+        ownEnvBean.setStage_name(ownStage);
+        when(environDAO.getByStage(ownEnv, ownStage)).thenReturn(ownEnvBean);
+
+        // Authorized (WRITE) on this specific env/stage.
+        when(authorizer.authorize(any(), eq("WRITE"), any(), any())).thenReturn(true);
+
+        Pindeploy pindeploy = new Pindeploy(context);
+        pindeploy.enablePindeployPipeline(sc, ownEnv, ownStage, "my-own-pipeline");
+
+        verify(pindeployDAO, times(1)).insertOrUpdate(any());
+    }
+
+    @Test
+    public void disable_rejectsCallerWithNoWriteGrantOnOwningEnv() throws Exception {
+        String pipeline = "some-other-teams-pipeline";
+        String victimEnvId = "env-payments-prod-001";
+
+        PindeployBean existing = new PindeployBean();
+        existing.setEnv_id(victimEnvId);
+        existing.setPipeline(pipeline);
+        when(pindeployDAO.getByPipeline(pipeline)).thenReturn(existing);
+
+        EnvironBean victimEnvBean = new EnvironBean();
+        victimEnvBean.setEnv_id(victimEnvId);
+        victimEnvBean.setEnv_name("payments-critical-service");
+        victimEnvBean.setStage_name("prod");
+        when(environDAO.getById(victimEnvId)).thenReturn(victimEnvBean);
+
+        when(authorizer.authorize(any(), anyString(), any(), any())).thenReturn(false);
+
+        Pindeploy pindeploy = new Pindeploy(context);
+
+        assertThrows(
+                ForbiddenException.class, () -> pindeploy.disablePindeployPipeline(sc, pipeline));
+
+        verify(pindeployDAO, never()).delete(anyString());
+    }
+}


### PR DESCRIPTION
Pindeploy.enablePindeployPipeline/disablePindeployPipeline had no per-instance authorization check, only the class-level @RolesAllowed(READ) that every authenticated Teletraan user holds by default. Neither method could use @ResourceAuthZInfo, since envName/stageName/pipeline arrive as query params, a location TeletraanAuthZResourceExtractorFactory doesn't support (only PATH/BODY are wired). So any authenticated caller could flip pindeploy pipeline wiring for any environment/stage, not just ones they hold a role on.

This adds an on-the-fly WRITE check (requireWriteOnEnvStage) using the same on-the-fly-authorizer pattern already used in EnvironmentHandler.validateSystemPriorityPermission, plus a method-level @RolesAllowed(WRITE) gate on both endpoints. disablePindeployPipeline only takes a bare pipeline name with no env/stage, so a PindeployDAO.getByPipeline lookup was added to resolve the owning environment before authorizing the delete.

Added PindeployAuthorizationGapPocTest covering: caller with no grant on the target env is rejected before any DAO write, caller with WRITE on the target env still succeeds, and the disable path resolves the owning env before rejecting. Full `common`/`universal`/`teletraanservice` suite still green (220 tests).