### PR TITLE
Apply entitlement logic to ASG page

### DIFF
--- a/deploy-board/deploy_board/templates/groups/asg_config.tmpl
+++ b/deploy-board/deploy_board/templates/groups/asg_config.tmpl
@@ -18,7 +18,16 @@
                 Auto Scaling Group
                 {% endif %}
             </a>
+            {% if useEntitlements %}
+            <span class="label label-default" style="margin-left: 8px; vertical-align: middle;">CAPACITY READ-ONLY</span>
+            {% endif %}
         </h4>
+        {% if useEntitlements %}
+        <div class="pull-right text-muted" style="padding-top: 3px;">
+            <span class="glyphicon glyphicon-lock"></span>
+            Capacity managed by Entitlements
+        </div>
+        {% endif %}
     </div>
 </div>
 <div id="autoscalingConfigId" class="collapse in panel-body">
@@ -27,13 +36,56 @@
             <input type="hidden" name="asgStatus" value="{{ asg.status }}">
             <input type="hidden" name="groupName" value="{{ group_name }}">
             <fieldset id="envConfigFieldSetId">
-                <asg-capacity-config
-                    original-min-size="{{ asg.minSize }}" original-max-size="{{ asg.maxSize }}" current-size="{{ group_size }}"
-                    label-bootstrap-class="col-xs-2" input-bootstrap-class="col-xs-4"
-                    label-title="Capacity (Current size is {{ group_size }})"
-                    label-text="Minimun and maximum number of hosts in one autoscaling group"
-                    :remaining-capacity="remainingCapacity" :placements="placements">
-                </asg-capacity-config>
+                {% if useEntitlements %}
+                <input type="hidden" name="minSize" value="{{ asg.minSize }}">
+                <input type="hidden" name="maxSize" value="{{ asg.maxSize }}">
+                {% endif %}
+                <fieldset id="asgCapacityFieldSetId" {% if useEntitlements %}disabled
+                        title="Click View Entitlement to make capacity updates"{% endif %}>
+                    <asg-capacity-config
+                        original-min-size="{{ asg.minSize }}" original-max-size="{{ asg.maxSize }}" current-size="{{ group_size }}"
+                        label-bootstrap-class="col-xs-2" input-bootstrap-class="col-xs-4"
+                        label-title="Capacity (Current size is {{ group_size }})"
+                        label-text="Minimun and maximum number of hosts in one autoscaling group"
+                        :remaining-capacity="remainingCapacity" :placements="placements">
+                    </asg-capacity-config>
+                </fieldset>
+                {% if useEntitlements %}
+                <div class="form-group">
+                    <div class="col-xs-8 col-xs-offset-2">
+                        <div class="alert alert-info" style="margin-bottom: 0;">
+                            <p style="margin-bottom: 8px;">
+                                <strong>Capacity is read-only here — managed by Entitlements.</strong>
+                            </p>
+                            <ul style="margin-bottom: 0; padding-left: 18px;">
+                                <li>
+                                    <strong>Mid-incident?</strong>
+                                    Click <strong>View Entitlement</strong> below
+                                    <span class="glyphicon glyphicon-arrow-down"></span>
+                                    and turn on <strong>Emergency Request</strong> — it bypasses the
+                                    budget and approval gates. Emergency requests are for incidents only.
+                                </li>
+                                <li>
+                                    <strong>Guide:</strong>
+                                    <a href="{{ entitlement_support.guide_url }}" target="_blank" rel="noopener">
+                                        Teletraan Entitlements Guide
+                                        <span class="glyphicon glyphicon-new-window"></span>
+                                    </a>
+                                </li>
+                                <li>
+                                    <strong>Questions:</strong>
+                                    <strong>{{ entitlement_support.slack_channel }}</strong>
+                                    — tag <strong>{{ entitlement_support.slack_user_group }}</strong> (routes to the oncall)
+                                </li>
+                                <li>
+                                    <strong>Platform help (Teletraan):</strong>
+                                    <strong>{{ entitlement_support.platform_channel }}</strong>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+                {% endif %}
 
                 <div class="form-group">
                     <label for="terminationPolicy" class="deployToolTip control-label col-xs-2"
