### PR TITLE
Single-flight the agent count refresh to prevent ping stampedes on large stages

### DIFF
--- a/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
+++ b/deploy-service/common/src/main/java/com/pinterest/deployservice/handler/PingHandler.java
@@ -364,40 +364,28 @@ public class PingHandler {
             return true;
         }
 
-        // TODO use ecache to optimize
         // Make sure we do not exceed allowed number of concurrent active deploying agent
         String envId = envBean.getEnv_id();
-        AgentCountBean agentCountBean = agentCountDAO.get(envId);
-        long totalNonFirstDeployAgents =
-                (isAgentCountValid(envId, agentCountBean) == true)
-                        ? agentCountBean.getExisting_count()
-                        : agentDAO.countNonFirstDeployingAgent(envId);
-        long parallelThreshold =
-                PingHandler.calculateParallelThreshold(
-                        envBean, totalNonFirstDeployAgents, this.maxParallelThreshold);
 
-        try {
-            // Note: This count already excludes first deploy agents, includes agents in STOP state
-            long totalDeployingAgents =
-                    (isAgentCountValid(envId, agentCountBean) == true)
-                            ? agentCountBean.getActive_count()
-                            : agentDAO.countDeployingAgent(envId);
-            if (totalDeployingAgents >= parallelThreshold) {
+        /*
+         * Fast path: a fresh agent count that already reports the env at capacity lets us
+         * reject without taking the lock and without recounting. On large stages most hosts
+         * are queued behind the threshold, so this is the common case.
+         */
+        AgentCountBean cachedCount = agentCountDAO.get(envId);
+        if (isAgentCountValid(envId, cachedCount)) {
+            long cachedThreshold =
+                    PingHandler.calculateParallelThreshold(
+                            envBean, cachedCount.getExisting_count(), this.maxParallelThreshold);
+            if (cachedCount.getActive_count() >= cachedThreshold) {
                 LOG.debug(
                         "Env {}: active agents {}, parallel threshold {}. host {} will wait for deploy",
                         envId,
-                        totalDeployingAgents,
-                        parallelThreshold,
+                        cachedCount.getActive_count(),
+                        cachedThreshold,
                         host);
                 return false;
             }
-        } catch (Exception e) {
-            LOG.warn(
-                    "Env {}, host {}: Failed to check if can deploy or not, exception = {}",
-                    envId,
-                    host,
-                    e.toString());
-            return false;
         }
 
         // Make sure we also follow the schedule if specified
@@ -412,56 +400,85 @@ public class PingHandler {
             return false;
         }
 
-        // Looks like we can proceed with deploy, but let us double check with lock, and
-        // Update table to occupy one seat if condition still hold
+        /*
+         * Recounting is expensive: two COUNT(*) over every agent row of the env. Take the
+         * lock before recounting rather than after, so at most one ping per env pays for it
+         * while the cache is expired. Pings that lose the lock defer to their next cycle
+         * instead of duplicating the scans.
+         */
         String deployLockName = String.format("DEPLOY-%s", envId);
         Connection connection = utilDAO.getLock(deployLockName);
-        if (connection != null) {
-            LOG.info("Successfully get lock on {}", deployLockName);
-            try {
+        if (connection == null) {
+            LOG.debug(
+                    "Env {}: agent count is being refreshed by another host, host {} will wait for deploy.",
+                    envId,
+                    host);
+            return false;
+        }
+        LOG.info("Successfully get lock on {}", deployLockName);
+        try {
+            LOG.debug(
+                    "Got lock on behavor of host {} for env {}, verify active agents", host, envId);
+            AgentCountBean agentCountBean = agentCountDAO.get(envId);
+            boolean staleCount = !isAgentCountValid(envId, agentCountBean);
+            long totalNonFirstDeployAgents;
+            long totalActiveAgents;
+            if (staleCount) {
+                totalNonFirstDeployAgents = agentDAO.countNonFirstDeployingAgent(envId);
+                // Note: This count already excludes first deploy agents, includes agents in STOP
+                // state
+                totalActiveAgents = agentDAO.countDeployingAgent(envId);
+            } else {
+                totalNonFirstDeployAgents = agentCountBean.getExisting_count();
+                totalActiveAgents = agentCountBean.getActive_count();
+            }
+
+            long parallelThreshold =
+                    PingHandler.calculateParallelThreshold(
+                            envBean, totalNonFirstDeployAgents, this.maxParallelThreshold);
+
+            boolean canProceed = totalActiveAgents < parallelThreshold;
+            if (!canProceed) {
                 LOG.debug(
-                        "Got lock on behavor of host {} for env {}, verify active agents",
-                        host,
-                        envId);
-                long totalActiveAgents =
-                        (isAgentCountValid(envId, agentCountBean) == true)
-                                ? agentCountBean.getActive_count()
-                                : agentDAO.countDeployingAgent(envId);
-                if (totalActiveAgents >= parallelThreshold) {
-                    LOG.debug(
-                            "Env {}: active agents {}, parallel threshold {}. host {} will wait for deploy",
-                            envId,
-                            totalActiveAgents,
-                            parallelThreshold,
-                            host);
-                    return false;
-                }
+                        "Env {}: active agents {}, parallel threshold {}. host {} will wait for deploy",
+                        envId,
+                        totalActiveAgents,
+                        parallelThreshold,
+                        host);
+            } else if (!canDeploywithSchedule(envBean)) {
                 // Make sure again we also follow the schedule if specified
-                if (!canDeploywithSchedule(envBean)) {
-                    LOG.debug("Env {}: schedule does not allow host {} to proceed.", envId, host);
-                    return false;
-                }
-
+                LOG.debug("Env {}: schedule does not allow host {} to proceed.", envId, host);
+                canProceed = false;
+            } else if (!canDeployWithConstraint(agentBean.getHost_id(), envBean)) {
                 // Make sure we also follow the deploy constraint if specified
-                if (!canDeployWithConstraint(agentBean.getHost_id(), envBean)) {
-                    LOG.debug(
-                            "Env {}: deploy constraint does not allow host {} to proceed.",
-                            envId,
-                            host);
-                    return false;
-                }
+                LOG.debug(
+                        "Env {}: deploy constraint does not allow host {} to proceed.",
+                        envId,
+                        host);
+                canProceed = false;
+            }
 
+            /*
+             * Persist a recount even when this host is not admitted. Otherwise nothing writes
+             * the cache while the env sits at capacity, and the expired window lasts for the
+             * rest of the deploy instead of a single ttl.
+             */
+            if (staleCount || canProceed) {
                 if (agentCountBean == null) {
                     agentCountBean = new AgentCountBean();
                     agentCountBean.setEnv_id(envId);
                 }
                 agentCountBean.setExisting_count(totalNonFirstDeployAgents);
-                agentCountBean.setActive_count(totalActiveAgents + 1);
+                agentCountBean.setActive_count(
+                        canProceed ? totalActiveAgents + 1 : totalActiveAgents);
                 agentCountBean.setDeploy_id(agentBean.getDeploy_id());
-                // we invalidate cache after ttl.
-                if (isAgentCountValid(envId, agentCountBean) == false) {
-                    long now = System.currentTimeMillis();
-                    agentCountBean.setLast_refresh(now);
+                /*
+                 * active_count is only ever incremented, so it drifts above the real value
+                 * until the ttl forces a recount. Extend the ttl on a recount only, otherwise
+                 * a continuously busy env would never resync.
+                 */
+                if (staleCount) {
+                    agentCountBean.setLast_refresh(System.currentTimeMillis());
                 }
                 /* Typically, should update agentCount and agent in transaction,
                  * however, treating agentCount as cache w/ ttl and
@@ -475,30 +492,28 @@ public class PingHandler {
                         agentCountBean.getLast_refresh(),
                         agentCountCacheTtl);
                 agentCountDAO.insertOrUpdate(agentCountBean);
-                agentDAO.insertOrUpdate(agentBean);
-                LOG.debug(
-                        "There are currently only {} agent actively deploying for env {}, update and proceed on host {}.",
-                        totalActiveAgents,
-                        envId,
-                        host);
-                return true;
-            } catch (Exception e) {
-                LOG.warn(
-                        "Env {} host {}: Failed to check if can deploy or not, exception = {}",
-                        envId,
-                        host,
-                        e.toString());
-                return false;
-            } finally {
-                utilDAO.releaseLock(deployLockName, connection);
-                LOG.info("Successfully released lock on {}", deployLockName);
             }
-        } else {
-            LOG.warn(
-                    "Failed to grab PARALLEL_LOCK for env = {}, host = {}, return false.",
+
+            if (!canProceed) {
+                return false;
+            }
+            agentDAO.insertOrUpdate(agentBean);
+            LOG.debug(
+                    "There are currently only {} agent actively deploying for env {}, update and proceed on host {}.",
+                    totalActiveAgents,
                     envId,
                     host);
+            return true;
+        } catch (Exception e) {
+            LOG.warn(
+                    "Env {} host {}: Failed to check if can deploy or not, exception = {}",
+                    envId,
+                    host,
+                    e.toString());
             return false;
+        } finally {
+            utilDAO.releaseLock(deployLockName, connection);
+            LOG.info("Successfully released lock on {}", deployLockName);
         }
     }
 

--- a/deploy-service/common/src/test/java/com/pinterest/deployservice/handler/PingHandlerTest.java
+++ b/deploy-service/common/src/test/java/com/pinterest/deployservice/handler/PingHandlerTest.java
@@ -31,6 +31,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.pinterest.deployservice.ServiceContext;
+import com.pinterest.deployservice.bean.AgentBean;
+import com.pinterest.deployservice.bean.AgentCountBean;
 import com.pinterest.deployservice.bean.EnvironBean;
 import com.pinterest.deployservice.bean.HostAgentBean;
 import com.pinterest.deployservice.bean.KnoxStatus;
@@ -50,6 +52,7 @@ import com.pinterest.deployservice.dao.HostDAO;
 import com.pinterest.deployservice.dao.HostTagDAO;
 import com.pinterest.deployservice.dao.ScheduleDAO;
 import com.pinterest.deployservice.dao.UtilDAO;
+import java.sql.Connection;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
@@ -60,8 +63,17 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
 
 public class PingHandlerTest {
+
+    private static final long TEST_TTL_MS = 15000L;
+
+    /**
+     * createRandomEnvironBean sets max_parallel=10 and max_parallel_pct=0, so against 100
+     * non-first-deploy agents the parallel threshold resolves to 10.
+     */
+    private static final long TEST_THRESHOLD = 10L;
 
     private AgentDAO agentDAO;
     private AgentCountDAO agentCountDAO;
@@ -112,6 +124,8 @@ public class PingHandlerTest {
         serviceContext.setHostTagDAO(hostTagDAO);
         serviceContext.setGroupDAO(groupDAO);
         serviceContext.setDeployConstraintDAO(deployConstraintDAO);
+        serviceContext.setAgentCountCacheTtl(TEST_TTL_MS);
+        serviceContext.setMaxParallelThreshold(5000L);
 
         pingHandler = new PingHandler(serviceContext);
     }
@@ -432,5 +446,160 @@ public class PingHandlerTest {
         assertEquals(1, PingHandler.calculateParallelThreshold(bean, 2, 1), 1);
         assertEquals(10, PingHandler.calculateParallelThreshold(bean, 2, 1), 10);
         assertEquals(10, PingHandler.calculateParallelThreshold(bean, 2, 1), 100);
+    }
+
+    private AgentBean waitingAgent(String envId) {
+        AgentBean bean = new AgentBean();
+        bean.setHost_id("host-1");
+        bean.setHost_name("hostname-1");
+        bean.setEnv_id(envId);
+        bean.setDeploy_id("deploy-1");
+        bean.setFirst_deploy(false);
+        return bean;
+    }
+
+    private AgentCountBean agentCount(String envId, long existing, long active, long lastRefresh) {
+        AgentCountBean bean = new AgentCountBean();
+        bean.setEnv_id(envId);
+        bean.setDeploy_id("deploy-1");
+        bean.setExisting_count(existing);
+        bean.setActive_count(active);
+        bean.setLast_refresh(lastRefresh);
+        return bean;
+    }
+
+    @Test
+    public void testCanDeploy_freshCountAtCapacity_rejectsWithoutLockOrRecount() throws Exception {
+        EnvironBean environ = createRandomEnvironBean();
+        String envId = environ.getEnv_id();
+        when(agentCountDAO.get(envId))
+                .thenReturn(agentCount(envId, 100L, TEST_THRESHOLD, System.currentTimeMillis()));
+
+        assertFalse(pingHandler.canDeploy(environ, "hostname-1", waitingAgent(envId)));
+
+        // The hot rejection path must not scan or contend for the lock.
+        verify(agentDAO, never()).countNonFirstDeployingAgent(anyString());
+        verify(agentDAO, never()).countDeployingAgent(anyString());
+        verify(utilDAO, never()).getLock(anyString());
+    }
+
+    @Test
+    public void testCanDeploy_staleCountLockUnavailable_skipsRecount() throws Exception {
+        EnvironBean environ = createRandomEnvironBean();
+        String envId = environ.getEnv_id();
+        when(agentCountDAO.get(envId))
+                .thenReturn(
+                        agentCount(envId, 100L, 3L, System.currentTimeMillis() - 10 * TEST_TTL_MS));
+        when(utilDAO.getLock(anyString())).thenReturn(null);
+
+        assertFalse(pingHandler.canDeploy(environ, "hostname-1", waitingAgent(envId)));
+
+        // Losing the single flight must defer, not fall back to recounting.
+        verify(agentDAO, never()).countNonFirstDeployingAgent(anyString());
+        verify(agentDAO, never()).countDeployingAgent(anyString());
+        verify(agentCountDAO, never()).insertOrUpdate(any(AgentCountBean.class));
+    }
+
+    @Test
+    public void testCanDeploy_staleCountAtCapacity_persistsRecount() throws Exception {
+        EnvironBean environ = createRandomEnvironBean();
+        String envId = environ.getEnv_id();
+        Connection connection = mock(Connection.class);
+        when(agentCountDAO.get(envId))
+                .thenReturn(
+                        agentCount(envId, 100L, 3L, System.currentTimeMillis() - 10 * TEST_TTL_MS));
+        when(utilDAO.getLock(anyString())).thenReturn(connection);
+        when(agentDAO.countNonFirstDeployingAgent(envId)).thenReturn(100L);
+        when(agentDAO.countDeployingAgent(envId)).thenReturn(TEST_THRESHOLD);
+
+        long before = System.currentTimeMillis();
+        assertFalse(pingHandler.canDeploy(environ, "hostname-1", waitingAgent(envId)));
+
+        // Rejected, but the recount is still persisted so the expired window is bounded by
+        // the ttl instead of lasting for the rest of the deploy.
+        ArgumentCaptor<AgentCountBean> captor = ArgumentCaptor.forClass(AgentCountBean.class);
+        verify(agentCountDAO).insertOrUpdate(captor.capture());
+        assertEquals(TEST_THRESHOLD, captor.getValue().getActive_count().longValue());
+        assertTrue(captor.getValue().getLast_refresh() >= before);
+        verify(agentDAO, never()).insertOrUpdate(any(AgentBean.class));
+        verify(utilDAO).releaseLock(anyString(), eq(connection));
+    }
+
+    @Test
+    public void testCanDeploy_staleCountBelowCapacity_admitsAndRefreshes() throws Exception {
+        EnvironBean environ = createRandomEnvironBean();
+        String envId = environ.getEnv_id();
+        Connection connection = mock(Connection.class);
+        when(agentCountDAO.get(envId))
+                .thenReturn(
+                        agentCount(envId, 100L, 9L, System.currentTimeMillis() - 10 * TEST_TTL_MS));
+        when(utilDAO.getLock(anyString())).thenReturn(connection);
+        when(agentDAO.countNonFirstDeployingAgent(envId)).thenReturn(100L);
+        when(agentDAO.countDeployingAgent(envId)).thenReturn(4L);
+
+        long before = System.currentTimeMillis();
+        assertTrue(pingHandler.canDeploy(environ, "hostname-1", waitingAgent(envId)));
+
+        // Exactly one recount happened, under the lock.
+        verify(agentDAO, times(1)).countNonFirstDeployingAgent(envId);
+        verify(agentDAO, times(1)).countDeployingAgent(envId);
+        ArgumentCaptor<AgentCountBean> captor = ArgumentCaptor.forClass(AgentCountBean.class);
+        verify(agentCountDAO).insertOrUpdate(captor.capture());
+        assertEquals(5L, captor.getValue().getActive_count().longValue());
+        assertTrue(captor.getValue().getLast_refresh() >= before);
+        verify(agentDAO).insertOrUpdate(any(AgentBean.class));
+        verify(utilDAO).releaseLock(anyString(), eq(connection));
+    }
+
+    @Test
+    public void testCanDeploy_freshCountBelowCapacity_admitsWithoutRecount() throws Exception {
+        EnvironBean environ = createRandomEnvironBean();
+        String envId = environ.getEnv_id();
+        long lastRefresh = System.currentTimeMillis();
+        when(agentCountDAO.get(envId)).thenReturn(agentCount(envId, 100L, 4L, lastRefresh));
+        when(utilDAO.getLock(anyString())).thenReturn(mock(Connection.class));
+
+        assertTrue(pingHandler.canDeploy(environ, "hostname-1", waitingAgent(envId)));
+
+        // A fresh count is trusted, so the seat is taken without any scan, and the ttl is
+        // not extended: active_count only self-corrects on the next recount.
+        verify(agentDAO, never()).countNonFirstDeployingAgent(anyString());
+        verify(agentDAO, never()).countDeployingAgent(anyString());
+        ArgumentCaptor<AgentCountBean> captor = ArgumentCaptor.forClass(AgentCountBean.class);
+        verify(agentCountDAO).insertOrUpdate(captor.capture());
+        assertEquals(5L, captor.getValue().getActive_count().longValue());
+        assertEquals(lastRefresh, captor.getValue().getLast_refresh().longValue());
+    }
+
+    @Test
+    public void testCanDeploy_missingCount_recountsUnderLock() throws Exception {
+        EnvironBean environ = createRandomEnvironBean();
+        String envId = environ.getEnv_id();
+        when(agentCountDAO.get(envId)).thenReturn(null);
+        when(utilDAO.getLock(anyString())).thenReturn(mock(Connection.class));
+        when(agentDAO.countNonFirstDeployingAgent(envId)).thenReturn(100L);
+        when(agentDAO.countDeployingAgent(envId)).thenReturn(0L);
+
+        assertTrue(pingHandler.canDeploy(environ, "hostname-1", waitingAgent(envId)));
+
+        ArgumentCaptor<AgentCountBean> captor = ArgumentCaptor.forClass(AgentCountBean.class);
+        verify(agentCountDAO).insertOrUpdate(captor.capture());
+        assertEquals(envId, captor.getValue().getEnv_id());
+        assertEquals(1L, captor.getValue().getActive_count().longValue());
+        assertEquals(100L, captor.getValue().getExisting_count().longValue());
+    }
+
+    @Test
+    public void testCanDeploy_firstDeployBypassesThreshold() throws Exception {
+        EnvironBean environ = createRandomEnvironBean();
+        String envId = environ.getEnv_id();
+        AgentBean agent = waitingAgent(envId);
+        agent.setFirst_deploy(true);
+
+        assertTrue(pingHandler.canDeploy(environ, "hostname-1", agent));
+
+        verify(agentDAO).insertOrUpdate(agent);
+        verify(agentCountDAO, never()).get(anyString());
+        verify(utilDAO, never()).getLock(anyString());
     }
 }


### PR DESCRIPTION
## Summary

### Problem (Why)

`agent_counts` is a per-env cache with a ttl (`agentCountCacheTtl`), read at the top of `PingHandler.canDeploy`. While the entry is fresh, admission decisions are served from it cheaply. Once it expires, the ping recomputes it with two `COUNT(*)` queries over every `agents` row belonging to the env.

Two defects compound in that expired path. Both are plain from reading the code.

**The lock did not protect the expensive work.** The `DEPLOY-<envId>` lock was acquired *after* both counts had already run, so it only guarded the write. Every ping arriving while the entry was expired paid for its own pair of scans, and all but the one that won the lock threw the result away. `getLock` uses a zero timeout, so the losers failed immediately and returned without refreshing anything — a textbook cache stampede.

**Nothing refreshed the cache while the env was at capacity.** Both reject paths returned without writing `agent_counts`. A stage pinned at its parallel threshold — the normal steady state for most of a large rollout, particularly when `maxParallelThreshold` caps the configured `max_parallel_pct` — therefore never updated `last_refresh`. The expired window lasted for the remainder of the deploy rather than a single ttl, so every ping from every waiting host rescanned.

Together these mean the expensive path is entered far more often than the ttl implies, and its cost scales with the same variable as the arrival rate into it: a bigger stage means more `agents` rows per scan *and* more hosts polling.

Worth noting separately that `GET_DEPLOYING_TOTAL` is an expensive scan regardless: its top-level `OR state = 'STOP'` prevents use of `agent_first_deploy_state_idx (env_id, first_deploy, deploy_stage, state)`, so it degenerates into scanning the env's rows and filtering. This PR reduces how often that query runs rather than fixing the query itself.

#### What was observed in production, and how strongly it is attributable

A MySQL primary backing Teletraan saturated CPU in eight windows over ten days, peaking near 90% user CPU in bursts of three to eight minutes. The signature during those bursts is that of an aggregate over a large row set rather than a traffic increase: rows examined per row returned rose from roughly 2.4 to roughly 256, rows read rose about 70x, and threads running went from about 170 to over 13,000, while rows returned to callers and rows changed both stayed flat or dipped slightly. Query volume was not elevated. Cost per query was.

The most suggestive single datapoint is that writes to `agent_counts` were measured falling by about half during a spike. That is backwards for any explanation based on load alone, but it is exactly what the second defect above predicts, since the write is skipped precisely when the env sits at capacity.

To be explicit about the limits of that attribution: no query digest was captured naming these two `COUNT(*)` statements, and no individual deploy has been placed inside a specific saturation window. This PR is therefore best read as fixing a defect that is real in the code and whose signature matches what was measured — not as a proven root cause. Two earlier hypotheses in the same investigation reproduced the observed peak arithmetically and both turned out to be wrong, so the distinction is worth keeping. Confirmation would come from `events_statements_summary_by_digest` sampled before and during a wave, and from re-measuring rows read and threads running on the first large rollout after this ships.

### Solution (What + How)

Restructure `canDeploy` into three paths so the recount happens at most once per env per ttl.

1. **Fast path.** A fresh count already reporting the env at capacity rejects immediately on a single primary-key lookup — no lock, no scans. This is the common case for hosts queued behind the threshold.
2. **Single flight.** Acquire `DEPLOY-<envId>` *before* recounting instead of after. The winner recounts inside the critical section; pings that lose the lock return and retry on their next cycle rather than duplicating the scans. The winner now also runs two counts instead of three, since the old code counted before the lock and re-counted inside it.
3. **Bounded staleness.** Persist the recount even when the host is not admitted, so an env sitting at capacity still refreshes `last_refresh` and the expired window can never exceed one ttl.

`last_refresh` is still extended only on a recount, never on an ordinary admission write. That is deliberate: `active_count` is increment-only and is never decremented when an agent finishes, so periodic expiry is the only thing that resyncs it against reality. Refreshing it on every admission would let the count inflate without bound and stall the rollout.

```mermaid
flowchart TB
    subgraph before ["Before: every expired-cache ping scans"]
        b1["Ping arrives, cache expired"] --> b2["COUNT(*) non-first-deploy agents"]
        b2 --> b3["COUNT(*) deploying agents"]
        b3 --> b4{"At capacity?"}
        b4 -->|yes| b5["Return false, cache never written"]
        b4 -->|no| b6["GET_LOCK"]
        b6 -->|lock lost| b7["Return false, scans wasted"]
        b6 -->|lock won| b8["Third COUNT, write cache, take seat"]
    end

    subgraph after ["After: one ping per ttl scans"]
        a1["Ping arrives, cache expired"] --> a2["GET_LOCK"]
        a2 -->|lock lost| a3["Return false, no scans"]
        a2 -->|lock won| a4["COUNT(*) non-first-deploy agents"]
        a4 --> a5["COUNT(*) deploying agents"]
        a5 --> a6["Write refreshed cache"]
        a6 --> a7{"At capacity?"}
        a7 -->|yes| a8["Return false, staleness bounded by ttl"]
        a7 -->|no| a9["Take a seat, return true"]
    end
```

Three behavior changes reviewers should weigh:

- The "failed to grab lock" log dropped from `WARN` to `DEBUG`. Losing the lock is now the expected outcome for most pings rather than an anomaly, so leaving it at `WARN` would flood the logs. Any alerting keyed on that line needs updating.
- Rejecting on an expired cache now requires taking the lock, where previously it could reject without one. That is inherent to single-flight, and it is why the recount is persisted on rejection.
- `countNonFirstDeployingAgent` now runs inside the `try`, so an exception there returns `false` instead of propagating out of `canDeploy`. This matches how `countDeployingAgent` already behaved.

## Test Plan

Added seven cases to `PingHandlerTest` covering the new control flow:

- a fresh at-capacity count rejects without calling either count query or `getLock`
- losing the lock skips both counts and writes nothing
- a stale at-capacity count rejects but still persists a refreshed `last_refresh`
- a stale under-capacity count recounts exactly once, admits, and increments `active_count`
- a fresh under-capacity count admits without recounting and leaves `last_refresh` untouched
- a missing `agent_counts` row recounts and initializes the row
- `first_deploy` still bypasses the threshold entirely

```bash
mvn -pl common -am -Dtest=PingHandlerTest test
# Tests run: 27, Failures: 0, Errors: 0, Skipped: 0

mvn -pl common -am test
# Tests run: 194, Failures: 0, Errors: 3, Skipped: 1
# The 3 errors are DBAgentDAOImplTest, DBDAOTest and DBEnvironDAOImplTest failing in
# setUpClass because no Docker environment was available for Testcontainers locally.
# They are unrelated to this change, but they are the suites that exercise the real
# SQL in DBAgentDAOImpl, so CI should be green on them before this is trusted.
```
