### PR TITLE
Clarify read-only Cluster Capacity UI and deep-link Entitlements form

### DIFF
--- a/deploy-board/deploy_board/templates/clusters/cluster_capacity.tmpl
+++ b/deploy-board/deploy_board/templates/clusters/cluster_capacity.tmpl
@@ -1,9 +1,26 @@
 <div id="clusterPanelId" v-if="hasCluster" class="panel panel-default">
+    {% if useEntitlements %}
+    <div class="panel-heading clearfix">
+        <h4 class="panel-title pull-left pointer-cursor">
+            <a data-toggle="collapse" data-target="#clusterConfigId">
+                <span id="clusterConfigIdToggler" class="glyphicon glyphicon-chevron-down"></span>
+                Cluster Capacity
+            </a>
+            <span class="label label-default" style="margin-left: 8px; vertical-align: middle;">READ-ONLY</span>
+        </h4>
+        <div class="pull-right text-muted" style="padding-top: 3px;">
+            <span class="glyphicon glyphicon-lock"></span>
+            Managed by Entitlements
+        </div>
+    </div>
+    {% else %}
     <panel-heading title="Cluster Capacity" target="#clusterConfigId" initcollapse="false"></panel-heading>
+    {% endif %}
     <div id="clusterConfigId" class="collapse in panel-body">
         <div class="container-fluid">
             <form id="clusterConfigFormId" class="form-horizontal" role="form">
-                <fieldset id="clusterConfigFieldSetId" {% if is_managed_resource or useEntitlements %}disabled{% endif %}>
+                <fieldset id="clusterConfigFieldSetId" {% if is_managed_resource or useEntitlements %}disabled{% endif %}
+                        {% if useEntitlements %}title="Click View Entitlement to make capacity updates"{% endif %}>
                     <label-info title="Cluster State" name="Cluster State" v-bind:text="clusterstate" v-bind:styleclass="clusterStateStyle"></label-info>
                     <label-info title="Cell" name="Cell" v-bind:text="cell"></label-info>
                     <static-capacity-config v-if="!autoscalingEnabled"
@@ -17,6 +34,18 @@
                         :remaining-capacity="remainingCapacity" :placements="placements">
                     </asg-capacity-config>
                 </fieldset>
+                {% if useEntitlements %}
+                <div class="form-group" style="margin-bottom: 0;">
+                    <div class="col-xs-8 col-xs-offset-4">
+                        <div class="alert alert-info" style="margin-bottom: 0;">
+                            <strong>Capacity is read-only here.</strong>
+                            Click <strong>View Entitlement</strong> below
+                            <span class="glyphicon glyphicon-arrow-down"></span>
+                            to make capacity updates.
+                        </div>
+                    </div>
+                </div>
+                {% endif %}
                 {% if is_managed_resource %}
                 <div class="form-group">
                     <label class="control-label col-xs-4" for="isManagedResourceCheckboxId" style="padding-top: 0px">Resource is managed</label>
@@ -36,10 +65,16 @@
         </div>
     </div>
     <div class="panel-footer clearfix">
+        {% if useEntitlements %}
+        <div class="pull-left text-muted" style="padding-top: 7px;">
+            <span class="glyphicon glyphicon-refresh"></span>
+            All capacity updates go through Entitlements, which auto-syncs to Teletraan.
+        </div>
+        {% endif %}
         <div class="pull-right">
             {% if useEntitlements %}
-            <a href="{{ entitlements_ui_link }}?service={{envName}}-{{stageName}}&budgetingEntity=all" target="_blank" type="button" id="saveClusterConfigBtnId" class="btn btn-default"
-                    title="View in Entitlements UI">
+            <a href="{{ entitlements_ui_link }}?openForm=request&platform=teletraan&service={{envName}}-{{stageName}}&budgetingEntity=all" target="_blank" type="button" id="saveClusterConfigBtnId" class="btn btn-primary"
+                    title="Update capacity in the Entitlements UI">
                 <span class="glyphicon glyphicon-new-window"></span>
                 View Entitlement
             </a>
@@ -60,6 +95,15 @@
     </modal>
 </div>
 
+{% if useEntitlements %}
+<script>
+    $(function () {
+        $('#clusterConfigId').on('hide.bs.collapse show.bs.collapse', function () {
+            $('#clusterConfigIdToggler').toggleClass('glyphicon-chevron-down glyphicon-chevron-right', 100);
+        });
+    });
+</script>
+{% endif %}
 {% if is_managed_resource %}
 <script>
     document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
## Summary
- When capacity is entitlement-managed, the Cluster Capacity panel now shows a clear READ-ONLY badge, lock label, and info callout that points users to **View Entitlement**.
- Promotes the **View Entitlement** control to the primary action and adds footer copy explaining that capacity updates sync from Entitlements.
- Deep-links the button to open the request form with `openForm=request&platform=teletraan` (service remains `{{envName}}-{{stageName}}`; staging/prod host still comes from `ENTITLEMENTS_UI_LINK`).

## Test plan
- [ ] On an entitlement-managed env/stage, open Capacity config and confirm READ-ONLY badge, info banner, and primary **View Entitlement** button.
- [ ] Click **View Entitlement** and confirm URL includes `openForm=request`, `platform=teletraan`, `service=<env>-<stage>`, and `budgetingEntity=all`.
- [ ] Confirm prod uses `pinconsole.pinadmin.com` and staging/dev uses `pinconsole-staging.pinadmin.com`.
- [ ] On a non-entitlement env/stage, confirm the panel is unchanged (editable fields + Save).
- [ ] Confirm the panel heading still collapses/expands correctly in the entitlement-managed case.


Made with [Cursor](https://cursor.com)