@@ -60,7 +112,20 @@
 
 
 <div class="panel-footer clearfix">
+    {% if useEntitlements %}
+    <div class="pull-left text-muted" style="padding-top: 7px;">
+        <span class="glyphicon glyphicon-refresh"></span>
+        All capacity updates go through Entitlements, which auto-syncs to Teletraan.
+    </div>
+    {% endif %}
     <div class="pull-right">
+        {% if useEntitlements %}
+        <a href="{{ entitlements_ui_link }}?openForm=request&platform=teletraan&service={{ envName }}-{{ stageName }}&budgetingEntity=all" target="_blank" class="btn btn-primary"
+                title="Update capacity in the Entitlements UI">
+            <span class="glyphicon glyphicon-new-window"></span>
+            View Entitlement
+        </a>
+        {% endif %}
         <button id="resetEnvConfigBtnId" class="btn btn-default" data-loading-text="Reloading...">
             <span class="glyphicon glyphicon-refresh"></span> Reload
         </button>

--- a/deploy-board/deploy_board/templates/groups/asg_config.tmpl
+++ b/deploy-board/deploy_board/templates/groups/asg_config.tmpl
@@ -19,13 +19,13 @@
                 {% endif %}
             </a>
             {% if useEntitlements %}
-            <span class="label label-default" style="margin-left: 8px; vertical-align: middle;">CAPACITY READ-ONLY</span>
+            <span class="label label-default" style="margin-left: 8px; vertical-align: middle;">READ-ONLY</span>
             {% endif %}
         </h4>
         {% if useEntitlements %}
         <div class="pull-right text-muted" style="padding-top: 3px;">
             <span class="glyphicon glyphicon-lock"></span>
-            Capacity managed by Entitlements
+            Managed by Entitlements
         </div>
         {% endif %}
     </div>
@@ -35,76 +35,55 @@
         <form id="autoscalingGroupConfigFormId" class="form-horizontal" role="form">
             <input type="hidden" name="asgStatus" value="{{ asg.status }}">
             <input type="hidden" name="groupName" value="{{ group_name }}">
-            <fieldset id="envConfigFieldSetId">
-                {% if useEntitlements %}
-                <input type="hidden" name="minSize" value="{{ asg.minSize }}">
-                <input type="hidden" name="maxSize" value="{{ asg.maxSize }}">
+            <fieldset id="envConfigFieldSetId" {% if useEntitlements %}disabled
+                    title="Click View Entitlement to make capacity updates"{% endif %}>
+                <asg-capacity-config
+                    original-min-size="{{ asg.minSize }}" original-max-size="{{ asg.maxSize }}" current-size="{{ group_size }}"
+                    label-bootstrap-class="col-xs-2" input-bootstrap-class="col-xs-4"
+                    label-title="Capacity (Current size is {{ group_size }})"
+                    label-text="Minimun and maximum number of hosts in one autoscaling group"
+                    :remaining-capacity="remainingCapacity" :placements="placements">
+                </asg-capacity-config>
+                {% if not useEntitlements %}
+                {% include "groups/asg_termination_policy.tmpl" %}
                 {% endif %}
