### PR TITLE
Add entitlement Help & Support escalation guidance to Cluster Capacity

### DIFF
--- a/deploy-board/deploy_board/settings.py
+++ b/deploy-board/deploy_board/settings.py
@@ -458,3 +458,16 @@ if IS_PINTEREST:
 
     # Entitlements UI Links
     ENTITLEMENTS_UI_LINK = os.getenv("ENTITLEMENTS_UI_LINK")
+
+    # Entitlement support / escalation (mirrors the Capacity Management System
+    # pdocs guide + oncall runbook; keep in sync with pinconsole
+    # entitlementSupport.ts). The "ask" rail (channel + oncall handle) is
+    # constant across surfaces; tagging @entitlement-support in
+    # #entitlement-users routes directly to the oncall (it is not a user group).
+    # The platform "page" rail points at the Teletraan/CDP oncall via #teletraan.
+    ENTITLEMENT_SUPPORT = {
+        "guide_url": "https://pdocs.pinadmin.com/docs/capacity-management-system/user-guide/teletraan/index",
+        "slack_channel": "#entitlement-users",
+        "slack_user_group": "@entitlement-support",
+        "platform_channel": "#teletraan",
+    }

--- a/deploy-board/deploy_board/templates/clusters/cluster_capacity.tmpl
+++ b/deploy-board/deploy_board/templates/clusters/cluster_capacity.tmpl
@@ -38,10 +38,34 @@
                 <div class="form-group" style="margin-bottom: 0;">
                     <div class="col-xs-8 col-xs-offset-4">
                         <div class="alert alert-info" style="margin-bottom: 0;">
-                            <strong>Capacity is read-only here.</strong>
-                            Click <strong>View Entitlement</strong> below
-                            <span class="glyphicon glyphicon-arrow-down"></span>
-                            to make capacity updates.
+                            <p style="margin-bottom: 8px;">
+                                <strong>Capacity is read-only here — managed by Entitlements.</strong>
+                            </p>
+                            <ul style="margin-bottom: 0; padding-left: 18px;">
+                                <li>
+                                    <strong>Mid-incident?</strong>
+                                    Click <strong>View Entitlement</strong> below
+                                    <span class="glyphicon glyphicon-arrow-down"></span>
+                                    and turn on <strong>Emergency Request</strong> — it bypasses the
+                                    budget and approval gates. Emergency requests are for incidents only.
+                                </li>
+                                <li>
+                                    <strong>Guide:</strong>
+                                    <a href="{{ entitlement_support.guide_url }}" target="_blank" rel="noopener">
+                                        Teletraan Entitlements Guide
+                                        <span class="glyphicon glyphicon-new-window"></span>
+                                    </a>
+                                </li>
+                                <li>
+                                    <strong>Questions:</strong>
+                                    <strong>{{ entitlement_support.slack_channel }}</strong>
+                                    — tag <strong>{{ entitlement_support.slack_user_group }}</strong> (routes to the oncall)
+                                </li>
+                                <li>
+                                    <strong>Platform help (Teletraan):</strong>
+                                    <strong>{{ entitlement_support.platform_channel }}</strong>
+                                </li>
+                            </ul>
                         </div>
                     </div>
                 </div>

--- a/deploy-board/deploy_board/templates/configs/capacity.html
+++ b/deploy-board/deploy_board/templates/configs/capacity.html
@@ -161,7 +161,7 @@ var alert = new Vue({
 
 <div id="mainPanel">
     {% if is_pinterest %}
-        {% include "clusters/cluster_capacity.tmpl" with is_managed_resource=is_managed_resource entitlements_ui_link=entitlements_ui_link useEntitlements=env.useEntitlements envName=env.envName stageName=env.stageName %}
+        {% include "clusters/cluster_capacity.tmpl" with is_managed_resource=is_managed_resource entitlements_ui_link=entitlements_ui_link useEntitlements=env.useEntitlements envName=env.envName stageName=env.stageName entitlement_support=entitlement_support %}
     {% endif %}
     {% include "configs/capacity.tmpl" %}
 </div>

--- a/deploy-board/deploy_board/webapp/capacity_views.py
+++ b/deploy-board/deploy_board/webapp/capacity_views.py
@@ -33,6 +33,7 @@ from deploy_board.settings import (
     IS_PINTEREST,
     CONFLICTING_DEPLOY_SERVICE_WIKI_URL,
     ENTITLEMENTS_UI_LINK,
+    ENTITLEMENT_SUPPORT,
 )
 
 
@@ -134,6 +135,7 @@ class EnvCapacityConfigView(View):
             "conflicting_deploy_service_wiki_url": CONFLICTING_DEPLOY_SERVICE_WIKI_URL,
             "is_managed_resource": is_managed_resource,
             "entitlements_ui_link": ENTITLEMENTS_UI_LINK,
+            "entitlement_support": ENTITLEMENT_SUPPORT,
         }
         data["info"] = json.dumps(data)
         return render(request, "configs/capacity.html", data)


### PR DESCRIPTION
## Summary

When capacity fields on the Cluster Capacity page are read-only (the `useEntitlements` path), users currently have no in-context way to find who to ask or how to escalate. This expands that read-only notice into a short **escalation ladder** so people can self-serve or reach the right place fast:

- **Emergency Request** pointer for incidents only (no time-to-apply claims).
- **User guide** link (Capacity Management System → Teletraan).
- **Questions** rail: `#entitlement-users` — tag `@entitlement-support` to reach the oncall.
- **Platform help** rail: `#teletraan`.

Support handles/links are centralized in `settings.ENTITLEMENT_SUPPORT` and injected into the template via the capacity view, so they can be updated in one place.

## Notes

- Only renders on the existing read-only (`useEntitlements`) path — no change to the editable capacity flow.
- Public-repo hygiene: no internal Slack workspace deep-links or channel IDs are included; the channel name renders as plain text.

## Test plan

- [ ] Load Cluster Capacity for a cluster on the `useEntitlements` path and confirm the escalation ladder renders with working guide link.
- [ ] Confirm the editable capacity flow is unchanged.