-                <fieldset id="asgCapacityFieldSetId" {% if useEntitlements %}disabled
-                        title="Click View Entitlement to make capacity updates"{% endif %}>
-                    <asg-capacity-config
-                        original-min-size="{{ asg.minSize }}" original-max-size="{{ asg.maxSize }}" current-size="{{ group_size }}"
-                        label-bootstrap-class="col-xs-2" input-bootstrap-class="col-xs-4"
-                        label-title="Capacity (Current size is {{ group_size }})"
-                        label-text="Minimun and maximum number of hosts in one autoscaling group"
-                        :remaining-capacity="remainingCapacity" :placements="placements">
-                    </asg-capacity-config>
-                </fieldset>
-                {% if useEntitlements %}
-                <div class="form-group">
-                    <div class="col-xs-8 col-xs-offset-2">
-                        <div class="alert alert-info" style="margin-bottom: 0;">
-                            <p style="margin-bottom: 8px;">
-                                <strong>Capacity is read-only here — managed by Entitlements.</strong>
-                            </p>
-                            <ul style="margin-bottom: 0; padding-left: 18px;">
-                                <li>
-                                    <strong>Mid-incident?</strong>
-                                    Click <strong>View Entitlement</strong> below
-                                    <span class="glyphicon glyphicon-arrow-down"></span>
-                                    and turn on <strong>Emergency Request</strong> — it bypasses the
-                                    budget and approval gates. Emergency requests are for incidents only.
-                                </li>
-                                <li>
-                                    <strong>Guide:</strong>
-                                    <a href="{{ entitlement_support.guide_url }}" target="_blank" rel="noopener">
-                                        Teletraan Entitlements Guide
-                                        <span class="glyphicon glyphicon-new-window"></span>
-                                    </a>
-                                </li>
-                                <li>
-                                    <strong>Questions:</strong>
-                                    <strong>{{ entitlement_support.slack_channel }}</strong>
-                                    — tag <strong>{{ entitlement_support.slack_user_group }}</strong> (routes to the oncall)
-                                </li>
-                                <li>
-                                    <strong>Platform help (Teletraan):</strong>
-                                    <strong>{{ entitlement_support.platform_channel }}</strong>
-                                </li>
-                            </ul>
-                        </div>
-                    </div>
-                </div>
-                {% endif %}
-
-                <div class="form-group">
-                    <label for="terminationPolicy" class="deployToolTip control-label col-xs-2"
-                            data-toggle="tooltip" title="termination policy">
-                        Termination Policy
-                    </label>
-                    <div class="col-xs-4">
-                        <select class="form-control" name="terminationPolicy" required="true" id="terminationPolicyInput">
-                        {% for policy in terminationPolicies %}
-                            {% if policy == asg.terminationPolicy %}
-                                <option value="{{policy}}" selected>{{policy}}</option>
-                            {% else %}
-                                <option value="{{policy}}">{{policy}}</option>
-                            {% endif %}
-                        {% endfor %}
-                        </select>
-                    </div>
-                </div>
             </fieldset>
+            {% if useEntitlements %}
+            <div class="form-group" style="margin-bottom: 0;">
+                <div class="col-xs-8 col-xs-offset-2">
+                    <div class="alert alert-info" style="margin-bottom: 0;">
+                        <p style="margin-bottom: 8px;">
+                            <strong>Capacity is read-only here — managed by Entitlements.</strong>
+                        </p>
+                        <ul style="margin-bottom: 0; padding-left: 18px;">
+                            <li>
+                                <strong>Mid-incident?</strong>
+                                Click <strong>View Entitlement</strong> below
+                                <span class="glyphicon glyphicon-arrow-down"></span>
+                                and turn on <strong>Emergency Request</strong> — it bypasses the
+                                budget and approval gates. Emergency requests are for incidents only.
+                            </li>
+                            <li>
+                                <strong>Guide:</strong>
+                                <a href="{{ entitlement_support.guide_url }}" target="_blank" rel="noopener">
+                                    Teletraan Entitlements Guide
+                                    <span class="glyphicon glyphicon-new-window"></span>
+                                </a>
+                            </li>
+                            <li>
+                                <strong>Questions:</strong>
+                                <strong>{{ entitlement_support.slack_channel }}</strong>
+                                — tag <strong>{{ entitlement_support.slack_user_group }}</strong> (routes to the oncall)
+                            </li>
+                            <li>
+                                <strong>Platform help (Teletraan):</strong>
+                                <strong>{{ entitlement_support.platform_channel }}</strong>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+            {% endif %}
         {% csrf_token %}
         </form>
     </div>
@@ -117,15 +96,15 @@
         <span class="glyphicon glyphicon-refresh"></span>
         All capacity updates go through Entitlements, which auto-syncs to Teletraan.
     </div>
-    {% endif %}
     <div class="pull-right">
-        {% if useEntitlements %}
         <a href="{{ entitlements_ui_link }}?openForm=request&platform=teletraan&service={{ envName }}-{{ stageName }}&budgetingEntity=all" target="_blank" class="btn btn-primary"
                 title="Update capacity in the Entitlements UI">
             <span class="glyphicon glyphicon-new-window"></span>
             View Entitlement
         </a>
-        {% endif %}
+    </div>
+    {% else %}
+    <div class="pull-right">
         <button id="resetEnvConfigBtnId" class="btn btn-default" data-loading-text="Reloading...">
             <span class="glyphicon glyphicon-refresh"></span> Reload
         </button>
@@ -133,7 +112,38 @@
             <span class="glyphicon glyphicon-floppy-save"></span> Save
         </button>
     </div>
+    {% endif %}
 </div>
+
+{% if useEntitlements %}
+<div id="terminationPolicyPid" class="panel panel-default">
+    {% include "panel_heading.tmpl" with panel_title="Termination Policy" panel_body_id="terminationPolicyConfigId" direction="down" %}
+    <div id="terminationPolicyConfigId" class="collapse in panel-body">
+        <div class="container-fluid">
+            <form id="terminationPolicyFormId" class="form-horizontal" role="form">
+                <input type="hidden" name="asgStatus" value="{{ asg.status }}">
+                <input type="hidden" name="groupName" value="{{ group_name }}">
+                <input type="hidden" name="minSize" value="{{ asg.minSize }}">
+                <input type="hidden" name="maxSize" value="{{ asg.maxSize }}">
+                <fieldset>
+                    {% include "groups/asg_termination_policy.tmpl" %}
+                </fieldset>
+            {% csrf_token %}
+            </form>
+        </div>
+    </div>
+    <div class="panel-footer clearfix">
+        <div class="pull-right">
+            <button id="resetEnvConfigBtnId" class="btn btn-default" data-loading-text="Reloading...">
+                <span class="glyphicon glyphicon-refresh"></span> Reload
+            </button>
+            <button id="saveEnvConfigBtnId" class="btn btn-primary" data-loading-text="Saving...">
+                <span class="glyphicon glyphicon-floppy-save"></span> Save
+            </button>
+        </div>
+    </div>
+</div>
+{% endif %}
 
 <div id="suspendedProcessesPid"></div>
 <div id="scheduledActionsPid"></div>
@@ -146,6 +156,12 @@ $(function() {
         $('#pasConfigPid').html(response);
     });
 });
+
+{% if useEntitlements %}
+var configFormId = '#terminationPolicyFormId';
+{% else %}
+var configFormId = '#autoscalingGroupConfigFormId';
+{% endif %}
 
 var asgConfigVue = new Vue({
     el: '#autoscalingConfigId',
@@ -216,17 +232,17 @@ $(function () {
         $("#spotInstanceConfigDiv").addClass("hidden");
     }
 
-    $('#autoscalingGroupConfigFormId input').keyup(function() {
+    $(configFormId + ' input').keyup(function() {
         $('#saveEnvConfigBtnId').removeAttr('disabled');
         $('#resetEnvConfigBtnId').removeAttr('disabled');
     });
 
-    $('#autoscalingGroupConfigFormId select').change(function() {
+    $(configFormId + ' select').change(function() {
         $('#saveEnvConfigBtnId').removeAttr('disabled');
         $('#resetEnvConfigBtnId').removeAttr('disabled');
     });
 
-    $('#autoscalingGroupConfigFormId input').change(function() {
+    $(configFormId + ' input').change(function() {
         $('#saveEnvConfigBtnId').removeAttr('disabled');
         $('#resetEnvConfigBtnId').removeAttr('disabled');
     });
@@ -244,7 +260,7 @@ $(function () {
         $.ajax({
             type: 'POST',
             url: '/groups/{{ group_name }}/autoscaling/update_config/',
-            data: $("#autoscalingGroupConfigFormId").serialize(),
+            data: $(configFormId).serialize(),
             dataType: 'json',
             beforeSend: function () {
                 btn.button('loading');

--- a/deploy-board/deploy_board/templates/groups/asg_termination_policy.tmpl
+++ b/deploy-board/deploy_board/templates/groups/asg_termination_policy.tmpl
@@ -1,0 +1,17 @@
+<div class="form-group">
+    <label for="terminationPolicy" class="deployToolTip control-label col-xs-2"
+            data-toggle="tooltip" title="termination policy">
+        Termination Policy
+    </label>
+    <div class="col-xs-4">
+        <select class="form-control" name="terminationPolicy" required="true" id="terminationPolicyInput">
+        {% for policy in terminationPolicies %}
+            {% if policy == asg.terminationPolicy %}
+                <option value="{{policy}}" selected>{{policy}}</option>
+            {% else %}
+                <option value="{{policy}}">{{policy}}</option>
+            {% endif %}
+        {% endfor %}
+        </select>
+    </div>
+</div>

--- a/deploy-board/deploy_board/webapp/group_view.py
+++ b/deploy-board/deploy_board/webapp/group_view.py
@@ -13,7 +13,12 @@
 # limitations under the License.
 
 
-from deploy_board.settings import IS_PINTEREST, PHOBOS_URL
+from deploy_board.settings import (
+    IS_PINTEREST,
+    PHOBOS_URL,
+    ENTITLEMENTS_UI_LINK,
+    ENTITLEMENT_SUPPORT,
+)
 from django.middleware.csrf import get_token
 from django.shortcuts import render, redirect
 from django.views.generic import View
@@ -407,6 +412,8 @@ def get_asg_config(request, group_name):
             )
     except Exception as e:
         log.warning("Failed to get placements: {}".format(e))
+    envs = environs_helper.get_all_envs_by_group(request, group_name)
+    entitlement_env = next((env for env in envs if env.get("useEntitlements")), None)
     content = render_to_string(
         "groups/asg_config.tmpl",
         {
@@ -418,6 +425,11 @@ def get_asg_config(request, group_name):
             "csrf_token": get_token(request),
             "pas_config": pas_config,
             "placements": json.dumps(placements),
+            "useEntitlements": entitlement_env is not None,
+            "envName": entitlement_env.get("envName") if entitlement_env else None,
+            "stageName": entitlement_env.get("stageName") if entitlement_env else None,
+            "entitlements_ui_link": ENTITLEMENTS_UI_LINK,
+            "entitlement_support": ENTITLEMENT_SUPPORT,
         },
     )
     return HttpResponse(json.dumps(content), content_type="application/json")


### PR DESCRIPTION
## Summary

Previously, the cluster capacity page had the entitlement logic (e.g. capacity inputs disabled, link to Entitlements UI).

Apply the logic to the ASG page as well.

## Screenshots

**Stage with Entitlements Enabled**

<img width="1066" height="763" alt="Screenshot 2026-09-10 at 8 40 55 AM" src="https://github.com/user-attachments/assets/456d6bc7-b562-44f9-9ad0-1865d7a3e8aa" />

<br/>
<br/>


**Stage without Entitlements Enabled**

<img width="1105" height="433" alt="Screenshot 2026-09-10 at 8 42 25 AM" src="https://github.com/user-attachments/assets/bf166bfe-fc09-471f-b2ca-0fe6a2437332" />
